### PR TITLE
chore: rename sample class to remove warning

### DIFF
--- a/tests/unit/macaroons/test_caveats.py
+++ b/tests/unit/macaroons/test_caveats.py
@@ -137,7 +137,9 @@ class TestDeserialization:
             deserialize(b'{"version": 1, "permissions": "user"}')
 
     def test_deserialize_with_defaults(self):
-        assert SampleCaveat.__deserialize__([1]) == SampleCaveat(first=1, second=2, third=3)
+        assert SampleCaveat.__deserialize__([1]) == SampleCaveat(
+            first=1, second=2, third=3
+        )
         assert SampleCaveat.__deserialize__([1, 5]) == SampleCaveat(
             first=1, second=5, third=3
         )

--- a/tests/unit/macaroons/test_caveats.py
+++ b/tests/unit/macaroons/test_caveats.py
@@ -40,7 +40,7 @@ from ...common.db.packaging import ProjectFactory
 
 
 @dataclass(frozen=True)
-class TestCaveat(Caveat):
+class SampleCaveat(Caveat):
     first: int
     second: int = 2
     third: int = dataclasses.field(default_factory=lambda: 3)
@@ -137,11 +137,11 @@ class TestDeserialization:
             deserialize(b'{"version": 1, "permissions": "user"}')
 
     def test_deserialize_with_defaults(self):
-        assert TestCaveat.__deserialize__([1]) == TestCaveat(first=1, second=2, third=3)
-        assert TestCaveat.__deserialize__([1, 5]) == TestCaveat(
+        assert SampleCaveat.__deserialize__([1]) == SampleCaveat(first=1, second=2, third=3)
+        assert SampleCaveat.__deserialize__([1, 5]) == SampleCaveat(
             first=1, second=5, third=3
         )
-        assert TestCaveat.__deserialize__([1, 5, 7]) == TestCaveat(
+        assert SampleCaveat.__deserialize__([1, 5, 7]) == SampleCaveat(
             first=1, second=5, third=7
         )
 


### PR DESCRIPTION
pytest attempts to collect any test cases or classes based on naming convention of `Test*` prefix.

This dataclass is a test object, not a test case class, and produces an unnecessary warning as a result:

```
PytestCollectionWarning: cannot collect test class 'TestCaveat' because
it has a __init__ constructor (from: tests/unit/macaroons/test_caveats.py)
```

Signed-off-by: Mike Fiedler <miketheman@gmail.com>