### PR TITLE
Anti-spam suggestion for pypi repositories

### DIFF
--- a/warehouse/malware/checks/pkg_info_patterns/__init__.py
+++ b/warehouse/malware/checks/pkg_info_patterns/__init__.py
@@ -10,6 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .package_turnover import PackageTurnoverCheck  # noqa
-from .setup_patterns import SetupPatternCheck  # noqa
-from .pkg_info_patterns import PkgInfoPatternCheck  # noqa
+from .check import PkgInfoPatternCheck  # noqa

--- a/warehouse/malware/checks/pkg_info_patterns/check.py
+++ b/warehouse/malware/checks/pkg_info_patterns/check.py
@@ -1,0 +1,113 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from textwrap import dedent
+
+import yara
+
+from warehouse.malware.checks.base import MalwareCheckBase
+from warehouse.malware.checks.utils import extract_file_content, fetch_url_content, extract_file_list
+from warehouse.malware.errors import FatalCheckError
+from warehouse.malware.models import VerdictClassification, VerdictConfidence
+
+
+class PkgInfoPatternCheck(MalwareCheckBase):
+    _yara_rule_file = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "pkg_info_rules.yara"
+    )
+
+    version = 3
+    short_description = "A check for common malicious patterns in PKG-INFO"
+    long_description = dedent(
+        """
+        This check uses YARA to search for common malicious patterns in the PKG-INFO
+        files of uploaded release archives.
+        """
+    )
+    check_type = "event_hook"
+    hooked_object = "File"
+
+    def __init__(self, db):
+        super().__init__(db)
+        self._yara_rules = self._load_yara_rules()
+
+    def _load_yara_rules(self):
+        return yara.compile(filepath=self._yara_rule_file)
+
+    def scan(self, **kwargs):
+        release_file = kwargs.get("obj")
+        file_url = kwargs.get("file_url")
+        if release_file is None or file_url is None:
+            raise FatalCheckError(
+                "Release file or file url is None, indicating user error."
+            )
+
+        archive_stream = fetch_url_content(file_url)
+
+        file_list = extract_file_list(archive_stream)
+        if len(file_list) == 1 and "PKG-INFO" in file_list:
+            self.add_verdict(
+                file_id=release_file.id,
+                classification=VerdictClassification.Indeterminate,
+                confidence=VerdictConfidence.High,
+                message="There is only PKG-INFO file, probably spam / malicious / advertisements",
+            )
+
+        pkg_info_contents = extract_file_content(archive_stream, "PKG-INFO")
+        if pkg_info_contents is None:
+            self.add_verdict(
+                file_id=release_file.id,
+                classification=VerdictClassification.Indeterminate,
+                confidence=VerdictConfidence.High,
+                message="This project does not contain PKG-INFO file",
+            )
+            return
+
+        matches = self._yara_rules.match(data=pkg_info_contents)
+        if len(matches) > 0:
+            # We reduce N matches into a single verdict by taking the maximum
+            # classification and confidence.
+            classification = max(
+                VerdictClassification(m.meta["classification"]) for m in matches
+            )
+            confidence = max(VerdictConfidence(m.meta["confidence"]) for m in matches)
+            message = ":".join(m.rule for m in matches)
+
+            details = {}
+            for match in matches:
+                details[match.rule] = {
+                    "classification": match.meta["classification"],
+                    "confidence": match.meta["confidence"],
+                    # NOTE: We could include the raw bytes here (s[2]),
+                    # but we'd have to serialize/encode it to make JSON happy.
+                    # It probably suffices to include the offset and identifier
+                    # for triage purposes.
+                    "strings": [[s[0], s[1]] for s in match.strings],
+                }
+
+            self.add_verdict(
+                file_id=release_file.id,
+                classification=classification,
+                confidence=confidence,
+                message=message,
+                details=details,
+            )
+        else:
+            # No matches? Report a low-confidence benign verdict.
+            self.add_verdict(
+                file_id=release_file.id,
+                classification=VerdictClassification.Benign,
+                confidence=VerdictConfidence.Low,
+                message="No malicious patterns found in PKG-INFO",
+            )

--- a/warehouse/malware/checks/pkg_info_patterns/check.py
+++ b/warehouse/malware/checks/pkg_info_patterns/check.py
@@ -17,7 +17,8 @@ from textwrap import dedent
 import yara
 
 from warehouse.malware.checks.base import MalwareCheckBase
