### PR TITLE
Modify add API token messages to create API token

### DIFF
--- a/warehouse/locale/am/LC_MESSAGES/messages.po
+++ b/warehouse/locale/am/LC_MESSAGES/messages.po
@@ -2841,13 +2841,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6394,7 +6394,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/ar/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ar/LC_MESSAGES/messages.po
@@ -3159,13 +3159,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6983,7 +6983,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/bn/LC_MESSAGES/messages.po
+++ b/warehouse/locale/bn/LC_MESSAGES/messages.po
@@ -2932,13 +2932,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6527,7 +6527,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/ca/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ca/LC_MESSAGES/messages.po
@@ -3185,13 +3185,13 @@ msgstr "Testimonis de l’API actius en aquest compte"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Afegeix un testimoni de l’API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -7022,7 +7022,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/ckb/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ckb/LC_MESSAGES/messages.po
@@ -3257,13 +3257,13 @@ msgstr "نیشانەکانی API چالاک بۆ ئەم ئەکاونتە"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "زیادکردنی نیشانەی API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">ناونیشانی ئیمەیڵی سەرەکی خۆت پشتڕاست بکەرەوە</a> بۆ "
@@ -6883,7 +6883,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/cs/LC_MESSAGES/messages.po
+++ b/warehouse/locale/cs/LC_MESSAGES/messages.po
@@ -3299,13 +3299,13 @@ msgstr "Aktivovat API tokeny pro tento účet"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Přidat API token"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "Pro přidání API tokenu<a href=\"%(href)s\">ověř svou primární emailovou "
@@ -7405,7 +7405,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/da/LC_MESSAGES/messages.po
+++ b/warehouse/locale/da/LC_MESSAGES/messages.po
@@ -2991,13 +2991,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6659,7 +6659,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/de/LC_MESSAGES/messages.po
+++ b/warehouse/locale/de/LC_MESSAGES/messages.po
@@ -3379,13 +3379,13 @@ msgstr "Aktive API-Token für dieses Konto"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "API-Token hinzufügen"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Primäre E-Mail-Adresse bestätigen</a>, um API-Token zu "
@@ -7841,7 +7841,7 @@ msgstr "(überprüfen Sie Ihre <a href=\"%(href)s\">Kontoeinstellungen</a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Öffnen Sie den Abschnitt API-Token in Ihren <a href=\"%(href)s"
 "\">Kontoeinstellungen</a> und wählen Sie \"API-Token hinzufügen\""

--- a/warehouse/locale/el/LC_MESSAGES/messages.po
+++ b/warehouse/locale/el/LC_MESSAGES/messages.po
@@ -3383,13 +3383,13 @@ msgstr "Ενεργά API tokens για αυτόν τον λογαριασμό"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Προσθήκη API token"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Επιβεβαιώστε την κύρια διεύθυνση email σας</a> "
@@ -7855,7 +7855,7 @@ msgstr "(ελέγξτε τις <a href=\"%(href)s\">ρυθμίσεις λογα�
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Μέσα από τις <a href=\"%(href)s\">ρυθμίσεις λογαριασμού</a>, πηγαίνετε στο "
 "πεδίο API tokens και επιλέξτε \"Προσθήκη API token\""

--- a/warehouse/locale/eo/LC_MESSAGES/messages.po
+++ b/warehouse/locale/eo/LC_MESSAGES/messages.po
@@ -3296,13 +3296,13 @@ msgstr "Aktivaj API-ĵetonoj de ĉi tiu konto"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Aldoni API-ĵetonon"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Kontrolu vian ĉefan retpoŝtan adreson</a> por aldoni "
@@ -7669,7 +7669,7 @@ msgstr "(kontrolu viajn <a href=\"%(href)s\">kontajn agordojn</a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "En la <a href=\"%(href)s\">agordoj pri via konto</a>, iru al la paragrafo "
 "pri la API-ĵetonoj, kaj elektu \"Aldoni API-ĵetonon\""

