### PR TITLE
Add support for metadata 2.2 and 2.3

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -399,6 +399,52 @@ class TestValidation:
         with pytest.raises(ValidationError):
             legacy._validate_dynamic(form, field)
 
+    @pytest.mark.parametrize(
+        "data", [(["dev"]), (["dev-test"])]
+    )
+    def test_validate_extras_valid(self, db_request, data):
+        form = pretend.stub(
+            provides_extra=pretend.stub(data=data),
+            metadata_version=pretend.stub(data="2.3"),
+        )
+        field = pretend.stub(data=data)
+
+        legacy._validate_extras(form, field)
+
+    @pytest.mark.parametrize("data", [(["dev_test"]), (["dev.lint", "dev--test"])])
+    def test_validate_extras_invalid(self, db_request, data):
+        form = pretend.stub(
+            provides_extra=pretend.stub(data=data),
+            metadata_version=pretend.stub(data="2.3"),
+        )
+        field = pretend.stub(data=data)
+
+        with pytest.raises(ValidationError):
+            legacy._validate_extras(form, field)
+
+    @pytest.mark.parametrize(
+        "data", [(["dev"]), (["dev-test"])]
+    )
+    def test_validate_extras_valid_2_2(self, db_request, data):
+        form = pretend.stub(
+            provides_extra=pretend.stub(data=data),
+            metadata_version=pretend.stub(data="2.2"),
+        )
+        field = pretend.stub(data=data)
+
+        legacy._validate_extras(form, field)
+
+    @pytest.mark.parametrize("data", [(["dev_test"]), (["dev.lint", "dev--test"])])
+    def test_validate_extras_invalid_2_2(self, db_request, data):
+
+        form = pretend.stub(
+            provides_extra=pretend.stub(data=data),
+            metadata_version=pretend.stub(data="2.2"),
+        )
+        field = pretend.stub(data=data)
+
+        legacy._validate_extras(form, field)
+
 
 def test_construct_dependencies():
     types = {"requires": DependencyKind.requires, "provides": DependencyKind.provides}

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -382,6 +382,23 @@ class TestValidation:
         with pytest.raises(ValidationError):
             legacy._validate_classifiers(form, field)
 
+    @pytest.mark.parametrize(
+        "data", [(["Requires-Dist"]), (["Requires-Dist", "Requires-Python"])]
+    )
+    def test_validate_dynamic_valid(self, db_request, data):
+        form = pretend.stub()
+        field = pretend.stub(data=data)
+
+        legacy._validate_dynamic(form, field)
+
+    @pytest.mark.parametrize("data", [(["Version"]), (["Name"]), (["Version", "Name"])])
+    def test_validate_dynamic_invalid(self, db_request, data):
+        form = pretend.stub()
+        field = pretend.stub(data=data)
+
+        with pytest.raises(ValidationError):
+            legacy._validate_dynamic(form, field)
+
 
 def test_construct_dependencies():
     types = {"requires": DependencyKind.requires, "provides": DependencyKind.provides}

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -383,7 +383,7 @@ class TestValidation:
             legacy._validate_classifiers(form, field)
 
     @pytest.mark.parametrize(
-        "data", [(["Requires-Dist"]), (["Requires-Dist", "Requires-Python"])]
+        "data", [["Requires-Dist"], ["Requires-Dist", "Requires-Python"]]
     )
     def test_validate_dynamic_valid(self, db_request, data):
         form = pretend.stub()
@@ -391,7 +391,7 @@ class TestValidation:
 
         legacy._validate_dynamic(form, field)
 
-    @pytest.mark.parametrize("data", [(["Version"]), (["Name"]), (["Version", "Name"])])
+    @pytest.mark.parametrize("data", [["Version"], ["Name"], ["Version", "Name"]])
     def test_validate_dynamic_invalid(self, db_request, data):
         form = pretend.stub()
         field = pretend.stub(data=data)
@@ -399,9 +399,7 @@ class TestValidation:
         with pytest.raises(ValidationError):
             legacy._validate_dynamic(form, field)
 
