### PR TITLE
Add shortcut for /2fa

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -541,6 +541,7 @@ def test_routes(warehouse):
     assert config.add_redirect.calls == [
         pretend.call("/sponsor/", "/sponsors/", domain=warehouse),
         pretend.call("/u/{username}/", "/user/{username}/", domain=warehouse),
+        pretend.call("/2fa/", "/manage/account/two-factor/", domain=warehouse),
         pretend.call("/p/{name}/", "/project/{name}/", domain=warehouse),
         pretend.call("/pypi/{name}/", "/project/{name}/", domain=warehouse),
         pretend.call(

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -185,6 +185,7 @@ def includeme(config):
     config.add_route(
         "manage.account.two-factor", "/manage/account/two-factor/", domain=warehouse
     )
+    config.add_redirect("/2fa/", "/manage/account/two-factor/", domain=warehouse)
     config.add_route(
         "manage.account.totp-provision",
         "/manage/account/totp-provision",


### PR DESCRIPTION
This adds a convenience redirect from https://pypi.org/2fa/ to https://pypi.org/manage/account/two-factor/.