### PR TITLE
Use OrderedDict for sorting releases in JSON

### DIFF
--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -121,7 +121,7 @@ def json_release(release, request):
 
     # Map our releases + files into a dictionary that maps each release to a
     # list of all its files.
-    releases = {}
+    releases = OrderedDict()
     for r, file_ in release_files:
         files = releases.setdefault(r, [])
         if file_ is not None:


### PR DESCRIPTION
Right now releases in JSON are sorted as strings and not as versions, and that might be because of unsorted dict usage.

https://pypi.org/pypi/boto3/1.9.220/json