### PR TITLE
Fix #11862

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -1299,7 +1299,7 @@ class TestBasicAuthWith2FAEmail:
             pyramid_request, stub_user, project_name=project_name
         )
 
-        assert result == {}
+        assert result == {"project_name": project_name}
         assert pyramid_request.task.calls == [pretend.call(send_email)]
         assert send_email.delay.calls == [
             pretend.call(

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -305,7 +305,7 @@ def send_token_compromised_email_leak(request, user, *, public_url, origin):
     repeat_window=datetime.timedelta(days=1),
 )
 def send_basic_auth_with_two_factor_email(request, user, *, project_name):
-    return {}
+    return {"project_name": project_name}
 
 
 @_email("account-deleted")


### PR DESCRIPTION
Actually pass the project name to the renderer to make it available in the template.