--- a/warehouse/locale/es/LC_MESSAGES/messages.po
+++ b/warehouse/locale/es/LC_MESSAGES/messages.po
@@ -3369,13 +3369,13 @@ msgstr "Fichas de API activas de esta cuenta"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Añadir ficha de API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Verifique su dirección de correo principal</a> para "
@@ -7749,7 +7749,7 @@ msgstr "(revise la <a href=\"%(href)s\">configuración de su cuenta</a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "En la <a href=\"%(href)s\">configuración de su cuenta</a>, vaya a la sección "
 "Fichas de API y seleccione «Añadir ficha de API»"

--- a/warehouse/locale/et/LC_MESSAGES/messages.po
+++ b/warehouse/locale/et/LC_MESSAGES/messages.po
@@ -2835,13 +2835,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6388,7 +6388,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/fa/LC_MESSAGES/messages.po
+++ b/warehouse/locale/fa/LC_MESSAGES/messages.po
@@ -3301,13 +3301,13 @@ msgstr "رمزهای API فعال برای این حساب"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "رمز API اضافه کنید"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">آدرس ایمیل اصلی خود را تأیید کنید</a> برای افزودن "
@@ -7195,7 +7195,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/fi/LC_MESSAGES/messages.po
+++ b/warehouse/locale/fi/LC_MESSAGES/messages.po
@@ -3041,13 +3041,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6887,7 +6887,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/fil/LC_MESSAGES/messages.po
+++ b/warehouse/locale/fil/LC_MESSAGES/messages.po
@@ -2914,13 +2914,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6484,7 +6484,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/fr/LC_MESSAGES/messages.po
+++ b/warehouse/locale/fr/LC_MESSAGES/messages.po
@@ -3312,13 +3312,13 @@ msgstr "Jetons d'API actifs pour ce compte"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Ajouter un jeton d'API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Vérifiez votre adresse e-mail principale</a> pour "
@@ -7579,7 +7579,7 @@ msgstr "(vérifiez vos <a href=\"%(href)s\">paramètres de compte</a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Dans les <a href=\"%(href)s\">paramètres de votre compte</a>, rendez-vous "
 "dans la section des jetons d'API et sélectionnez « Ajouter un jeton d'API »"

--- a/warehouse/locale/fr_CA/LC_MESSAGES/messages.po
+++ b/warehouse/locale/fr_CA/LC_MESSAGES/messages.po
@@ -3396,13 +3396,13 @@ msgstr "Jetons d'API actifs pour ce compte"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Ajouter un jeton d'API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Vérifiez votre adresse courriel principale</a> pour "
@@ -7889,7 +7889,7 @@ msgstr "(vérifiez vos <a href=\"%(href)s\">paramètres de compte</a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Dans vos <a href=\"%(href)s\">paramètres de compte</a>, rendez-vous dans la "
 "section des jetons d'API et sélectionnez « Ajouter un jeton d'API »"

--- a/warehouse/locale/frc/LC_MESSAGES/messages.po
+++ b/warehouse/locale/frc/LC_MESSAGES/messages.po
@@ -2833,13 +2833,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6386,7 +6386,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/frm/LC_MESSAGES/messages.po
+++ b/warehouse/locale/frm/LC_MESSAGES/messages.po
@@ -2833,13 +2833,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6386,7 +6386,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/fro/LC_MESSAGES/messages.po
+++ b/warehouse/locale/fro/LC_MESSAGES/messages.po
@@ -2833,13 +2833,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6386,7 +6386,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/gl/LC_MESSAGES/messages.po
+++ b/warehouse/locale/gl/LC_MESSAGES/messages.po
@@ -2897,13 +2897,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6555,7 +6555,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/he/LC_MESSAGES/messages.po
+++ b/warehouse/locale/he/LC_MESSAGES/messages.po
@@ -3274,13 +3274,13 @@ msgstr "אסימוני API פעילים עבור חשבון זה"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "הוספת אסימון API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">אמת/י את כתובת האי-מייל הראשית שלך</a> כדי להוסיף "
@@ -7709,7 +7709,7 @@ msgstr "(בדק/י את <a href=\"%(href)s\">הגדרות החשבון</a> של�
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "ב<a href=\"%(href)s\">הגדרות החשבון</a> שלך, גש/י אל אזור אסימוני ה-API "
 "ובחר/י ב-\"הוספת אסימון API\""

