### PR TITLE
Add link to manage project page

### DIFF
--- a/warehouse/templates/email/two-factor-mandate/body.html
+++ b/warehouse/templates/email/two-factor-mandate/body.html
@@ -16,7 +16,7 @@
 
 {% block content %}
 <p>
-Congratulations! A project you ('{{ username }}') maintain has been designated as a critical project on PyPI.
+Congratulations! A project you ('{{ username }}') maintain has been designated as a critical project on PyPI. You can see which project(s) has been designated at {{ request.route_url("manage.projects") }}.
 </p>
 
 <p>

--- a/warehouse/templates/email/two-factor-mandate/body.txt
+++ b/warehouse/templates/email/two-factor-mandate/body.txt
@@ -14,7 +14,7 @@
 {% extends "email/_base/body.txt" %}
 
 {% block content %}
-Congratulations! A project you ('{{ username }}') maintain has been designated as a critical project on PyPI.
+Congratulations! A project you ('{{ username }}') maintain has been designated as a critical project on PyPI. You can see which project(s) has been designated at {{ request.route_url("manage.projects") }}.
 
 As part of this effort, in the coming months maintainers of projects designated as critical, like yourself, will be required to enable two-factor authentication on their account in order to add new releases or otherwise modify a critical project.
 


### PR DESCRIPTION
Because we're not actually telling them which projects have been designated critical in the email.