### PR TITLE
chore(deps): update to stimulus 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,30 +5171,30 @@
       }
     },
     "@stimulus/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@stimulus/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-PVJv7IpuQx0MVPCBblXc6O2zbCmU8dlxXNH4bC9KK6LsvGaE+PCXXrXQfXUwAsse1/CmRu/iQG7Ov58himjiGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==",
       "requires": {
-        "@stimulus/mutation-observers": "^1.1.1"
+        "@stimulus/mutation-observers": "^2.0.0"
       }
     },
     "@stimulus/multimap": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@stimulus/multimap/-/multimap-1.1.1.tgz",
-      "integrity": "sha512-26R1fI3a8uUj0WlMmta4qcfIQGlagegdP4PTz6lz852q/dXlG6r+uPS/bx+H8GtfyS+OOXVr3SkZ0Zg0iRqRfQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/multimap/-/multimap-2.0.0.tgz",
+      "integrity": "sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w=="
     },
     "@stimulus/mutation-observers": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@stimulus/mutation-observers/-/mutation-observers-1.1.1.tgz",
-      "integrity": "sha512-/zCnnw1KJlWO2mrx0yxYaRFZWMGnDMdOgSnI4hxDLxdWVuL2HMROU8FpHWVBLjKY3T9A+lGkcrmPGDHF3pfS9w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz",
+      "integrity": "sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==",
       "requires": {
-        "@stimulus/multimap": "^1.1.1"
+        "@stimulus/multimap": "^2.0.0"
       }
     },
     "@stimulus/webpack-helpers": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@stimulus/webpack-helpers/-/webpack-helpers-1.1.1.tgz",
-      "integrity": "sha512-XOkqSw53N9072FLHvpLM25PIwy+ndkSSbnTtjKuyzsv8K5yfkFB2rv68jU1pzqYa9FZLcvZWP4yazC0V38dx9A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz",
+      "integrity": "sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA=="
     },
     "@testing-library/dom": {
       "version": "6.2.0",
@@ -22153,12 +22153,12 @@
       }
     },
     "stimulus": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stimulus/-/stimulus-1.1.1.tgz",
-      "integrity": "sha512-R0mBqKp48YnRDZOxZ8hiOH4Ilph3Yj78CIFTBkCwyHs4iGCpe7xlEdQ7cjIxb+7qVCSxFKgxO+mAQbsNgt/5XQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stimulus/-/stimulus-2.0.0.tgz",
+      "integrity": "sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==",
       "requires": {
-        "@stimulus/core": "^1.1.1",
-        "@stimulus/webpack-helpers": "^1.1.1"
+        "@stimulus/core": "^2.0.0",
+        "@stimulus/webpack-helpers": "^2.0.0"
       }
     },
     "stream-browserify": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "imports-loader": "0.7.1",
     "jquery": "3.5.0",
     "normalize.css": "^8.0.1",
-    "stimulus": "1.1.1",
+    "stimulus": "2.0.0",
     "uglify-js": "3.2.1",
     "vinyl-named": "1.1.0",
     "webpack": "^4.42.1",