-from warehouse.malware.checks.utils import extract_file_content, fetch_url_content, extract_file_list
+from warehouse.malware.checks.utils import extract_file_content,\
+    fetch_url_content, extract_file_list
 from warehouse.malware.errors import FatalCheckError
 from warehouse.malware.models import VerdictClassification, VerdictConfidence
 
@@ -61,7 +62,8 @@ class PkgInfoPatternCheck(MalwareCheckBase):
                 file_id=release_file.id,
                 classification=VerdictClassification.Indeterminate,
                 confidence=VerdictConfidence.High,
-                message="There is only PKG-INFO file, probably spam / malicious / advertisements",
+                message="There is only PKG-INFO file, "
+                        "probably spam / malicious / advertisements",
             )
 
         pkg_info_contents = extract_file_content(archive_stream, "PKG-INFO")

--- a/warehouse/malware/checks/pkg_info_patterns/check.py
+++ b/warehouse/malware/checks/pkg_info_patterns/check.py
@@ -17,7 +17,7 @@ from textwrap import dedent
 import yara
 
 from warehouse.malware.checks.base import MalwareCheckBase
-from warehouse.malware.checks.utils import extract_file_content,\
+from warehouse.malware.checks.utils import extract_file_content, \
     fetch_url_content, extract_file_list
 from warehouse.malware.errors import FatalCheckError
 from warehouse.malware.models import VerdictClassification, VerdictConfidence

--- a/warehouse/malware/checks/pkg_info_patterns/pkg_info_rules.yara
+++ b/warehouse/malware/checks/pkg_info_patterns/pkg_info_rules.yara
@@ -1,0 +1,32 @@
+/* Patterns that indicate spam / malicious activity: usage
+ * of pypi as link storage for malicious / links of
+ * "free" codes for popular games, activation codes for services,
+ * etc.
+ *
+ * These indicators are classified as "threat" to reflect the low
+ * probability that their presence is legitimate - despite
+ * this repos cannot harm actual developers but
+ * mere users that visited this link via other resources as forums
+ */
+
+rule spam_free_offers {
+    meta:
+        confidence = "high"
+        classification = "threat"
+
+    strings:
+        $cliche1 = "not human verification"
+        $cliche2 = "without paying"
+        $cliche3 = "no survey"
+        $cliche4 = "gift card generator"
+        $cliche5 = "for kids"
+        $cliche6 = "no offers"
+
+        $victim_roblox1 = "robux"
+        $victim_roblox2 = "roblox"
+        $victim_amazon = "amazon"
+        $victim_fortnite = "fortnite"
+
+    condition:
+        2 of ($cliche*) or (any of ($victim*) and 1 of ($cliche*))
+}

--- a/warehouse/malware/checks/utils.py
+++ b/warehouse/malware/checks/utils.py
@@ -78,3 +78,29 @@ def extract_file_content(archive_stream, file_path):
                 return None
         except tarfile.TarError:
             return None
+
+
+def extract_file_list(archive_stream):
+    """
+    Retrieves file list of archive stream. It needs for some kind of
+    checks that depends on file names or existence of certain files.
+
+    Returns None on any sort of failure.
+    """
+    if zipfile.is_zipfile(archive_stream):
+        with zipfile.ZipFile(archive_stream) as zipobj:
+            return zipobj.namelist()
+    else:
+        # NOTE: is_zipfile doesn't rewind the fileobj it's given.
+        archive_stream.seek(0)
+
+        # NOTE: We don't need to perform a sanity check on
+        # the (presumed) tarfile's compression here, since we're
+        # extracting from a stream that's already gone through
+        # upload validation.
+        # See _is_valid_dist_file in forklift/legacy.py.
+        try:
+            with tarfile.open(fileobj=archive_stream) as tarobj:
+                return tarobj.getmembers()
+        except tarfile.TarError:
+            return None


### PR DESCRIPTION
Hello!

I found out that there is a spammer who creates many repositories containing only a PKG-INFO file advertising his (probably fake) roblox currency generator, amazon gift codes, etc.

Even though this repository does not have a malicious effect on developers, it is definitely a malicious/unwanted activity.

One of such "developers" for example:

![image](https://user-images.githubusercontent.com/25303578/161704501-b208eb47-0d18-4d95-a9c0-4b9d01d3a113.png)

Google indexes this kind of links, it may harm the reputation of pypi:

![image](https://user-images.githubusercontent.com/25303578/161705053-69b70dd7-b85f-4cc8-843a-7ee41a62d778.png)

So I wrote a heuristics for this kind of situations.