### PR TITLE
Test development setup with GitHub Actions

### DIFF
--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -1,0 +1,24 @@
+# Testing development setup in https://warehouse.readthedocs.io/development/getting-started.html
+
+name: Dev Setup
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make build
+      - run: |
+          # `make serve` daemonized
+          docker-compose up -d
+      - run: make initdb
+      - run: make tests

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -20,5 +20,7 @@ jobs:
       - run: |
           # `make serve` daemonized
           docker-compose up -d
+      - run: docker-compose ps
+      - run: ./bin/wait-for-db.sh
       - run: make initdb
       - run: make tests

--- a/bin/wait-for-db.sh
+++ b/bin/wait-for-db.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# healthy
+# unhealthy
+# starting
+
+CONTAINER=warehouse_db_1
+check() {
+    docker inspect --format "{{.State.Health.Status }}" $CONTAINER
+}
+
+while [[ "$STATUS" != "healthy" ]]
+do
+    STATUS=$(check)
+    echo "$STATUS ${SECONDS}"
+    (( SECONDS > 60 )) && exit 1
+    sleep 3
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,11 @@ services:
     ports:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   redis:
     image: redis:4.0


### PR DESCRIPTION
This adds a new workflow that sets up development environment and runs tests with `docker-compose` as described in getting started docs. This could be used to improve the setup time, which takes more than 10 minutes right now.

https://github.com/abitrolly/warehouse/runs/3640554285?check_suite_focus=true