### PR TITLE
Add 'created' column to all DB models

### DIFF
--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -264,9 +264,6 @@ class ProhibitedUserName(db.Model):
 
     __repr__ = make_repr("name")
 
-    created = Column(
-        DateTime(timezone=False), nullable=False, server_default=sql.func.now()
-    )
     name = Column(Text, unique=True, nullable=False)
     _prohibited_by = Column(
         "prohibited_by", UUID(as_uuid=True), ForeignKey("users.id"), index=True
@@ -286,5 +283,4 @@ class TitanPromoCode(db.Model):
         unique=True,
     )
     code = Column(String, nullable=False, unique=True)
-    created = Column(DateTime, nullable=False, server_default=sql.func.now())
     distributed = Column(DateTime, nullable=True)

--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -19,7 +19,7 @@ import sqlalchemy
 import venusian
 import zope.sqlalchemy
 
-from sqlalchemy import event, inspect
+from sqlalchemy import Column, DateTime, event, inspect, sql
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.ext.declarative import declarative_base  # type: ignore
@@ -89,6 +89,11 @@ class Model(ModelBase):
         UUID(as_uuid=True),
         primary_key=True,
         server_default=sqlalchemy.text("gen_random_uuid()"),
+    )
+    created = Column(
+        DateTime(timezone=False),
+        server_default=sql.func.now(),
+        index=True,
     )
 
 

--- a/warehouse/email/ses/models.py
+++ b/warehouse/email/ses/models.py
@@ -14,7 +14,7 @@ import enum
 
 import automat
 
-from sqlalchemy import Boolean, Column, DateTime, Enum, ForeignKey, Text, orm, sql
+from sqlalchemy import Boolean, Column, Enum, ForeignKey, Text, orm, sql
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm.session import object_session
@@ -232,7 +232,6 @@ class EmailMessage(db.Model):
 
     __tablename__ = "ses_emails"
 
