### PR TITLE
Fix MFA management link and a typo in mandate email

### DIFF
--- a/warehouse/templates/email/two-factor-mandate/body.html
+++ b/warehouse/templates/email/two-factor-mandate/body.html
@@ -28,7 +28,7 @@ As part of this effort, in the coming months maintainers of projects designated 
 {% if has_two_factor %}
 Since you already have two-factor authentication enabled on your account, there's nothing you need to do at this time.
 {% else %}
-You can enable two-factor authenticaion on your account today by visiting <a href="{{ request.route_url("manage.account.two-factor", _host="pypi.org") }}">{{ request.route_url("manage.account.two-factor", _host="pypi.org") }}</a>.
+You can enable two-factor authentication on your account today by visiting <a href="{{ request.route_url("manage.account.two-factor", _host="pypi.org") }}">{{ request.route_url("manage.account.two-factor", _host="pypi.org") }}</a>.
 {% endif %}
 </p>
 

--- a/warehouse/templates/email/two-factor-mandate/body.html
+++ b/warehouse/templates/email/two-factor-mandate/body.html
@@ -28,7 +28,7 @@ As part of this effort, in the coming months maintainers of projects designated 
 {% if has_two_factor %}
 Since you already have two-factor authentication enabled on your account, there's nothing you need to do at this time.
 {% else %}
-You can enable two-factor authenticaion on your account today by visiting <a href="{{ request.route_url("accounts.two-factor", _host="pypi.org") }}">{{ request.route_url("accounts.two-factor", _host="pypi.org") }}</a>.
+You can enable two-factor authenticaion on your account today by visiting <a href="{{ request.route_url("manage.account.two-factor", _host="pypi.org") }}">{{ request.route_url("manage.account.two-factor", _host="pypi.org") }}</a>.
 {% endif %}
 </p>
 

--- a/warehouse/templates/email/two-factor-mandate/body.txt
+++ b/warehouse/templates/email/two-factor-mandate/body.txt
@@ -21,7 +21,7 @@ As part of this effort, in the coming months maintainers of projects designated 
 {% if has_two_factor -%}
 Since you already have two-factor authentication enabled on your account, there's nothing you need to do at this time.
 {%- else -%}
-You can enable two-factor authenticaion on your account today by visiting {{ request.route_url("accounts.two-factor", _host="pypi.org") }}.
+You can enable two-factor authenticaion on your account today by visiting {{ request.route_url("manage.account.two-factor", _host="pypi.org") }}.
 {%- endif %}
 
 PS: To make it easier for maintainers like you to enable two-factor authentication, we're also distributing security keys to eligible maintainers. See {{ request.route_url("security-key-giveaway", _host="pypi.org") }} for more details.

--- a/warehouse/templates/email/two-factor-mandate/body.txt
+++ b/warehouse/templates/email/two-factor-mandate/body.txt
@@ -21,7 +21,7 @@ As part of this effort, in the coming months maintainers of projects designated 
 {% if has_two_factor -%}
 Since you already have two-factor authentication enabled on your account, there's nothing you need to do at this time.
 {%- else -%}
-You can enable two-factor authenticaion on your account today by visiting {{ request.route_url("manage.account.two-factor", _host="pypi.org") }}.
+You can enable two-factor authentication on your account today by visiting {{ request.route_url("manage.account.two-factor", _host="pypi.org") }}.
 {%- endif %}
 
 PS: To make it easier for maintainers like you to enable two-factor authentication, we're also distributing security keys to eligible maintainers. See {{ request.route_url("security-key-giveaway", _host="pypi.org") }} for more details.


### PR DESCRIPTION
* The email points to http://pypi.org/account/two-factor/ , which redirects to https://pypi.org/manage/projects/ . The correct link (from the "MFA is available" banner) is https://pypi.org/manage/account/two-factor/ .
  * Might be nice if `accounts.two-factor` redirected to `manage.account.two-factor` instead of to the projects page.
* Typo: `authenticaion`