--- a/warehouse/locale/hi/LC_MESSAGES/messages.po
+++ b/warehouse/locale/hi/LC_MESSAGES/messages.po
@@ -3302,13 +3302,13 @@ msgstr "इस खाते के सक्रिय API टोकन"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "API टोकन जोड़ें"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "खाते में API टोकन जोड़ने के लिए <a href=\"%(href)s\">अपने प्राथमिक ईमेल पते को सत्यापित "
@@ -7455,7 +7455,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/hu/LC_MESSAGES/messages.po
+++ b/warehouse/locale/hu/LC_MESSAGES/messages.po
@@ -2923,13 +2923,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6514,7 +6514,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/hy/LC_MESSAGES/messages.po
+++ b/warehouse/locale/hy/LC_MESSAGES/messages.po
@@ -2840,13 +2840,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6393,7 +6393,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/id/LC_MESSAGES/messages.po
+++ b/warehouse/locale/id/LC_MESSAGES/messages.po
@@ -3358,13 +3358,13 @@ msgstr "Token API aktif untuk akun ini"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Tambah API token"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Verifikasikan alamat email utama Anda</a> untuk "
@@ -7684,7 +7684,7 @@ msgstr "(periksa <a href=\"%(href)s\">pengaturan akun</a> Anda)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Di <a href=\"%(href)s\">pengaturan akun</a> Anda, buka bagian token API dan "
 "pilih \"Tambahkan token API\""

--- a/warehouse/locale/it/LC_MESSAGES/messages.po
+++ b/warehouse/locale/it/LC_MESSAGES/messages.po
@@ -3374,13 +3374,13 @@ msgstr "Tokens API attivi per questo account"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Aggiungi token API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Verifica il tuo indirizzo email principale</a> per "
@@ -7812,7 +7812,7 @@ msgstr "(Controlla le tue <a href=\"%(href)s\">Impostazioni account</a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Nelle tue <a href=\"%(href)s\">impostazioni account</a>, vai nella sezione "
 "dei tokens API e seleziona \"Aggiungi token API\""

--- a/warehouse/locale/ja/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ja/LC_MESSAGES/messages.po
@@ -3406,13 +3406,13 @@ msgstr "アカウントでアクティブな APIトークン"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "APIトークンの追加"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "アカウントに APIトークンを追加するには<a href=\"%(href)s\">主要メールアドレス"
@@ -7755,10 +7755,10 @@ msgstr "（ <a href=\"%(href)s\">アカウント設定</a>を確認してくだ�
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "<a href=\"%(href)s\">アカウント設定</a>でAPIトークンの選択に進み「APIトークン"
-"の追加（Add API token）」を選択する"
+"の追加（Create API token）」を選択する"
 
 #: warehouse/templates/pages/help.html:495
 msgid "To use an API token:"

