### PR TITLE
chore(ci): update ci to test against node 14.19.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: ${{ matrix.needs-node }}
         with:
-          node-version: 14.15.5
+          node-version: 14.19.1
           cache: 'npm'
       - name: Install Node dependencies
         if: ${{ matrix.needs-node }}


### PR DESCRIPTION
We didn't maintain parity when upgrading last time.

~~Instead of trying to keep two items in sync, use the `engines` keyword
in `package.json` to set the desired node version, and have the CI
action use it for setup.~~

~~I have yet to find a way to use the same value in a `Dockerfile`
definition, but one fewer location seems better.~~

~~Refs: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines~~
Functionality to support this not yet released on `actions/setup-node` 🤦 

Signed-off-by: Mike Fiedler <miketheman@gmail.com>