### PR TITLE
Render unused recovery code count correctly.

### DIFF
--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -101,7 +101,7 @@ class User(SitemapMixin, HasEvents, db.Model):
     )
 
     recovery_codes = orm.relationship(
-        "RecoveryCode", backref="user", cascade="all, delete-orphan", lazy=True
+        "RecoveryCode", backref="user", cascade="all, delete-orphan", lazy="dynamic"
     )
 
     emails = orm.relationship(

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -315,7 +315,7 @@
               </tr>
               <tr>
                 <td>{{ user.recovery_codes[0].generated }}</td>
-                <td>{{ user.recovery_codes|length }}</td>
+                <td>{{ user.recovery_codes.filter_by(burned=None).all()|length }}</td>
               </tr>
             </table>
           </div>

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3211,6 +3211,11 @@ msgstr ""
 msgid "generated %(generated_datetime)s"
 msgstr ""
 
+#: warehouse/templates/manage/manage_base.html:39
+#, python-format
+msgid "%(remaining)s unused"
+msgstr ""
+
 #: warehouse/templates/manage/account/recovery_codes-burn.html:49
 #: warehouse/templates/manage/manage_base.html:43
 msgid "Regenerate"

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -36,7 +36,7 @@
       <tbody>
         <tr>
           <th scope="row">
-            {% trans %}Recovery codes{% endtrans %} - {% trans generated_datetime=humanize(request.user.recovery_codes[0].generated, time="true") %}generated {{ generated_datetime }}{% endtrans %}
+            {% trans %}Recovery codes{% endtrans %} - {% trans generated_datetime=humanize(request.user.recovery_codes[0].generated, time="true") %}generated {{ generated_datetime }}{% endtrans %} ({% trans remaining=request.user.recovery_codes.filter_by(burned=None).count() %}{{ remaining }} unused{% endtrans %}).
           </th>
           <td class="table__align-right">
             <a href="{{ request.route_path('manage.account.recovery-codes.regenerate') }}" class="button button--secondary">


### PR DESCRIPTION
Our admin interface always showed 8, this also exposes to users how many remain.