--- a/warehouse/locale/ka/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ka/LC_MESSAGES/messages.po
@@ -2835,13 +2835,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6388,7 +6388,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/ko/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ko/LC_MESSAGES/messages.po
@@ -3275,13 +3275,13 @@ msgstr "이 계정에 활성화된 API 토큰"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "API 토큰 추가하기"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "API 토큰을 추가하기 위해 먼저 <a href=\"%(href)s\">기본 이메일 주소를 인증</"
@@ -7312,7 +7312,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/lzh/LC_MESSAGES/messages.po
+++ b/warehouse/locale/lzh/LC_MESSAGES/messages.po
@@ -2844,13 +2844,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6399,7 +6399,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2845,7 +2845,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
@@ -6390,7 +6390,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/mk/LC_MESSAGES/messages.po
+++ b/warehouse/locale/mk/LC_MESSAGES/messages.po
@@ -2840,13 +2840,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6393,7 +6393,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/ml/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ml/LC_MESSAGES/messages.po
@@ -2886,13 +2886,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6454,7 +6454,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/mni/LC_MESSAGES/messages.po
+++ b/warehouse/locale/mni/LC_MESSAGES/messages.po
@@ -2835,13 +2835,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6388,7 +6388,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/mr/LC_MESSAGES/messages.po
+++ b/warehouse/locale/mr/LC_MESSAGES/messages.po
@@ -2958,13 +2958,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6665,7 +6665,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/nb_NO/LC_MESSAGES/messages.po
+++ b/warehouse/locale/nb_NO/LC_MESSAGES/messages.po
@@ -3154,13 +3154,13 @@ msgstr "Aktive API-symboler for denne kontoen"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Legg til API-symbol"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6967,7 +6967,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/ne/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ne/LC_MESSAGES/messages.po
@@ -2856,13 +2856,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6409,7 +6409,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/nl/LC_MESSAGES/messages.po
+++ b/warehouse/locale/nl/LC_MESSAGES/messages.po
@@ -3315,13 +3315,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -7142,7 +7142,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/or/LC_MESSAGES/messages.po
+++ b/warehouse/locale/or/LC_MESSAGES/messages.po
@@ -2846,13 +2846,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6414,7 +6414,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/pl/LC_MESSAGES/messages.po
+++ b/warehouse/locale/pl/LC_MESSAGES/messages.po
@@ -3288,13 +3288,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -7260,7 +7260,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/pt/LC_MESSAGES/messages.po
+++ b/warehouse/locale/pt/LC_MESSAGES/messages.po
@@ -3296,13 +3296,13 @@ msgstr "Tokens de API ativos para esta conta"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Adicionar token de API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Verifique o seu endereço de e-mail principal</a> para "
@@ -7726,7 +7726,7 @@ msgstr "(confira as suas <a href=\"%(href)s\">configurações de conta</a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Nas suas <a href=\"%(href)s\">configurações de conta</a>, vá à secção de "
 "tokens de API e selecione \"Adicionar token de API\""

--- a/warehouse/locale/pt_BR/LC_MESSAGES/messages.po
+++ b/warehouse/locale/pt_BR/LC_MESSAGES/messages.po
@@ -3301,13 +3301,13 @@ msgstr "Tokens de API ativos para esta conta"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Adicionar token de API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Verifique seu endereço de e-mail principal</a> para "
@@ -7675,7 +7675,7 @@ msgstr "(confira suas <a href=\"%(href)s\">configurações de conta</a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Em suas <a href=\"%(href)s\">configurações de conta</a>, vá para a seção de "
 "tokens de API e selecione \"Adicionar token de API\""

--- a/warehouse/locale/pt_PT/LC_MESSAGES/messages.po
+++ b/warehouse/locale/pt_PT/LC_MESSAGES/messages.po
@@ -3359,13 +3359,13 @@ msgstr "Tokens de API ativos para esta conta"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Adicionar token de API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Verifique o seu endereço de e-mail principal</a> para "
@@ -7807,7 +7807,7 @@ msgstr "(confira as suas <a href=\"%(href)s\">configurações de conta</a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Nas suas <a href=\"%(href)s\">configurações de conta</a>, vá à secção de "
 "tokens de API e selecione \"Adicionar token de API\""

--- a/warehouse/locale/ro/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ro/LC_MESSAGES/messages.po
@@ -2950,13 +2950,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6598,7 +6598,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/ru/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ru/LC_MESSAGES/messages.po
@@ -3358,13 +3358,13 @@ msgstr "Активные API-токены этой учётной записи"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Добавить API-токен"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "Чтобы добавить API-токены в свою учётную запись, <a href=\"%(href)s"
@@ -7854,7 +7854,7 @@ msgstr "(проверьте <a href=\"%(href)s\">настройки своей �
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "В <a href=\"%(href)s\">настройках своей учётной записи</a> перейдите в "
 "раздел «API-токены» и нажмите на кнопку «Добавить API-токен»"

