### PR TITLE
chore: update static base image to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # our static assets with. It is important that the steps in this remain the
 # same as the steps in Dockerfile.static, EXCEPT this may include additional
 # steps appended onto the end.
-FROM node:14.19.1 as static
+FROM node:14.19.1-bullseye as static
 
 WORKDIR /opt/warehouse/src/
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM node:14.19.1 as static
+FROM node:14.19.1-bullseye as static
 
 WORKDIR /opt/warehouse/src/
 


### PR DESCRIPTION
As previously attempted in #11472 and reverted in #11493

After isolating the condition that was observed and removing the calls to compile `gifsicle` in #12232, upgrade the `static` containers only with this changest.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>