### PR TITLE
Fix organization rename case sensitivity

### DIFF
--- a/tests/unit/admin/views/test_projects.py
+++ b/tests/unit/admin/views/test_projects.py
@@ -440,7 +440,7 @@ class TestProjectSetLimit:
 
 class TestDeleteProject:
     def test_no_confirm(self):
-        project = pretend.stub(normalized_name="foo")
+        project = pretend.stub(name="foo", normalized_name="foo")
         request = pretend.stub(
             POST={},
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
@@ -457,7 +457,7 @@ class TestDeleteProject:
         ]
 
     def test_wrong_confirm(self):
-        project = pretend.stub(normalized_name="foo")
+        project = pretend.stub(name="foo", normalized_name="foo")
         request = pretend.stub(
             POST={"confirm_project_name": "bar"},
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
@@ -485,7 +485,7 @@ class TestDeleteProject:
         db_request.session = pretend.stub(
             flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        db_request.POST["confirm_project_name"] = project.normalized_name
+        db_request.POST["confirm_project_name"] = project.name
         db_request.user = UserFactory.create()
 
         views.delete_project(project, db_request)

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -5697,6 +5697,7 @@ class TestManageProjectSettings:
     def test_remove_organization_project_no_confirm(self):
         user = pretend.stub()
         project = pretend.stub(
+            name="foo",
             normalized_name="foo",
             organization=pretend.stub(owners=[user]),
             owners=[user],
@@ -5724,6 +5725,7 @@ class TestManageProjectSettings:
     def test_remove_organization_project_wrong_confirm(self):
         user = pretend.stub()
         project = pretend.stub(
+            name="foo",
             normalized_name="foo",
             organization=pretend.stub(owners=[user]),
             owners=[user],
@@ -5783,7 +5785,7 @@ class TestManageProjectSettings:
 
         db_request.POST = MultiDict(
             {
-                "confirm_remove_organization_project_name": project.normalized_name,
+                "confirm_remove_organization_project_name": project.name,
             }
         )
         db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
@@ -5857,7 +5859,7 @@ class TestManageProjectSettings:
 
         db_request.POST = MultiDict(
             {
-                "confirm_remove_organization_project_name": project.normalized_name,
+                "confirm_remove_organization_project_name": project.name,
             }
         )
         db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
@@ -5899,7 +5901,7 @@ class TestManageProjectSettings:
 
         db_request.POST = MultiDict(
             {
-                "confirm_remove_organization_project_name": project.normalized_name,
+                "confirm_remove_organization_project_name": project.name,
             }
         )
         db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
@@ -5945,6 +5947,7 @@ class TestManageProjectSettings:
     def test_transfer_organization_project_no_confirm(self):
         user = pretend.stub()
         project = pretend.stub(
+            name="foo",
             normalized_name="foo",
             organization=pretend.stub(owners=[user]),
         )
@@ -5971,6 +5974,7 @@ class TestManageProjectSettings:
     def test_transfer_organization_project_wrong_confirm(self):
         user = pretend.stub()
         project = pretend.stub(
+            name="foo",
             normalized_name="foo",
             organization=pretend.stub(owners=[user]),
         )
@@ -6030,7 +6034,7 @@ class TestManageProjectSettings:
         db_request.POST = MultiDict(
             {
                 "organization": organization.normalized_name,
-                "confirm_transfer_organization_project_name": project.normalized_name,
+                "confirm_transfer_organization_project_name": project.name,
             }
         )
         db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
@@ -6127,7 +6131,7 @@ class TestManageProjectSettings:
         db_request.POST = MultiDict(
             {
                 "organization": organization.normalized_name,
-                "confirm_transfer_organization_project_name": project.normalized_name,
+                "confirm_transfer_organization_project_name": project.name,
             }
         )
         db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
@@ -6198,7 +6202,7 @@ class TestManageProjectSettings:
         db_request.POST = MultiDict(
             {
                 "organization": "",
-                "confirm_transfer_organization_project_name": project.normalized_name,
+                "confirm_transfer_organization_project_name": project.name,
             }
         )
         db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
@@ -6234,7 +6238,7 @@ class TestManageProjectSettings:
         db_request.POST = MultiDict(
             {
                 "organization": organization.normalized_name,
-                "confirm_transfer_organization_project_name": project.normalized_name,
+                "confirm_transfer_organization_project_name": project.name,
             }
         )
         db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
@@ -6319,7 +6323,7 @@ class TestManageProjectSettings:
         ]
 
     def test_delete_project_wrong_confirm(self):
-        project = pretend.stub(normalized_name="foo")
+        project = pretend.stub(name="foo", normalized_name="foo")
         request = pretend.stub(
             POST={"confirm_project_name": "bar"},
             flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
@@ -6401,7 +6405,7 @@ class TestManageProjectSettings:
         db_request.session = pretend.stub(
             flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        db_request.POST["confirm_project_name"] = project.normalized_name
+        db_request.POST["confirm_project_name"] = project.name
         db_request.user = UserFactory.create()
 
         RoleFactory.create(project=project, user=db_request.user, role_name="Owner")
@@ -6470,7 +6474,7 @@ class TestManageProjectDocumentation:
         ]
 
     def test_destroy_project_docs_wrong_confirm(self):
-        project = pretend.stub(normalized_name="foo")
+        project = pretend.stub(name="foo", normalized_name="foo")
         request = pretend.stub(
             POST={"confirm_project_name": "bar"},
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
@@ -6500,7 +6504,7 @@ class TestManageProjectDocumentation:
         db_request.session = pretend.stub(
             flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        db_request.POST["confirm_project_name"] = project.normalized_name
+        db_request.POST["confirm_project_name"] = project.name
         db_request.user = UserFactory.create()
         db_request.task = task
 
@@ -7226,7 +7230,10 @@ class TestManageProjectRelease:
         ]
 
     def test_delete_project_release_file_no_confirm(self):
-        release = pretend.stub(version="1.2.3", project=pretend.stub(name="foobar"))
+        release = pretend.stub(
+            version="1.2.3",
+            project=pretend.stub(name="foobar", normalized_name="foobar"),
+        )
         request = pretend.stub(
             POST={"confirm_project_name": ""},
             method="POST",

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -2923,10 +2923,10 @@ class TestManageOrganizationSettings:
         enable_organizations,
         monkeypatch,
     ):
-        organization = OrganizationFactory.create(name="old-name")
+        organization = OrganizationFactory.create(name="foobar")
         db_request.POST = {
             "confirm_current_organization_name": organization.name,
-            "name": "new-name",
+            "name": "FooBar",
         }
         db_request.route_path = pretend.call_recorder(
             lambda *a, organization_name, **kw: (
@@ -2981,30 +2981,30 @@ class TestManageOrganizationSettings:
             f"/manage/organization/{organization.normalized_name}/settings/#modal-close"
         )
         assert organization_service.rename_organization.calls == [
-            pretend.call(organization.id, "new-name")
+            pretend.call(organization.id, "FooBar")
         ]
         assert send_email.calls == [
             pretend.call(
                 db_request,
                 admins,
-                organization_name="new-name",
-                previous_organization_name="old-name",
+                organization_name="FooBar",
+                previous_organization_name="foobar",
             ),
             pretend.call(
                 db_request,
                 {pyramid_user},
-                organization_name="new-name",
-                previous_organization_name="old-name",
+                organization_name="FooBar",
+                previous_organization_name="foobar",
             ),
         ]
 
     def test_save_organization_name_wrong_confirm(
         self, db_request, organization_service, enable_organizations, monkeypatch
     ):
-        organization = OrganizationFactory.create(name="old-name")
+        organization = OrganizationFactory.create(name="foobar")
         db_request.POST = {
             "confirm_current_organization_name": organization.name.upper(),
-            "name": "new-name",
+            "name": "FooBar",
         }
         db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/the-redirect")
         db_request.session = pretend.stub(
@@ -3019,7 +3019,7 @@ class TestManageOrganizationSettings:
             pretend.call(
                 (
                     "Could not rename organization - "
-                    "'OLD-NAME' is not the same as 'old-name'"
+                    "'FOOBAR' is not the same as 'foobar'"
                 ),
                 queue="error",
             )
@@ -3028,10 +3028,10 @@ class TestManageOrganizationSettings:
     def test_save_organization_name_validation_fails(
         self, db_request, organization_service, enable_organizations, monkeypatch
     ):
-        organization = OrganizationFactory.create(name="old-name")
+        organization = OrganizationFactory.create(name="foobar")
         db_request.POST = {
             "confirm_current_organization_name": organization.name,
-            "name": "new-name",
+            "name": "FooBar",
         }
 
         def rename_organization(organization_id, organization_name):
@@ -4898,7 +4898,7 @@ class TestManageTeamSettings:
 
     def test_save_team(self, db_request, organization_service, enable_organizations):
         team = TeamFactory.create(name="Team Name")
-        db_request.POST = MultiDict({"name": "New Team Name"})
+        db_request.POST = MultiDict({"name": "Team name"})
         db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/foo/bar/")
 
         view = views.ManageTeamSettingsViews(team, db_request)
@@ -4906,7 +4906,7 @@ class TestManageTeamSettings:
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/foo/bar/"
-        assert team.name == "New Team Name"
+        assert team.name == "Team name"
 
     def test_save_team_validation_fails(
         self, db_request, organization_service, enable_organizations

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -4884,8 +4884,17 @@ class TestManageTeamSettings:
     def test_save_team_validation_fails(
         self, db_request, organization_service, enable_organizations
     ):
-        team = TeamFactory.create(name="Team Name")
-        db_request.POST = MultiDict({"name": "Team Name"})
+        organization = OrganizationFactory.create()
+        team = TeamFactory.create(
+            name="Team Name",
+            organization=organization,
+        )
+        TeamFactory.create(
+            name="Existing Team Name",
+            organization=organization,
+        )
+
+        db_request.POST = MultiDict({"name": "Existing Team Name"})
 
         view = views.ManageTeamSettingsViews(team, db_request)
         result = view.save_team()
@@ -4897,7 +4906,7 @@ class TestManageTeamSettings:
         }
         assert team.name == "Team Name"
         assert form.name.errors == [
-            ("This team name has already been used. " "Choose a different team name.")
+            "This team name has already been used. Choose a different team name."
         ]
 
     def test_delete_team(

--- a/tests/unit/utils/test_organization.py
+++ b/tests/unit/utils/test_organization.py
@@ -19,7 +19,7 @@ from warehouse.utils.organization import confirm_organization
 
 
 def test_confirm():
-    organization = stub(normalized_name="foobar")
+    organization = stub(name="foobar", normalized_name="foobar")
     request = stub(
         POST={"confirm_organization_name": "foobar"},
         route_path=call_recorder(lambda *a, **kw: stub()),
@@ -33,7 +33,7 @@ def test_confirm():
 
 
 def test_confirm_no_input():
-    organization = stub(normalized_name="foobar")
+    organization = stub(name="foobar", normalized_name="foobar")
     request = stub(
         POST={"confirm_organization_name": ""},
         route_path=call_recorder(lambda *a, **kw: "/the-redirect"),
@@ -49,7 +49,7 @@ def test_confirm_no_input():
 
 
 def test_confirm_incorrect_input():
-    organization = stub(normalized_name="foobar")
+    organization = stub(name="foobar", normalized_name="foobar")
     request = stub(
         POST={"confirm_organization_name": "bizbaz"},
         route_path=call_recorder(lambda *a, **kw: "/the-redirect"),

--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -42,7 +42,7 @@ from ...common.db.packaging import (
 
 
 def test_confirm():
-    project = stub(normalized_name="foobar")
+    project = stub(name="foobar", normalized_name="foobar")
     request = stub(
         POST={"confirm_project_name": "foobar"},
         route_path=call_recorder(lambda *a, **kw: stub()),
@@ -56,7 +56,7 @@ def test_confirm():
 
 
 def test_confirm_no_input():
-    project = stub(normalized_name="foobar")
+    project = stub(name="foobar", normalized_name="foobar")
     request = stub(
         POST={"confirm_project_name": ""},
         route_path=call_recorder(lambda *a, **kw: "/the-redirect"),
@@ -72,7 +72,7 @@ def test_confirm_no_input():
 
 
 def test_confirm_incorrect_input():
-    project = stub(normalized_name="foobar")
+    project = stub(name="foobar", normalized_name="foobar")
     request = stub(
         POST={"confirm_project_name": "bizbaz"},
         route_path=call_recorder(lambda *a, **kw: "/the-redirect"),

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4303,6 +4303,10 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/organization/settings.html:197
+msgid "Change organization account name for"
+msgstr ""
+
+#: warehouse/templates/manage/organization/settings.html:197
 msgid "Current organization account name"
 msgstr ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -328,7 +328,7 @@ msgid ""
 "period, underscore, hyphen, or slash. Choose a different team name."
 msgstr ""
 
-#: warehouse/manage/forms.py:658
+#: warehouse/manage/forms.py:669
 msgid "This team name has already been used. Choose a different team name."
 msgstr ""
 
@@ -354,11 +354,11 @@ msgid ""
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:1980 warehouse/manage/views.py:4132
+#: warehouse/manage/views.py:1980 warehouse/manage/views.py:4134
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2037 warehouse/manage/views.py:4199
+#: warehouse/manage/views.py:2037 warehouse/manage/views.py:4201
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
@@ -366,39 +366,39 @@ msgstr ""
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2091 warehouse/manage/views.py:4243
+#: warehouse/manage/views.py:2091 warehouse/manage/views.py:4245
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2124 warehouse/manage/views.py:4267
+#: warehouse/manage/views.py:2124 warehouse/manage/views.py:4269
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views.py:2512
+#: warehouse/manage/views.py:2514
 msgid "User '${username}' is already a team member"
 msgstr ""
 
-#: warehouse/manage/views.py:2927
+#: warehouse/manage/views.py:2929
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/manage/views.py:4017
+#: warehouse/manage/views.py:4019
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4086
+#: warehouse/manage/views.py:4088
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4119
+#: warehouse/manage/views.py:4121
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4232
+#: warehouse/manage/views.py:4234
 msgid "Could not find role invitation."
 msgstr ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -270,65 +270,65 @@ msgid ""
 "organization account name."
 msgstr ""
 
-#: warehouse/manage/forms.py:430
+#: warehouse/manage/forms.py:436
 msgid ""
 "This organization account name has already been used. Choose a different "
 "organization account name."
 msgstr ""
 
-#: warehouse/manage/forms.py:471
+#: warehouse/manage/forms.py:477
 msgid "Select project"
 msgstr ""
 
-#: warehouse/manage/forms.py:476
+#: warehouse/manage/forms.py:482
 msgid "Specify project name"
 msgstr ""
 
-#: warehouse/manage/forms.py:479
+#: warehouse/manage/forms.py:485
 msgid ""
 "Start and end with a letter or numeral containing only ASCII numeric and "
 "'.', '_' and '-'."
 msgstr ""
 
-#: warehouse/manage/forms.py:486
+#: warehouse/manage/forms.py:492
 msgid "This project name has already been used. Choose a different project name."
 msgstr ""
 
-#: warehouse/manage/forms.py:556
+#: warehouse/manage/forms.py:563
 msgid ""
 "The organization name is too long. Choose a organization name with 100 "
 "characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:568
+#: warehouse/manage/forms.py:575
 msgid ""
 "The organization URL is too long. Choose a organization URL with 400 "
 "characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:582
+#: warehouse/manage/forms.py:589
 msgid ""
 "The organization description is too long. Choose a organization "
 "description with 400 characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:612
+#: warehouse/manage/forms.py:619
 msgid ""
 "No organization owner, manager, or member found with that username. "
 "Please try again."
 msgstr ""
 
-#: warehouse/manage/forms.py:628
+#: warehouse/manage/forms.py:635
 msgid "Choose a team name with 50 characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:634
+#: warehouse/manage/forms.py:641
 msgid ""
 "The team name is invalid. Team names cannot start or end with a space, "
 "period, underscore, hyphen, or slash. Choose a different team name."
 msgstr ""
 
-#: warehouse/manage/forms.py:651
+#: warehouse/manage/forms.py:658
 msgid "This team name has already been used. Choose a different team name."
 msgstr ""
 
@@ -344,61 +344,61 @@ msgstr ""
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:1954
+#: warehouse/manage/views.py:1955
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:1965
+#: warehouse/manage/views.py:1966
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:1979 warehouse/manage/views.py:4131
+#: warehouse/manage/views.py:1980 warehouse/manage/views.py:4132
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2036 warehouse/manage/views.py:4198
+#: warehouse/manage/views.py:2037 warehouse/manage/views.py:4199
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:2076
+#: warehouse/manage/views.py:2077
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2090 warehouse/manage/views.py:4242
+#: warehouse/manage/views.py:2091 warehouse/manage/views.py:4243
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2123 warehouse/manage/views.py:4266
+#: warehouse/manage/views.py:2124 warehouse/manage/views.py:4267
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views.py:2511
+#: warehouse/manage/views.py:2512
 msgid "User '${username}' is already a team member"
 msgstr ""
 
-#: warehouse/manage/views.py:2926
+#: warehouse/manage/views.py:2927
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/manage/views.py:4016
+#: warehouse/manage/views.py:4017
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4085
+#: warehouse/manage/views.py:4086
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4118
+#: warehouse/manage/views.py:4119
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4231
+#: warehouse/manage/views.py:4232
 msgid "Could not find role invitation."
 msgstr ""
 

--- a/warehouse/manage/forms.py
+++ b/warehouse/manage/forms.py
@@ -425,7 +425,13 @@ class OrganizationNameMixin:
     )
 
     def validate_name(self, field):
-        if self.organization_service.find_organizationid(field.data) is not None:
+        # Find organization by name.
+        organization_id = self.organization_service.find_organizationid(field.data)
+
+        # Name is valid if one of the following is true:
+        # - There is no name conflict with any organization.
+        # - The name conflict is with the current organization.
+        if organization_id is not None and organization_id != self.organization_id:
             raise wtforms.validators.ValidationError(
                 _(
                     "This organization account name has already been used. "
@@ -539,9 +545,10 @@ class SaveOrganizationNameForm(OrganizationNameMixin, forms.Form):
 
     __params__ = ["name"]
 
-    def __init__(self, *args, organization_service, **kwargs):
+    def __init__(self, *args, organization_service, organization_id=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.organization_service = organization_service
+        self.organization_id = organization_id
 
 
 class SaveOrganizationForm(forms.Form):

--- a/warehouse/manage/forms.py
+++ b/warehouse/manage/forms.py
@@ -647,13 +647,24 @@ class SaveTeamForm(forms.Form):
         ]
     )
 
-    def __init__(self, *args, organization_id, organization_service, **kwargs):
+    def __init__(
+        self, *args, organization_service, organization_id, team_id=None, **kwargs
+    ):
         super().__init__(*args, **kwargs)
+        self.team_id = team_id
         self.organization_id = organization_id
         self.organization_service = organization_service
 
     def validate_name(self, field):
-        if self.organization_service.find_teamid(self.organization_id, field.data):
+        # Find team by name.
+        team_id = self.organization_service.find_teamid(
+            self.organization_id, field.data
+        )
+
+        # Name is valid if one of the following is true:
+        # - There is no name conflict with any team.
+        # - The name conflict is with the current team.
+        if team_id is not None and team_id != self.team_id:
             raise wtforms.validators.ValidationError(
                 _(
                     "This team name has already been used. "

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -1446,6 +1446,7 @@ class ManageOrganizationSettingsViews:
         form = SaveOrganizationNameForm(
             self.request.POST,
             organization_service=self.organization_service,
+            organization_id=self.organization.id,
         )
 
         if form.validate():

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -1678,8 +1678,8 @@ class ManageOrganizationTeamsViews:
             "organization": self.organization,
             "create_team_form": CreateTeamForm(
                 self.request.POST,
-                organization_id=self.organization.id,
                 organization_service=self.organization_service,
+                organization_id=self.organization.id,
             ),
         }
 
@@ -2317,8 +2317,9 @@ class ManageTeamSettingsViews:
             "team": self.team,
             "save_team_form": SaveTeamForm(
                 name=self.team.name,
-                organization_id=self.team.organization_id,
                 organization_service=self.organization_service,
+                organization_id=self.team.organization_id,
+                team_id=self.team.id,
             ),
         }
 
@@ -2330,8 +2331,9 @@ class ManageTeamSettingsViews:
     def save_team(self):
         form = SaveTeamForm(
             self.request.POST,
-            organization_id=self.team.organization_id,
             organization_service=self.organization_service,
+            organization_id=self.team.organization_id,
+            team_id=self.team.id,
         )
 
         if form.validate():

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -392,7 +392,7 @@
 %}
   {% set slug = confirm_name.lower().replace(' ', '-') + '-modal' %}
   <a href="#{{ slug }}" class="button button{{ modifier }}" {% if tooltip != None %}title="{{ tooltip }}"{% endif %}>
-    {{ title }}
+    {{ confirm_button_label if confirm_button_label else title }}
   </a>
   {{ confirm_modal(title, label, confirm_name, confirm_string, slug, confirm_button_label=confirm_button_label, extra_fields=extra_fields, extra_description=extra_description, action=action, warning=warning, confirm_string_in_title=confirm_string_in_title, modifier=modifier) }}
 {% endmacro %}

--- a/warehouse/templates/manage/organization/settings.html
+++ b/warehouse/templates/manage/organization/settings.html
@@ -194,7 +194,7 @@
           {% endif %}
         </div>
       {% endset %}
-      {{ confirm_button(gettext("Change organization account name"), gettext("Current organization account name"), "current_organization_name", organization.name, extra_fields=extra_fields, action=action, confirm_string_in_title=False) }}
+      {{ confirm_button(gettext("Change organization account name for"), gettext("Current organization account name"), "current_organization_name", organization.name, confirm_button_label=gettext("Change organization account name"), extra_fields=extra_fields, action=action) }}
     </div>
   </section>
 

--- a/warehouse/utils/organization.py
+++ b/warehouse/utils/organization.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from packaging.utils import canonicalize_name
 from pyramid.httpexceptions import HTTPSeeOther
 
 
@@ -21,23 +20,27 @@ def confirm_organization(
     field_name="confirm_organization_name",
     error_message="Could not delete organization",
 ):
-    confirm = request.POST.get(field_name)
-    organization_name = organization.normalized_name
+    confirm = request.POST.get(field_name, "").strip()
     if not confirm:
         request.session.flash("Confirm the request", queue="error")
         raise HTTPSeeOther(
-            request.route_path(fail_route, organization_name=organization_name)
+            request.route_path(
+                fail_route,
+                organization_name=organization.normalized_name,
+            )
         )
-    if canonicalize_name(confirm) != organization.normalized_name:
+
+    organization_name = organization.name.strip()
+    if confirm != organization_name:
         request.session.flash(
-            (
-                f"{error_message} - "
-                f"{confirm!r} is not the same as {organization.normalized_name!r}"
-            ),
+            f"{error_message} - {confirm!r} is not the same as {organization_name!r}",
             queue="error",
         )
         raise HTTPSeeOther(
-            request.route_path(fail_route, organization_name=organization_name)
+            request.route_path(
+                fail_route,
+                organization_name=organization.normalized_name,
+            )
         )
 
 

--- a/warehouse/utils/organization.py
+++ b/warehouse/utils/organization.py
@@ -51,23 +51,27 @@ def confirm_team(
     field_name="confirm_team_name",
     error_message="Could not delete team",
 ):
-    confirm = request.POST.get(field_name)
-    organization_name = team.organization.normalized_name
-    team_name = team.normalized_name
+    confirm = request.POST.get(field_name, "").strip()
     if not confirm:
         request.session.flash("Confirm the request", queue="error")
         raise HTTPSeeOther(
             request.route_path(
-                fail_route, organization_name=organization_name, team_name=team_name
+                fail_route,
+                organization_name=team.organization.normalized_name,
+                team_name=team.normalized_name,
             )
         )
-    if confirm.strip() != team.name.strip():
+
+    team_name = team.name.strip()
+    if confirm != team_name:
         request.session.flash(
-            (f"{error_message} - " f"{confirm!r} is not the same as {team.name!r}"),
+            f"{error_message} - {confirm!r} is not the same as {team_name!r}",
             queue="error",
         )
         raise HTTPSeeOther(
             request.route_path(
-                fail_route, organization_name=organization_name, team_name=team_name
+                fail_route,
+                organization_name=team.organization.normalized_name,
+                team_name=team.normalized_name,
             )
         )

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -180,18 +180,28 @@ def confirm_project(
     field_name="confirm_project_name",
     error_message="Could not delete project",
 ):
-    confirm = request.POST.get(field_name)
-    project_name = project.normalized_name
+    confirm = request.POST.get(field_name, "").strip()
     if not confirm:
         request.session.flash("Confirm the request", queue="error")
-        raise HTTPSeeOther(request.route_path(fail_route, project_name=project_name))
-    if canonicalize_name(confirm) != project.normalized_name:
+        raise HTTPSeeOther(
+            request.route_path(
+                fail_route,
+                project_name=project.normalized_name,
+            )
+        )
+
+    project_name = project.name.strip()
+    if confirm != project_name:
         request.session.flash(
-            f"{error_message} - "
-            + f"{confirm!r} is not the same as {project.normalized_name!r}",
+            f"{error_message} - {confirm!r} is not the same as {project_name!r}",
             queue="error",
         )
-        raise HTTPSeeOther(request.route_path(fail_route, project_name=project_name))
+        raise HTTPSeeOther(
+            request.route_path(
+                fail_route,
+                project_name=project.normalized_name,
+            )
+        )
 
 
 def remove_project(project, request, flash=True):


### PR DESCRIPTION
- Use case sensitive check to confirm organization, team, project name.
- Allow changing case with organization or team rename.
- Show organization name in title of rename confirm modal.
- Closes #12048.
