### PR TITLE
Return "versions" on legacy JSON api

### DIFF
--- a/docs/api-reference/json.rst
+++ b/docs/api-reference/json.rst
@@ -167,6 +167,7 @@ Project
                     "yanked_reason": null
                 }
             ],
+            "versions": ["1.0", "1.2.0"],
             "vulnerabilities": []
         }
 

--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -326,6 +326,7 @@ class TestJSONProject:
                     }
                 ],
             },
+            "versions": ["0.1", "1.0", "2.0", "3.0"],
             "urls": [
                 {
                     "comment_text": None,

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -173,6 +173,7 @@ def _json_data(request, project, release, *, all_releases):
 
     if all_releases:
         data["releases"] = releases
+        data["versions"] = sorted(releases)
 
     return data
 


### PR DESCRIPTION
Anticipating the removal of deprecated "releases": retain information
about the available versions of a package.

Fixes #11991