### PR TITLE
feat: add notice for missing source distributions

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -529,6 +529,7 @@ msgstr ""
 #: warehouse/templates/manage/project/releases.html:140
 #: warehouse/templates/manage/project/releases.html:179
 #: warehouse/templates/packaging/detail.html:350
+#: warehouse/templates/packaging/detail.html:369
 #: warehouse/templates/pages/classifiers.html:25
 #: warehouse/templates/pages/help.html:20
 #: warehouse/templates/pages/help.html:212
@@ -5928,7 +5929,7 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">installing packages</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:354
+#: warehouse/templates/packaging/detail.html:352
 msgid ""
 "\n"
 "                Source Distribution\n"
@@ -5940,11 +5941,18 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/packaging/detail.html:364
+#: warehouse/templates/packaging/detail.html:368
 msgid "No source distribution files available for this release."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:370
+#: warehouse/templates/packaging/detail.html:369
+#, python-format
+msgid ""
+"See tutorial on <a href=\"%(href)s\" title=\"%(title)s\" "
+"target=\"_blank\" rel=\"noopener\">generating distribution archives</a>."
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:376
 msgid ""
 "\n"
 "                Built Distribution\n"

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -5940,7 +5940,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/packaging/detail.html:366
+#: warehouse/templates/packaging/detail.html:364
+msgid "No source distribution files available for this release."
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:370
 msgid ""
 "\n"
 "                Built Distribution\n"

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -359,6 +359,10 @@
             </h3>
 
             {{ file_table(sdists) }}
+            {% else %}
+            <h3>
+              {% trans %}No source distribution files available for this release.{% endtrans %}
+            </h3>
             {% endif %}
 
             {% if bdists %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -348,8 +348,6 @@
           <div id="files" data-project-tabs-target="content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="files-tab mobile-files-tab" tabindex="-1">
             <h2 class="page-title">{% trans %}Download files{% endtrans %}</h2>
             <p>{% trans href='https://packaging.python.org/installing/', title=gettext('External link') %}Download the file for your platform. If you're not sure which to choose, learn more about <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">installing packages</a>.{% endtrans %}</p>
-
-            {% if sdists %}
             <h3>
               {% trans count=sdists|length %}
                 Source Distribution
@@ -358,11 +356,19 @@
               {% endtrans %}
             </h3>
 
-            {{ file_table(sdists) }}
+            {% if sdists %}
+              {{ file_table(sdists) }}
             {% else %}
-            <h3>
-              {% trans %}No source distribution files available for this release.{% endtrans %}
-            </h3>
+              <div class="file">
+                <div class="file__graphic">
+                  <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                </div>
+
+                <div class="card">
+                  {% trans %}No source distribution files available for this release.{% endtrans %}
+                  {% trans href='https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives', title=gettext('External link') %}See tutorial on <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">generating distribution archives</a>.{% endtrans %}
+                </div>
+              </div>
             {% endif %}
 
             {% if bdists %}


### PR DESCRIPTION
In the event that the release has binary distributions but no source distributions, add a notice for the viewer that the files are missing.

Example rendering:

<img width="783" alt="Screen Shot 2022-10-07 at 8 56 33 PM" src="https://user-images.githubusercontent.com/529516/194679453-df6212da-32cc-4e5b-8a8d-0ee5498d17fa.png">

Resolves #11060

Signed-off-by: Mike Fiedler <miketheman@gmail.com>