### PR TITLE
API: Add "summary" field to vulnerability reports

### DIFF
--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -672,6 +672,7 @@ class TestJSONRelease:
             link="the link",
             aliases=["alias1", "alias2"],
             details="some details",
+            summary="some summary",
             fixed_in=["3.3.2"],
             releases=[release],
         )
@@ -688,6 +689,7 @@ class TestJSONRelease:
                 "link": "the link",
                 "aliases": ["alias1", "alias2"],
                 "details": "some details",
+                "summary": "some summary",
                 "fixed_in": ["3.3.2"],
             },
         ]

--- a/warehouse/integrations/vulnerabilities/__init__.py
+++ b/warehouse/integrations/vulnerabilities/__init__.py
@@ -31,6 +31,7 @@ class VulnerabilityReportRequest:
         advisory_link: str,
         aliases: List[str],
         details: str,
+        summary: str,
         fixed_in: List[str],
     ):
         self.project = project
@@ -39,6 +40,7 @@ class VulnerabilityReportRequest:
         self.advisory_link = advisory_link
         self.aliases = aliases
         self.details = details
+        self.summary = summary
         self.fixed_in = fixed_in
 
     @classmethod
@@ -64,6 +66,7 @@ class VulnerabilityReportRequest:
             advisory_link=request["link"],
             aliases=request["aliases"],
             details=request.get("details"),
+            summary=request.get("summary"),
             fixed_in=[
                 version
                 for event in request.get("events", [])

--- a/warehouse/integrations/vulnerabilities/models.py
+++ b/warehouse/integrations/vulnerabilities/models.py
@@ -62,6 +62,9 @@ class VulnerabilityRecord(db.Model):
     # Details about the vulnerability
     details = Column(String)
 
+    # A short, plaintext summary of the vulnerability
+    summary = Column(String)
+
     # Events of introduced/fixed versions
     fixed_in = Column(ARRAY(String))
 

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -90,6 +90,7 @@ def _analyze_vulnerability(request, vulnerability_report, origin, metrics):
             link=report.advisory_link,
             aliases=report.aliases,
             details=report.details,
+            summary=report.summary,
             fixed_in=report.fixed_in,
         )
         _add_vuln_record(request, vulnerability_record)

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -115,6 +115,7 @@ def _json_data(request, project, release, *, all_releases):
             "link": vulnerability_record.link,
             "aliases": vulnerability_record.aliases,
             "details": vulnerability_record.details,
+            "summary": vulnerability_record.summary,
             "fixed_in": vulnerability_record.fixed_in,
         }
         for vulnerability_record in release.vulnerabilities

--- a/warehouse/migrations/versions/1e61006a47c2_add_detail_to_vulnerabilityrecord.py
+++ b/warehouse/migrations/versions/1e61006a47c2_add_detail_to_vulnerabilityrecord.py
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add detail to VulnerabilityRecord
+
+Revision ID: 1e61006a47c2
+Revises: 8bee9c119e41
+Create Date: 2022-07-15 16:57:03.322702
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "1e61006a47c2"
+down_revision = "8bee9c119e41"
+
+
+def upgrade():
+    op.add_column("vulnerabilities", sa.Column("summary", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("vulnerabilities", "summary")


### PR DESCRIPTION
N.B.: Unless I'm misunderstanding, this will not backfill summaries from previous reports (since it's only a logical DB migration, not a data migration). But I think that'll be fine, since tools shouldn't always expect a summary and should gracefully degrade without one (and we can always manually backfill them in).

Closes #11734.