--- a/warehouse/locale/si/LC_MESSAGES/messages.po
+++ b/warehouse/locale/si/LC_MESSAGES/messages.po
@@ -2896,13 +2896,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6476,7 +6476,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/sl/LC_MESSAGES/messages.po
+++ b/warehouse/locale/sl/LC_MESSAGES/messages.po
@@ -2848,13 +2848,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6429,7 +6429,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/sr/LC_MESSAGES/messages.po
+++ b/warehouse/locale/sr/LC_MESSAGES/messages.po
@@ -2892,13 +2892,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6502,7 +6502,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/ta/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ta/LC_MESSAGES/messages.po
@@ -2927,13 +2927,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6551,7 +6551,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/th/LC_MESSAGES/messages.po
+++ b/warehouse/locale/th/LC_MESSAGES/messages.po
@@ -2950,13 +2950,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6567,7 +6567,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/tr/LC_MESSAGES/messages.po
+++ b/warehouse/locale/tr/LC_MESSAGES/messages.po
@@ -3296,13 +3296,13 @@ msgstr "Bu hesap için API tokenlerini etkinleştir"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "API Token Ekle"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "API tokeni eklemek için <a href=\"%(href)s\">birincil e-postanızı "
@@ -7716,7 +7716,7 @@ msgstr "(<a href=\"%(href)s\">hesap ayarlarınızı</a> kontrol edin)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "<a href=\"%(href)s\">Hesap ayarları</a>' nızda iken, API beliteçleri "
 "bölümüne gidin ve \"API belirteci ekle\"' yi seçin"

--- a/warehouse/locale/tzm/LC_MESSAGES/messages.po
+++ b/warehouse/locale/tzm/LC_MESSAGES/messages.po
@@ -2892,13 +2892,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6666,7 +6666,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/uk/LC_MESSAGES/messages.po
+++ b/warehouse/locale/uk/LC_MESSAGES/messages.po
@@ -3365,13 +3365,13 @@ msgstr "Активні API-токени для цього облікового �
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Додати API-токен"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Підтвердіть свою основну електронну адресу</a>, щоб "
@@ -7786,7 +7786,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "У <a href=\"%(href)s\">налаштуваннях свого облікового запису</a>, перейдіть "
 "до секції API-токени та оберіть «Додати API-токен»"

--- a/warehouse/locale/ur_PK/LC_MESSAGES/messages.po
+++ b/warehouse/locale/ur_PK/LC_MESSAGES/messages.po
@@ -2922,13 +2922,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6506,7 +6506,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/uz_Latn/LC_MESSAGES/messages.po
+++ b/warehouse/locale/uz_Latn/LC_MESSAGES/messages.po
@@ -3010,13 +3010,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6654,7 +6654,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/vi/LC_MESSAGES/messages.po
+++ b/warehouse/locale/vi/LC_MESSAGES/messages.po
@@ -3303,13 +3303,13 @@ msgstr "Kích hoạt mã khóa API cho tài khoản này"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "Thêm mã khóa API"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">Xác minh địa chỉ email chính của bạn</a> để thêm mã "
@@ -7396,7 +7396,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "Trong mục <a href=\"%(href)s\">cài đặt tài khoản</a>, đi tới phần mã khóa "
 "API và chọn \"Thêm mã khóa API\""

--- a/warehouse/locale/wae/LC_MESSAGES/messages.po
+++ b/warehouse/locale/wae/LC_MESSAGES/messages.po
@@ -2833,13 +2833,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6386,7 +6386,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/zgh/LC_MESSAGES/messages.po
+++ b/warehouse/locale/zgh/LC_MESSAGES/messages.po
@@ -2876,13 +2876,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 
@@ -6465,7 +6465,7 @@ msgstr ""
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:495

