### PR TITLE
Add a caveat for project IDs

### DIFF
--- a/warehouse/macaroons/caveats.py
+++ b/warehouse/macaroons/caveats.py
@@ -105,6 +105,32 @@ class ExpiryCaveat(Caveat):
         return True
 
 
+class ProjectIDsCaveat(Caveat):
+    def verify(self, predicate):
+        try:
+            data = json.loads(predicate)
+            project_ids = data["project_ids"]
+        except (KeyError, ValueError, TypeError):
+            self.failure_reason = "malformatted predicate"
+            return False
+
+        if not project_ids:
+            self.failure_reason = "missing fields"
+            return False
+
+        if not isinstance(self.verifier.context, Project):
+            self.failure_reason = (
+                "project-scoped token used outside of a project context"
+            )
+            return False
+
+        if str(self.verifier.context.id) not in project_ids:
+            self.failure_reason = "current project does not matched scoped project IDs"
+            return False
+
+        return True
+
+
 class Verifier:
     def __init__(self, macaroon, context, principals, permission):
         self.macaroon = macaroon
@@ -116,6 +142,7 @@ class Verifier:
     def verify(self, key):
         self.verifier.satisfy_general(V1Caveat(self))
         self.verifier.satisfy_general(ExpiryCaveat(self))
+        self.verifier.satisfy_general(ProjectIDsCaveat(self))
 
         try:
             return self.verifier.verify(self.macaroon, key)


### PR DESCRIPTION
This adds `ProjectIDsCaveat` (name suggestions *very* welcome), which constrains the set of valid projects not just by normalized name (as with `V1Caveat`) but also by their unique ID.

This provides an important security property: a project might be deleted and re-created by a new user, at which point any previously valid macaroons should no longer be valid for the new project.

**This is currently true** for all extant macaroons since they're tied to user identities, but that **won't** be true in the near future (#11272). These changes are therefore necessary to preserve a security invariant once users are only optionally associated with macaroons.