-    @pytest.mark.parametrize(
-        "data", [(["dev"]), (["dev-test"])]
-    )
+    @pytest.mark.parametrize("data", [["dev"], ["dev-test"]])
     def test_validate_extras_valid(self, db_request, data):
         form = pretend.stub(
             provides_extra=pretend.stub(data=data),
@@ -411,7 +409,7 @@ class TestValidation:
 
         legacy._validate_extras(form, field)
 
-    @pytest.mark.parametrize("data", [(["dev_test"]), (["dev.lint", "dev--test"])])
+    @pytest.mark.parametrize("data", [["dev_test"], ["dev.lint", "dev--test"]])
     def test_validate_extras_invalid(self, db_request, data):
         form = pretend.stub(
             provides_extra=pretend.stub(data=data),
@@ -422,9 +420,7 @@ class TestValidation:
         with pytest.raises(ValidationError):
             legacy._validate_extras(form, field)
 
-    @pytest.mark.parametrize(
-        "data", [(["dev"]), (["dev-test"])]
-    )
+    @pytest.mark.parametrize("data", [["dev"], ["dev-test"]])
     def test_validate_extras_valid_2_2(self, db_request, data):
         form = pretend.stub(
             provides_extra=pretend.stub(data=data),
@@ -434,7 +430,7 @@ class TestValidation:
 
         legacy._validate_extras(form, field)
 
-    @pytest.mark.parametrize("data", [(["dev_test"]), (["dev.lint", "dev--test"])])
+    @pytest.mark.parametrize("data", [["dev_test"], ["dev.lint", "dev--test"]])
     def test_validate_extras_invalid_2_2(self, db_request, data):
 
         form = pretend.stub(

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -426,9 +426,9 @@ _extra_name_re = re.compile("^([a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9])$")
 def _validate_extras(form, field):
 
     # TODO: is metadata_version guaranteed to be valid by this point?
-    metadata_version = float(form.metadata_version.data)
+    metadata_version = packaging.version.Version(form.metadata_version.data)
 
-    if metadata_version >= 2.3:
+    if metadata_version >= packaging.version.Version("2.3"):
         extra_names = field.data or []
 
         invalid = []

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -400,6 +400,26 @@ def _validate_classifiers(form, field):
             )
 
 
+def _validate_dynamic(form, field):
+    dynamic_fields = set(map(str.lower, field.data or []))
+
+    disallowed_dynamic_fields = []
+
+    for field_name in ("Name", "Version", "Metadata-Version"):
+        if field_name.lower() in dynamic_fields:
+            disallowed_dynamic_fields.append(field_name)
+
+    if disallowed_dynamic_fields:
+        if len(disallowed_dynamic_fields) == 1:
+            values = f"field {disallowed_dynamic_fields[0]!r}"
+        else:
+            values = f"fields {disallowed_dynamic_fields!r}"
+
+        raise wtforms.validators.ValidationError(
+            f"The {values} cannot be marked as dynamic.",
+        )
+
+
 def _construct_dependencies(form, types):
     for name, kind in types.items():
         for item in getattr(form, name).data:
@@ -425,7 +445,7 @@ class MetadataForm(forms.Form):
                 # Note: This isn't really Metadata 2.0, however bdist_wheel
                 #       claims it is producing a Metadata 2.0 metadata when in
                 #       reality it's more like 1.2 with some extensions.
-                ["1.0", "1.1", "1.2", "2.0", "2.1"],
+                ["1.0", "1.1", "1.2", "2.0", "2.1", "2.2"],
                 message="Use a known metadata version.",
             ),
         ],
@@ -500,6 +520,10 @@ class MetadataForm(forms.Form):
     classifiers = ListField(
         description="Classifier",
         validators=[_validate_no_deprecated_classifiers, _validate_classifiers],
+    )
+    dynamic = ListField(
+        description="Dynamic",
+        validators=[_validate_dynamic],
     )
     platform = wtforms.StringField(
         description="Platform", validators=[wtforms.validators.Optional()]


### PR DESCRIPTION
Fixes #9660 and #11526

I couldn't find any existing tests for the `Metadata-Version` validation so I haven't added any yet.
There are tests for the new validation functions for `Dynamic` and `Provides-Extra` though.