### PR TITLE
Unset `statement_timeout` on old long-running migration

### DIFF
--- a/warehouse/migrations/versions/9ca7d5668af4_refactor_description_to_its_own_table.py
+++ b/warehouse/migrations/versions/9ca7d5668af4_refactor_description_to_its_own_table.py
@@ -27,6 +27,7 @@ down_revision = "42f0409bb702"
 
 
 def upgrade():
+    op.execute("SET statement_timeout = 0")
     op.create_table(
         "release_descriptions",
         sa.Column(


### PR DESCRIPTION
Without this, initializing the development database fails.