### PR TITLE
Improve Alembic story

### DIFF
--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -131,8 +131,7 @@ def listens_for(target, identifier, *args, **kwargs):
 
 
 def _configure_alembic(config):
-    alembic_cfg = alembic.config.Config()
-    alembic_cfg.set_main_option("script_location", "warehouse:migrations")
+    alembic_cfg = alembic.config.Config("warehouse/migrations/alembic.ini")
     alembic_cfg.set_main_option("url", config.registry.settings["database.url"])
     return alembic_cfg
 

--- a/warehouse/migrations/alembic.ini
+++ b/warehouse/migrations/alembic.ini
@@ -1,0 +1,2 @@
+[alembic]
+script_location = warehouse:migrations

--- a/warehouse/migrations/alembic.ini
+++ b/warehouse/migrations/alembic.ini
@@ -1,2 +1,5 @@
 [alembic]
 script_location = warehouse:migrations
+
+[post_write_hooks]
+hooks = black, isort

--- a/warehouse/migrations/alembic.ini
+++ b/warehouse/migrations/alembic.ini
@@ -3,3 +3,6 @@ script_location = warehouse:migrations
 
 [post_write_hooks]
 hooks = black, isort
+
+black.type = console_scripts
+black.entrypoint = black


### PR DESCRIPTION
Fixes #10053.

Adds `alembic.ini`.
Runs `black` and `isort` after generating migrations.