### PR TITLE
feat: support markdown style math tags

### DIFF
--- a/tests/unit/test_csp.py
+++ b/tests/unit/test_csp.py
@@ -229,6 +229,7 @@ def test_includeme():
                         "'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='",
                         "https://cdn.jsdelivr.net/npm/mathjax@3.2.2/",
                         "'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='",
+                        "'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='",
                     ],
                     "style-src": [
                         "'self'",

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -115,6 +115,9 @@ def includeme(config):
                     "https://cdn.jsdelivr.net/npm/mathjax@3.2.2/",
                     # Hash for v3.2.2 of MathJax tex-svg.js
                     "'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='",
+                    # Hash for MathJax inline config
+                    # See warehouse/templates/packaging/detail.html
+                    "'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='",
                 ],
                 "style-src": [
                     SELF,

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -386,6 +386,13 @@
 {% endblock %}
 
 {% block extra_js %}
+<script>
+MathJax = {
+  tex: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']]
+  },
+};
+</script>
 <script async
   src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-svg.js"
   integrity="sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII="


### PR DESCRIPTION
We can configure MathJax to detect the convention of single dollar signs
in addition to its other methods, as it's not on by default.

The inline script needs to be supported by our CSP, and if the stanza
ever changes, we'll need to recalculate the hash and update the CSP
accordingly.

Resolves #12009
Resolves pypa/readme_renderer#214

Signed-off-by: Mike Fiedler <miketheman@gmail.com>