### PR TITLE
Fix redirect removing project from an org

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -5912,7 +5912,12 @@ class TestManageProjectSettings:
 
         result = views.remove_organization_project(project, db_request)
 
-        assert db_request.session.flash.calls == []
+        assert db_request.session.flash.calls == [
+            pretend.call(
+                ("Could not remove project from organization - no organization found"),
+                queue="error",
+            )
+        ]
         assert db_request.route_path.calls == [
             pretend.call("manage.project.settings", project_name="foo")
         ]
@@ -6035,7 +6040,10 @@ class TestManageProjectSettings:
             pretend.call("Removed the project 'foo' from 'bar'", queue="success")
         ]
         assert db_request.route_path.calls == [
-            pretend.call("manage.project.settings", project_name="foo")
+            pretend.call(
+                "manage.organization.projects",
+                organization_name=project.organization.normalized_name,
+            )
         ]
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -354,11 +354,11 @@ msgid ""
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:1980 warehouse/manage/views.py:4144
+#: warehouse/manage/views.py:1980 warehouse/manage/views.py:4155
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2037 warehouse/manage/views.py:4211
+#: warehouse/manage/views.py:2037 warehouse/manage/views.py:4222
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
@@ -366,11 +366,11 @@ msgstr ""
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2091 warehouse/manage/views.py:4255
+#: warehouse/manage/views.py:2091 warehouse/manage/views.py:4266
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2124 warehouse/manage/views.py:4279
+#: warehouse/manage/views.py:2124 warehouse/manage/views.py:4290
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
@@ -384,21 +384,21 @@ msgid ""
 "again later."
 msgstr ""
 
-#: warehouse/manage/views.py:4029
+#: warehouse/manage/views.py:4040
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4098
+#: warehouse/manage/views.py:4109
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4131
+#: warehouse/manage/views.py:4142
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4244
+#: warehouse/manage/views.py:4255
 msgid "Could not find role invitation."
 msgstr ""
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -3153,6 +3153,17 @@ def remove_organization_project(project, request):
             queue="success",
         )
 
+        return HTTPSeeOther(
+            request.route_path(
+                "manage.organization.projects",
+                organization_name=organization.normalized_name,
+            )
+        )
+
+    request.session.flash(
+        ("Could not remove project from organization - no organization found"),
+        queue="error",
+    )
     return HTTPSeeOther(
         request.route_path("manage.project.settings", project_name=project.name)
     )


### PR DESCRIPTION
- Redirect to org project management page instead of project settings
- Make tests and translations happy
- Fixes #12055 