### PR TITLE
External collaborator cannot leave the project

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -8655,10 +8655,65 @@ class TestDeleteProjectRole:
         result = views.delete_project_role(project, db_request)
 
         assert db_request.session.flash.calls == [
-            pretend.call("Cannot remove yourself as Owner", queue="error")
+            pretend.call("Cannot remove yourself as Sole Owner", queue="error")
         ]
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
+
+    def test_delete_not_sole_owner_role(self, db_request, monkeypatch):
+        project = ProjectFactory.create(name="foobar")
+        user = UserFactory.create()
+        RoleFactory.create(user=user, project=project, role_name="Owner")
+        user_2 = UserFactory.create(username="testuser")
+        role_2 = RoleFactory.create(user=user_2, project=project, role_name="Owner")
+
+        db_request.method = "POST"
+        db_request.user = user_2
+        db_request.POST = MultiDict({"role_id": role_2.id})
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/the-redirect")
+
+        send_collaborator_removed_email = pretend.call_recorder(lambda *a, **kw: None)
+        monkeypatch.setattr(
+            views, "send_collaborator_removed_email", send_collaborator_removed_email
+        )
+        send_removed_as_collaborator_email = pretend.call_recorder(
+            lambda *a, **kw: None
+        )
+        monkeypatch.setattr(
+            views,
+            "send_removed_as_collaborator_email",
+            send_removed_as_collaborator_email,
+        )
+
+        result = views.delete_project_role(project, db_request)
+
+        assert db_request.route_path.calls == [pretend.call("manage.projects")]
+        assert db_request.db.query(Role).filter(Role.user_id == user_2.id).all() == []
+        assert send_collaborator_removed_email.calls == [
+            pretend.call(
+                db_request, {user}, user=user_2, submitter=user_2, project_name="foobar"
+            )
+        ]
+        assert send_removed_as_collaborator_email.calls == [
+            pretend.call(db_request, user_2, submitter=user_2, project_name="foobar")
+        ]
+        assert db_request.session.flash.calls == [
+            pretend.call("Removed role", queue="success")
+        ]
+        assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Location"] == "/the-redirect"
+
+        entry = (
+            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+        )
+
+        assert entry.name == project.name
+        assert entry.action == "remove Owner testuser"
+        assert entry.submitted_by == db_request.user
+        assert entry.submitted_from == db_request.remote_addr
 
     def test_delete_non_owner_role(self, db_request):
         project = ProjectFactory.create(name="foobar")

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -338,61 +338,61 @@ msgstr ""
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:1970
+#: warehouse/manage/views.py:1987
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:1981
+#: warehouse/manage/views.py:1998
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:1995 warehouse/manage/views.py:4191
+#: warehouse/manage/views.py:2012 warehouse/manage/views.py:4224
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2052 warehouse/manage/views.py:4258
+#: warehouse/manage/views.py:2069 warehouse/manage/views.py:4291
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:2092
+#: warehouse/manage/views.py:2115
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2106 warehouse/manage/views.py:4302
+#: warehouse/manage/views.py:2129 warehouse/manage/views.py:4335
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2139 warehouse/manage/views.py:4326
+#: warehouse/manage/views.py:2162 warehouse/manage/views.py:4359
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views.py:2936
+#: warehouse/manage/views.py:2969
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/manage/views.py:3968
+#: warehouse/manage/views.py:4001
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4076
+#: warehouse/manage/views.py:4109
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4145
+#: warehouse/manage/views.py:4178
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4178
+#: warehouse/manage/views.py:4211
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4291
+#: warehouse/manage/views.py:4324
 msgid "Could not find role invitation."
 msgstr ""
 
@@ -4205,7 +4205,8 @@ msgid "Cannot remove other people from the organization"
 msgstr ""
 
 #: warehouse/templates/manage/organization/roles.html:123
-msgid "Cannot remove yourself as owner"
+#: warehouse/templates/manage/project/roles.html:196
+msgid "Cannot remove yourself as Sole Owner"
 msgstr ""
 
 #: warehouse/templates/manage/organization/roles.html:126
@@ -5031,10 +5032,6 @@ msgstr ""
 #: warehouse/templates/manage/project/roles.html:200
 #, python-format
 msgid "Remove %(collaborator)s from this project"
-msgstr ""
-
-#: warehouse/templates/manage/project/roles.html:196
-msgid "Cannot remove yourself as Owner"
 msgstr ""
 
 #: warehouse/templates/manage/project/roles.html:243

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -2259,10 +2259,10 @@ def delete_organization_role(organization, request):
     role_id = request.POST["role_id"]
     role = organization_service.get_organization_role(role_id)
     organizations_sole_owned = set(
-        organization.name
+        organization.id
         for organization in user_organizations(request)["organizations_with_sole_owner"]
     )
-    is_sole_owner = organization.name in organizations_sole_owned
+    is_sole_owner = organization.id in organizations_sole_owned
 
     if not role or role.organization_id != organization.id:
         request.session.flash("Could not find member", queue="error")

--- a/warehouse/templates/manage/organization/roles.html
+++ b/warehouse/templates/manage/organization/roles.html
@@ -119,8 +119,8 @@
         <td class="table__align-right">
         {% if not request.has_permission("manage:organization") and request.user.username != role.user.username %}
           <button class="button" title="{% trans %}Cannot remove other people from the organization{% endtrans %}" disabled>{% trans %}Remove{% endtrans %}</button>
-        {% elif request.has_permission("manage:organization") and request.user.username == role.user.username %}
-          <button class="button" title="{% trans %}Cannot remove yourself as owner{% endtrans %}" disabled>{% trans %}Remove{% endtrans %}</button>
+        {% elif request.has_permission("manage:organization") and request.user.username == role.user.username and organization.name in organizations_with_sole_owner %}
+          <button class="button" title="{% trans %}Cannot remove yourself as Sole Owner{% endtrans %}" disabled>{% trans %}Remove{% endtrans %}</button>
         {% else %}
           {% set extra_fields %}<input type="hidden" name="role_id" value="{{ role.id }}">{% endset %}
           {% set extra_description %}{% trans user=('yourself' if request.user.username == role.user.username else role.user.username) %}Remove {{ user }} from this organization{% endtrans %}{% trans %}.{% endtrans %}{% endset %}

--- a/warehouse/templates/manage/project/roles.html
+++ b/warehouse/templates/manage/project/roles.html
@@ -192,8 +192,8 @@
         </td>
         <td class="table__align-center">{{ two_factor_badge(role.user) }}</td>
         <td class="table__align-right">
-          {% if role.role_name == "Owner" and request.user.username == role.user.username %}
-            <button class="button" title="{% trans %}Cannot remove yourself as Owner{% endtrans %}" disabled>{% trans %}Remove{% endtrans %}</button>
+          {% if request.user.username == role.user.username and project.name in projects_sole_owned %}
+            <button class="button" title="{% trans %}Cannot remove yourself as Sole Owner{% endtrans %}" disabled>{% trans %}Remove{% endtrans %}</button>
           {% else %}
             {% set extra_fields %}<input type="hidden" name="role_id" value="{{ role.id }}">{% endset %}
             {% set extra_description %}{% trans collaborator=role.user.username %}Remove {{ collaborator }} from this project{% endtrans %}{% trans %}.{% endtrans %}{% endset %}


### PR DESCRIPTION
- Allow external collaborators with owner role to leave the project
- Add check to ensure user is not sole owner
- Apply same logic to organization owners i.e. allow them to leave unless sole owner
- Resolves #12049 
- Resolves #11642