### PR TITLE
Reworded the section about predictable URLs

### DIFF
--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,4 +1,4 @@
-doc8
+doc8>=1.1.0
 flake8
 curlylint
 pep8-naming


### PR DESCRIPTION
In #5535 it became clear that the current state of the documentation misleads people into thinking the predictable URL API might me some kind of barely maintained step child instead of the valuable asset for Linux package maintainers that it is.

# [Rendered](https://warehouse--5536.org.readthedocs.build/api-reference/integration-guide.html#predictable-urls)