### PR TITLE
Fix AssertionError in tests comparing LazyString

### DIFF
--- a/tests/unit/i18n/test_init.py
+++ b/tests/unit/i18n/test_init.py
@@ -181,5 +181,8 @@ def test_lazy_string():
         return string_in
 
     lazy_string = i18n.LazyString(stringify, "test_string")
+    equally_lazy_string = i18n.LazyString(stringify, "test_string")
 
     assert lazy_string.__json__(None) == "test_string"
+    assert lazy_string == "test_string"
+    assert lazy_string == equally_lazy_string

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -61,6 +61,13 @@ class LazyString:
     def __str__(self):
         return self.fn(*self.args, **self.kwargs)
 
+    def __eq__(self, other):
+        return (
+            self.args == other.args and self.kwargs == other.kwargs
+            if isinstance(other, LazyString)
+            else self.args == (other,) and not self.kwargs
+        )
+
 
 def _locale(request):
     """


### PR DESCRIPTION
Before this fix, running all tests would work fine:

    make tests

But running one specific set of tests:

    T=tests/unit/manage/test_views.py make tests

Would lead to errors:

    ...
    E       AssertionError: assert [<warehouse.i...ffff874e3fa0>] == ['This team n...t team name.']
    E         At index 0 diff: <warehouse.i18n.LazyString object at 0xffff874e3fa0> != 'This team name has already been used. Choose a different team name.'
    ...
    E       AssertionError: assert [<warehouse.i...ffff872be2c0>] == ['This team n...t team name.']
    E         At index 0 diff: <warehouse.i18n.LazyString object at 0xffff872be2c0> != 'This team name has already been used. Choose a different team name.'
    ...
    =========================== short test summary info ============================
    FAILED tests/unit/manage/test_views.py::TestManageOrganizationTeams::test_create_team_invalid
    FAILED tests/unit/manage/test_views.py::TestManageTeamSettings::test_save_team_validation_fails
    ================= 2 failed, 243 passed, 439 warnings in 22.43s =================

Partially fixes errors when running isolated tests:  
- Refs: #12227