### PR TITLE
chore: update URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: "(Maintainers Only) Blank issue"
-    url: https://github.com/pypa/warehouse/issues/new
+    url: https://github.com/pypi/warehouse/issues/new
     about: For maintainers only.

--- a/.github/ISSUE_TEMPLATE/~good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/~good-first-issue.md
@@ -9,7 +9,7 @@ about: For maintainers to create an issue that is good for new contributors
 <!-- End issue text, leave the following intact -->
 ---
 
-**Good First Issue**: This issue is good for first time contributors. If you've already contributed to Warehouse, work on [another issue without this label](https://github.com/pypa/warehouse/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3A%22good+first+issue%22) instead. If there is not a corresponding pull request for this issue, it is up for grabs. For directions for getting set up, see our [Getting Started Guide](https://warehouse.pypa.io/development/getting-started/).
+**Good First Issue**: This issue is good for first time contributors. If you've already contributed to Warehouse, work on [another issue without this label](https://github.com/pypi/warehouse/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3A%22good+first+issue%22) instead. If there is not a corresponding pull request for this issue, it is up for grabs. For directions for getting set up, see our [Getting Started Guide](https://warehouse.pypa.io/development/getting-started/).
 
 If you are working on this issue and have questions, feel free to ask them here, in the [`#pypa-dev` chat channel on Libera](https://web.libera.chat/#pypa-dev), the [PyPA Discord](https://discord.gg/pypa) or on the [Discourse](https://discuss.python.org/c/packaging/14).
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,4 +12,4 @@ Examples of contributions include:
 
 Extensive contribution guidelines are available in the repository at
 ``docs/development/index.rst`` or
-`online <https://warehouse.readthedocs.io/development/>`_.
+`online <https://warehouse.pypa.io/development/>`_.

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ rooms, and mailing lists is expected to follow the `PSF Code of Conduct`_.
 .. _`architectural overview`: https://warehouse.readthedocs.io/application/
 .. _`documentation`: https://warehouse.readthedocs.io
 .. _`Getting started`: https://warehouse.readthedocs.io/development/getting-started/
-.. _`Github issue tracker`: https://github.com/pypa/warehouse/issues
+.. _`Github issue tracker`: https://github.com/pypi/warehouse/issues
 .. _`pypi.org`: https://pypi.org/
 .. _`Running tests and linters section`: https://warehouse.readthedocs.io/development/getting-started/#running-tests-and-linters
 .. _BrowserStack: https://browserstack.com/

--- a/README.rst
+++ b/README.rst
@@ -48,15 +48,15 @@ Everyone interacting in the Warehouse project's codebases, issue trackers, chat
 rooms, and mailing lists is expected to follow the `PSF Code of Conduct`_.
 
 .. _`PyPI`: https://pypi.org/
-.. _`our development roadmap`: https://warehouse.readthedocs.io/roadmap/
-.. _`architectural overview`: https://warehouse.readthedocs.io/application/
-.. _`documentation`: https://warehouse.readthedocs.io
-.. _`Getting started`: https://warehouse.readthedocs.io/development/getting-started/
+.. _`our development roadmap`: https://warehouse.pypa.io/roadmap/
+.. _`architectural overview`: https://warehouse.pypa.io/application/
+.. _`documentation`: https://warehouse.pypa.io
+.. _`Getting started`: https://warehouse.pypa.io/development/getting-started/
 .. _`Github issue tracker`: https://github.com/pypi/warehouse/issues
 .. _`pypi.org`: https://pypi.org/
-.. _`Running tests and linters section`: https://warehouse.readthedocs.io/development/getting-started/#running-tests-and-linters
+.. _`Running tests and linters section`: https://warehouse.pypa.io/development/getting-started/#running-tests-and-linters
 .. _BrowserStack: https://browserstack.com/
-.. _`supported browsers`: https://warehouse.readthedocs.io/development/frontend/#browser-support
+.. _`supported browsers`: https://warehouse.pypa.io/development/frontend/#browser-support
 .. |BrowserStackImg| image:: docs/_static/browserstack-logo.png
 .. _BrowserStackImg: https://browserstack.com/
 .. _`PSF Code of Conduct`: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md

--- a/docs/api-reference/integration-guide.rst
+++ b/docs/api-reference/integration-guide.rst
@@ -126,5 +126,4 @@ where ``project_l`` is the first letter of the project name.
 structure PyPI used to hold on disk. In general this is only a good idea
 for ``source`` as a ``python_version`` to fetch tar and zip files.
 Otherwise, you will want to match the format of the ``python_version``
-field of the releases in the `JSON
-API <https://warehouse.pypa.io/api-reference/json/>`__.
+field of the releases in the :doc:`json`.

--- a/docs/api-reference/integration-guide.rst
+++ b/docs/api-reference/integration-guide.rst
@@ -20,7 +20,7 @@ to redirects, but you should use pypi.org instead.
 
 You should also watch `our status page <https://status.python.org/>`__
 and subscribe to `the PyPI announcement list (low-traffic)
-<https://mail.python.org/mm3/mailman3/lists/pypi-announce.python.org/>`_
+<https://mail.python.org/mailman3/lists/pypi-announce.python.org/>`_
 to find out about future changes.
 
 Here are some tips.
@@ -73,7 +73,7 @@ Here are some tips.
   regardless of their ``User-Agent``.
 
 * Subscribe to `the PyPI announcement list (low-traffic)
-  <https://mail.python.org/mm3/mailman3/lists/pypi-announce.python.org/>`_.
+  <https://mail.python.org/mailman3/lists/pypi-announce.python.org/>`_.
 
 If you're a PyPI end user or packager looking to migrate to the new
 PyPI, see `the official Python Packaging User Guide on migrating to PyPI

--- a/docs/api-reference/integration-guide.rst
+++ b/docs/api-reference/integration-guide.rst
@@ -58,12 +58,12 @@ Here are some tips.
   ``https://pypi.org/rss/packages.xml``. See :doc:`feeds` for
   descriptions. `The data differs from the legacy feed data because
   the new feeds are standards-compliant and fix inaccuracies in the
-  publication date <https://github.com/pypa/warehouse/issues/3238>`_.
+  publication date <https://github.com/pypi/warehouse/issues/3238>`_.
 
 * Documentation upload: Users can no longer use ``doc_upload`` in the
   API to upload documentation ZIP files, separate from packages, to be
   hosted at pythonhosted.org (`discussion
-  <https://github.com/pypa/warehouse/issues/509>`_).
+  <https://github.com/pypi/warehouse/issues/509>`_).
 
 * ``User-Agent`` Filtering: Some client user agents were filtered to
   always use ``legacy.pypi.org``, a temporary deployment of the legacy

--- a/docs/api-reference/integration-guide.rst
+++ b/docs/api-reference/integration-guide.rst
@@ -93,7 +93,7 @@ Official guidance
 -----------------
 
 Query PyPI’s `JSON
-API <https://warehouse.readthedocs.io/api-reference/json/>`__ to
+API <https://warehouse.pypa.io/api-reference/json/>`__ to
 determine where to download files from.
 
 If you so choose
@@ -127,4 +127,4 @@ structure PyPI used to hold on disk. In general this is only a good idea
 for ``source`` as a ``python_version`` to fetch tar and zip files.
 Otherwise, you will want to match the format of the ``python_version``
 field of the releases in the `JSON
-API <https://warehouse.readthedocs.io/api-reference/json/>`__.
+API <https://warehouse.pypa.io/api-reference/json/>`__.

--- a/docs/api-reference/json.rst
+++ b/docs/api-reference/json.rst
@@ -291,7 +291,7 @@ Known vulnerabilities
 ~~~~~~~~~~~~~~~~~~~~~
 
 In the example above, the combination of the requested project and version
-had no `known vulnerabilities <https://github.com/pypa/advisory-db>`_.
+had no `known vulnerabilities <https://github.com/pypa/advisory-database>`_.
 An example of a response for a project with known vulnerabilities is
 provided below, with unrelated fields collapsed for readability.
 

--- a/docs/api-reference/legacy.rst
+++ b/docs/api-reference/legacy.rst
@@ -109,7 +109,7 @@ The Simple API implements the HTML-based package index API as specified in `PEP
 
 
 .. _`pypi-legacy`: https://pypi.python.org/
-.. _`PEP 503`: https://www.python.org/dev/peps/pep-0503/
+.. _`PEP 503`: https://peps.python.org/pep-0503/
 
 .. _upload-api-forklift:
 

--- a/docs/api-reference/xml-rpc.rst
+++ b/docs/api-reference/xml-rpc.rst
@@ -203,4 +203,4 @@ Mirroring Support
   Retrieve a dictionary mapping package names to the last serial for each
   package.
 
-.. _pypi-announce: https://mail.python.org/mm3/mailman3/lists/pypi-announce.python.org/
+.. _pypi-announce: https://mail.python.org/mailman3/lists/pypi-announce.python.org/

--- a/docs/application.rst
+++ b/docs/application.rst
@@ -95,7 +95,7 @@ Directories within the repository:
   - `cache/ <https://github.com/pypi/warehouse/tree/main/warehouse/cache>`_ - caching
   - `classifiers/ <https://github.com/pypi/warehouse/tree/main/warehouse/classifiers>`_ - frame trove classifiers
   - `cli/ <https://github.com/pypi/warehouse/tree/main/warehouse/cli>`_ - entry scripts and
-    `the interactive shell <https://warehouse.readthedocs.io/development/getting-started/#running-the-interactive-shell>`_
+    `the interactive shell <https://warehouse.pypa.io/development/getting-started/#running-the-interactive-shell>`_
   - `email/ <https://github.com/pypi/warehouse/tree/main/warehouse/email>`_ - services for sending emails
   - `forklift/ <https://github.com/pypi/warehouse/tree/main/warehouse/forklift>`_ - :ref:`upload-api-forklift`
   - `i18n/ <https://github.com/pypi/warehouse/tree/main/warehouse/i18n>`_ - internationalization
@@ -139,7 +139,7 @@ may be used to from the legacy site, such as:
 - uploading to pythonhosted.com documentation hosting (`discussion and
   plans <https://github.com/pypi/warehouse/issues/582>`_)
 
-- `download counts visible in the API <https://warehouse.readthedocs.io/api-reference/xml-rpc/#changes-to-legacy-api>`_
+- `download counts visible in the API <https://warehouse.pypa.io/api-reference/xml-rpc/#changes-to-legacy-api>`_
   (instead, use `the Google BigQuery service <https://packaging.python.org/guides/analyzing-pypi-package-downloads/>`_)
 
 - key management: PyPI no longer has a UI for users to manage GPG or

--- a/docs/application.rst
+++ b/docs/application.rst
@@ -5,7 +5,7 @@ Warehouse uses the
 `Pyramid`_ web framework, the
 `SQLAlchemy <https://docs.sqlalchemy.org/en/latest/>`__ ORM, and
 `Postgres <https://www.postgresql.org/docs/>`__ for its database.
-Warehouse's front end uses `Jinja2 <http://jinja.pocoo.org/>`__ templates.
+Warehouse's front end uses `Jinja2 <https://jinja.palletsprojects.com/>`__ templates.
 
 The production deployment for Warehouse is deployed using
 `Cabotage <https://github.com/cabotage/cabotage-app>`__, which manages
@@ -146,7 +146,7 @@ may be used to from the legacy site, such as:
   SSH public keys
 
 - uploading new releases via the web UI: instead, maintainers should
-  use the command-line tool `Twine <http://twine.readthedocs.io/>`_
+  use the command-line tool `Twine <https://twine.readthedocs.io/>`_
 
 - updating release descriptions via the web UI: instead, to update
   release metadata, you need to upload a new release (`discussion

--- a/docs/application.rst
+++ b/docs/application.rst
@@ -13,7 +13,7 @@ The production deployment for Warehouse is deployed using
 
 In the development environment, we use several `Docker`_  containers
 orchestrated by `Docker Compose <https://docs.docker.com/compose/overview/>`__
-to `manage <https://github.com/pypi/warehouse/blob/master/docker-compose.yml#L3>`__
+to `manage <https://github.com/pypi/warehouse/blob/main/docker-compose.yml#L3>`__
 running the containers and the connections between them.
 
 Since Warehouse was built on top of an existing database (for legacy
@@ -84,39 +84,39 @@ The top-level directory of the Warehouse repo contains files including:
 
 Directories within the repository:
 
-- `bin/ <https://github.com/pypi/warehouse/tree/master/bin>`_ - high-level scripts for Docker, Continuous Integration, and Makefile commands
-- `dev/ <https://github.com/pypi/warehouse/tree/master/dev>`_ - assets for developer environment
-- `tests/ <https://github.com/pypi/warehouse/tree/master/tests>`_ - tests
-- `warehouse/ <https://github.com/pypi/warehouse/tree/master/warehouse>`_ - code in modules
+- `bin/ <https://github.com/pypi/warehouse/tree/main/bin>`_ - high-level scripts for Docker, Continuous Integration, and Makefile commands
+- `dev/ <https://github.com/pypi/warehouse/tree/main/dev>`_ - assets for developer environment
+- `tests/ <https://github.com/pypi/warehouse/tree/main/tests>`_ - tests
+- `warehouse/ <https://github.com/pypi/warehouse/tree/main/warehouse>`_ - code in modules
 
-  - `accounts/ <https://github.com/pypi/warehouse/tree/master/warehouse/accounts>`_ - user accounts
-  - `admin/ <https://github.com/pypi/warehouse/tree/master/warehouse/admin>`_ - application-administrator-specific
-  - `banners/ <https://github.com/pypi/warehouse/tree/master/warehouse/banners>`_ - notification banners
-  - `cache/ <https://github.com/pypi/warehouse/tree/master/warehouse/cache>`_ - caching
-  - `classifiers/ <https://github.com/pypi/warehouse/tree/master/warehouse/classifiers>`_ - frame trove classifiers
-  - `cli/ <https://github.com/pypi/warehouse/tree/master/warehouse/cli>`_ - entry scripts and
+  - `accounts/ <https://github.com/pypi/warehouse/tree/main/warehouse/accounts>`_ - user accounts
+  - `admin/ <https://github.com/pypi/warehouse/tree/main/warehouse/admin>`_ - application-administrator-specific
+  - `banners/ <https://github.com/pypi/warehouse/tree/main/warehouse/banners>`_ - notification banners
+  - `cache/ <https://github.com/pypi/warehouse/tree/main/warehouse/cache>`_ - caching
+  - `classifiers/ <https://github.com/pypi/warehouse/tree/main/warehouse/classifiers>`_ - frame trove classifiers
+  - `cli/ <https://github.com/pypi/warehouse/tree/main/warehouse/cli>`_ - entry scripts and
     `the interactive shell <https://warehouse.readthedocs.io/development/getting-started/#running-the-interactive-shell>`_
-  - `email/ <https://github.com/pypi/warehouse/tree/master/warehouse/email>`_ - services for sending emails
-  - `forklift/ <https://github.com/pypi/warehouse/tree/master/warehouse/forklift>`_ - :ref:`upload-api-forklift`
-  - `i18n/ <https://github.com/pypi/warehouse/tree/master/warehouse/i18n>`_ - internationalization
-  - `integrations/ <https://github.com/pypi/warehouse/tree/master/warehouse/integrations>`_ - integrations with other services
-  - `legacy/ <https://github.com/pypi/warehouse/tree/master/warehouse/legacy>`_ - most of the read-only APIs implemented here
-  - `locale/ <https://github.com/pypi/warehouse/tree/master/warehouse/locale>`_ - internationalization
-  - `macaroons/ <https://github.com/pypi/warehouse/tree/master/warehouse/macaroons>`_ - API token support
-  - `malware/ <https://github.com/pypi/warehouse/tree/master/warehouse/malware>`_ - automated malware checks
-  - `manage/ <https://github.com/pypi/warehouse/tree/master/warehouse/manage>`_ - logged-in user functionality (i.e., manage account &
+  - `email/ <https://github.com/pypi/warehouse/tree/main/warehouse/email>`_ - services for sending emails
+  - `forklift/ <https://github.com/pypi/warehouse/tree/main/warehouse/forklift>`_ - :ref:`upload-api-forklift`
+  - `i18n/ <https://github.com/pypi/warehouse/tree/main/warehouse/i18n>`_ - internationalization
+  - `integrations/ <https://github.com/pypi/warehouse/tree/main/warehouse/integrations>`_ - integrations with other services
+  - `legacy/ <https://github.com/pypi/warehouse/tree/main/warehouse/legacy>`_ - most of the read-only APIs implemented here
+  - `locale/ <https://github.com/pypi/warehouse/tree/main/warehouse/locale>`_ - internationalization
+  - `macaroons/ <https://github.com/pypi/warehouse/tree/main/warehouse/macaroons>`_ - API token support
+  - `malware/ <https://github.com/pypi/warehouse/tree/main/warehouse/malware>`_ - automated malware checks
+  - `manage/ <https://github.com/pypi/warehouse/tree/main/warehouse/manage>`_ - logged-in user functionality (i.e., manage account &
     owned/maintained projects)
-  - `metrics/ <https://github.com/pypi/warehouse/tree/master/warehouse/metrics>`_ - services for recording metrics
-  - `migrations/ <https://github.com/pypi/warehouse/tree/master/warehouse/migrations>`_ - changes to the database schema
-  - `packaging/ <https://github.com/pypi/warehouse/tree/master/warehouse/packaging>`_ - models
-  - `rate_limiting/ <https://github.com/pypi/warehouse/tree/master/warehouse/rate_limiting>`_ - rate limiting to prevent abuse
-  - `rss/ <https://github.com/pypi/warehouse/tree/master/warehouse/rss>`_ - RSS feeds: :doc:`api-reference/feeds`
-  - `search/ <https://github.com/pypi/warehouse/tree/master/warehouse/search>`_ - utilities for building and querying the search index
-  - `sitemap/ <https://github.com/pypi/warehouse/tree/master/warehouse/sitemap>`_ - site maps
-  - `sponsors/ <https://github.com/pypi/warehouse/tree/master/warehouse/sponsors>`_ - sponsors management
-  - `static/ <https://github.com/pypi/warehouse/tree/master/warehouse/static>`_ - static site assets
-  - `templates/ <https://github.com/pypi/warehouse/tree/master/warehouse/templates>`_ - Jinja templates for web pages, emails, etc.
-  - `utils/ <https://github.com/pypi/warehouse/tree/master/warehouse/utils>`_ - various utilities Warehouse uses
+  - `metrics/ <https://github.com/pypi/warehouse/tree/main/warehouse/metrics>`_ - services for recording metrics
+  - `migrations/ <https://github.com/pypi/warehouse/tree/main/warehouse/migrations>`_ - changes to the database schema
+  - `packaging/ <https://github.com/pypi/warehouse/tree/main/warehouse/packaging>`_ - models
+  - `rate_limiting/ <https://github.com/pypi/warehouse/tree/main/warehouse/rate_limiting>`_ - rate limiting to prevent abuse
+  - `rss/ <https://github.com/pypi/warehouse/tree/main/warehouse/rss>`_ - RSS feeds: :doc:`api-reference/feeds`
+  - `search/ <https://github.com/pypi/warehouse/tree/main/warehouse/search>`_ - utilities for building and querying the search index
+  - `sitemap/ <https://github.com/pypi/warehouse/tree/main/warehouse/sitemap>`_ - site maps
+  - `sponsors/ <https://github.com/pypi/warehouse/tree/main/warehouse/sponsors>`_ - sponsors management
+  - `static/ <https://github.com/pypi/warehouse/tree/main/warehouse/static>`_ - static site assets
+  - `templates/ <https://github.com/pypi/warehouse/tree/main/warehouse/templates>`_ - Jinja templates for web pages, emails, etc.
+  - `utils/ <https://github.com/pypi/warehouse/tree/main/warehouse/utils>`_ - various utilities Warehouse uses
 
 .. _Pyramid: https://docs.pylonsproject.org/projects/pyramid/en/latest/index.html
 .. _Docker: https://docs.docker.com/
@@ -157,7 +157,7 @@ may be used to from the legacy site, such as:
 - `HTTP access to APIs; now it's HTTPS-only <https://mail.python.org/pipermail/distutils-sig/2017-October/031712.html>`_
 
 - GPG/PGP signatures for packages (still visible in the :doc:`../api-reference/legacy/`
-  per `PEP 503 <https://www.python.org/dev/peps/pep-0503/>`_, but no
+  per `PEP 503 <https://peps.python.org/pep-0503/>`_, but no
   longer visible in the web UI)
 
 - `OpenID and Google auth login <https://mail.python.org/pipermail/distutils-sig/2018-January/031855.html>`_

--- a/docs/application.rst
+++ b/docs/application.rst
@@ -95,7 +95,7 @@ Directories within the repository:
   - `cache/ <https://github.com/pypi/warehouse/tree/main/warehouse/cache>`_ - caching
   - `classifiers/ <https://github.com/pypi/warehouse/tree/main/warehouse/classifiers>`_ - frame trove classifiers
   - `cli/ <https://github.com/pypi/warehouse/tree/main/warehouse/cli>`_ - entry scripts and
-    `the interactive shell <https://warehouse.pypa.io/development/getting-started/#running-the-interactive-shell>`_
+    :ref:`the interactive shell <running-the-interactive-shell>`
   - `email/ <https://github.com/pypi/warehouse/tree/main/warehouse/email>`_ - services for sending emails
   - `forklift/ <https://github.com/pypi/warehouse/tree/main/warehouse/forklift>`_ - :ref:`upload-api-forklift`
   - `i18n/ <https://github.com/pypi/warehouse/tree/main/warehouse/i18n>`_ - internationalization
@@ -139,7 +139,7 @@ may be used to from the legacy site, such as:
 - uploading to pythonhosted.com documentation hosting (`discussion and
   plans <https://github.com/pypi/warehouse/issues/582>`_)
 
-- `download counts visible in the API <https://warehouse.pypa.io/api-reference/xml-rpc/#changes-to-legacy-api>`_
+- :ref:`download counts visible in the API <changes-to-legacy-api>`
   (instead, use `the Google BigQuery service <https://packaging.python.org/guides/analyzing-pypi-package-downloads/>`_)
 
 - key management: PyPI no longer has a UI for users to manage GPG or

--- a/docs/application.rst
+++ b/docs/application.rst
@@ -13,7 +13,7 @@ The production deployment for Warehouse is deployed using
 
 In the development environment, we use several `Docker`_  containers
 orchestrated by `Docker Compose <https://docs.docker.com/compose/overview/>`__
-to `manage <https://github.com/pypa/warehouse/blob/master/docker-compose.yml#L3>`__
+to `manage <https://github.com/pypi/warehouse/blob/master/docker-compose.yml#L3>`__
 running the containers and the connections between them.
 
 Since Warehouse was built on top of an existing database (for legacy
@@ -84,39 +84,39 @@ The top-level directory of the Warehouse repo contains files including:
 
 Directories within the repository:
 
-- `bin/ <https://github.com/pypa/warehouse/tree/master/bin>`_ - high-level scripts for Docker, Continuous Integration, and Makefile commands
-- `dev/ <https://github.com/pypa/warehouse/tree/master/dev>`_ - assets for developer environment
-- `tests/ <https://github.com/pypa/warehouse/tree/master/tests>`_ - tests
-- `warehouse/ <https://github.com/pypa/warehouse/tree/master/warehouse>`_ - code in modules
+- `bin/ <https://github.com/pypi/warehouse/tree/master/bin>`_ - high-level scripts for Docker, Continuous Integration, and Makefile commands
+- `dev/ <https://github.com/pypi/warehouse/tree/master/dev>`_ - assets for developer environment
+- `tests/ <https://github.com/pypi/warehouse/tree/master/tests>`_ - tests
+- `warehouse/ <https://github.com/pypi/warehouse/tree/master/warehouse>`_ - code in modules
 
-  - `accounts/ <https://github.com/pypa/warehouse/tree/master/warehouse/accounts>`_ - user accounts
-  - `admin/ <https://github.com/pypa/warehouse/tree/master/warehouse/admin>`_ - application-administrator-specific
-  - `banners/ <https://github.com/pypa/warehouse/tree/master/warehouse/banners>`_ - notification banners
-  - `cache/ <https://github.com/pypa/warehouse/tree/master/warehouse/cache>`_ - caching
-  - `classifiers/ <https://github.com/pypa/warehouse/tree/master/warehouse/classifiers>`_ - frame trove classifiers
-  - `cli/ <https://github.com/pypa/warehouse/tree/master/warehouse/cli>`_ - entry scripts and
+  - `accounts/ <https://github.com/pypi/warehouse/tree/master/warehouse/accounts>`_ - user accounts
+  - `admin/ <https://github.com/pypi/warehouse/tree/master/warehouse/admin>`_ - application-administrator-specific
+  - `banners/ <https://github.com/pypi/warehouse/tree/master/warehouse/banners>`_ - notification banners
+  - `cache/ <https://github.com/pypi/warehouse/tree/master/warehouse/cache>`_ - caching
+  - `classifiers/ <https://github.com/pypi/warehouse/tree/master/warehouse/classifiers>`_ - frame trove classifiers
+  - `cli/ <https://github.com/pypi/warehouse/tree/master/warehouse/cli>`_ - entry scripts and
     `the interactive shell <https://warehouse.readthedocs.io/development/getting-started/#running-the-interactive-shell>`_
-  - `email/ <https://github.com/pypa/warehouse/tree/master/warehouse/email>`_ - services for sending emails
-  - `forklift/ <https://github.com/pypa/warehouse/tree/master/warehouse/forklift>`_ - :ref:`upload-api-forklift`
-  - `i18n/ <https://github.com/pypa/warehouse/tree/master/warehouse/i18n>`_ - internationalization
-  - `integrations/ <https://github.com/pypa/warehouse/tree/master/warehouse/integrations>`_ - integrations with other services
-  - `legacy/ <https://github.com/pypa/warehouse/tree/master/warehouse/legacy>`_ - most of the read-only APIs implemented here
-  - `locale/ <https://github.com/pypa/warehouse/tree/master/warehouse/locale>`_ - internationalization
-  - `macaroons/ <https://github.com/pypa/warehouse/tree/master/warehouse/macaroons>`_ - API token support
-  - `malware/ <https://github.com/pypa/warehouse/tree/master/warehouse/malware>`_ - automated malware checks
-  - `manage/ <https://github.com/pypa/warehouse/tree/master/warehouse/manage>`_ - logged-in user functionality (i.e., manage account &
+  - `email/ <https://github.com/pypi/warehouse/tree/master/warehouse/email>`_ - services for sending emails
+  - `forklift/ <https://github.com/pypi/warehouse/tree/master/warehouse/forklift>`_ - :ref:`upload-api-forklift`
+  - `i18n/ <https://github.com/pypi/warehouse/tree/master/warehouse/i18n>`_ - internationalization
+  - `integrations/ <https://github.com/pypi/warehouse/tree/master/warehouse/integrations>`_ - integrations with other services
+  - `legacy/ <https://github.com/pypi/warehouse/tree/master/warehouse/legacy>`_ - most of the read-only APIs implemented here
+  - `locale/ <https://github.com/pypi/warehouse/tree/master/warehouse/locale>`_ - internationalization
+  - `macaroons/ <https://github.com/pypi/warehouse/tree/master/warehouse/macaroons>`_ - API token support
+  - `malware/ <https://github.com/pypi/warehouse/tree/master/warehouse/malware>`_ - automated malware checks
+  - `manage/ <https://github.com/pypi/warehouse/tree/master/warehouse/manage>`_ - logged-in user functionality (i.e., manage account &
     owned/maintained projects)
-  - `metrics/ <https://github.com/pypa/warehouse/tree/master/warehouse/metrics>`_ - services for recording metrics
-  - `migrations/ <https://github.com/pypa/warehouse/tree/master/warehouse/migrations>`_ - changes to the database schema
-  - `packaging/ <https://github.com/pypa/warehouse/tree/master/warehouse/packaging>`_ - models
-  - `rate_limiting/ <https://github.com/pypa/warehouse/tree/master/warehouse/rate_limiting>`_ - rate limiting to prevent abuse
-  - `rss/ <https://github.com/pypa/warehouse/tree/master/warehouse/rss>`_ - RSS feeds: :doc:`api-reference/feeds`
-  - `search/ <https://github.com/pypa/warehouse/tree/master/warehouse/search>`_ - utilities for building and querying the search index
-  - `sitemap/ <https://github.com/pypa/warehouse/tree/master/warehouse/sitemap>`_ - site maps
-  - `sponsors/ <https://github.com/pypa/warehouse/tree/master/warehouse/sponsors>`_ - sponsors management
-  - `static/ <https://github.com/pypa/warehouse/tree/master/warehouse/static>`_ - static site assets
-  - `templates/ <https://github.com/pypa/warehouse/tree/master/warehouse/templates>`_ - Jinja templates for web pages, emails, etc.
-  - `utils/ <https://github.com/pypa/warehouse/tree/master/warehouse/utils>`_ - various utilities Warehouse uses
+  - `metrics/ <https://github.com/pypi/warehouse/tree/master/warehouse/metrics>`_ - services for recording metrics
+  - `migrations/ <https://github.com/pypi/warehouse/tree/master/warehouse/migrations>`_ - changes to the database schema
+  - `packaging/ <https://github.com/pypi/warehouse/tree/master/warehouse/packaging>`_ - models
+  - `rate_limiting/ <https://github.com/pypi/warehouse/tree/master/warehouse/rate_limiting>`_ - rate limiting to prevent abuse
+  - `rss/ <https://github.com/pypi/warehouse/tree/master/warehouse/rss>`_ - RSS feeds: :doc:`api-reference/feeds`
+  - `search/ <https://github.com/pypi/warehouse/tree/master/warehouse/search>`_ - utilities for building and querying the search index
+  - `sitemap/ <https://github.com/pypi/warehouse/tree/master/warehouse/sitemap>`_ - site maps
+  - `sponsors/ <https://github.com/pypi/warehouse/tree/master/warehouse/sponsors>`_ - sponsors management
+  - `static/ <https://github.com/pypi/warehouse/tree/master/warehouse/static>`_ - static site assets
+  - `templates/ <https://github.com/pypi/warehouse/tree/master/warehouse/templates>`_ - Jinja templates for web pages, emails, etc.
+  - `utils/ <https://github.com/pypi/warehouse/tree/master/warehouse/utils>`_ - various utilities Warehouse uses
 
 .. _Pyramid: https://docs.pylonsproject.org/projects/pyramid/en/latest/index.html
 .. _Docker: https://docs.docker.com/
@@ -137,7 +137,7 @@ may be used to from the legacy site, such as:
 - "hidden releases"
 
 - uploading to pythonhosted.com documentation hosting (`discussion and
-  plans <https://github.com/pypa/warehouse/issues/582>`_)
+  plans <https://github.com/pypi/warehouse/issues/582>`_)
 
 - `download counts visible in the API <https://warehouse.readthedocs.io/api-reference/xml-rpc/#changes-to-legacy-api>`_
   (instead, use `the Google BigQuery service <https://packaging.python.org/guides/analyzing-pypi-package-downloads/>`_)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,13 @@ exclude_patterns = ["_build"]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
+# Patterns to during `make linkcheck`
+linkcheck_ignore = [
+    r'http://localhost.*',
+    'http://134.122.111.11',  # example IP
+    'https://web.libera.chat/#pypa,#pypa-dev',  # can't visit anchors
+]
+
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -34,7 +34,7 @@ JavaScript tests use the `Jest testing framework <https://jestjs.io/>`_
 along with `jest-dom <https://github.com/testing-library/jest-dom>`_
 for assertion helpers. We can invoke Jest directly specify a particular
 test suite via ``node_modules/.bin/jest tests/frontend/<TEST_FILE>.js`` or
-add any of the `Jest CLI options <https://jestjs.io/docs/en/cli>`_ .
+add any of the `Jest CLI options <https://jestjs.io/docs/cli>`_ .
 All tests are located in the ``tests/frontend``.
 
 `Stimulus <https://stimulusjs.org/>`_ controller tests leverage on Jest
@@ -98,7 +98,7 @@ Exceptions to these rules include:
 
 We also allow both dashes and underscores in our class names, as we
 follow the `Nicholas Gallagher variation
-<http://nicolasgallagher.com/about-html-semantics-front-end-architecture/>`_
+<https://nicolasgallagher.com/about-html-semantics-front-end-architecture/>`_
 of the `BEM naming methodology <https://en.bem.info/>`_.
 
 More information on how BEM works can be found in `this article from

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -32,9 +32,9 @@ Detailed installation instructions
 
 Getting the Warehouse source code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`Fork <https://help.github.com/articles/fork-a-repo/>`_ the repository
+`Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_ the repository
 on `GitHub`_ and
-`clone <https://help.github.com/articles/cloning-a-repository/>`_ it to
+`clone <https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository>`_ it to
 your local machine:
 
 .. code-block:: console
@@ -42,8 +42,8 @@ your local machine:
     git clone git@github.com:YOUR-USERNAME/warehouse.git
 
 Add a `remote
-<https://help.github.com/articles/configuring-a-remote-for-a-fork/>`_ and
-regularly `sync <https://help.github.com/articles/syncing-a-fork/>`_ to make sure
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork>`_ and
+regularly `sync <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork>`_ to make sure
 you stay up-to-date with our repository:
 
 .. code-block:: console
@@ -421,7 +421,7 @@ compilation errors due to your system not including libraries
 or binaries required by some of Warehouse's dependencies.
 
 An example of such dependency is
-`psycopg2 <http://initd.org/psycopg/docs/install.html#prerequisites>`_
+`psycopg2 <https://www.psycopg.org/docs/install.html#prerequisites>`_
 which requires PostgreSQL binaries and will fail if not present.
 
 If there's a specific use case you think requires development outside
@@ -568,7 +568,7 @@ You can run linters, programs that check the code, with:
 
     make lint
 
-Warehouse uses `black <https://github.com/ambv/black>`_ for opinionated
+Warehouse uses `black <https://github.com/psf/black>`_ for opinionated
 formatting and linting. You can reformat with:
 
 .. code-block:: console
@@ -654,7 +654,7 @@ Resources to help you learn Warehouse's context:
 
 .. _`pip`: https://pypi.org/project/pip
 .. _`sphinx`: https://pypi.org/project/Sphinx
-.. _`reStructured Text`: http://sphinx-doc.org/rest.html
+.. _`reStructured Text`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _`open issues that are labelled "good first issue"`: https://github.com/pypi/warehouse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 .. _`GitHub`: https://github.com/pypi/warehouse
 .. _`on Libera`: https://web.libera.chat/#pypa,#pypa-dev

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -489,6 +489,8 @@ Styles are written in the scss variant of Sass and compiled using
 ``make serve`` is running.
 
 
+.. _running-the-interactive-shell:
+
 Running the Interactive Shell
 -----------------------------
 

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -48,7 +48,7 @@ you stay up-to-date with our repository:
 
 .. code-block:: console
 
-    git remote add upstream https://github.com/pypa/warehouse.git
+    git remote add upstream https://github.com/pypi/warehouse.git
     git checkout main
     git fetch upstream
     git merge upstream/main
@@ -398,7 +398,7 @@ migrations. Try modifying your Docker configuration to allow more RAM for each
 container, temporarily stop ``make_serve`` and run ``make initdb`` again.
 
 This may also be due to enabling Compose V2 (see
-https://github.com/pypa/warehouse/issues/10772 for more details).
+https://github.com/pypi/warehouse/issues/10772 for more details).
 
 
 ``make initdb`` complains about PostgreSQL Version
@@ -426,7 +426,7 @@ which requires PostgreSQL binaries and will fail if not present.
 
 If there's a specific use case you think requires development outside
 Docker please raise an issue in
-`Warehouse's issue tracker <https://github.com/pypa/warehouse/issues>`_.
+`Warehouse's issue tracker <https://github.com/pypi/warehouse/issues>`_.
 
 
 Disabling services locally
@@ -655,8 +655,8 @@ Resources to help you learn Warehouse's context:
 .. _`pip`: https://pypi.org/project/pip
 .. _`sphinx`: https://pypi.org/project/Sphinx
 .. _`reStructured Text`: http://sphinx-doc.org/rest.html
-.. _`open issues that are labelled "good first issue"`: https://github.com/pypa/warehouse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
-.. _`GitHub`: https://github.com/pypa/warehouse
+.. _`open issues that are labelled "good first issue"`: https://github.com/pypi/warehouse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+.. _`GitHub`: https://github.com/pypi/warehouse
 .. _`on Libera`: https://web.libera.chat/#pypa,#pypa-dev
 .. _`Discourse` : https://discuss.python.org/c/packaging/14
 .. _`PyPA Discord` : https://discord.gg/pypa

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -40,7 +40,7 @@ Get involved or find help using:
     malware-checks
     token-scanning
 
-.. _`GitHub`: https://github.com/pypa/warehouse
+.. _`GitHub`: https://github.com/pypi/warehouse
 .. _`"What to put in your bug report"`: http://www.contribution-guide.org/#what-to-put-in-your-bug-report
 .. _`Libera`: https://web.libera.chat/#pypa,#pypa-dev
 .. _`PyPA Discord`: https://discord.gg/pypa

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -41,7 +41,7 @@ Get involved or find help using:
     token-scanning
 
 .. _`GitHub`: https://github.com/pypi/warehouse
-.. _`"What to put in your bug report"`: http://www.contribution-guide.org/#what-to-put-in-your-bug-report
+.. _`"What to put in your bug report"`: https://www.contribution-guide.org/#what-to-put-in-your-bug-report
 .. _`Libera`: https://web.libera.chat/#pypa,#pypa-dev
 .. _`PyPA Discord`: https://discord.gg/pypa
 .. _`Discourse`: https://discuss.python.org/c/packaging/14

--- a/docs/development/malware-checks.rst
+++ b/docs/development/malware-checks.rst
@@ -169,23 +169,23 @@ uploads. This system was initially rolled out in February 2020 by
 
 
 .. |VerdictLifecycle| image:: ../_static/verdict-lifecycle.png
-.. _IMalwareCheckService: https://github.com/pypa/warehouse/blob/master/warehouse/malware/interfaces.py
-.. _DatabaseMalwareCheckService: https://github.com/pypa/warehouse/blob/master/warehouse/malware/services.py
+.. _IMalwareCheckService: https://github.com/pypi/warehouse/blob/master/warehouse/malware/interfaces.py
+.. _DatabaseMalwareCheckService: https://github.com/pypi/warehouse/blob/master/warehouse/malware/services.py
 .. _celery crontab: http://docs.celeryproject.org/en/latest/reference/celery.schedules.html#celery.schedules.crontab
-.. _prepare classmethod:  https://github.com/pypa/warehouse/blob/master/warehouse/malware/checks/base.py
-.. _MalwareVerdict model: https://github.com/pypa/warehouse/blob/master/warehouse/malware/models.py
+.. _prepare classmethod:  https://github.com/pypi/warehouse/blob/master/warehouse/malware/checks/base.py
+.. _MalwareVerdict model: https://github.com/pypi/warehouse/blob/master/warehouse/malware/models.py
 .. |CheckLifecycle| image:: ../_static/check-lifecycle.png
-.. _opening an issue: https://github.com/pypa/warehouse/issues/new?template=malware-check.md
+.. _opening an issue: https://github.com/pypi/warehouse/issues/new?template=malware-check.md
 .. _open a pull request to main: submitting-patches/
-.. _tests/common/checks/: https://github.com/pypa/warehouse/tree/master/tests/common/checks/
-.. _warehouse/malware/checks/: https://github.com/pypa/warehouse/tree/master/warehouse/malware/checks
-.. _dunder init file: https://github.com/pypa/warehouse/tree/master/warehouse/malware/checks/__init__.py
+.. _tests/common/checks/: https://github.com/pypi/warehouse/tree/master/tests/common/checks/
+.. _warehouse/malware/checks/: https://github.com/pypi/warehouse/tree/master/warehouse/malware/checks
+.. _dunder init file: https://github.com/pypi/warehouse/tree/master/warehouse/malware/checks/__init__.py
 .. _Getting Started: ../getting-started/#detailed-installation-instructions
-.. _dev/environment: https://github.com/pypa/warehouse/tree/master/dev/environment
+.. _dev/environment: https://github.com/pypi/warehouse/tree/master/dev/environment
 .. _twine: https://twine.readthedocs.io/en/latest/
-.. _tests directory: https://github.com/pypa/warehouse/blob/master/tests/unit/malware/checks
+.. _tests directory: https://github.com/pypi/warehouse/blob/master/tests/unit/malware/checks
 .. _Submitting Patches: submitting-patches/
-.. _SetupPatternCheck: https://github.com/pypa/warehouse/blob/master/warehouse/malware/checks/setup_patterns/check.py
-.. _PackageTurnoverCheck: https://github.com/pypa/warehouse/blob/master/warehouse/malware/checks/package_turnover/check.py
+.. _SetupPatternCheck: https://github.com/pypi/warehouse/blob/master/warehouse/malware/checks/setup_patterns/check.py
+.. _PackageTurnoverCheck: https://github.com/pypi/warehouse/blob/master/warehouse/malware/checks/package_turnover/check.py
 .. _Request for Proposal: https://github.com/python/request-for/blob/master/2019-Q4-PyPI/RFP.md#milestone-2---systems-for-automated-detection-of-malicious-uploads
-.. _pull request 7377: https://github.com/pypa/warehouse/pull/7377
+.. _pull request 7377: https://github.com/pypi/warehouse/pull/7377

--- a/docs/development/malware-checks.rst
+++ b/docs/development/malware-checks.rst
@@ -169,23 +169,22 @@ uploads. This system was initially rolled out in February 2020 by
 
 
 .. |VerdictLifecycle| image:: ../_static/verdict-lifecycle.png
-.. _IMalwareCheckService: https://github.com/pypi/warehouse/blob/master/warehouse/malware/interfaces.py
-.. _DatabaseMalwareCheckService: https://github.com/pypi/warehouse/blob/master/warehouse/malware/services.py
+.. _IMalwareCheckService: https://github.com/pypi/warehouse/blob/main/warehouse/malware/interfaces.py
+.. _DatabaseMalwareCheckService: https://github.com/pypi/warehouse/blob/main/warehouse/malware/services.py
 .. _celery crontab: http://docs.celeryproject.org/en/latest/reference/celery.schedules.html#celery.schedules.crontab
-.. _prepare classmethod:  https://github.com/pypi/warehouse/blob/master/warehouse/malware/checks/base.py
-.. _MalwareVerdict model: https://github.com/pypi/warehouse/blob/master/warehouse/malware/models.py
+.. _prepare classmethod:  https://github.com/pypi/warehouse/blob/main/warehouse/malware/checks/base.py
+.. _MalwareVerdict model: https://github.com/pypi/warehouse/blob/main/warehouse/malware/models.py
 .. |CheckLifecycle| image:: ../_static/check-lifecycle.png
 .. _opening an issue: https://github.com/pypi/warehouse/issues/new?template=malware-check.md
 .. _open a pull request to main: submitting-patches/
-.. _tests/common/checks/: https://github.com/pypi/warehouse/tree/master/tests/common/checks/
-.. _warehouse/malware/checks/: https://github.com/pypi/warehouse/tree/master/warehouse/malware/checks
-.. _dunder init file: https://github.com/pypi/warehouse/tree/master/warehouse/malware/checks/__init__.py
-.. _Getting Started: ../getting-started/#detailed-installation-instructions
-.. _dev/environment: https://github.com/pypi/warehouse/tree/master/dev/environment
+.. _tests/common/checks/: https://github.com/pypi/warehouse/tree/main/tests/common/checks/
+.. _warehouse/malware/checks/: https://github.com/pypi/warehouse/tree/main/warehouse/malware/checks
+.. _dunder init file: https://github.com/pypi/warehouse/blob/main/warehouse/malware/checks/__init__.py
+.. _dev/environment: https://github.com/pypi/warehouse/blob/main/dev/environment
 .. _twine: https://twine.readthedocs.io/en/latest/
-.. _tests directory: https://github.com/pypi/warehouse/blob/master/tests/unit/malware/checks
+.. _tests directory: https://github.com/pypi/warehouse/tree/main/tests/unit/malware/checks
 .. _Submitting Patches: submitting-patches/
-.. _SetupPatternCheck: https://github.com/pypi/warehouse/blob/master/warehouse/malware/checks/setup_patterns/check.py
-.. _PackageTurnoverCheck: https://github.com/pypi/warehouse/blob/master/warehouse/malware/checks/package_turnover/check.py
+.. _SetupPatternCheck: https://github.com/pypi/warehouse/blob/main/warehouse/malware/checks/setup_patterns/check.py
+.. _PackageTurnoverCheck: https://github.com/pypi/warehouse/blob/main/warehouse/malware/checks/package_turnover/check.py
 .. _Request for Proposal: https://github.com/python/request-for/blob/master/2019-Q4-PyPI/RFP.md#milestone-2---systems-for-automated-detection-of-malicious-uploads
 .. _pull request 7377: https://github.com/pypi/warehouse/pull/7377

--- a/docs/development/malware-checks.rst
+++ b/docs/development/malware-checks.rst
@@ -171,7 +171,7 @@ uploads. This system was initially rolled out in February 2020 by
 .. |VerdictLifecycle| image:: ../_static/verdict-lifecycle.png
 .. _IMalwareCheckService: https://github.com/pypi/warehouse/blob/main/warehouse/malware/interfaces.py
 .. _DatabaseMalwareCheckService: https://github.com/pypi/warehouse/blob/main/warehouse/malware/services.py
-.. _celery crontab: http://docs.celeryproject.org/en/latest/reference/celery.schedules.html#celery.schedules.crontab
+.. _celery crontab: https://docs.celeryq.dev/en/latest/reference/celery.schedules.html#celery.schedules.crontab
 .. _prepare classmethod:  https://github.com/pypi/warehouse/blob/main/warehouse/malware/checks/base.py
 .. _MalwareVerdict model: https://github.com/pypi/warehouse/blob/main/warehouse/malware/models.py
 .. |CheckLifecycle| image:: ../_static/check-lifecycle.png

--- a/docs/development/malware-checks.rst
+++ b/docs/development/malware-checks.rst
@@ -30,7 +30,7 @@ Check Lifecycle
 Ideas for new malware checks should first be shared by `opening an issue`_.
 This will initiate a discussion with PyPI administrators and among the broader
 Python community about the impact of the proposed check. After soliciting
-feedback, `open a pull request to main`_ containing the code for the new check,
+feedback, :doc:`open a pull request to main <submitting-patches>` containing the code for the new check,
 unit tests, and accompanying documentation. Once the code is reviewed and merged,
 it will automatically be deployed to production. PyPI administrators can begin
 evaluating the malware check by moving it into the `evaluation` state in the check
@@ -101,7 +101,7 @@ Workflow and Testing
 There are a few steps for executing new malware checks in a development
 environment:
 
-#. Complete the `Getting Started`_ instructions to setup a Warehouse
+#. Complete the :ref:`Getting Started <dev-env-install>` instructions to setup a Warehouse
    development environment
 #. Open `dev/environment`_ and set the ``MALWARE_CHECK_BACKEND`` variable
 
@@ -141,7 +141,7 @@ environment:
       twine upload --repository-url http://localhost/legacy/ dist/*
 
 Once you've manually validated the basic functioning of your check, add tests
-to the `tests directory`_. See `Submitting Patches`_ for more information about
+to the `tests directory`_. See :doc:`submitting-patches` for more information about
 how to contribute.
 
 Existing Checks
@@ -176,14 +176,12 @@ uploads. This system was initially rolled out in February 2020 by
 .. _MalwareVerdict model: https://github.com/pypi/warehouse/blob/main/warehouse/malware/models.py
 .. |CheckLifecycle| image:: ../_static/check-lifecycle.png
 .. _opening an issue: https://github.com/pypi/warehouse/issues/new?template=malware-check.md
-.. _open a pull request to main: submitting-patches/
 .. _tests/common/checks/: https://github.com/pypi/warehouse/tree/main/tests/common/checks/
 .. _warehouse/malware/checks/: https://github.com/pypi/warehouse/tree/main/warehouse/malware/checks
 .. _dunder init file: https://github.com/pypi/warehouse/blob/main/warehouse/malware/checks/__init__.py
 .. _dev/environment: https://github.com/pypi/warehouse/blob/main/dev/environment
 .. _twine: https://twine.readthedocs.io/en/latest/
 .. _tests directory: https://github.com/pypi/warehouse/tree/main/tests/unit/malware/checks
-.. _Submitting Patches: submitting-patches/
 .. _SetupPatternCheck: https://github.com/pypi/warehouse/blob/main/warehouse/malware/checks/setup_patterns/check.py
 .. _PackageTurnoverCheck: https://github.com/pypi/warehouse/blob/main/warehouse/malware/checks/package_turnover/check.py
 .. _Request for Proposal: https://github.com/python/request-for/blob/master/2019-Q4-PyPI/RFP.md#milestone-2---systems-for-automated-detection-of-malicious-uploads

--- a/docs/development/malware-checks.rst
+++ b/docs/development/malware-checks.rst
@@ -101,8 +101,8 @@ Workflow and Testing
 There are a few steps for executing new malware checks in a development
 environment:
 
-#. Complete the :ref:`Getting Started <dev-env-install>` instructions to setup a Warehouse
-   development environment
+#. Complete the :ref:`Getting Started <dev-env-install>` instructions to setup
+   a Warehouse development environment
 #. Open `dev/environment`_ and set the ``MALWARE_CHECK_BACKEND`` variable
 
     .. code-block:: bash

--- a/docs/development/patterns.rst
+++ b/docs/development/patterns.rst
@@ -109,4 +109,4 @@ Class                     Method
 
 .. |pip-tools| replace:: ``pip-tools``
 .. _pip-tools: https://pypi.org/project/pip-tools/
-.. _Dependabot pull requests: https://github.com/pypa/warehouse/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies
+.. _Dependabot pull requests: https://github.com/pypi/warehouse/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies

--- a/docs/development/reviewing-patches.rst
+++ b/docs/development/reviewing-patches.rst
@@ -58,8 +58,8 @@ Has this output:
 
   origin  https://github.com/<username>/warehouse.git (fetch)
   origin  https://github.com/<username>/warehouse.git (push)
-  upstream  https://github.com/pypa/warehouse.git (fetch)
-  upstream  https://github.com/pypa/warehouse.git (push)
+  upstream  https://github.com/pypi/warehouse.git (fetch)
+  upstream  https://github.com/pypi/warehouse.git (push)
 
 In this output, ``<username>`` is your GitHub username. If you do not have an
 ``upstream`` branch configured, you can add one by running the following

--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -73,7 +73,7 @@ necessary to update references to these files any time source strings are change
 line numbers of the source strings in the source files. This can be done by running ``make translations``.
 
 For instructions on how to mark strings and views for translation,
-see the `Translation Docs`_.
+see the :doc:`../translations` docs.
 
 
 Keeping your local branch updated
@@ -190,4 +190,3 @@ feature branch at least once while you are working on it.
 .. _`doc8`: https://github.com/PyCQA/doc8
 .. _`coverage.py`: https://pypi.org/project/coverage
 .. _`the Black Code Style`: https://github.com/psf/black#the-black-code-style
-.. _`Translation Docs`: https://warehouse.pypa.io/translations/

--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -184,10 +184,10 @@ as dependency upgrades are merged, so you will probably have to update your
 feature branch at least once while you are working on it.
 
 
-.. _`Write comments as complete sentences.`: http://nedbatchelder.com/blog/201401/comments_should_be_sentences.html
-.. _`syntax`: http://sphinx-doc.org/domains.html#info-field-lists
-.. _`Studies have shown`: https://smartbear.com/smartbear/media/pdfs/wp-cc-11-best-practices-of-peer-code-review.pdf
-.. _`doc8`: https://github.com/stackforge/doc8
+.. _`Write comments as complete sentences.`: https://nedbatchelder.com/blog/201401/comments_should_be_sentences.html
+.. _`syntax`: https://sphinx-doc.org/domains.html#info-field-lists
+.. _`Studies have shown`: https://static1.smartbear.co/support/media/resources/cc/book/code-review-cisco-case-study.pdf
+.. _`doc8`: https://github.com/PyCQA/doc8
 .. _`coverage.py`: https://pypi.org/project/coverage
-.. _`the Black Code Style`: https://github.com/ambv/black#the-black-code-style
-.. _`Translation Docs`: https://warehouse.readthedocs.io/translations/
+.. _`the Black Code Style`: https://github.com/psf/black#the-black-code-style
+.. _`Translation Docs`: https://warehouse.pypa.io/translations/

--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -97,8 +97,8 @@ Your output looks like this:
 
   origin  https://github.com/username/warehouse.git (fetch)
   origin  https://github.com/username/warehouse.git (push)
-  upstream  https://github.com/pypa/warehouse.git (fetch)
-  upstream  https://github.com/pypa/warehouse.git (push)
+  upstream  https://github.com/pypi/warehouse.git (fetch)
+  upstream  https://github.com/pypi/warehouse.git (push)
 
 
 In the example above, ``<username>`` is your username on GitHub.

--- a/docs/development/token-scanning.rst
+++ b/docs/development/token-scanning.rst
@@ -34,7 +34,7 @@ tokens identified within a "push" event, they send us reports in bulk. The
 format is explained thouroughly in `their doc
 <https://docs.github.com/en/developers/overview/secret-scanning>`_ as well as
 in the `warehouse implementation ticket
-<https://github.com/pypa/warehouse/issues/6051>`_.
+<https://github.com/pypi/warehouse/issues/6051>`_.
 
 In short: they send us a cryptographically signed payload describing each
 leaked token alongside with a public URL pointing to it.
@@ -74,7 +74,7 @@ GitLab Secret Detection
 
 GitLab also has an equivalent mechanism, named "Secret Detection", not
 implemented in Warehouse yet (see `#9280
-<https://github.com/pypa/warehouse/issues/9280>`_).
+<https://github.com/pypi/warehouse/issues/9280>`_).
 
 PyPI token disclosure infrastructure
 ------------------------------------

--- a/docs/development/token-scanning.rst
+++ b/docs/development/token-scanning.rst
@@ -32,7 +32,7 @@ GitHub's Token scanning feature used to be called "Token Scanning" and is now
 the regex above (actually the limit to at least 130 characters long). For all
 tokens identified within a "push" event, they send us reports in bulk. The
 format is explained thouroughly in `their doc
-<https://docs.github.com/en/developers/overview/secret-scanning>`_ as well as
+<https://docs.github.com/en/developers/overview/secret-scanning-partner-program>`_ as well as
 in the `warehouse implementation ticket
 <https://github.com/pypi/warehouse/issues/6051>`_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,5 +35,5 @@ Indices and tables
 * :ref:`search`
 
 .. _`Python package index (repository)`: https://packaging.python.org/glossary/#term-package-index
-.. _`web application`: https://github.com/pypa/warehouse
+.. _`web application`: https://github.com/pypi/warehouse
 .. _PyPI: https://pypi.org

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -77,14 +77,14 @@ Sprint planners should consider the following checklist for organising events:
   useful for large issues, or for newer developers.
 
 .. _`security, accessibility, and localization work funded by the Open Technology Fund`: https://pyfound.blogspot.com/2019/03/commencing-security-accessibility-and.html
-.. _`two-factor authentication for PyPI`: https://github.com/pypa/warehouse/issues/996
-.. _`Security milestone`: https://github.com/pypa/warehouse/milestone/13
-.. _`accessibility milestone`: https://github.com/pypa/warehouse/milestone/15
-.. _`localisation milestone`: https://github.com/pypa/warehouse/milestone/14
-.. _`package signing & detection/verification milestone`: https://github.com/pypa/warehouse/milestone/16
+.. _`two-factor authentication for PyPI`: https://github.com/pypi/warehouse/issues/996
+.. _`Security milestone`: https://github.com/pypi/warehouse/milestone/13
+.. _`accessibility milestone`: https://github.com/pypi/warehouse/milestone/15
+.. _`localisation milestone`: https://github.com/pypi/warehouse/milestone/14
+.. _`package signing & detection/verification milestone`: https://github.com/pypi/warehouse/milestone/16
 .. _`This work is funded by a gift from Facebook.`: https://pyfound.blogspot.com/2018/12/upcoming-pypi-improvements-for-2019.html
-.. _`issues marked with the post-legacy shutdown milestone`: https://github.com/pypa/warehouse/milestone/12
-.. _`issues marked with the cool-but-not-urgent milestone`: https://github.com/pypa/warehouse/milestone/11
-.. _`contact us`: https://github.com/pypa/warehouse/blob/master/README.rst#discussion
+.. _`issues marked with the post-legacy shutdown milestone`: https://github.com/pypi/warehouse/milestone/12
+.. _`issues marked with the cool-but-not-urgent milestone`: https://github.com/pypi/warehouse/milestone/11
+.. _`contact us`: https://github.com/pypi/warehouse/blob/master/README.rst#discussion
 .. _`our past roadmap`: https://wiki.python.org/psf/WarehouseRoadmap
 .. _`sprints`: https://wiki.python.org/psf/PackagingSprints

--- a/docs/translations.rst
+++ b/docs/translations.rst
@@ -6,7 +6,7 @@ We use `Weblate <https://weblate.org/>`_ to manage PyPI translations across seve
 to contribute.
 
 If you are experiencing issues as a translator, please let us know by opening a
-`translation issue on the Warehouse issue tracker <https://github.com/pypa/warehouse/issues/new?template=translation-issue.md>`_.
+`translation issue on the Warehouse issue tracker <https://github.com/pypi/warehouse/issues/new?template=translation-issue.md>`_.
 
 Adding a newly completed translation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -20,7 +20,7 @@ it's MO file (Machine Object file) compiled.
 To add a new known locale:
 
 1. Check for `outstanding Weblate pull requests
-   <https://github.com/pypa/warehouse/pulls/weblate>`_ and merge them if so.
+   <https://github.com/pypi/warehouse/pulls/weblate>`_ and merge them if so.
 2. In a new branch, add a key/value to the ``KNOWN_LOCALES`` mapping in
    |warehouse/i18n/__init__.py|_.
    The key is the locale code, and corresponds to a directory in
@@ -28,7 +28,7 @@ To add a new known locale:
 3. Commit these changes and make a new pull request.
 
 .. |warehouse/i18n/__init__.py| replace:: ``warehouse/i18n/__init__.py``
-.. _warehouse/i18n/__init__.py: https://github.com/pypa/warehouse/blob/master/warehouse/i18n/__init__.py
+.. _warehouse/i18n/__init__.py: https://github.com/pypi/warehouse/blob/master/warehouse/i18n/__init__.py
 
 Marking new strings for translation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/translations.rst
+++ b/docs/translations.rst
@@ -28,7 +28,7 @@ To add a new known locale:
 3. Commit these changes and make a new pull request.
 
 .. |warehouse/i18n/__init__.py| replace:: ``warehouse/i18n/__init__.py``
-.. _warehouse/i18n/__init__.py: https://github.com/pypi/warehouse/blob/master/warehouse/i18n/__init__.py
+.. _warehouse/i18n/__init__.py: https://github.com/pypi/warehouse/blob/main/warehouse/i18n/__init__.py
 
 Marking new strings for translation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ui-principles.rst
+++ b/docs/ui-principles.rst
@@ -69,7 +69,7 @@ Warehouse follows the `Material design writing style guide
 When writing interfaces use direct, clear and simple language. This is
 especially important as Warehouse caters to an international audience with
 varying proficiency in English. If you're unsure, `check the readability of
-your text <http://www.webpagefx.com/tools/read-able/>`_.
+your text <https://www.webpagefx.com/tools/read-able/>`_.
 For consistency, we prefer using American English spellings over British
 English.
 

--- a/docs/ui-principles.rst
+++ b/docs/ui-principles.rst
@@ -28,12 +28,12 @@ When working on the UI:
 
 - Ensure contrast is high, particularly on text. This can be checked:
    - On Chrome by installing `Accessibility Developer Tools
-     <http://bit.ly/1ikZ68B>`_
+     <https://bit.ly/1ikZ68B>`_
    - On Firefox by installing the `WCAG Contrast Checker
-     <https://addons.mozilla.org/en-us/firefox/addon/wcag-contrast-checker/>`_
+     <https://addons.mozilla.org/en-US/firefox/addon/wcag-contrast-checker/>`_
 - Write `semantic HTML <https://en.wikipedia.org/wiki/Semantic_HTML>`_
 - Ensure image `alt tags are present and meaningful
-  <http://webaim.org/techniques/alttext/>`_
+  <https://webaim.org/techniques/alttext/>`_
 - Add labels to all form fields (if you want to hide a label visually but leave
   it readable to screen readers, apply ``.sr-only``)
 - Where possible add `ARIA roles
@@ -69,7 +69,7 @@ Warehouse follows the `Material design writing style guide
 When writing interfaces use direct, clear and simple language. This is
 especially important as Warehouse caters to an international audience with
 varying proficiency in English. If you're unsure, `check the readability of
-your text <https://www.webpagefx.com/tools/read-able/>`_.
+your text <https://www.webfx.com/tools/read-able/>`_.
 For consistency, we prefer using American English spellings over British
 English.
 

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -53,7 +53,7 @@ redis>=2.8.0,<5.0.0
 rfc3986
 sentry-sdk
 setuptools
-sqlalchemy[asyncio]>=0.9,<1.5.0  # https://github.com/pypa/warehouse/pull/9228
+sqlalchemy[asyncio]>=0.9,<1.5.0  # https://github.com/pypi/warehouse/pull/9228
 sqlalchemy-citext
 sqlalchemy-utils
 stdlib-list

--- a/tests/functional/test_templates.py
+++ b/tests/functional/test_templates.py
@@ -39,7 +39,7 @@ FILTERS = {
 def test_templates_for_empty_titles():
     """
     Test if all HTML templates have defined the title block. See
-    https://github.com/pypa/warehouse/issues/784
+    https://github.com/pypi/warehouse/issues/784
     """
     dir_name = os.path.join(os.path.dirname(warehouse.__file__), "templates")
 
@@ -76,7 +76,7 @@ def test_templates_for_empty_titles():
 def test_render_templates():
     """
     Test if all HTML templates are rendered without Jinja exceptions.
-    see https://github.com/pypa/warehouse/issues/6634
+    see https://github.com/pypi/warehouse/issues/6634
     """
     dir_name = os.path.join(os.path.dirname(warehouse.__file__), "templates")
 

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -379,7 +379,7 @@ class TestRelease:
                 "https://api.github.com/repos/pypa/warehouse",
             ),
             (
-                "https://github.com/pypi/warehouse/tree/master",
+                "https://github.com/pypi/warehouse/tree/main",
                 "https://api.github.com/repos/pypa/warehouse",
             ),
             (

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -372,22 +372,22 @@ class TestRelease:
             (None, None),
             (
                 "https://github.com/pypi/warehouse",
-                "https://api.github.com/repos/pypa/warehouse",
+                "https://api.github.com/repos/pypi/warehouse",
             ),
             (
                 "https://github.com/pypi/warehouse/",
-                "https://api.github.com/repos/pypa/warehouse",
+                "https://api.github.com/repos/pypi/warehouse",
             ),
             (
                 "https://github.com/pypi/warehouse/tree/main",
-                "https://api.github.com/repos/pypa/warehouse",
+                "https://api.github.com/repos/pypi/warehouse",
             ),
             (
-                "https://www.github.com/pypa/warehouse",
-                "https://api.github.com/repos/pypa/warehouse",
+                "https://www.github.com/pypi/warehouse",
+                "https://api.github.com/repos/pypi/warehouse",
             ),
             ("https://github.com/pypa/", None),
-            ("https://google.com/pypa/warehouse/tree/master", None),
+            ("https://google.com/pypi/warehouse/tree/main", None),
             ("https://google.com", None),
             ("incorrect url", None),
         ],

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -371,15 +371,15 @@ class TestRelease:
         [
             (None, None),
             (
-                "https://github.com/pypa/warehouse",
+                "https://github.com/pypi/warehouse",
                 "https://api.github.com/repos/pypa/warehouse",
             ),
             (
-                "https://github.com/pypa/warehouse/",
+                "https://github.com/pypi/warehouse/",
                 "https://api.github.com/repos/pypa/warehouse",
             ),
             (
-                "https://github.com/pypa/warehouse/tree/master",
+                "https://github.com/pypi/warehouse/tree/master",
                 "https://api.github.com/repos/pypa/warehouse",
             ),
             (

--- a/warehouse/cache/origin/__init__.py
+++ b/warehouse/cache/origin/__init__.py
@@ -118,7 +118,7 @@ def key_maker_factory(cache_keys, purge_keys):
             # a limit to how many surrogate keys we can attach to a single HTTP
             # response, and being able to use use `iterate_on` would allow this
             # size to be unbounded.
-            # ref: https://github.com/pypa/warehouse/pull/3189
+            # ref: https://github.com/pypi/warehouse/pull/3189
             cache=[k.format(obj=obj) for k in cache_keys],
             purge=chain.from_iterable(key(obj) for key in purge_keys),
         )

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -793,8 +793,8 @@ def file_upload(request):
 
     # Ensure that user has a verified, primary email address. This should both
     # reduce the ease of spam account creation and activity, as well as act as
-    # a forcing function for https://github.com/pypa/warehouse/issues/3632.
-    # TODO: Once https://github.com/pypa/warehouse/issues/3632 has been solved,
+    # a forcing function for https://github.com/pypi/warehouse/issues/3632.
+    # TODO: Once https://github.com/pypi/warehouse/issues/3632 has been solved,
     #       we might consider a different condition, possibly looking at
     #       User.is_active instead.
     if not (request.user.primary_email and request.user.primary_email.verified):
@@ -833,8 +833,8 @@ def file_upload(request):
     # Check if any fields were supplied as a tuple and have become a
     # FieldStorage. The 'content' and 'gpg_signature' fields _should_ be a
     # FieldStorage, however.
-    # ref: https://github.com/pypa/warehouse/issues/2185
-    # ref: https://github.com/pypa/warehouse/issues/2491
+    # ref: https://github.com/pypi/warehouse/issues/2185
+    # ref: https://github.com/pypi/warehouse/issues/2491
     for field in set(request.POST) - {"content", "gpg_signature"}:
         values = request.POST.getall(field)
         if any(isinstance(value, FieldStorage) for value in values):
@@ -1224,7 +1224,7 @@ def file_upload(request):
                 # Note: Changing this error message to something that doesn't
                 # start with "File already exists" will break the
                 # --skip-existing functionality in twine
-                # ref: https://github.com/pypa/warehouse/issues/3482
+                # ref: https://github.com/pypi/warehouse/issues/3482
                 # ref: https://github.com/pypa/twine/issues/332
                 "File already exists. See "
                 + request.help_url(_anchor="file-name-reuse")

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -621,7 +621,7 @@ msgstr ""
 
 #: warehouse/templates/500.html:37
 msgid ""
-"Consider <a href=\"https://github.com/pypa/warehouse\" target=\"_blank\" "
+"Consider <a href=\"https://github.com/pypi/warehouse\" target=\"_blank\" "
 "rel=\"noopener\"> contributing </a> or <a "
 "href=\"https://psfmember.org/civicrm/contribute/transact?reset=1&id=13\" "
 "target=\"_blank\" rel=\"noopener\"> donating </a> to help us build a more"

--- a/warehouse/macaroons/caveats.py
+++ b/warehouse/macaroons/caveats.py
@@ -29,7 +29,7 @@ class Caveat:
     def __init__(self, verifier):
         self.verifier = verifier
         # TODO: Surface this failure reason to the user.
-        # See: https://github.com/pypa/warehouse/issues/9018
+        # See: https://github.com/pypi/warehouse/issues/9018
         self.failure_reason = None
 
     def verify(self, predicate) -> bool:

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -331,7 +331,7 @@ def update_bigquery_release_files(task, request, dist_metadata):
                 # str instead of a list, hence, this workaround to comply
                 # with PEP 345 and the Core Metadata specifications.
                 # This extra check can be removed once
-                # https://github.com/pypa/warehouse/issues/8257 is fixed
+                # https://github.com/pypi/warehouse/issues/8257 is fixed
                 if isinstance(field_data, str):
                     json_rows[sch.name] = [field_data]
                 else:
@@ -392,7 +392,7 @@ def sync_bigquery_release_files(request):
                     # str instead of a list, hence, this workaround to comply
                     # with PEP 345 and the Core Metadata specifications.
                     # This extra check can be removed once
-                    # https://github.com/pypa/warehouse/issues/8257 is fixed
+                    # https://github.com/pypi/warehouse/issues/8257 is fixed
                     if isinstance(field_data, str):
                         row_data[sch.name] = [field_data]
                     else:

--- a/warehouse/templates/500.html
+++ b/warehouse/templates/500.html
@@ -36,7 +36,7 @@
       {% trans %}Rely on PyPI to get your job done?{% endtrans %}<br>
       {% trans trimmed %}
       Consider
-      <a href="https://github.com/pypa/warehouse" target="_blank" rel="noopener">
+      <a href="https://github.com/pypi/warehouse" target="_blank" rel="noopener">
         contributing
       </a>
       or

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -281,9 +281,9 @@
           <nav aria-label="{% trans %}How to contribute navigation{% endtrans %}">
             <ul>
               <li><a href="{{ request.route_path('help')}}#feedback">{% trans %}Bugs and feedback{% endtrans %}</a></li>
-              <li><a href="https://github.com/pypa/warehouse" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}Contribute on GitHub{% endtrans %}</a></li>
+              <li><a href="https://github.com/pypi/warehouse" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}Contribute on GitHub{% endtrans %}</a></li>
               <li><a href="https://hosted.weblate.org/projects/pypa/warehouse/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}Translate PyPI{% endtrans %}</a></li>
-              <li><a href="https://github.com/pypa/warehouse/graphs/contributors" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}Development credits{% endtrans %}</a></li>
+              <li><a href="https://github.com/pypi/warehouse/graphs/contributors" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}Development credits{% endtrans %}</a></li>
             </ul>
           </nav>
         </div>

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -54,7 +54,7 @@
     <form class="search-form search-form--large search-form--fullwidth" action="{{ request.route_path('search') }}" role="search">
       <label for="search" class="sr-only">{% trans %}Search PyPI{% endtrans %}</label>
 
-      <!-- The following input is intentionally not autofocused, see https://github.com/pypa/warehouse/issues/6088 for more details -->
+      <!-- The following input is intentionally not autofocused, see https://github.com/pypi/warehouse/issues/6088 for more details -->
       <input id="search" class="search-form__search large-input" type="text" name="q" placeholder="{% trans %}Search projects{% endtrans %}" autocomplete="off" autocapitalize="off" spellcheck="false" data-controller="search-focus" data-action="keydown@window->search-focus#focusSearchField" data-search-focus-target="searchField">
 
       <button type="submit" class="search-form__button">

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -613,12 +613,12 @@
 
         <h3 id="vulnerability-data">{{ vulnerability_data() }}</h3>
         <p>
-          {% trans trimmed osv_href='https://osv.dev/', title=gettext('External link'), vulns_href='https://github.com/pypa/advisory-db' %}
+          {% trans trimmed osv_href='https://osv.dev/', title=gettext('External link'), vulns_href='https://github.com/pypa/advisory-database' %}
           PyPI receives reports on vulnerabilities in the packages hosted on it from the <a href="{{ osv_href }}" title="{{ title }}" target="_blank" rel="noopener">Open Source Vulnerabilities project</a>, which in turn ingests vulnerabilities from the <a href="{{ vulns_href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging Advisory Database</a>.
           {% endtrans %}
         </p>
         <p>
-          {% trans trimmed file_issue_href='https://github.com/pypa/advisory-db/issues', title=gettext('External link') %}
+          {% trans trimmed file_issue_href='https://github.com/pypa/advisory-database/issues', title=gettext('External link') %}
             If you believe vulnerability data for your project is invalid or incorrect, <a href="{{ file_issue_href }}" title="{{ title }}" target="_blank" rel="noopener">file an issue</a> with details.
           {% endtrans %}
         </p>
@@ -852,7 +852,7 @@
 
         <h3 id="upcoming-changes">{{ upcoming_changes() }}</h3>
         <p>
-          {% trans trimmed mailing_list_href='https://mail.python.org/mm3/mailman3/lists/pypi-announce.python.org/', blog_href='https://pyfound.blogspot.com/search/label/pypi', atom_href='https://pyfound.blogspot.com/feeds/posts/default/-/pypi', rss_href='https://pyfound.blogspot.com/feeds/posts/default/-/pypi?alt=rss', title=gettext('External link') %}
+          {% trans trimmed mailing_list_href='https://mail.python.org/mailman3/lists/pypi-announce.python.org/', blog_href='https://pyfound.blogspot.com/search/label/pypi', atom_href='https://pyfound.blogspot.com/feeds/posts/default/-/pypi', rss_href='https://pyfound.blogspot.com/feeds/posts/default/-/pypi?alt=rss', title=gettext('External link') %}
           Changes to PyPI are generally announced on both the
           <a href="{{ mailing_list_href }}" title="{{ title }}" target="_blank" rel="noopener">pypi-announce mailing list</a>
           and the <a href="{{ blog_href }}" title="{{ title }}" target="_blank" rel="noopener">PSF blog</a> under the label "pypi".

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -709,7 +709,7 @@
           {% endtrans %}
         </p>
         <p>
-          {% trans trimmed href='https://github.com/pypa/warehouse/issues', title=gettext('External link') %}
+          {% trans trimmed href='https://github.com/pypi/warehouse/issues', title=gettext('External link') %}
             If you are experiencing an accessibility problem, <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">report it to us on GitHub</a>, so we can try to fix the problem, for you and others.
           {% endtrans %}
         </p>
@@ -760,7 +760,7 @@
 
         <h3 id="feedback">{{ feedback() }}</h3>
         <p>
-          {% trans trimmed href='https://github.com/pypa/warehouse/issues', title=gettext('External link') %}
+          {% trans trimmed href='https://github.com/pypi/warehouse/issues', title=gettext('External link') %}
             If you're experiencing an issue with PyPI itself, we welcome <strong>constructive</strong> feedback and bug reports
             via our <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">issue tracker</a>.
             Please note that this tracker is only for issues with the software that runs PyPI.
@@ -827,7 +827,7 @@
         <p><strong>{% trans %}Financial:{% endtrans %}</strong> {% trans href='https://donate.pypi.org/' %}We would deeply appreciate <a href="{{ href }}">your donations to fund development and maintenance</a>.{% endtrans %}</p>
         <p><strong>{% trans %}Development:{% endtrans %}</strong> {% trans %}Warehouse is open source, and we would love to see some new faces working on the project. You <strong>do not</strong> need to be an experienced open-source developer to make a contribution – in fact, we'd love to help you make your first open source pull request!{% endtrans %}</p>
         <p>
-          {% trans trimmed getting_started_href='https://warehouse.readthedocs.io/development/getting-started/', issue_tracker_href='https://github.com/pypa/warehouse/issues', good_first_issue_href='https://github.com/pypa/warehouse/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22', title=gettext('External link') %}
+          {% trans trimmed getting_started_href='https://warehouse.readthedocs.io/development/getting-started/', issue_tracker_href='https://github.com/pypi/warehouse/issues', good_first_issue_href='https://github.com/pypi/warehouse/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22', title=gettext('External link') %}
           If you have skills in Python, ElasticSearch, HTML, SCSS, JavaScript, or SQLAlchemy then skim our
           <a href="{{ getting_started_href }}" title="{{ title }}" target="_blank" rel="noopener">"Getting started" guide</a>,
           then take a look at the <a href="{{ issue_tracker_href }}" title="{{ title }}" target="_blank" rel="noopener">issue tracker</a>.
@@ -835,7 +835,7 @@
           {% endtrans %}
         </p>
         <p>
-          {% trans trimmed href='https://github.com/pypa/warehouse/milestones', title=gettext('External link') %}
+          {% trans trimmed href='https://github.com/pypi/warehouse/milestones', title=gettext('External link') %}
             Issues are grouped into <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">milestones</a>;
             working on issues in the current milestone is a great way to help push the project forward.
             If you're interested in working on a particular issue, leave a comment and we can guide you through the contribution process.

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -518,13 +518,13 @@
         <h2>{% trans %}Integrating{% endtrans %}</h2>
 
         <h3 id="APIs">{{ APIs() }}</h3>
-        <p>{% trans %}Yes, including RSS feeds of new packages and new releases.{% endtrans %} <a href="https://warehouse.readthedocs.io/api-reference/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}See the API reference.{% endtrans %}</a></p>
+        <p>{% trans %}Yes, including RSS feeds of new packages and new releases.{% endtrans %} <a href="https://warehouse.pypa.io/api-reference/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}See the API reference.{% endtrans %}</a></p>
 
         <h3 id="mirroring">{{ mirroring() }}</h3>
         <p>{% trans href='https://pypi.org/project/bandersnatch/' %}If you need to run your own mirror of PyPI, the <a href="{{ href }}">bandersnatch project</a> is the recommended solution. Note that the storage requirements for a PyPI mirror would exceed 1 terabyte—and growing!{% endtrans %}</p>
 
         <h3 id="project-release-notifications">{{ project_release_notifications() }}</h3>
-        <p>{% trans href='https://github.com/marketplace?category=dependency-management&query=python', title=gettext('External link'), rss_href='https://warehouse.readthedocs.io/api-reference/feeds/#project-releases-feed' %}You can subscribe to the <a href="{{ rss_href }}" title="{{ title }}" target="_blank" rel="noopener">project releases RSS feed</a>. Additionally, there are several third-party services that offer comprehensive monitoring and notifications for project releases and vulnerabilities listed as <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">GitHub apps</a>.{% endtrans %}</p>
+        <p>{% trans href='https://github.com/marketplace?category=dependency-management&query=python', title=gettext('External link'), rss_href='https://warehouse.pypa.io/api-reference/feeds/#project-releases-feed' %}You can subscribe to the <a href="{{ rss_href }}" title="{{ title }}" target="_blank" rel="noopener">project releases RSS feed</a>. Additionally, there are several third-party services that offer comprehensive monitoring and notifications for project releases and vulnerabilities listed as <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">GitHub apps</a>.{% endtrans %}</p>
 
         <h3 id="statistics">{{ statistics() }}</h3>
         <p>{% trans href='https://packaging.python.org/guides/analyzing-pypi-package-downloads/', title=gettext('External link') %}You can analyze PyPI project/package metadata and <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">download usage statistics</a> via our public dataset on Google BigQuery.{% endtrans %}</p>
@@ -776,7 +776,7 @@
 
         <h3 id="maintainers">{{ maintainers() }}</h3>
         <p>
-          {% trans trimmed href='https://warehouse.readthedocs.io/', title=gettext('External link') %}
+          {% trans trimmed href='https://warehouse.pypa.io/', title=gettext('External link') %}
           PyPI is powered by the Warehouse project; <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Warehouse</a> is an open source project developed under the umbrella of the Python Packaging Authority (PyPA) and supported by the Python Packaging Working Group (PackagingWG).
           {% endtrans %}
         </p>
@@ -796,7 +796,7 @@
 
         <h3 id="sponsors">{{ sponsors() }}</h3>
         <p>
-          {% trans trimmed warehouse_href='https://warehouse.readthedocs.io/', sponsors_href=request.route_path('sponsors'), title=gettext('External link') %}
+          {% trans trimmed warehouse_href='https://warehouse.pypa.io/', sponsors_href=request.route_path('sponsors'), title=gettext('External link') %}
             PyPI is powered by <a href="{{ warehouse_href }}" title="{{ title }}" target="_blank" rel="noopener">Warehouse</a>
             and by a variety of tools and services provided by our <a href="{{ sponsors_href }}">generous sponsors</a>.
           {% endtrans %}
@@ -819,7 +819,7 @@
 
         <h3 id="contributing">{{ contributing() }}</h3>
         <p>
-          {% trans trimmed href='https://warehouse.readthedocs.io/', title=gettext('External link') %}
+          {% trans trimmed href='https://warehouse.pypa.io/', title=gettext('External link') %}
             We have a huge amount of work to do to continue to maintain and improve PyPI
             (also known as <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">the Warehouse project</a>).
           {% endtrans %}
@@ -827,7 +827,7 @@
         <p><strong>{% trans %}Financial:{% endtrans %}</strong> {% trans href='https://donate.pypi.org/' %}We would deeply appreciate <a href="{{ href }}">your donations to fund development and maintenance</a>.{% endtrans %}</p>
         <p><strong>{% trans %}Development:{% endtrans %}</strong> {% trans %}Warehouse is open source, and we would love to see some new faces working on the project. You <strong>do not</strong> need to be an experienced open-source developer to make a contribution – in fact, we'd love to help you make your first open source pull request!{% endtrans %}</p>
         <p>
-          {% trans trimmed getting_started_href='https://warehouse.readthedocs.io/development/getting-started/', issue_tracker_href='https://github.com/pypi/warehouse/issues', good_first_issue_href='https://github.com/pypi/warehouse/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22', title=gettext('External link') %}
+          {% trans trimmed getting_started_href='https://warehouse.pypa.io/development/getting-started/', issue_tracker_href='https://github.com/pypi/warehouse/issues', good_first_issue_href='https://github.com/pypi/warehouse/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22', title=gettext('External link') %}
           If you have skills in Python, ElasticSearch, HTML, SCSS, JavaScript, or SQLAlchemy then skim our
           <a href="{{ getting_started_href }}" title="{{ title }}" target="_blank" rel="noopener">"Getting started" guide</a>,
           then take a look at the <a href="{{ issue_tracker_href }}" title="{{ title }}" target="_blank" rel="noopener">issue tracker</a>.

--- a/warehouse/utils/db/windowed_query.py
+++ b/warehouse/utils/db/windowed_query.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 # Taken from "Theatrum Chemicum" at
-# https://bitbucket.org/zzzeek/sqlalchemy/wiki/UsageRecipes/WindowedRangeQuery
+# https://github.com/sqlalchemy/sqlalchemy/wiki/RangeQuery-and-WindowedRangeQuery
 
 from sqlalchemy import and_, func, text
 


### PR DESCRIPTION
I came across a few broken URLs, and also got a fair amount of redirections, so took the opportunity to update URLs as necessary. I tried my best to keep the commits split by topic to make a review easier.

Sphinx's `make linkcheck` target is useful to identify and check a lot of these, but since many are intentionally redirects (like a bitly link) or a language-specific one for locale, I didn't add an automated check at this time, or intentionally exclude all of them via config.

A couple of internal references were updated to use Sphinx syntax, since the existing links didn't link correctly to the desired page or anchor.