--- a/warehouse/locale/zh_Hans/LC_MESSAGES/messages.po
+++ b/warehouse/locale/zh_Hans/LC_MESSAGES/messages.po
@@ -3121,13 +3121,13 @@ msgstr "此账户的有效 API 令牌"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "添加 API 令牌"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr ""
 "<a href=\"%(href)s\">验证主要电子邮件地址</a> ，以便将API令牌添加到你的账户"
@@ -7075,7 +7075,7 @@ msgstr "（检查<a href=\"%(href)s\">账户设置</a>）"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "在你的<a href=\"%(href)s\">账户设置</a>中，转到API令牌部分并选择“添加API令牌”"
 

--- a/warehouse/locale/zh_Hant/LC_MESSAGES/messages.po
+++ b/warehouse/locale/zh_Hant/LC_MESSAGES/messages.po
@@ -3233,13 +3233,13 @@ msgstr "為帳戶啟用 API 密鑰"
 
 #: warehouse/templates/manage/account.html:449
 #: warehouse/templates/manage/account/token.html:17
-msgid "Add API token"
+msgid "Create API token"
 msgstr "增加 API 密鑰"
 
 #: warehouse/templates/manage/account.html:451
 #, python-format
 msgid ""
-"<a href=\"%(href)s\">Verify your primary email address</a> to add API tokens "
+"<a href=\"%(href)s\">Verify your primary email address</a> to create API tokens "
 "to your account."
 msgstr "<a href=\"%(href)s\"> 驗證主要信箱地址</a> 以增加 API 密鑰。"
 
@@ -7407,7 +7407,7 @@ msgstr "(檢查你的 <a href=\"%(href)s\"> 帳戶設定 </a>)"
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
-"section and select \"Add API token\""
+"section and select \"Create API token\""
 msgstr ""
 "在你的 <a href=\"%(href)s\"> 帳戶設定 </a>中, 選擇 API 密鑰作業，再選擇 \"增"
 "加 API 密鑰\""

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -446,9 +446,9 @@
     {% endif %}
 
     {% if user.has_primary_verified_email %}
-    <a href="{{ request.route_path('manage.account.token') }}" class="button button--primary">{% trans %}Add API token{% endtrans %}</a>
+    <a href="{{ request.route_path('manage.account.token') }}" class="button button--primary">{% trans %}Create API token{% endtrans %}</a>
     {% else %}
-    <p><strong>{% trans href='#account-emails' %}<a href="{{ href }}">Verify your primary email address</a> to add API tokens to your account.{% endtrans %}</strong></p>
+    <p><strong>{% trans href='#account-emails' %}<a href="{{ href }}">Verify your primary email address</a> to create API tokens to your account.{% endtrans %}</strong></p>
     {% endif %}
 
   </section>

--- a/warehouse/templates/manage/account/token.html
+++ b/warehouse/templates/manage/account/token.html
@@ -14,7 +14,7 @@
 {% extends "manage/manage_base.html" %}
 
 {% set user = request.user %}
-{% set title = gettext("Add API token") %}
+{% set title = gettext("Create API token") %}
 
 {% set active_tab = 'account' %}
 

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -489,7 +489,7 @@
 
         <ul>
           <li><a href="#verified-email">{% trans %}Verify your email address{% endtrans %}</a> {% trans href=request.route_path('manage.account') %}(check your <a href="{{ href }}">account settings</a>){% endtrans %}</li>
-          <li>{% trans href=request.route_path('manage.account') %}In your <a href="{{ href }}">account settings</a>, go to the API tokens section and select "Add API token"{% endtrans %}</li>
+          <li>{% trans href=request.route_path('manage.account') %}In your <a href="{{ href }}">account settings</a>, go to the API tokens section and select "Create API token"{% endtrans %}</li>
         </ul>
 
         <p>{% trans %}To use an API token:{% endtrans %}</p>


### PR DESCRIPTION
This PR fixes the issue about unclear wording reported in https://github.com/pypi/warehouse/issues/11874 making the messages about adding the API token clearer by instead stating that the action is to create an API token. 

I accepted, please add the `hacktoberfest-accepted` label to this PR.