### PR TITLE
Add functionality to hide user avatar

### DIFF
--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -85,6 +85,7 @@ class User(SitemapMixin, HasEvents, db.Model):
     prohibit_password_reset = Column(
         Boolean, nullable=False, server_default=sql.false()
     )
+    hide_avatar = Column(Boolean, nullable=False, server_default=sql.false())
     date_joined = Column(DateTime, server_default=sql.func.now())
     last_login = Column(TZDateTime, nullable=False, server_default=sql.func.now())
     disabled_for = Column(

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -185,6 +185,11 @@
               <div class="box-body">
                 {{ render_field("Prohibit Password Reset", form.prohibit_password_reset, "prohibit-password-reset")}}
               </div>
+
+              <div class="box-body">
+                {{ render_field("Hide avatar", form.hide_avatar, "hide-avatar")}}
+              </div>
+
             </div>
 
             <div>

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -93,6 +93,7 @@ class UserForm(forms.Form):
     is_psf_staff = wtforms.fields.BooleanField()
 
     prohibit_password_reset = wtforms.fields.BooleanField()
+    hide_avatar = wtforms.fields.BooleanField()
 
     emails = wtforms.fields.FieldList(wtforms.fields.FormField(EmailForm))
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1179,7 +1179,7 @@ msgid "Log in to %(title)s"
 msgstr ""
 
 #: warehouse/templates/accounts/login.html:49
-#: warehouse/templates/accounts/profile.html:40
+#: warehouse/templates/accounts/profile.html:41
 #: warehouse/templates/accounts/register.html:89
 #: warehouse/templates/email/organization-member-added/body.html:30
 #: warehouse/templates/email/organization-member-invited/body.html:30
@@ -1239,16 +1239,16 @@ msgstr ""
 msgid "Avatar for {user} from gravatar.com"
 msgstr ""
 
-#: warehouse/templates/accounts/profile.html:51
+#: warehouse/templates/accounts/profile.html:52
 msgid "Date joined"
 msgstr ""
 
-#: warehouse/templates/accounts/profile.html:52
+#: warehouse/templates/accounts/profile.html:53
 #, python-format
 msgid "Joined %(start_date)s"
 msgstr ""
 
-#: warehouse/templates/accounts/profile.html:66
+#: warehouse/templates/accounts/profile.html:67
 #, python-format
 msgid ""
 "\n"
@@ -1261,11 +1261,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/accounts/profile.html:72
+#: warehouse/templates/accounts/profile.html:73
 msgid "No projects"
 msgstr ""
 
-#: warehouse/templates/accounts/profile.html:81
+#: warehouse/templates/accounts/profile.html:82
 #: warehouse/templates/manage/organization/projects.html:71
 #: warehouse/templates/manage/projects.html:34
 #: warehouse/templates/manage/projects.html:104
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "Last released %(release_date)s"
 msgstr ""
 
-#: warehouse/templates/accounts/profile.html:89
+#: warehouse/templates/accounts/profile.html:90
 #, python-format
 msgid "%(user)s has not uploaded any projects to PyPI, yet"
 msgstr ""

--- a/warehouse/migrations/versions/d0f67adbcb80_add_avatar_hidden_column_to_user_model.py
+++ b/warehouse/migrations/versions/d0f67adbcb80_add_avatar_hidden_column_to_user_model.py
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add 'avatar_hidden' column to User model
+
+Revision ID: d0f67adbcb80
+Revises: fe2e3d22b3fa
+Create Date: 2022-09-28 16:02:44.054680
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "d0f67adbcb80"
+down_revision = "fe2e3d22b3fa"
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column(
+            "hide_avatar", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("users", "hide_avatar")

--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -29,7 +29,8 @@
     <div class="left-layout__sidebar">
       <div class="author-profile">
         {% set alt = gettext("Avatar for {user} from gravatar.com").format(user=user.name|default(user.username, true)) %}
-        <img src="{{ gravatar(request, user.email, size=225) }}" alt="{{ alt }}" title="{{ alt }}">
+        {% set email = 'hidden@pypi.org' if user.hide_avatar else user.email %}
+        <img src="{{ gravatar(request, email, size=225) }}" alt="{{ alt }}" title="{{ alt }}">
         <div class="author-profile__info">
           {% if user.name %}
           <h1 class="author-profile__name">{{ user.name }}</h1>


### PR DESCRIPTION
Since Gravatar seems to be completely unresponsive to moderation requests, and since this is 'user-published content' on PyPI that we don't have any control over, this PR gives admins the ability to hide a user's avatar on their profile.