### PR TITLE
Use docker initialization scripts for DB init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,9 @@ requirements/%.txt: requirements/%.in
 	docker-compose run --rm web bin/pip-compile --allow-unsafe --generate-hashes --output-file=$@ $<
 
 resetdb: .state/docker-build-web
-	docker-compose up --recreate db
+	docker-compose stop db
+	docker volume rm warehouse_pgdata
+	docker-compose up -d --recreate db
 
 migrate: .state/docker-build-web
 	docker-compose run --rm web python -m warehouse db upgrade head

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+<<<<<<< HEAD
+=======
+BINDIR = $(PWD)/.state/env/bin
+COMPOSE_PROJECT_NAME ?= $(notdir $(abspath .))
+GITHUB_ACTIONS := $(shell echo "$${GITHUB_ACTIONS:-false}")
+GITHUB_BASE_REF := $(shell echo "$${GITHUB_BASE_REF:-false}")
+>>>>>>> e1349bda (Calculate compose project name instead of hardcoding it)
 DB := example
 IPYTHON := no
 
@@ -84,7 +91,7 @@ requirements/%.txt: requirements/%.in
 
 resetdb: .state/docker-build-web
 	docker-compose stop db
-	docker volume rm warehouse_pgdata
+	docker volume rm $(COMPOSE_PROJECT_NAME)_pgdata
 	docker-compose up -d --recreate db
 
 migrate: .state/docker-build-web

--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,10 @@ translations: .state/docker-build-web
 requirements/%.txt: requirements/%.in
 	docker-compose run --rm web bin/pip-compile --allow-unsafe --generate-hashes --output-file=$@ $<
 
-initdb: .state/docker-build-web
-	docker-compose run --rm web psql -h db -d postgres -U postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname ='warehouse';"
-	docker-compose run --rm web psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS warehouse"
-	docker-compose run --rm web psql -h db -d postgres -U postgres -c "CREATE DATABASE warehouse ENCODING 'UTF8'"
-	docker-compose run --rm web bash -c "xz -d -f -k dev/$(DB).sql.xz --stdout | psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f -"
+resetdb: .state/docker-build-web
+	docker-compose up --recreate
+
+migrate: .state/docker-build-web
 	docker-compose run --rm web python -m warehouse db upgrade head
 	docker-compose run --rm web python -m warehouse sponsors populate-db
 	$(MAKE) reindex

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ requirements/%.txt: requirements/%.in
 	docker-compose run --rm web bin/pip-compile --allow-unsafe --generate-hashes --output-file=$@ $<
 
 resetdb: .state/docker-build-web
-	docker-compose up --recreate
+	docker-compose up --recreate db
 
 migrate: .state/docker-build-web
 	docker-compose run --rm web python -m warehouse db upgrade head

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,4 @@
-<<<<<<< HEAD
-=======
-BINDIR = $(PWD)/.state/env/bin
 COMPOSE_PROJECT_NAME ?= $(notdir $(abspath .))
-GITHUB_ACTIONS := $(shell echo "$${GITHUB_ACTIONS:-false}")
-GITHUB_BASE_REF := $(shell echo "$${GITHUB_BASE_REF:-false}")
->>>>>>> e1349bda (Calculate compose project name instead of hardcoding it)
 DB := example
 IPYTHON := no
 

--- a/dev/environment
+++ b/dev/environment
@@ -8,7 +8,7 @@ AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=foo
 BROKER_URL=sqs://localstack:4566/?region=us-east-1&queue_name_prefix=warehouse-dev
 
-DATABASE_URL=postgresql://postgres@db/warehouse
+DATABASE_URL=postgresql://postgres:password@db/warehouse
 
 ELASTICSEARCH_URL=http://elasticsearch:9200/development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,12 +25,17 @@ services:
       - ./dev/vault:/etc/vault
 
   db:
-    image: postgres:10.1
+    image: postgres:10.18
     ports:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "postgres"]
+      test: ["CMD", "pg_isready", "-d", "warehouse"]
+    environment:
+      POSTGRES_DB: warehouse
+      POSTGRES_PASSWORD: password
+    volumes:
+      - ./dev/example.sql.xz:/docker-entrypoint-initdb.d/example.sql.xz
 
   redis:
     image: redis:4.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.9'
 volumes:
   simple:
   packages:
+  pgdata:
   sponsorlogos:
   vault:
 
@@ -35,6 +36,7 @@ services:
       POSTGRES_DB: warehouse
       POSTGRES_PASSWORD: password
     volumes:
+      - pgdata:/var/lib/postgresql/data
       - ./dev/example.sql.xz:/docker-entrypoint-initdb.d/example.sql.xz:ro
 
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       POSTGRES_DB: warehouse
       POSTGRES_PASSWORD: password
     volumes:
-      - ./dev/example.sql.xz:/docker-entrypoint-initdb.d/example.sql.xz
+      - ./dev/example.sql.xz:/docker-entrypoint-initdb.d/example.sql.xz:ro
 
   redis:
     image: redis:4.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - ./dev/vault:/etc/vault
 
   db:
-    image: postgres:10.18
+    image: postgres:10
     ports:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -238,7 +238,27 @@ or that the ``static`` container has finished compiling the static assets:
     static_1 | [20:28:37] Starting 'watch'...
     static_1 | [20:28:37] Finished 'watch' after 11 ms
 
-or maybe something else.
+After the docker containers are setup in the previous step, run:
+
+.. code-block:: console
+
+    make migrate
+
+This command will:
+
+* run migrations on the Postgres database,
+* index all the data for the search database, and
+* load some example data from `Test PyPI`_.
+
+The Postgres database is created automatically when its docker
+container starts for the first time. It also gets populated with
+example data. If you will need to reset the database, use:
+
+.. code-block:: console
+
+    make resetdb
+
+Once the ``make initdb`` command has finished, you are ready to continue.
 
 
 Viewing Warehouse in a browser


### PR DESCRIPTION
The behavior is explained here https://hub.docker.com/_/postgres

>  After the entrypoint calls initdb to create the default postgres user and database, it will run any *.sql files, run any executable *.sh scripts, and source any non-executable *.sh scripts found in that directory to do further initialization before starting the service.

Also fixes #5980.