### PR TITLE
Fix for #2877 - add nonanalyzed (i.e. keyword) 'name' field to package search

### DIFF
--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -32,6 +32,7 @@ NameAnalyzer = analyzer(
 
 @doc_type
 class Project(Document):
+
     name = Text(fields={'keyword': Keyword()})
     normalized_name = Text(analyzer=NameAnalyzer)
     version = Keyword(multi=True)

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -32,8 +32,7 @@ NameAnalyzer = analyzer(
 
 @doc_type
 class Project(Document):
-
-    name = Text()
+    name = Text(fields={'keyword': Keyword()})
     normalized_name = Text(analyzer=NameAnalyzer)
     version = Keyword(multi=True)
     latest_version = Keyword()

--- a/warehouse/search/queries.py
+++ b/warehouse/search/queries.py
@@ -10,27 +10,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SEARCH_FIELDS = [
-    "author",
-    "author_email",
-    "description",
-    "download_url",
-    "home_page",
-    "keywords",
-    "license",
-    "maintainer",
-    "maintainer_email",
-    "normalized_name",
-    "platform",
-    "summary",
-]
 SEARCH_BOOSTS = {
     "name": 10,
     "normalized_name": 10,
     "description": 5,
     "keywords": 5,
     "summary": 5,
+    "author": 1,
+    "author_email": 1,
+    "download_url": 1,
+    "home_page": 1,
+    "license": 1,
+    "maintainer": 1,
+    "maintainer_email": 1,
+    "platform": 1,
 }
+
 SEARCH_FILTER_ORDER = (
     "Framework",
     "Topic",

--- a/warehouse/search/queries.py
+++ b/warehouse/search/queries.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 SEARCH_BOOSTS = {
+    "name.keyword": 20,
     "name": 10,
     "normalized_name": 10,
     "description": 5,

--- a/warehouse/search/queries.py
+++ b/warehouse/search/queries.py
@@ -26,7 +26,6 @@ SEARCH_BOOSTS = {
     "maintainer_email": 1,
     "platform": 1,
 }
-
 SEARCH_FILTER_ORDER = (
     "Framework",
     "Topic",

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -41,7 +41,7 @@ from warehouse.cache.origin import origin_cache
 from warehouse.cache.http import add_vary, cache_control
 from warehouse.classifiers.models import Classifier
 from warehouse.packaging.models import Project, Release, File, release_classifiers
-from warehouse.search.queries import SEARCH_BOOSTS, SEARCH_FIELDS, SEARCH_FILTER_ORDER
+from warehouse.search.queries import SEARCH_BOOSTS, SEARCH_FILTER_ORDER
 from warehouse.utils.row_counter import RowCount
 from warehouse.utils.paginate import ElasticsearchPage, paginate_url_factory
 
@@ -160,41 +160,41 @@ def index(request):
         r[0]
         for r in (
             request.db.query(Project.name)
-            .order_by(Project.zscore.desc().nullslast(), func.random())
-            .limit(5)
-            .all()
+                .order_by(Project.zscore.desc().nullslast(), func.random())
+                .limit(5)
+                .all()
         )
     ]
     release_a = aliased(
         Release,
         request.db.query(Release)
-        .distinct(Release.name)
-        .filter(Release.name.in_(project_names))
-        .order_by(
+            .distinct(Release.name)
+            .filter(Release.name.in_(project_names))
+            .order_by(
             Release.name,
             Release.is_prerelease.nullslast(),
             Release._pypi_ordering.desc(),
         )
-        .subquery(),
+            .subquery(),
     )
     trending_projects = (
         request.db.query(release_a)
-        .options(joinedload(release_a.project))
-        .order_by(func.array_idx(project_names, release_a.name))
-        .all()
+            .options(joinedload(release_a.project))
+            .order_by(func.array_idx(project_names, release_a.name))
+            .all()
     )
 
     latest_releases = (
         request.db.query(Release)
-        .options(joinedload(Release.project))
-        .order_by(Release.created.desc())
-        .limit(5)
-        .all()
+            .options(joinedload(Release.project))
+            .order_by(Release.created.desc())
+            .limit(5)
+            .all()
     )
 
     counts = dict(
         request.db.query(RowCount.table_name, RowCount.count)
-        .filter(
+            .filter(
             RowCount.table_name.in_(
                 [
                     Project.__tablename__,
@@ -204,7 +204,7 @@ def index(request):
                 ]
             )
         )
-        .all()
+            .all()
     )
 
     return {
@@ -221,9 +221,9 @@ def index(request):
 def classifiers(request):
     classifiers = (
         request.db.query(Classifier.classifier)
-        .filter(Classifier.deprecated.is_(False))
-        .order_by(Classifier.classifier)
-        .all()
+            .filter(Classifier.deprecated.is_(False))
+            .order_by(Classifier.classifier)
+            .all()
     )
 
     return {"classifiers": classifiers}
@@ -241,7 +241,6 @@ def classifiers(request):
     ],
 )
 def search(request):
-
     q = request.params.get("q", "")
     q = q.replace("'", '"')
 
@@ -283,14 +282,14 @@ def search(request):
 
     classifiers_q = (
         request.db.query(Classifier)
-        .with_entities(Classifier.classifier)
-        .filter(Classifier.deprecated.is_(False))
-        .filter(
+            .with_entities(Classifier.classifier)
+            .filter(Classifier.deprecated.is_(False))
+            .filter(
             exists([release_classifiers.c.trove_id]).where(
                 release_classifiers.c.trove_id == Classifier.id
             )
         )
-        .order_by(Classifier.classifier)
+            .order_by(Classifier.classifier)
     )
 
     for cls in classifiers_q:
@@ -347,10 +346,10 @@ def stats(request):
     total_size_query = request.db.query(func.sum(File.size)).all()
     top_100_packages = (
         request.db.query(File.name, func.sum(File.size))
-        .group_by(File.name)
-        .order_by(func.sum(File.size).desc())
-        .limit(100)
-        .all()
+            .group_by(File.name)
+            .order_by(func.sum(File.size).desc())
+            .limit(100)
+            .all()
     )
     # Move top packages into a dict to make JSON more self describing
     top_packages = {
@@ -413,8 +412,8 @@ def form_query(query_type, query):
     Returns a multi match query
     """
     fields = [
-        field + "^" + str(SEARCH_BOOSTS[field]) if field in SEARCH_BOOSTS else field
-        for field in SEARCH_FIELDS
+        field + "^" + str(boost) if boost != 1 else field
+        for field, boost in SEARCH_BOOSTS.items()
     ]
     return Q("multi_match", fields=fields, query=query, type=query_type)
 

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -160,41 +160,41 @@ def index(request):
         r[0]
         for r in (
             request.db.query(Project.name)
-                .order_by(Project.zscore.desc().nullslast(), func.random())
-                .limit(5)
-                .all()
+            .order_by(Project.zscore.desc().nullslast(), func.random())
+            .limit(5)
+            .all()
         )
     ]
     release_a = aliased(
         Release,
         request.db.query(Release)
-            .distinct(Release.name)
-            .filter(Release.name.in_(project_names))
-            .order_by(
+        .distinct(Release.name)
+        .filter(Release.name.in_(project_names))
+        .order_by(
             Release.name,
             Release.is_prerelease.nullslast(),
             Release._pypi_ordering.desc(),
         )
-            .subquery(),
+        .subquery(),
     )
     trending_projects = (
         request.db.query(release_a)
-            .options(joinedload(release_a.project))
-            .order_by(func.array_idx(project_names, release_a.name))
-            .all()
+        .options(joinedload(release_a.project))
+        .order_by(func.array_idx(project_names, release_a.name))
+        .all()
     )
 
     latest_releases = (
         request.db.query(Release)
-            .options(joinedload(Release.project))
-            .order_by(Release.created.desc())
-            .limit(5)
-            .all()
+        .options(joinedload(Release.project))
+        .order_by(Release.created.desc())
+        .limit(5)
+        .all()
     )
 
     counts = dict(
         request.db.query(RowCount.table_name, RowCount.count)
-            .filter(
+        .filter(
             RowCount.table_name.in_(
                 [
                     Project.__tablename__,
@@ -204,7 +204,7 @@ def index(request):
                 ]
             )
         )
-            .all()
+        .all()
     )
 
     return {
@@ -221,9 +221,9 @@ def index(request):
 def classifiers(request):
     classifiers = (
         request.db.query(Classifier.classifier)
-            .filter(Classifier.deprecated.is_(False))
-            .order_by(Classifier.classifier)
-            .all()
+        .filter(Classifier.deprecated.is_(False))
+        .order_by(Classifier.classifier)
+        .all()
     )
 
     return {"classifiers": classifiers}
@@ -241,6 +241,7 @@ def classifiers(request):
     ],
 )
 def search(request):
+
     q = request.params.get("q", "")
     q = q.replace("'", '"')
 
@@ -282,14 +283,14 @@ def search(request):
 
     classifiers_q = (
         request.db.query(Classifier)
-            .with_entities(Classifier.classifier)
-            .filter(Classifier.deprecated.is_(False))
-            .filter(
+        .with_entities(Classifier.classifier)
+        .filter(Classifier.deprecated.is_(False))
+        .filter(
             exists([release_classifiers.c.trove_id]).where(
                 release_classifiers.c.trove_id == Classifier.id
             )
         )
-            .order_by(Classifier.classifier)
+        .order_by(Classifier.classifier)
     )
 
     for cls in classifiers_q:
@@ -346,10 +347,10 @@ def stats(request):
     total_size_query = request.db.query(func.sum(File.size)).all()
     top_100_packages = (
         request.db.query(File.name, func.sum(File.size))
-            .group_by(File.name)
-            .order_by(func.sum(File.size).desc())
-            .limit(100)
-            .all()
+        .group_by(File.name)
+        .order_by(func.sum(File.size).desc())
+        .limit(100)
+        .all()
     )
     # Move top packages into a dict to make JSON more self describing
     top_packages = {


### PR DESCRIPTION
To whom it may concern,

I fixed the bug to the best of my understanding, but I still have a few issues. I'm "prematurely" opening this PR with the purpose of receiving some review, feedback, and help.

See some code comments about the fix inline.

About my status:

1. I managed to set up and run warehouse in a container (😄)
2. I couldn't get the tests to execute :\. When I run "make tests" I get the following error:
```
    env: ‘bin/tests’: No such file or directory
    Makefile:99: recipe for target 'tests' failed
```
3. I couldn't replicate the bug on my PC, hence I couldn't make sure the bug is solved. Finding "bad" examples is hard even in production, and the test ES probably has much fewer packages. The bug can probably be fabricated by adding carefully named mock packages to the index, but I've no idea how to do that.

4. The "tests" I did run were making sure that 1) search still works, 2) `make initdb` still succeeds and 3) the ES search query contains the new search field, `name.keyword`.


Any help and guidance would be appreciated.
Thanks!