### PR TITLE
Switch Documentation to Furo

### DIFF
--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -4,8 +4,6 @@ API reference
 Warehouse has several API endpoints. See :doc:`../application` for the
 parts of Warehouse that generate them.
 
-.. contents:: :local:
-
 API policies
 ------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,14 +59,10 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-if sphinx_rtd_theme:
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-else:
-    html_theme = "default"
+html_theme = "furo"
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Warehousedoc'
+htmlhelp_basename = "Warehousedoc"
 
 # Enable display of todos
 todo_include_todos = True

--- a/docs/development/email.rst
+++ b/docs/development/email.rst
@@ -1,9 +1,6 @@
 Working with E-mails
 ====================
 
-.. contents::
-    :local:
-
 Writing e-mails
 ---------------
 

--- a/docs/development/malware-checks.rst
+++ b/docs/development/malware-checks.rst
@@ -1,9 +1,6 @@
 Malware Checks
 ==============
 
-.. contents::
-    :local:
-
 Overview
 ------------
 This is a high-level diagram of the automated malware check system.

--- a/docs/development/patterns.rst
+++ b/docs/development/patterns.rst
@@ -1,9 +1,6 @@
 Patterns
 ========
 
-.. contents::
-    :local:
-
 Dependency management
 ---------------------
 

--- a/docs/development/token-scanning.rst
+++ b/docs/development/token-scanning.rst
@@ -6,8 +6,6 @@ content managers run regexes to try and identify published secrets, and ideally
 have them deactivated. PyPI has started integrating with such systems in order
 to help secure packages.
 
-.. contents::
-    :local:
 
 How to recognize a PyPI secret
 ------------------------------

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,3 +1,3 @@
+furo
 Sphinx
-sphinx_rtd_theme
 sphinxcontrib-httpdomain

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,6 +12,10 @@ babel==2.10.3 \
     --hash=sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51 \
     --hash=sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb
     # via sphinx
+beautifulsoup4==4.11.1 \
+    --hash=sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30 \
+    --hash=sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693
+    # via furo
 certifi==2022.6.15 \
     --hash=sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d \
     --hash=sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412
@@ -20,12 +24,14 @@ charset-normalizer==2.1.0 \
     --hash=sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5 \
     --hash=sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413
     # via requests
-docutils==0.17.1 \
-    --hash=sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125 \
-    --hash=sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61
-    # via
-    #   sphinx
-    #   sphinx-rtd-theme
+docutils==0.18.1 \
+    --hash=sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c \
+    --hash=sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06
+    # via sphinx
+furo==2022.6.21 \
+    --hash=sha256:061b68e323345e27fcba024cf33a1e77f3dfd8d9987410be822749a706e2add6 \
+    --hash=sha256:9aa983b7488a4601d13113884bfb7254502c8729942e073a0acb87a5512af223
+    # via -r requirements/docs.in
 idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
     --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
@@ -87,7 +93,9 @@ packaging==21.3 \
 pygments==2.12.0 \
     --hash=sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb \
     --hash=sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519
-    # via sphinx
+    # via
+    #   furo
+    #   sphinx
 pyparsing==3.0.9 \
     --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
     --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
@@ -108,17 +116,22 @@ snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
     # via sphinx
+soupsieve==2.3.2.post1 \
+    --hash=sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759 \
+    --hash=sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d
+    # via beautifulsoup4
 sphinx==5.0.2 \
     --hash=sha256:b18e978ea7565720f26019c702cd85c84376e948370f1cd43d60265010e1c7b0 \
     --hash=sha256:d3e57663eed1d7c5c50895d191fdeda0b54ded6f44d5621b50709466c338d1e8
     # via
     #   -r requirements/docs.in
-    #   sphinx-rtd-theme
+    #   furo
+    #   sphinx-basic-ng
     #   sphinxcontrib-httpdomain
-sphinx-rtd-theme==1.0.0 \
-    --hash=sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8 \
-    --hash=sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c
-    # via -r requirements/docs.in
+sphinx-basic-ng==0.0.1a12 \
+    --hash=sha256:cffffb14914ddd26c94b1330df1d72dab5a42e220aaeb5953076a40b9c50e801 \
+    --hash=sha256:e8b6efd2c5ece014156de76065eda01ddfca0fee465aa020b1e3c12f84570bbe
+    # via furo
 sphinxcontrib-applehelp==1.0.2 \
     --hash=sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a \
     --hash=sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -59,9 +59,9 @@ doc8==0.11.2 \
     --hash=sha256:9187da8c9f115254bbe34f74e2bbbdd3eaa1b9e92efd19ccac7461e347b5055c \
     --hash=sha256:c35a231f88f15c204659154ed3d499fa4d402d7e63d41cba7b54cf5e646123ab
     # via -r requirements/lint.in
-docutils==0.17.1 \
-    --hash=sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125 \
-    --hash=sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61
+docutils==0.18.1 \
+    --hash=sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c \
+    --hash=sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06
     # via
     #   doc8
     #   restructuredtext-lint

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -346,9 +346,9 @@ dnspython==2.2.1 \
     --hash=sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e \
     --hash=sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f
     # via email-validator
-docutils==0.17.1 \
-    --hash=sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125 \
-    --hash=sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61
+docutils==0.18.1 \
+    --hash=sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c \
+    --hash=sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06
     # via readme-renderer
 elasticsearch==7.10.1 \
     --hash=sha256:4ebd34fd223b31c99d9f3b6b6236d3ac18b3046191a37231e8235b06ae7db955 \


### PR DESCRIPTION
Furo's theme tends to look a bit nicer and produce better output, it also doesn't itself restrict the version of docutils in use, which lets us upgrade docutils to ``0.18.1`` (``0.19`` is blocked on Sphinx itself making a new release).

The manually added ToCs are not required on Furo, so this also drops those.