### PR TITLE
Refactor BigQuery sync task to optimize memory consumption

### DIFF
--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -12,8 +12,6 @@
 
 import datetime
 
-from itertools import product
-
 from google.cloud.bigquery import LoadJobConfig
 
 from warehouse import tasks
@@ -239,7 +237,7 @@ def sync_bigquery_release_files(request):
     del db_release_files
 
     bq_query_job = bq.query(
-        "SELECT DISTINCT md5_digest " f"FROM {table_name} " "ORDER BY md5_digest ASC"
+        f"SELECT DISTINCT md5_digest FROM {table_name} ORDER BY md5_digest ASC"
     )
     bq_query_job.result()
     destination = bq.get_table(bq_query_job.destination)

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -147,7 +147,11 @@ def update_bigquery_release_files(task, request, dist_metadata):
 
         # Replace all empty objects to None will ensure
         # proper checks if a field is nullable or not
-        if not isinstance(field_data, bool) and not field_data:
+        if (
+            not isinstance(field_data, bool)
+            and not isinstance(field_data, int)
+            and not field_data
+        ):
             field_data = None
 
         if field_data is None and sch.mode == "REPEATED":
@@ -205,7 +209,11 @@ def sync_bigquery_release_files(request):
 
             # Replace all empty objects to None will ensure
             # proper checks if a field is nullable or not
-            if not isinstance(field_data, bool) and not field_data:
+            if (
+                not isinstance(field_data, bool)
+                and not isinstance(field_data, int)
+                and not field_data
+            ):
                 field_data = None
 
             if field_data is None and sch.mode == "REPEATED":


### PR DESCRIPTION
This PR is one last attempt at optimizing the `sync_bigquery_release_files` task. Instead of creating new variables for every computation, these changes minimize the memory footprint of the variables and removes variables from memory if not required. Reducing memory footprint did increase execution time but not by a considerable amount.

Expected usage for 3 million release files,
Peak memory usage for variables: ~50-60MB
Task execution time: ~1 min