-    created = Column(DateTime, nullable=False, server_default=sql.func.now())
     status = Column(
         Enum(EmailStatuses, values_callable=lambda x: [e.value for e in x]),
         nullable=False,
@@ -265,8 +264,6 @@ class EventTypes(enum.Enum):
 class Event(db.Model):
 
     __tablename__ = "ses_events"
-
-    created = Column(DateTime, nullable=False, server_default=sql.func.now())
 
     email_id = Column(
         UUID(as_uuid=True),

--- a/warehouse/macaroons/models.py
+++ b/warehouse/macaroons/models.py
@@ -49,7 +49,6 @@ class Macaroon(db.Model):
     # Store some information about the Macaroon to give users some mechanism
     # to differentiate between them.
     description = Column(String(100), nullable=False)
-    created = Column(DateTime, nullable=False, server_default=sql.func.now())
     last_used = Column(DateTime, nullable=True)
 
     # Human-readable "permissions" for this macaroon, corresponding to the

--- a/warehouse/malware/models.py
+++ b/warehouse/malware/models.py
@@ -124,7 +124,6 @@ class MalwareCheck(db.Model):
         nullable=False,
         server_default=("disabled"),
     )
-    created = Column(DateTime, nullable=False, server_default=sql.func.now())
 
     @property
     def is_stale(self):

--- a/warehouse/migrations/versions/f728ae2695a2_add_created_column_to_all_db_models.py
+++ b/warehouse/migrations/versions/f728ae2695a2_add_created_column_to_all_db_models.py
@@ -1,0 +1,572 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add 'created' column to all DB models
+
+Revision ID: f728ae2695a2
+Revises: 7eaad728b806
+Create Date: 2022-09-14 16:57:28.024958
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "f728ae2695a2"
+down_revision = "7eaad728b806"
+
+
+def upgrade():
+    op.add_column(
+        "banners",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(op.f("ix_banners_created"), "banners", ["created"], unique=False)
+    op.alter_column(
+        "macaroons",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.create_index(
+        op.f("ix_macaroons_created"), "macaroons", ["created"], unique=False
+    )
+    op.alter_column(
+        "malware_checks",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.create_index(
+        op.f("ix_malware_checks_created"), "malware_checks", ["created"], unique=False
+    )
+    op.add_column(
+        "malware_verdicts",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_malware_verdicts_created"),
+        "malware_verdicts",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "oidc_provider_project_association",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_oidc_provider_project_association_created"),
+        "oidc_provider_project_association",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "oidc_providers",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_oidc_providers_created"), "oidc_providers", ["created"], unique=False
+    )
+    op.add_column(
+        "organization_events",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_organization_events_created"),
+        "organization_events",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "organization_invitations",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_organization_invitations_created"),
+        "organization_invitations",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "organization_name_catalog",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_organization_name_catalog_created"),
+        "organization_name_catalog",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "organization_project",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_organization_project_created"),
+        "organization_project",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "organization_roles",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_organization_roles_created"),
+        "organization_roles",
+        ["created"],
+        unique=False,
+    )
+    op.alter_column(
+        "organizations",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.alter_column(
+        "prohibited_project_names",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.create_index(
+        op.f("ix_prohibited_project_names_created"),
+        "prohibited_project_names",
+        ["created"],
+        unique=False,
+    )
+    op.alter_column(
+        "prohibited_user_names",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.create_index(
+        op.f("ix_prohibited_user_names_created"),
+        "prohibited_user_names",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "project_events",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_project_events_created"), "project_events", ["created"], unique=False
+    )
+    op.alter_column(
+        "projects",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.add_column(
+        "release_dependencies",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_release_dependencies_created"),
+        "release_dependencies",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "release_descriptions",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_release_descriptions_created"),
+        "release_descriptions",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "release_files",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_release_files_created"), "release_files", ["created"], unique=False
+    )
+    op.add_column(
+        "release_urls",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_release_urls_created"), "release_urls", ["created"], unique=False
+    )
+    op.alter_column(
+        "releases",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.create_index(op.f("ix_releases_created"), "releases", ["created"], unique=False)
+    op.add_column(
+        "role_invitations",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_role_invitations_created"),
+        "role_invitations",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "roles",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(op.f("ix_roles_created"), "roles", ["created"], unique=False)
+    op.add_column(
+        "row_counts",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_row_counts_created"), "row_counts", ["created"], unique=False
+    )
+    op.alter_column(
+        "ses_emails",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.create_index(
+        op.f("ix_ses_emails_created"), "ses_emails", ["created"], unique=False
+    )
+    op.alter_column(
+        "ses_events",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.create_index(
+        op.f("ix_ses_events_created"), "ses_events", ["created"], unique=False
+    )
+    op.add_column(
+        "sponsors",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(op.f("ix_sponsors_created"), "sponsors", ["created"], unique=False)
+    op.add_column(
+        "team_events",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_team_events_created"), "team_events", ["created"], unique=False
+    )
+    op.add_column(
+        "team_project_roles",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_team_project_roles_created"),
+        "team_project_roles",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "team_roles",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_team_roles_created"), "team_roles", ["created"], unique=False
+    )
+    op.alter_column(
+        "teams",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.add_column(
+        "user_events",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_user_events_created"), "user_events", ["created"], unique=False
+    )
+    op.add_column(
+        "user_recovery_codes",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_user_recovery_codes_created"),
+        "user_recovery_codes",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "user_security_keys",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_user_security_keys_created"),
+        "user_security_keys",
+        ["created"],
+        unique=False,
+    )
+    op.alter_column(
+        "user_titan_codes",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+        existing_server_default=sa.text("now()"),
+    )
+    op.create_index(
+        op.f("ix_user_titan_codes_created"),
+        "user_titan_codes",
+        ["created"],
+        unique=False,
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(op.f("ix_users_created"), "users", ["created"], unique=False)
+    op.add_column(
+        "vulnerabilities",
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_vulnerabilities_created"), "vulnerabilities", ["created"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_vulnerabilities_created"), table_name="vulnerabilities")
+    op.drop_column("vulnerabilities", "created")
+    op.drop_index(op.f("ix_users_created"), table_name="users")
+    op.drop_column("users", "created")
+    op.drop_index(op.f("ix_user_titan_codes_created"), table_name="user_titan_codes")
+    op.alter_column(
+        "user_titan_codes",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(
+        op.f("ix_user_security_keys_created"), table_name="user_security_keys"
+    )
+    op.drop_column("user_security_keys", "created")
+    op.drop_index(
+        op.f("ix_user_recovery_codes_created"), table_name="user_recovery_codes"
+    )
+    op.drop_column("user_recovery_codes", "created")
+    op.drop_index(op.f("ix_user_events_created"), table_name="user_events")
+    op.drop_column("user_events", "created")
+    op.alter_column(
+        "teams",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(op.f("ix_team_roles_created"), table_name="team_roles")
+    op.drop_column("team_roles", "created")
+    op.drop_index(
+        op.f("ix_team_project_roles_created"), table_name="team_project_roles"
+    )
+    op.drop_column("team_project_roles", "created")
+    op.drop_index(op.f("ix_team_events_created"), table_name="team_events")
+    op.drop_column("team_events", "created")
+    op.drop_index(op.f("ix_sponsors_created"), table_name="sponsors")
+    op.drop_column("sponsors", "created")
+    op.drop_index(op.f("ix_ses_events_created"), table_name="ses_events")
+    op.alter_column(
+        "ses_events",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(op.f("ix_ses_emails_created"), table_name="ses_emails")
+    op.alter_column(
+        "ses_emails",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(op.f("ix_row_counts_created"), table_name="row_counts")
+    op.drop_column("row_counts", "created")
+    op.drop_index(op.f("ix_roles_created"), table_name="roles")
+    op.drop_column("roles", "created")
+    op.drop_index(op.f("ix_role_invitations_created"), table_name="role_invitations")
+    op.drop_column("role_invitations", "created")
+    op.drop_index(op.f("ix_releases_created"), table_name="releases")
+    op.alter_column(
+        "releases",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(op.f("ix_release_urls_created"), table_name="release_urls")
+    op.drop_column("release_urls", "created")
+    op.drop_index(op.f("ix_release_files_created"), table_name="release_files")
+    op.drop_column("release_files", "created")
+    op.drop_index(
+        op.f("ix_release_descriptions_created"), table_name="release_descriptions"
+    )
+    op.drop_column("release_descriptions", "created")
+    op.drop_index(
+        op.f("ix_release_dependencies_created"), table_name="release_dependencies"
+    )
+    op.drop_column("release_dependencies", "created")
+    op.alter_column(
+        "projects",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(op.f("ix_project_events_created"), table_name="project_events")
+    op.drop_column("project_events", "created")
+    op.drop_index(
+        op.f("ix_prohibited_user_names_created"), table_name="prohibited_user_names"
+    )
+    op.alter_column(
+        "prohibited_user_names",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(
+        op.f("ix_prohibited_project_names_created"),
+        table_name="prohibited_project_names",
+    )
+    op.alter_column(
+        "prohibited_project_names",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.alter_column(
+        "organizations",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(
+        op.f("ix_organization_roles_created"), table_name="organization_roles"
+    )
+    op.drop_column("organization_roles", "created")
+    op.drop_index(
+        op.f("ix_organization_project_created"), table_name="organization_project"
+    )
+    op.drop_column("organization_project", "created")
+    op.drop_index(
+        op.f("ix_organization_name_catalog_created"),
+        table_name="organization_name_catalog",
+    )
+    op.drop_column("organization_name_catalog", "created")
+    op.drop_index(
+        op.f("ix_organization_invitations_created"),
+        table_name="organization_invitations",
+    )
+    op.drop_column("organization_invitations", "created")
+    op.drop_index(
+        op.f("ix_organization_events_created"), table_name="organization_events"
+    )
+    op.drop_column("organization_events", "created")
+    op.drop_index(op.f("ix_oidc_providers_created"), table_name="oidc_providers")
+    op.drop_column("oidc_providers", "created")
+    op.drop_index(
+        op.f("ix_oidc_provider_project_association_created"),
+        table_name="oidc_provider_project_association",
+    )
+    op.drop_column("oidc_provider_project_association", "created")
+    op.drop_index(op.f("ix_malware_verdicts_created"), table_name="malware_verdicts")
+    op.drop_column("malware_verdicts", "created")
+    op.drop_index(op.f("ix_malware_checks_created"), table_name="malware_checks")
+    op.alter_column(
+        "malware_checks",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(op.f("ix_macaroons_created"), table_name="macaroons")
+    op.alter_column(
+        "macaroons",
+        "created",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+    op.drop_index(op.f("ix_banners_created"), table_name="banners")
+    op.drop_column("banners", "created")

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -178,12 +178,6 @@ class Organization(HasEvents, db.Model):
     description = Column(Text, nullable=False)
     is_active = Column(Boolean, nullable=False, server_default=sql.false())
     is_approved = Column(Boolean)
-    created = Column(
-        DateTime(timezone=False),
-        nullable=False,
-        server_default=sql.func.now(),
-        index=True,
-    )
     date_approved = Column(
         DateTime(timezone=False),
         nullable=True,
@@ -503,12 +497,6 @@ class Team(HasEvents, db.Model):
     organization_id = Column(
         ForeignKey("organizations.id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
-    )
-    created = Column(
-        DateTime(timezone=False),
-        nullable=False,
-        server_default=sql.func.now(),
-        index=True,
     )
 
     organization = orm.relationship("Organization", lazy=False, backref="teams")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -181,12 +181,6 @@ class Project(SitemapMixin, TwoFactorRequireable, HasEvents, db.Model):
         server_default=FetchedValue(),
         server_onupdate=FetchedValue(),
     )
-    created = Column(
-        DateTime(timezone=False),
-        nullable=False,
-        server_default=sql.func.now(),
-        index=True,
-    )
     has_docs = Column(Boolean)
     upload_limit = Column(Integer, nullable=True)
     total_size_limit = Column(BigInteger, nullable=True)
@@ -442,9 +436,6 @@ class Release(db.Model):
     download_url = Column(Text)
     _pypi_ordering = Column(Integer)
     requires_python = Column(Text)
-    created = Column(
-        DateTime(timezone=False), nullable=False, server_default=sql.func.now()
-    )
 
     description_id = Column(
         ForeignKey("release_descriptions.id", onupdate="CASCADE", ondelete="CASCADE"),
@@ -720,9 +711,6 @@ class ProhibitedProjectName(db.Model):
 
     __repr__ = make_repr("name")
 
-    created = Column(
-        DateTime(timezone=False), nullable=False, server_default=sql.func.now()
-    )
     name = Column(Text, unique=True, nullable=False)
     _prohibited_by = Column(
         "prohibited_by", UUID(as_uuid=True), ForeignKey("users.id"), index=True


### PR DESCRIPTION
We've got a fair amount of duplication on the `created` column for models that support it, and a number of tables that are missing a `created` column entirely.

This PR attempts to ensure all current and future models/rows have a `created` field/column by default.

Note that this unsets `nullable=False` as we can't backfill creation dates for models that don't already have the field, but also sets a default, so these should never be null going forward.