### PR TITLE
End 2FA security key giveaway

### DIFF
--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -455,26 +455,3 @@ class RequestPasswordResetForm(forms.Form):
 class ResetPasswordForm(NewPasswordMixin, forms.Form):
 
     pass
-
-
-class TitanPromoCodeForm(forms.Form):
-    country = wtforms.SelectField(
-        "Select destination country",
-        choices=[
-            ("", "Select destination country"),
-            ("Austria", "Austria"),
-            ("Belgium", "Belgium"),
-            ("Canada", "Canada"),
-            ("France", "France"),
-            ("Germany", "Germany"),
-            ("Italy", "Italy"),
-            ("Japan", "Japan"),
-            ("Spain", "Spain"),
-            ("Switzerland", "Switzerland"),
-            ("United Kingdom", "United Kingdom"),
-            ("United States", "United States"),
-        ],
-        validators=[
-            wtforms.validators.DataRequired(message="Select destination country")
-        ],
-    )

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -281,18 +281,3 @@ class ProhibitedUserName(db.Model):
     )
     prohibited_by = orm.relationship(User)
     comment = Column(Text, nullable=False, server_default="")
-
-
-class TitanPromoCode(db.Model):
-    __tablename__ = "user_titan_codes"
-
-    user_id = Column(
-        UUID(as_uuid=True),
-        ForeignKey("users.id", deferrable=True, initially="DEFERRED"),
-        nullable=True,
-        index=True,
-        unique=True,
-    )
-    code = Column(String, nullable=False, unique=True)
-    created = Column(DateTime, nullable=False, server_default=sql.func.now())
-    distributed = Column(DateTime, nullable=True)

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1,10 +1,10 @@
-#: warehouse/views.py:128
+#: warehouse/views.py:125
 msgid ""
 "Two-factor authentication must be enabled on your account to perform this"
 " action."
 msgstr ""
 
-#: warehouse/views.py:291
+#: warehouse/views.py:288
 msgid "Locale updated"
 msgstr ""
 

--- a/warehouse/migrations/versions/90f6ee9298db_drop_titan_promo_code_table.py
+++ b/warehouse/migrations/versions/90f6ee9298db_drop_titan_promo_code_table.py
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Drop titan_promo_code table
+
+Revision ID: 90f6ee9298db
+Revises: d0f67adbcb80
+Create Date: 2022-10-03 18:48:39.327937
+"""
+
+
+from alembic import op
+
+revision = "90f6ee9298db"
+down_revision = "d0f67adbcb80"
+
+
+def upgrade():
+    op.drop_index("ix_user_titan_codes_user_id", table_name="user_titan_codes")
+    op.drop_table("user_titan_codes")
+
+
+def downgrade():
+    raise RuntimeError("Can't roll back")

--- a/warehouse/templates/email/two-factor-mandate/body.html
+++ b/warehouse/templates/email/two-factor-mandate/body.html
@@ -30,8 +30,4 @@ Since you already have two-factor authentication enabled on your account, there'
 You can enable two-factor authentication on your account today by visiting <a href="{{ request.route_url("manage.account.two-factor", _host="pypi.org") }}">{{ request.route_url("manage.account.two-factor", _host="pypi.org") }}</a>.
 {% endif %}
 </p>
-
-<p>
-PS: To make it easier for maintainers like you to enable two-factor authentication, we're also distributing security keys to eligible maintainers. See <a href="{{ request.route_url("security-key-giveaway", _host="pypi.org") }}">{{ request.route_url("security-key-giveaway", _host="pypi.org") }}</a> for more details.
-</p>
 {% endblock %}

--- a/warehouse/templates/email/two-factor-mandate/body.txt
+++ b/warehouse/templates/email/two-factor-mandate/body.txt
@@ -24,6 +24,4 @@ Since you already have two-factor authentication enabled on your account, there'
 You can enable two-factor authentication on your account today by visiting {{ request.route_url("manage.account.two-factor", _host="pypi.org") }}.
 {%- endif %}
 
-PS: To make it easier for maintainers like you to enable two-factor authentication, we're also distributing security keys to eligible maintainers. See {{ request.route_url("security-key-giveaway", _host="pypi.org") }} for more details.
-
 {% endblock %}

--- a/warehouse/templates/pages/security-key-giveaway.html
+++ b/warehouse/templates/pages/security-key-giveaway.html
@@ -21,6 +21,10 @@
   <div class="horizontal-section">
     <div class="narrow-container">
       <h1 class="page-title">PyPI 2FA Security Key Giveaway</h1>
+      <div class="callout-block callout-block--danger">
+        <h2>Giveaway has ended</h2>
+        <p>The givaway has closed as of Oct 1, 2022.</p>
+      </div>
       <p>
         <img src="{{ request.static_path('warehouse:static/dist/images/titan.png') }}" alt="Two Titan security keys, one USB-A and one USB-C">
         <center><small>Pictured: two Titan security keys, one USB-A and the other USB-C. (Source: <a href="https://store.google.com/product/titan_security_key">Google</a>)</small></center>
@@ -40,60 +44,11 @@
         project maintainers.
       </p>
       <p>
-        <b>
-          As of Sept 23, 2022, these keys are available to any PyPI account that
-          existed before this restriction was removed, while supplies remain.
-        </b>
-      </p>
-      <p>
         Eligible maintainers will be able to redeem a promo code for two
         free <a
         href="https://store.google.com/product/titan_security_key">Titan
         Security Keys</a> (either USB-C or USB-A), including free shipping.
       </p>
-
-      <div class="callout-block">
-      <h2>Determine your eligibility</h2>
-      {% if promo_code %}
-        {# Show the user their promo code #}
-        <p>
-        Success! Your promo code is:
-        </p>
-        <p class="copyable">
-            <span id="promo-code">{{ promo_code.code }}</span>
-            <button type="button" class="copy-tooltip copy-tooltip-s" data-clipboard-target="#promo-code" data-tooltip-label="Copy to clipboard">
-              <i class="fa fa-copy" aria-hidden="true"></i>
-              <span class="sr-only">Copy promo code</span>
-            </button>
-        </p>
-        <p>
-        You can order your keys via <a href="https://store.google.com/product/titan_security_key">the Google Store</a> by applying this promo code at checkout. This code expires on October 1, 2022.
-        </p>
-      {% elif not request.user %}
-        {# The user is logged out, ask them to log in #}
-        <a href="{{ request.route_url("accounts.login", _query={REDIRECT_FIELD_NAME: request.path_qs}) }}" class="button button--primary">
-          Log in to determine if you are eligible
-        </a>
-      {% elif not eligible %}
-        {# The user is not eligible, tell them why #}
-        <p>Sorry, you're not currently eligible for a promo code.</p>
-        <p><b>Reason:</b> {{ reason_ineligible }}</p>
-      {% else %}
-        {# The user is eligible, show the form #}
-        <p>
-          Congrats, you may be eligible to receive a promo code!
-        </p>
-        <p>
-          We just need a little more information. (<a href="#regions">Why?</a>)
-          <form method="POST">
-            <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-            {{ form.country }}
-            <button type="submit" class="button button--primary">Request a promo code</button>
-          </form>
-        </p>
-      {% endif %}
-      </div>
-
 
       <section class="faq-group">
       <h2 id="faq">FAQ</h2>


### PR DESCRIPTION
Removes forms, models, and corresponding tables.  Leaves the page for now, but adds a warning that the giveaway has ended.

Fixes #11625.