### PR TITLE
chore: add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,22 @@
+Adolfo Jayme-Barrientos <fitojb@ubuntu.com> Adolfo Jayme Barrientos <fitojb@ubuntu.com>
+Alex Chan <alex@alexwlchan.net> <a.chan@wellcome.ac.uk>
+Chris Lei <chris@divbzero.com> chris <chris@divbzero.com>
+dependabot[bot] <dependabot[bot]@users.noreply.github.com> <27856297+dependabot-preview[bot]@users.noreply.github.com>
+dependabot[bot] <dependabot[bot]@users.noreply.github.com> <49699333+dependabot[bot]@users.noreply.github.com>
+dependabot[bot] <dependabot[bot]@users.noreply.github.com> <dependabot-preview[bot]@users.noreply.github.com>
+Ee Durbin <ewdurbin@gmail.com>
+Honza Král <Honza.Kral@gmail.com> <honza.kral@gmail.com>
+Joachim Jablon <ewjoachim@gmail.com> <joachim.jablon@people-doc.com>
+Neel Patel <patelneel55@gmail.com> <neelp@google.com>
+Nicole Harris <n.harris@kabucreative.com> <n.harris@kabucreative.com.au>
+Pradyun Gedam <pradyunsg@gmail.com> <3275593+pradyunsg@users.noreply.github.com>
+Pradyun Gedam <pradyunsg@gmail.com> Pradyun <pradyunsg@users.noreply.github.com>
+Rafael Fontenelle <rafaelff@gnome.org> <rffontenelle@users.noreply.github.com>
+Sviatoslav Sydorenko <wk@sydorenko.org.ua> <webknjaz@redhat.com>
+Sviatoslav Sydorenko <wk@sydorenko.org.ua> <wk+weblate.org@sydorenko.org.ua>
+Weblate (bot) <hosted@weblate.org> <noreply@weblate.org>
+Weblate (bot) <hosted@weblate.org> Hosted Weblate <hosted@weblate.org>
+William Woodruff <william@yossarian.net> <william.woodruff@trailofbits.com>
+William Woodruff <william@yossarian.net> <william@trailofbits.com>
+Yeray Diaz Diaz <yeraydiazdiaz@gmail.com> <yeraydiazdiaz@fastmail.com>
+Yusuke Miyazaki <miyazaki.dev@gmail.com> <ymyzk@users.noreply.github.com>


### PR DESCRIPTION
As naturally happens over time, email addresses and names change.

Leveraging a `.mailmap` file allows tools like `git` to accurately
represent an individual over time, allowing for:

- the desired name associated with all commits from that email address
- multiple email addresses associated with a single individual

The existence of a `.mailmap` file allows for any tools that know how to
leverage it to present the specified information.

Refs: https://git-scm.com/docs/gitmailmap

Signed-off-by: Mike Fiedler <miketheman@gmail.com>

This is not an exhaustive audit, rather me poking around and finding duplicates and reducing them - taking the total authors as identified by `git shortlog -se` from 356 to 333.

There's an open feature request for GitHub to support this file as well: https://github.com/github-community/community/discussions/6754