### PR TITLE
feat: display author name on details

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -227,3 +227,17 @@ def test_is_recent(delta, expected):
 
 def test_is_recent_none():
     assert filters.is_recent(None) is False
+
+
+@pytest.mark.parametrize(
+    ("meta_email", "expected_name", "expected_email"),
+    [
+        ("not-an-email-address", "", ""),
+        ("foo@bar.com", "", "foo@bar.com"),
+        ('"Foo Bar" <foo@bar.com>', "Foo Bar", "foo@bar.com"),
+    ],
+)
+def test_format_author_email(meta_email, expected_name, expected_email):
+    author_name, author_email = filters.format_author_email(meta_email)
+    assert author_name == expected_name
+    assert author_email == expected_email

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -421,6 +421,7 @@ def configure(settings=None):
     filters.setdefault("localize_datetime", "warehouse.filters:localize_datetime")
     filters.setdefault("is_recent", "warehouse.filters:is_recent")
     filters.setdefault("canonicalize_name", "packaging.utils:canonicalize_name")
+    filters.setdefault("format_author_email", "warehouse.filters:format_author_email")
 
     # We also want to register some global functions for Jinja
     jglobals = config.get_settings().setdefault("jinja2.globals", {})

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -18,6 +18,7 @@ import hmac
 import json
 import re
 import urllib.parse
+
 from email.utils import getaddresses
 
 import html5lib

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -18,6 +18,7 @@ import hmac
 import json
 import re
 import urllib.parse
+from email.utils import getaddresses
 
 import html5lib
 import html5lib.serializer
@@ -161,6 +162,20 @@ def is_recent(timestamp):
     if timestamp:
         return timestamp + datetime.timedelta(days=30) > datetime.datetime.now()
     return False
+
+
+def format_author_email(metadata_email: str) -> tuple[str, str]:
+    """
+    Return the name and email address from a metadata RFC-822 string.
+    Use Jinja's `first` and `last` to access each part in a template.
+    TODO: Support more than one email address, per RFC-822.
+    """
+    author_emails = []
+    for author_name, author_email in getaddresses([metadata_email]):
+        if "@" not in author_email:
+            return author_name, ""
+        author_emails.append((author_name, author_email))
+    return author_emails[0][0], author_emails[0][1]
 
 
 def includeme(config):

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -76,7 +76,7 @@
   <p><strong>{% trans %}License:{% endtrans %}</strong> {{ license }}</p>
   {% endif %}
   {% if release.author_email %}
-    <p><strong>{% trans %}Author:{% endtrans %}</strong> <a href="mailto:{{ release.author_email }}">{{ release.author or release.author_email }}</a></p>
+    <p><strong>{% trans %}Author:{% endtrans %}</strong> <a href="mailto:{{ release.author_email|format_author_email|last }}">{{ release.author or release.author_email|format_author_email|first }}</a></p>
   {% elif release.author %}
     <p><strong>{% trans %}Author:{% endtrans %}</strong> {{ release.author }}</p>
   {% endif %}


### PR DESCRIPTION
When using a valid RFC-822 identifier in `author-email` metadata,
display the name value and link to the email address.

Does not yet support multiple values in `author-email`.

Resolves #11990

Signed-off-by: Mike Fiedler <miketheman@gmail.com>