--- a/tests/frontend/confirm_controller_test.js
+++ b/tests/frontend/confirm_controller_test.js
@@ -26,10 +26,10 @@ describe("Confirm controller", () => {
         <h3 class="modal__title">Delete package?</h3>
         <p>Confirm to continue.</p>
         <label for="package">Delete</label>
-        <input id="input-target" name="package" data-action="input->confirm#check" data-target="confirm.input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off">
+        <input id="input-target" name="package" data-action="input->confirm#check" data-confirm-target="input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off">
         </div>
         <div class="modal__footer">
-          <button id="button-target" data-target="confirm.button" data-expected="package" type="submit">
+          <button id="button-target" data-confirm-target="button" data-expected="package" type="submit">
               Confirm
           </button>
       </div>

--- a/tests/frontend/modal_close_controller_test.js
+++ b/tests/frontend/modal_close_controller_test.js
@@ -27,9 +27,9 @@ describe("Modal close controller", () => {
       </a>
       <div class="modal__body">
         <h3 class="modal__title">Modal Title</h3>
-        <input id="input-target" name="package" data-target="modal-close.input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off">
+        <input id="input-target" name="package" data-modal-close-target="input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off">
         <div class="modal__footer">
-          <button id="button-target" data-target="modal-close.button" type="submit">
+          <button id="button-target" data-modal-close-target="button" type="submit">
               Confirm
           </button>
         </div>

--- a/tests/frontend/notification_controller_test.js
+++ b/tests/frontend/notification_controller_test.js
@@ -17,9 +17,9 @@ import { Application } from "stimulus";
 import NotificationController from "../../warehouse/static/js/warehouse/controllers/notification_controller";
 
 const notificationContent = `
-  <div id="notification" class="notification-bar notification-bar--danger notification-bar--dismissable" data-controller="notification" data-target="notification.notification">
+  <div id="notification" class="notification-bar notification-bar--danger notification-bar--dismissable" data-controller="notification" data-notification-target="notification">
     <span class="notification-bar__message">message</span>
-    <button type="button" title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
+    <button type="button" title="Dismiss this notification" data-notification-target="dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
   </div>
 `;
 

--- a/tests/frontend/password_breach_controller_test.js
+++ b/tests/frontend/password_breach_controller_test.js
@@ -24,8 +24,8 @@ describe("Password breach controller", () => {
   beforeEach(() => {
     document.body.innerHTML = `
   <div id="controller" data-controller="password-breach">
-    <input id="password" data-target="password-breach.password" data-action="input->password-breach#check" placeholder="Your password" type="password" />
-    <p id="message" data-target="password-breach.message" class="hidden">Password breached</p>
+    <input id="password" data-password-breach-target="password" data-action="input->password-breach#check" placeholder="Your password" type="password" />
+    <p id="message" data-password-breach-target="message" class="hidden">Password breached</p>
   </div>
     `;
 

--- a/tests/frontend/password_controller_test.js
+++ b/tests/frontend/password_controller_test.js
@@ -21,10 +21,10 @@ describe("Password controller", () => {
     document.body.innerHTML = `
   <div data-controller="password">
     <label for="show-password">
-      <input data-action="change->password#togglePasswords" data-target="password.showPassword" type="checkbox">&nbsp;Show password
+      <input data-action="change->password#togglePasswords" data-password-target="showPassword" type="checkbox">&nbsp;Show password
     </label>
-    <input id="password" data-target="password.password" placeholder="Your password" type="password" />
-    <input id="confirm" data-target="password.password" placeholder="Confirm password" type="password" />
+    <input id="password" data-password-target="password" placeholder="Your password" type="password" />
+    <input id="confirm" data-password-target="password" placeholder="Confirm password" type="password" />
   </div>
     `;
 

--- a/tests/frontend/password_match_controller_test.js
+++ b/tests/frontend/password_match_controller_test.js
@@ -21,10 +21,10 @@ describe("Password match controller", () => {
   beforeEach(() => {
     document.body.innerHTML = `
   <div data-controller="password-match">
-    <input id="password" data-target="password-match.passwordMatch" placeholder="Your password" type="password" data-action="input->password-match#checkPasswordsMatch" />
-    <input id="confirm" data-target="password-match.passwordMatch" placeholder="Confirm password" type="password" data-action="input->password-match#checkPasswordsMatch" />
-    <p data-target="password-match.matchMessage" class="hidden"></p>
-    <input type="submit" data-target="password-match.submit">
+    <input id="password" data-password-match-target="passwordMatch" placeholder="Your password" type="password" data-action="input->password-match#checkPasswordsMatch" />
+    <input id="confirm" data-password-match-target="passwordMatch" placeholder="Confirm password" type="password" data-action="input->password-match#checkPasswordsMatch" />
+    <p data-password-match-target="matchMessage" class="hidden"></p>
+    <input type="submit" data-password-match-target="submit">
   </div>
     `;
 

--- a/tests/frontend/password_strength_gauge_controller_test.js
+++ b/tests/frontend/password_strength_gauge_controller_test.js
@@ -21,11 +21,11 @@ describe("Password strength gauge controller", () => {
   beforeEach(() => {
     document.body.innerHTML = `
   <div data-controller="password-strength-gauge">
-    <input id="password" data-target="password-strength-gauge.password" placeholder="Your password" type="password" data-action="input->password-strength-gauge#checkPasswordStrength" />
+    <input id="password" data-password-strength-gauge-target="password" placeholder="Your password" type="password" data-action="input->password-strength-gauge#checkPasswordStrength" />
     <p class="form-group__help-text">
       <strong>Password strength:</strong>
       <span class="password-strength">
-        <span id="gauge" class="password-strength__gauge" data-target="password-strength-gauge.strengthGauge">
+        <span id="gauge" class="password-strength__gauge" data-password-strength-gauge-target="strengthGauge">
           <span class="sr-only">Password field is empty</span>
         </span>
       </span>

--- a/tests/frontend/project_tabs_controller_test.js
+++ b/tests/frontend/project_tabs_controller_test.js
@@ -27,19 +27,19 @@ const tabsHTML = `
           <nav aria-label="Navigation for lunr">
             <ul class="vertical-tabs__list" role="tablist">
               <li role="tab">
-                <a id="description-tab" href="#description" data-target="project-tabs.tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--is-active" aria-selected="true" aria-label="Project description. Focus will be moved to the description.">
+                <a id="description-tab" href="#description" data-project-tabs-target="tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--is-active" aria-selected="true" aria-label="Project description. Focus will be moved to the description.">
                   <i class="fa fa-align-left" aria-hidden="true"></i>
                   Project description
                 </a>
               </li>
               <li role="tab">
-                <a id="history-tab" href="#history" data-target="project-tabs.tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon" aria-label="Release history. Focus will be moved to the history panel.">
+                <a id="history-tab" href="#history" data-project-tabs-target="tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon" aria-label="Release history. Focus will be moved to the history panel.">
                   <i class="fa fa-history" aria-hidden="true"></i>
                   Release history
                 </a>
               </li>
               <li role="tab">
-                <a id="data-tab" href="#files" data-target="project-tabs.tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon" aria-label="Download files. Focus will be moved to the project files.">
+                <a id="data-tab" href="#files" data-project-tabs-target="tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon" aria-label="Download files. Focus will be moved to the project files.">
                   <i class="fa fa-download" aria-hidden="true"></i>
                   Download files
                 </a>
@@ -53,18 +53,18 @@ const tabsHTML = `
         <nav aria-label="Navigation for project">
           <ul class="vertical-tabs__list" role="tablist">
             <li role="tab">
-              <a id="mobile-description-tab" href="#description" data-target="project-tabs.mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile vertical-tabs__tab--no-top-border vertical-tabs__tab--is-active" aria-selected="true" aria-label="Project description. Focus will be moved to the description.">
+              <a id="mobile-description-tab" href="#description" data-project-tabs-target="mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile vertical-tabs__tab--no-top-border vertical-tabs__tab--is-active" aria-selected="true" aria-label="Project description. Focus will be moved to the description.">
                 <i class="fa fa-align-left" aria-hidden="true"></i>
                 Project description
               </a>
             </li>
             <li role="tab">
-              <a id="mobile-history-tab" href="#history" data-target="project-tabs.mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="Release history. Focus will be moved to the history panel.">
+              <a id="mobile-history-tab" href="#history" data-project-tabs-target="mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="Release history. Focus will be moved to the history panel.">
               <i class="fa fa-history" aria-hidden="true"></i>
               Release history
             </a>
             <li role="tab">
-              <a id="mobile-data-tab" href="#data" data-target="project-tabs.mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="Project details. Focus will be moved to the project details.">
+              <a id="mobile-data-tab" href="#data" data-project-tabs-target="mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="Project details. Focus will be moved to the project details.">
                 <i class="fa fa-info-circle" aria-hidden="true"></i>
                 Project details
               </a>
@@ -73,19 +73,19 @@ const tabsHTML = `
           </ul>
         </nav>
         {# Tab: Project description #}
-        <div id="description" data-target="project-tabs.content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="description-tab mobile-description-tab" tabindex="-1">
+        <div id="description" data-project-tabs-target="content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="description-tab mobile-description-tab" tabindex="-1">
           <h2 class="page-title">Project description</h2>
           <div class="project-description">Description</div>
         </div>
 
         {# Tab: project details #}
-        <div id="data" data-target="project-tabs.content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="mobile-data-tab" tabindex="-1">
+        <div id="data" data-project-tabs-target="content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="mobile-data-tab" tabindex="-1">
           <h2 class="page-title">Project details</h2>
           <br>
         </div>
 
         {# Tab: Release history #}
-        <div id="history" data-target="project-tabs.content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="history-tab mobile-history-tab" tabindex="-1">
+        <div id="history" data-project-tabs-target="content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="history-tab mobile-history-tab" tabindex="-1">
           <h2 class="page-title split-layout">
             <span>Release history</span>
             <a class="reset-text margin-top" href="#project-release-notifications">Release notifications</a>

--- a/tests/frontend/viewport_toggle_controller_test.js
+++ b/tests/frontend/viewport_toggle_controller_test.js
@@ -20,11 +20,11 @@ import ViewportToggleController from "../../warehouse/static/js/warehouse/contro
 const viewportContent = `
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <div data-controller="viewport-toggle">
-      <button id="switch-to-mobile" class="button button--primary button--switch-to-mobile hidden" data-target="viewport-toggle.switchToMobile" data-action="viewport-toggle#switchToMobile">
+      <button id="switch-to-mobile" class="button button--primary button--switch-to-mobile hidden" data-viewport-toggle-target="switchToMobile" data-action="viewport-toggle#switchToMobile">
         Switch to mobile version
       </button>
       <div class="centered hide-on-desktop">
-          <button id="switch-to-desktop" class="button button--switch-to-desktop hidden" data-target="viewport-toggle.switchToDesktop" data-action="viewport-toggle#switchToDesktop">
+          <button id="switch-to-desktop" class="button button--switch-to-desktop hidden" data-viewport-toggle-target="switchToDesktop" data-action="viewport-toggle#switchToDesktop">
               Desktop version
           </button>
       </div>

--- a/warehouse/static/sass/blocks/_notification-bar.scss
+++ b/warehouse/static/sass/blocks/_notification-bar.scss
@@ -60,18 +60,18 @@
 
     - .notification-bar--dismissable to its classes
     - data-controller="notification" as an attribute
-    - data-target="notification.notification" as an attribute
+    - data-notification-target="notification" as an attribute
     - a dismiss button (see html example below)
 
-  The data-controller and data-target are used for handling visibility,
+  The data-controller and data-notification-target are used for handling visibility,
   including adding .notification-bar--visible to notification-bar div if it has
   not been dismissed (and persisted) yet.
 
   <div class="notification-bar notification-bar--dismissable"
-    data-controller="notification" data-target="notification.notification">
+    data-controller="notification" data-notification-target="notification">
       <button
        title="Dismiss this notification"
-       data-target="notification.dismissButton"
+       data-notification-target="dismissButton"
        data-action="click->notification#dismiss"
        class="notification-bar__dismiss"
        aria-label="close">

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -72,7 +72,7 @@
               {% endif %}
             </label>
           </div>
-          {{ form.password(placeholder=gettext("Your password"), required="required", class_="form-group__field", autocomplete="current-password", spellcheck="false", data_target="password.password", **{"aria-describedby":"password-errors"}) }}
+          {{ form.password(placeholder=gettext("Your password"), required="required", class_="form-group__field", autocomplete="current-password", spellcheck="false", data_password_target="password", **{"aria-describedby":"password-errors"}) }}
           <div id="password-errors">
             {% if form.password.errors %}
             <ul class="form-errors" role="alert">
@@ -88,7 +88,7 @@
                 <input type="submit" value="{% trans %}Log in{% endtrans %}" class="button button--primary">
               </div>
               <label for="show-password">
-                <input data-action="change->password#togglePasswords" data-target="password.showPassword"
+                <input data-action="change->password#togglePasswords" data-password-target="showPassword"
                   id="show-password" type="checkbox">&nbsp;{% trans %}Show password{% endtrans %}
               </label>
             </div>

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -113,11 +113,11 @@
                 {% endif %}
               </label>
               <label for="show-password">
-                <input data-action="change->password#togglePasswords" data-target="password.showPassword"
+                <input data-action="change->password#togglePasswords" data-password-target="showPassword"
                   id="show-password" type="checkbox">&nbsp;{% trans %}Show passwords{% endtrans %}
               </label>
             </div>
-            {{ form.new_password(placeholder=gettext("Select a password"), required="required", class_="form-group__field", autocomplete="new-password", spellcheck="false", data_target="password.password password-match.passwordMatch password-strength-gauge.password password-breach.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength input->password-breach#check", **{"aria-describedby":"password-errors password-strength"}) }}
+            {{ form.new_password(placeholder=gettext("Select a password"), required="required", class_="form-group__field", autocomplete="new-password", spellcheck="false", data_password_target="password", data_password_match_target="passwordMatch", data_password_strength_gauge_target="password", data_password_breach_target="password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength input->password-breach#check", **{"aria-describedby":"password-errors password-strength"}) }}
             <div id="password-errors">
               {% if form.new_password.errors %}
               <ul class="form-errors" role="alert">
@@ -127,7 +127,7 @@
               </ul>
               {% endif %}
             </div>
-            {{ password_strength_gauge(data_target="password-strength-gauge.strengthGauge") }}
+            {{ password_strength_gauge(data_password_strength_gauge_target="strengthGauge") }}
           </div>
 
           <div class="form-group">
@@ -137,7 +137,7 @@
               <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
               {% endif %}
             </label>
-            {{ form.password_confirm(placeholder=gettext("Confirm password"), required="required", class_="form-group__field", autocomplete="new-password", spellcheck="false", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{"aria-describedby":"password-confirm-errors"}) }}
+            {{ form.password_confirm(placeholder=gettext("Confirm password"), required="required", class_="form-group__field", autocomplete="new-password", spellcheck="false", data_password_target="password", data_password_match_target="passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{"aria-describedby":"password-confirm-errors"}) }}
             <div id="password-confirm-errors">
               {% if form.password_confirm.errors %}
               <ul class="form-errors" role="alert">
@@ -152,14 +152,14 @@
 
         <div class="form-group">
           <ul class="form-errors">
-            <li data-target="password-match.matchMessage" class="hidden"></li>
-            <li data-target="password-breach.message" class="hidden">
+            <li data-password-match-target="matchMessage" class="hidden"></li>
+            <li data-password-breach-target="message" class="hidden">
               {{ gettext("This password appears in a security breach or has been compromised and cannot be used. Please refer to the <a href=\"/help/#compromised-password\">FAQ</a> for more information.") }}
             </li>
           </ul>
         </div>
 
-        <input type="submit" value="{% trans %}Create account{% endtrans %}" class="button button--primary" data-target="password-match.submit">
+        <input type="submit" value="{% trans %}Create account{% endtrans %}" class="button button--primary" data-password-match-target="submit">
       </form>
     </div>
   </div>

--- a/warehouse/templates/accounts/reset-password.html
+++ b/warehouse/templates/accounts/reset-password.html
@@ -41,10 +41,10 @@
               {% endif %}
             </label>
             <label for="show-password">
-              <input data-action="change->password#togglePasswords" data-target="password.showPassword" id="show-password" type="checkbox" tabindex="4">&nbsp;{% trans %}Show passwords{% endtrans %}
+              <input data-action="change->password#togglePasswords" data-password-target="showPassword" id="show-password" type="checkbox" tabindex="4">&nbsp;{% trans %}Show passwords{% endtrans %}
             </label>
           </div>
-          {{ form.new_password(placeholder=gettext("Select a new password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__field", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"password-errors password-strength"}) }}
+          {{ form.new_password(placeholder=gettext("Select a new password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__field", data_password_target="password", data_password_match_target="passwordMatch", data_password_strength_gauge_target="password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"password-errors password-strength"}) }}
           {% if form.new_password.errors %}
           <ul id="password-errors" class="form-errors" role="alert">
             {% for error in form.new_password.errors %}
@@ -52,7 +52,7 @@
             {% endfor %}
           </ul>
           {% endif %}
-          {{ password_strength_gauge(data_target="password-strength-gauge.strengthGauge") }}
+          {{ password_strength_gauge(data_password_strength_gauge_target="strengthGauge") }}
         </div>
 
         <div class="form-group">
@@ -62,7 +62,7 @@
             <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
             {% endif %}
           </label>
-          {{ form.password_confirm(placeholder=gettext("Confirm password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__field", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{"aria-describedby":"confirm-password-errors"}) }}
+          {{ form.password_confirm(placeholder=gettext("Confirm password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__field", data_password_target="password", data_password_match_target="passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{"aria-describedby":"confirm-password-errors"}) }}
           {% if form.password_confirm.errors %}
           <ul id="confirm-password-errors" class="form-errors" role="alert">
             {% for error in form.password_confirm.errors %}
@@ -74,11 +74,11 @@
 
         <div class="form-group">
           <ul class="form-errors" role="alert">
-            <li data-target="password-match.matchMessage" class="hidden"></li>
+            <li data-password-match-target="matchMessage" class="hidden"></li>
           </ul>
         </div>
 
-        <input type="submit" value="{% trans %}Reset password{% endtrans %}" class="button button--primary" data-target="password-match.submit" tabindex="3">
+        <input type="submit" value="{% trans %}Reset password{% endtrans %}" class="button button--primary" data-password-match-target="submit" tabindex="3">
       </form>
     </div>
   </div>

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -18,7 +18,7 @@
 </time>
 {%- endmacro %}
 
-{% macro password_strength_gauge(data_target=None) -%}
+{% macro password_strength_gauge(data_password_strength_gauge_target=None) -%}
 <div id="password-strength">
   <p class="form-group__help-text">
     {% trans %}Choose a strong password that contains letters (uppercase and lowercase), numbers and special characters. Avoid common words or repetition.{% endtrans %}
@@ -26,7 +26,7 @@
   <p class="form-group__help-text">
     <strong>{% trans %}Password strength:{% endtrans %}</strong>
     <span class="password-strength">
-      <span class="password-strength__gauge"{% if data_target %} data-target="{{ data_target }}"{% endif %}>
+      <span class="password-strength__gauge"{% if data_password_strength_gauge_target %} data-password-strength-gauge-target="{{ data_password_strength_gauge_target }}"{% endif %}>
         <span class="sr-only">{% trans %}Password field is empty{% endtrans %}</span>
       </span>
     </span>
@@ -140,7 +140,7 @@
     <!-- Accessibility: this link should always be the first piece of content inside the body-->
     <a href="#content" class="skip-to-content">{% trans %}Skip to main content{% endtrans %}</a>
 
-    <button type="button" class="button button--primary button--switch-to-mobile hidden" data-target="viewport-toggle.switchToMobile" data-action="viewport-toggle#switchToMobile">
+    <button type="button" class="button button--primary button--switch-to-mobile hidden" data-viewport-toggle-target="switchToMobile" data-action="viewport-toggle#switchToMobile">
       {% trans %}Switch to mobile version{% endtrans %}
     </button>
 
@@ -210,7 +210,7 @@
 
             <form class="search-form search-form--primary" action="{{ request.route_path('search') }}" role="search">
               <label for="search" class="sr-only">{% trans %}Search PyPI{% endtrans %}</label>
-              <input id="search" class="search-form__search" type="text" name="q" placeholder="{% trans %}Search projects{% endtrans %}" value="{{ term }}" autocomplete="off" autocapitalize="off" spellcheck="false" data-controller="search-focus" data-action="keydown@window->search-focus#focusSearchField" data-target="search-focus.searchField">
+              <input id="search" class="search-form__search" type="text" name="q" placeholder="{% trans %}Search projects{% endtrans %}" value="{{ term }}" autocomplete="off" autocapitalize="off" spellcheck="false" data-controller="search-focus" data-action="keydown@window->search-focus#focusSearchField" data-search-focus-target="searchField">
               {% block search_form_extra_inputs %}{% endblock %}
               <button type="submit" class="search-form__button">
                 <i class="fa fa-search" aria-hidden="true"></i>
@@ -320,7 +320,7 @@
       </div>
 
       <div class="centered hide-on-desktop">
-        <button type="button" class="button button--switch-to-desktop hidden" data-target="viewport-toggle.switchToDesktop" data-action="viewport-toggle#switchToDesktop">
+        <button type="button" class="button button--switch-to-desktop hidden" data-viewport-toggle-target="switchToDesktop" data-action="viewport-toggle#switchToDesktop">
           {% trans %}Switch to desktop version{% endtrans %}
         </button>
       </div>

--- a/warehouse/templates/includes/flash-messages.html
+++ b/warehouse/templates/includes/flash-messages.html
@@ -13,41 +13,41 @@
 -#}
 
 {% for message in request.session.pop_flash(queue="error") %}
-<div class="notification-bar notification-bar--danger notification-bar--dismissable" data-controller="notification" data-target="notification.notification" role="alert">
+<div class="notification-bar notification-bar--danger notification-bar--dismissable" data-controller="notification" data-notification-target="notification" role="alert">
   <span class="notification-bar__icon">
     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
     <span class="sr-only">{% trans %}Error{% endtrans %}</span>
   </span>
   <span class="notification-bar__message">{{ message }}</span>
-  <button type="button" title="{% trans %}Dismiss this notification{% endtrans %}" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
+  <button type="button" title="{% trans %}Dismiss this notification{% endtrans %}" data-notification-target="dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
 </div>
 {% endfor %}
 
 {% for message in request.session.pop_flash(queue="warning") %}
-<div class="notification-bar notification-bar--warning notification-bar--dismissable" data-controller="notification" data-target="notification.notification" role="alert">
+<div class="notification-bar notification-bar--warning notification-bar--dismissable" data-controller="notification" data-notification-target="notification" role="alert">
   <span class="notification-bar__icon">
     <i class="fa fa-exclamation" aria-hidden="true"></i>
     <span class="sr-only">{% trans %}Warning{% endtrans %}</span>
   </span>
   <span class="notification-bar__message">{{ message }}</span>
-  <button type="button" title="{% trans %}Dismiss this notification{% endtrans %}" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
+  <button type="button" title="{% trans %}Dismiss this notification{% endtrans %}" data-notification-target="dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
 </div>
 {% endfor %}
 
 {% for message in request.session.pop_flash() %}
-<div class="notification-bar notification-bar--dismissable" data-controller="notification" data-target="notification.notification">
+<div class="notification-bar notification-bar--dismissable" data-controller="notification" data-notification-target="notification">
   <span class="notification-bar__message">{{ message }}</span>
-  <button type="button" title="{% trans %}Dismiss this notification{% endtrans %}" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
+  <button type="button" title="{% trans %}Dismiss this notification{% endtrans %}" data-notification-target="dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
 </div>
 {% endfor %}
 
 {% for message in request.session.pop_flash(queue="success") %}
-<div class="notification-bar notification-bar--success notification-bar--dismissable" data-controller="notification" data-target="notification.notification" role="status">
+<div class="notification-bar notification-bar--success notification-bar--dismissable" data-controller="notification" data-notification-target="notification" role="status">
   <span class="notification-bar__icon">
     <i class="fa fa-check" aria-hidden="true"></i>
     <span class="sr-only">{% trans %}Success{% endtrans %}</span>
   </span>
   <span class="notification-bar__message">{{ message }}</span>
-  <button type="button" title="{% trans %}Dismiss this notification{% endtrans %}" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
+  <button type="button" title="{% trans %}Dismiss this notification{% endtrans %}" data-notification-target="dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
 </div>
 {% endfor %}

--- a/warehouse/templates/includes/session-notifications.html
+++ b/warehouse/templates/includes/session-notifications.html
@@ -31,13 +31,13 @@
     </span>
   </div>
   {% elif not request.user.has_two_factor %}
-  <div class="notification-bar notification-bar--dismissable" data-controller="notification" data-target="notification.notification">
+  <div class="notification-bar notification-bar--dismissable" data-controller="notification" data-notification-target="notification">
     <span class="notification-bar__message">
       {% trans trimmed href=request.route_path('manage.account.two-factor') %}
         Two factor authentication is available, <a href="{{ href }}">enable it now for your account.</a>
       {% endtrans %}
     </span>
-    <button type="button" title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
+    <button type="button" title="Dismiss this notification" data-notification-target="dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
   </div>
   {% elif not request.user.has_recovery_codes %}
   <div class="notification-bar notification-bar--warning">

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -55,7 +55,7 @@
       <label for="search" class="sr-only">{% trans %}Search PyPI{% endtrans %}</label>
 
       <!-- The following input is intentionally not autofocused, see https://github.com/pypa/warehouse/issues/6088 for more details -->
-      <input id="search" class="search-form__search large-input" type="text" name="q" placeholder="{% trans %}Search projects{% endtrans %}" autocomplete="off" autocapitalize="off" spellcheck="false" data-controller="search-focus" data-action="keydown@window->search-focus#focusSearchField" data-target="search-focus.searchField">
+      <input id="search" class="search-form__search large-input" type="text" name="q" placeholder="{% trans %}Search projects{% endtrans %}" autocomplete="off" autocapitalize="off" spellcheck="false" data-controller="search-focus" data-action="keydown@window->search-focus#focusSearchField" data-search-focus-target="searchField">
 
       <button type="submit" class="search-form__button">
         <i class="fa fa-search" aria-hidden="true"></i>

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -370,11 +370,11 @@
             {% endif %}
           </label>
           <label for="show-password">
-            <input data-action="change->password#togglePasswords" data-target="password.showPassword"
+            <input data-action="change->password#togglePasswords" data-password-target="showPassword"
               id="show-password" type="checkbox">&nbsp;{% trans %}Show passwords{% endtrans %}
           </label>
         </div>
-        {{ change_password_form.password(placeholder=gettext("Your current password"), required="required", autocomplete="current-password", spellcheck="false", class_="form-group__field", data_target="password.password", **{"aria-describedby":"current-password-errors"}) }}
+        {{ change_password_form.password(placeholder=gettext("Your current password"), required="required", autocomplete="current-password", spellcheck="false", class_="form-group__field", data_password_target="password", **{"aria-describedby":"current-password-errors"}) }}
         <div id="current-password-errors">
           {{ field_errors(change_password_form.password) }}
         </div>
@@ -388,12 +388,12 @@
         </label>
         {# the password field needs to be wrapped in a div to properly place tooltips #}
         <div>
-          {{ change_password_form.new_password(placeholder=gettext("Select a new password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__field", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"new-password-errors"}) }}
+          {{ change_password_form.new_password(placeholder=gettext("Select a new password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__field", data_password_target="password", data_password_match_target="passwordMatch", data_password_strength_gauge_target="password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"new-password-errors"}) }}
         </div>
         <div id="new-password-errors">
           {{ field_errors(change_password_form.new_password) }}
         </div>
-        {{ password_strength_gauge(data_target="password-strength-gauge.strengthGauge") }}
+        {{ password_strength_gauge(data_password_strength_gauge_target="strengthGauge") }}
       </div>
       <div class="form-group">
         <label class="form-group__label" for="name">
@@ -402,18 +402,18 @@
           <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
           {% endif %}
         </label>
-        {{ change_password_form.password_confirm(placeholder=gettext("Confirm password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__field", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{"aria-describedby":"confirm-password-errors"}) }}
+        {{ change_password_form.password_confirm(placeholder=gettext("Confirm password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__field", data_password_target="password", data_password_match_target="passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{"aria-describedby":"confirm-password-errors"}) }}
         <div id="confirm-password-errors">
           {{ field_errors(change_password_form.password_confirm) }}
         </div>
       </div>
       <div class="form-group">
         <ul class="form-errors">
-          <li data-target="password-match.matchMessage" class="hidden"></li>
+          <li data-password-match-target="matchMessage" class="hidden"></li>
         </ul>
       </div>
       <div>
-        <input value="{% trans %}Update password{% endtrans %}" class="button button--primary" type="submit" data-target="password-match.submit">
+        <input value="{% trans %}Update password{% endtrans %}" class="button button--primary" type="submit" data-password-match-target="submit">
       </div>
     </form>
   </section>

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -310,12 +310,12 @@
           {% set name = "confirm_" + confirm_name.lower().replace(' ', '_') %}
           <div class="form-group">
             <label for="{{ slug }}-{{ name }}">{{ label }}</label>
-            <input id="{{ slug }}-{{ name }}" name="{{ name }}" data-action="input->confirm#check" data-target="confirm.input modal-close.input" type="text" autocomplete="off" autocapitalize="off" spellcheck="false">
+            <input id="{{ slug }}-{{ name }}" name="{{ name }}" data-action="input->confirm#check" data-confirm-target="input" data-modal-close-target="input" type="text" autocomplete="off" autocapitalize="off" spellcheck="false">
           </div>
         </div>
         <div class="modal__footer">
           <button type="reset" class="button modal__action js-cancel" data-action="click->modal-close#cancel">{% trans %}Cancel{% endtrans %}</button>
-          <button type="submit" class="button button{{ modifier }} modal__action js-confirm" data-target="confirm.button modal-close.button" data-expected="{{ confirm_string }}">
+          <button type="submit" class="button button{{ modifier }} modal__action js-confirm" data-confirm-target="button" data-modal-close-target="button" data-expected="{{ confirm_string }}">
             {{ confirm_button_label if confirm_button_label else title }}
           </button>
         </div>
@@ -358,16 +358,16 @@
             <div class="split-layout">
               <label for="confirm_password">{% trans %}Password{% endtrans %}</label>
               <label for="show-confirm-password-{{ slug }}" class="show-password">
-                <input data-action="change->confirm-password#setPasswordVisibility" data-target="confirm-password.showPassword" id="show-confirm-password-{{ slug }}" type="checkbox">
+                <input data-action="change->confirm-password#setPasswordVisibility" data-confirm-password-target="showPassword" id="show-confirm-password-{{ slug }}" type="checkbox">
                 {% trans %}Show password{% endtrans %}
               </label>
             </div>
-            <input name="confirm_password" data-action="input->confirm-password#check" data-target="confirm-password.password modal-close.input" type="password" autocomplete="off" autocorrect="off" autocapitalize="off">
+            <input name="confirm_password" data-action="input->confirm-password#check" data-confirm-password-target="password" data-modal-close-target="input" type="password" autocomplete="off" autocorrect="off" autocapitalize="off">
           </div>
         </div>
         <div class="modal__footer">
           <button type="reset" class="button modal__action js-cancel" data-action="click->modal-close#cancel">{% trans %}Cancel{% endtrans %}</button>
-          <button type="submit" class="button button--danger modal__action js-confirm" data-target="confirm-password.button modal-close.button">{{ confirm_button_label }}</button>
+          <button type="submit" class="button button--danger modal__action js-confirm" data-confirm-password-target="button" data-modal-close-target="button">{{ confirm_button_label }}</button>
         </div>
       </form>
     </div>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -207,20 +207,20 @@
           <nav aria-label="{% trans project=release.project.name %}Navigation for {{ project }}{% endtrans %}">
             <ul class="vertical-tabs__list" role="tablist">
               <li role="tab">
-                <a id="description-tab" href="#description" data-target="project-tabs.tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--is-active" aria-selected="true" aria-label="{% trans %}Project description. Focus will be moved to the description.{% endtrans %}">
+                <a id="description-tab" href="#description" data-project-tabs-target="tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--is-active" aria-selected="true" aria-label="{% trans %}Project description. Focus will be moved to the description.{% endtrans %}">
                   <i class="fa fa-align-left" aria-hidden="true"></i>
                   {% trans %}Project description{% endtrans %}
                 </a>
               </li>
               <li role="tab">
-                <a id="history-tab" href="#history" data-target="project-tabs.tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon" aria-label="{% trans %}Release history. Focus will be moved to the history panel.{% endtrans %}">
+                <a id="history-tab" href="#history" data-project-tabs-target="tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon" aria-label="{% trans %}Release history. Focus will be moved to the history panel.{% endtrans %}">
                   <i class="fa fa-history" aria-hidden="true"></i>
                   {% trans %}Release history{% endtrans %}
                 </a>
               </li>
               {% if files %}
               <li role="tab">
-                <a id="files-tab" href="#files" data-target="project-tabs.tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon" aria-label="{% trans %}Download files. Focus will be moved to the project files.{% endtrans %}">
+                <a id="files-tab" href="#files" data-project-tabs-target="tab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon" aria-label="{% trans %}Download files. Focus will be moved to the project files.{% endtrans %}">
                   <i class="fa fa-download" aria-hidden="true"></i>
                   {% trans %}Download files{% endtrans %}
                 </a>
@@ -238,26 +238,26 @@
         <nav aria-label="{% trans project=release.project.name %}Navigation for {{ project }}{% endtrans %}">
           <ul class="vertical-tabs__list" role="tablist">
             <li role="tab">
-              <a id="mobile-description-tab" href="#description" data-target="project-tabs.mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile vertical-tabs__tab--no-top-border vertical-tabs__tab--is-active" aria-selected="true" aria-label="{% trans %}Project description. Focus will be moved to the description.{% endtrans %}">
+              <a id="mobile-description-tab" href="#description" data-project-tabs-target="mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile vertical-tabs__tab--no-top-border vertical-tabs__tab--is-active" aria-selected="true" aria-label="{% trans %}Project description. Focus will be moved to the description.{% endtrans %}">
                 <i class="fa fa-align-left" aria-hidden="true"></i>
                 {% trans %}Project description{% endtrans %}
               </a>
             </li>
             <li role="tab">
-              <a id="mobile-data-tab" href="#data" data-target="project-tabs.mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="{% trans %}Project details. Focus will be moved to the project details.{% endtrans %}">
+              <a id="mobile-data-tab" href="#data" data-project-tabs-target="mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="{% trans %}Project details. Focus will be moved to the project details.{% endtrans %}">
                 <i class="fa fa-info-circle" aria-hidden="true"></i>
                 {% trans %}Project details{% endtrans %}
               </a>
             </li>
             <li role="tab">
-              <a id="mobile-history-tab" href="#history" data-target="project-tabs.mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="{% trans %}Release history. Focus will be moved to the history panel.{% endtrans %}">
+              <a id="mobile-history-tab" href="#history" data-project-tabs-target="mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="{% trans %}Release history. Focus will be moved to the history panel.{% endtrans %}">
               <i class="fa fa-history" aria-hidden="true"></i>
               {% trans %}Release history{% endtrans %}
             </a>
             </li>
             {% if files %}
             <li role="tab">
-              <a id="mobile-files-tab" href="#files" data-target="project-tabs.mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="{% trans %}Download files. Focus will be moved to the project files.{% endtrans %}">
+              <a id="mobile-files-tab" href="#files" data-project-tabs-target="mobileTab" data-action="project-tabs#onTabClick" class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" aria-label="{% trans %}Download files. Focus will be moved to the project files.{% endtrans %}">
                 <i class="fa fa-download" aria-hidden="true"></i>
                 {% trans %}Download files{% endtrans %}
               </a>
@@ -267,7 +267,7 @@
         </nav>
 
         {# Tab: Project description #}
-        <div id="description" data-target="project-tabs.content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="description-tab mobile-description-tab" tabindex="-1">
+        <div id="description" data-project-tabs-target="content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="description-tab mobile-description-tab" tabindex="-1">
           <h2 class="page-title">{% trans %}Project description{% endtrans %}</h2>
           {% if description %}
           <div class="project-description">
@@ -281,14 +281,14 @@
         </div>
 
         {# Tab: project details #}
-        <div id="data" data-target="project-tabs.content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="mobile-data-tab" tabindex="-1">
+        <div id="data" data-project-tabs-target="content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="mobile-data-tab" tabindex="-1">
           <h2 class="page-title">{% trans %}Project details{% endtrans %}</h2>
           {% include "warehouse:templates/includes/packaging/project-data.html" %}
           <br>
         </div>
 
         {# Tab: Release history #}
-        <div id="history" data-target="project-tabs.content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="history-tab mobile-history-tab" tabindex="-1">
+        <div id="history" data-project-tabs-target="content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="history-tab mobile-history-tab" tabindex="-1">
           <h2 class="page-title split-layout">
             <span>{% trans %}Release history{% endtrans %}</span>
             <span class="reset-text margin-top">
@@ -345,7 +345,7 @@
 
         {% if files %}
           {# Tab: Downloads #}
-          <div id="files" data-target="project-tabs.content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="files-tab mobile-files-tab" tabindex="-1">
+          <div id="files" data-project-tabs-target="content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="files-tab mobile-files-tab" tabindex="-1">
             <h2 class="page-title">{% trans %}Download files{% endtrans %}</h2>
             <p>{% trans href='https://packaging.python.org/installing/', title=gettext('External link') %}Download the file for your platform. If you're not sure which to choose, learn more about <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">installing packages</a>.{% endtrans %}</p>
 

--- a/warehouse/templates/re-auth.html
+++ b/warehouse/templates/re-auth.html
@@ -52,7 +52,7 @@
                 {% endif %}
               </label>
             </div>
-            {{ form.password(placeholder=gettext("Your password"), required="required", class_="form-group__field", autocomplete="current-password", spellcheck="false", data_target="password.password", **{"aria-describedby":"password-errors"}) }}
+            {{ form.password(placeholder=gettext("Your password"), required="required", class_="form-group__field", autocomplete="current-password", spellcheck="false", data_password_target="password", **{"aria-describedby":"password-errors"}) }}
             <div id="password-errors">
               {% if form.password.errors %}
               <ul class="form-errors" role="alert">
@@ -68,7 +68,7 @@
                   <input type="submit" value="{% trans %}Confirm password{% endtrans %}" class="button button--primary">
                 </div>
                 <label for="show-password">
-                  <input data-action="change->password#togglePasswords" data-target="password.showPassword"
+                  <input data-action="change->password#togglePasswords" data-password-target="showPassword"
                     id="show-password" type="checkbox">&nbsp;{% trans %}Show password{% endtrans %}
                 </label>
               </div>


### PR DESCRIPTION
As a stepping-stone to 3.0.0, enabling this provides Console warnings
for deprecated values.

A blocker to getting to 3.x is some interplay between babel, gulp, jest, and ES6 targets. I spent some time poking at this unsuccessfully, and considered it would be wise to get this shipped for now, and iterate on getting to 3.x

Signed-off-by: Mike Fiedler <miketheman@gmail.com>