### PR TITLE
Support the word `Sponsor` for monetization project URLs

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -27,7 +27,7 @@
   {% set icon = "fas fa-book" %}
 {% elif name.lower().startswith(("bug", "issue", "tracker", "report")) %}
   {% set icon = "fas fa-bug" %}
-{% elif name.lower().startswith(("funding", "donate", "donation")) %}
+{% elif name.lower().startswith(("funding", "donate", "donation", "sponsor")) %}
   {% set icon = "fas fa-donate" %}
 {% elif parsed.netloc in ["github.com", "github.io"] or parsed.netloc.endswith((".github.com", ".github.io")) %}
   {% set icon = "fab fa-github" %}


### PR DESCRIPTION
People are now familiar with the word from GitHub Sponsors