### PR TITLE
Organization updated email notification

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -2576,6 +2576,90 @@ class TestOrganizationMemberEmails:
         ]
 
 
+class TestOrganizationUpdateEmails:
+    @pytest.fixture
+    def organization_update(self, pyramid_user):
+        self.user = UserFactory.create()
+        EmailFactory.create(user=self.user, verified=True)
+        self.organization_name = "example"
+        self.organization_display_name = "Example"
+        self.organization_link_url = "https://www.example.com/"
+        self.organization_description = "An example organization for testing"
+        self.organization_orgtype = "Company"
+        self.previous_organization_display_name = "Example Group"
+        self.previous_organization_link_url = "https://www.example.com/group/"
+        self.previous_organization_description = "An example group for testing"
+        self.previous_organization_orgtype = "Community"
+
+    def test_send_organization_renamed_email(
+        self,
+        db_request,
+        organization_update,
+        make_email_renderers,
+        send_email,
+    ):
+        subject_renderer, body_renderer, html_renderer = make_email_renderers(
+            "organization-updated"
+        )
+
+        result = email.send_organization_updated_email(
+            db_request,
+            self.user,
+            organization_name=self.organization_name,
+            organization_display_name=self.organization_display_name,
+            organization_link_url=self.organization_link_url,
+            organization_description=self.organization_description,
+            organization_orgtype=self.organization_orgtype,
+            previous_organization_display_name=self.previous_organization_display_name,
+            previous_organization_link_url=self.previous_organization_link_url,
+            previous_organization_description=self.previous_organization_description,
+            previous_organization_orgtype=self.previous_organization_orgtype,
+        )
+
+        assert result == {
+            "organization_name": self.organization_name,
+            "organization_display_name": self.organization_display_name,
+            "organization_link_url": self.organization_link_url,
+            "organization_description": self.organization_description,
+            "organization_orgtype": self.organization_orgtype,
+            "previous_organization_display_name": (
+                self.previous_organization_display_name
+            ),
+            "previous_organization_link_url": self.previous_organization_link_url,
+            "previous_organization_description": self.previous_organization_description,
+            "previous_organization_orgtype": self.previous_organization_orgtype,
+        }
+        subject_renderer.assert_(**result)
+        body_renderer.assert_(**result)
+        html_renderer.assert_(**result)
+        assert db_request.task.calls == [pretend.call(send_email)]
+        assert send_email.delay.calls == [
+            pretend.call(
+                f"{self.user.name} <{self.user.email}>",
+                {
+                    "subject": subject_renderer.string_response,
+                    "body_text": body_renderer.string_response,
+                    "body_html": (
+                        f"<html>\n"
+                        f"<head></head>\n"
+                        f"<body><p>{html_renderer.string_response}</p></body>\n"
+                        f"</html>\n"
+                    ),
+                },
+                {
+                    "tag": "account:email:sent",
+                    "user_id": self.user.id,
+                    "additional": {
+                        "from_": db_request.registry.settings["mail.sender"],
+                        "to": self.user.email,
+                        "subject": subject_renderer.string_response,
+                        "redact_ip": True,
+                    },
+                },
+            )
+        ]
+
+
 class TestOrganizationRenameEmails:
     @pytest.fixture
     def organization_rename(self, pyramid_user):

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -2892,7 +2892,12 @@ class TestManageOrganizationSettings:
         ]
 
     def test_save_organization(
-        self, db_request, organization_service, enable_organizations, monkeypatch
+        self,
+        db_request,
+        pyramid_user,
+        organization_service,
+        enable_organizations,
+        monkeypatch,
     ):
         organization = OrganizationFactory.create()
         db_request.POST = {
@@ -2916,12 +2921,33 @@ class TestManageOrganizationSettings:
         )
         monkeypatch.setattr(views, "SaveOrganizationForm", save_organization_cls)
 
+        send_email = pretend.call_recorder(lambda *a, **kw: None)
+        monkeypatch.setattr(views, "send_organization_updated_email", send_email)
+        monkeypatch.setattr(
+            views, "organization_owners", lambda *a, **kw: [pyramid_user]
+        )
+
         view = views.ManageOrganizationSettingsViews(organization, db_request)
         result = view.save_organization()
 
         assert isinstance(result, HTTPSeeOther)
         assert organization_service.update_organization.calls == [
             pretend.call(organization.id, **db_request.POST)
+        ]
+        assert send_email.calls == [
+            pretend.call(
+                db_request,
+                {pyramid_user},
+                organization_name=organization.name,
+                organization_display_name=organization.display_name,
+                organization_link_url=organization.link_url,
+                organization_description=organization.description,
+                organization_orgtype=organization.orgtype,
+                previous_organization_display_name=organization.display_name,
+                previous_organization_link_url=organization.link_url,
+                previous_organization_description=organization.description,
+                previous_organization_orgtype=organization.orgtype,
+            ),
         ]
 
     def test_save_organization_validation_fails(

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -2887,19 +2887,20 @@ class TestManageOrganizationSettings:
                 link_url=organization.link_url,
                 description=organization.description,
                 orgtype=organization.orgtype,
-                organization_service=organization_service,
             ),
         ]
 
+    @pytest.mark.parametrize("orgtype", list(OrganizationType))
     def test_save_organization(
         self,
         db_request,
         pyramid_user,
+        orgtype,
         organization_service,
         enable_organizations,
         monkeypatch,
     ):
-        organization = OrganizationFactory.create()
+        organization = OrganizationFactory.create(orgtype=orgtype)
         db_request.POST = {
             "display_name": organization.display_name,
             "link_url": organization.link_url,

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -569,6 +569,34 @@ def send_role_changed_as_organization_member_email(
     }
 
 
+@_email("organization-updated")
+def send_organization_updated_email(
+    request,
+    user,
+    *,
+    organization_name,
+    organization_display_name,
+    organization_link_url,
+    organization_description,
+    organization_orgtype,
+    previous_organization_display_name,
+    previous_organization_link_url,
+    previous_organization_description,
+    previous_organization_orgtype,
+):
+    return {
+        "organization_name": organization_name,
+        "organization_display_name": organization_display_name,
+        "organization_link_url": organization_link_url,
+        "organization_description": organization_description,
+        "organization_orgtype": organization_orgtype,
+        "previous_organization_display_name": previous_organization_display_name,
+        "previous_organization_link_url": previous_organization_link_url,
+        "previous_organization_description": previous_organization_description,
+        "previous_organization_orgtype": previous_organization_orgtype,
+    }
+
+
 @_email("organization-renamed")
 def send_organization_renamed_email(
     request, user, *, organization_name, previous_organization_name

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:447 warehouse/manage/views.py:954
+#: warehouse/accounts/views.py:447 warehouse/manage/views.py:955
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -326,73 +326,73 @@ msgstr ""
 msgid "This team name has already been used. Choose a different team name."
 msgstr ""
 
-#: warehouse/manage/views.py:367
+#: warehouse/manage/views.py:368
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views.py:902
+#: warehouse/manage/views.py:903
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views.py:903
+#: warehouse/manage/views.py:904
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:1965
+#: warehouse/manage/views.py:1988
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:1976
+#: warehouse/manage/views.py:1999
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:1990 warehouse/manage/views.py:4186
+#: warehouse/manage/views.py:2013 warehouse/manage/views.py:4209
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2047 warehouse/manage/views.py:4253
+#: warehouse/manage/views.py:2070 warehouse/manage/views.py:4276
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:2087
+#: warehouse/manage/views.py:2110
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2101 warehouse/manage/views.py:4297
+#: warehouse/manage/views.py:2124 warehouse/manage/views.py:4320
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2134 warehouse/manage/views.py:4321
+#: warehouse/manage/views.py:2157 warehouse/manage/views.py:4344
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views.py:2931
+#: warehouse/manage/views.py:2954
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/manage/views.py:3963
+#: warehouse/manage/views.py:3986
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4071
+#: warehouse/manage/views.py:4094
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4140
+#: warehouse/manage/views.py:4163
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4173
+#: warehouse/manage/views.py:4196
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4286
+#: warehouse/manage/views.py:4309
 msgid "Could not find role invitation."
 msgstr ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3547,7 +3547,7 @@ msgstr ""
 
 #: warehouse/templates/manage/organization/settings.html:48
 #: warehouse/templates/manage/organizations.html:170
-msgid "Organization name"
+msgid "Organization display name"
 msgstr ""
 
 #: warehouse/templates/manage/organization/settings.html:54

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -312,17 +312,17 @@ msgid ""
 "description with 400 characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:630
+#: warehouse/manage/forms.py:629
 msgid "Choose a team name with 50 characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:636
+#: warehouse/manage/forms.py:635
 msgid ""
 "The team name is invalid. Team names cannot start or end with a space, "
 "period, underscore, hyphen, or slash. Choose a different team name."
 msgstr ""
 
-#: warehouse/manage/forms.py:664
+#: warehouse/manage/forms.py:663
 msgid "This team name has already been used. Choose a different team name."
 msgstr ""
 
@@ -338,61 +338,61 @@ msgstr ""
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:1988
+#: warehouse/manage/views.py:1987
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:1999
+#: warehouse/manage/views.py:1998
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:2013 warehouse/manage/views.py:4209
+#: warehouse/manage/views.py:2012 warehouse/manage/views.py:4208
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2070 warehouse/manage/views.py:4276
+#: warehouse/manage/views.py:2069 warehouse/manage/views.py:4275
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:2110
+#: warehouse/manage/views.py:2109
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2124 warehouse/manage/views.py:4320
+#: warehouse/manage/views.py:2123 warehouse/manage/views.py:4319
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2157 warehouse/manage/views.py:4344
+#: warehouse/manage/views.py:2156 warehouse/manage/views.py:4343
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views.py:2954
+#: warehouse/manage/views.py:2953
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/manage/views.py:3986
+#: warehouse/manage/views.py:3985
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4094
+#: warehouse/manage/views.py:4093
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4163
+#: warehouse/manage/views.py:4162
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4196
+#: warehouse/manage/views.py:4195
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4309
+#: warehouse/manage/views.py:4308
 msgid "Could not find role invitation."
 msgstr ""
 
@@ -738,8 +738,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:716
 #: warehouse/templates/manage/manage_base.html:305
 #: warehouse/templates/manage/manage_base.html:364
-#: warehouse/templates/manage/organization/settings.html:186
-#: warehouse/templates/manage/organization/settings.html:241
+#: warehouse/templates/manage/organization/settings.html:193
+#: warehouse/templates/manage/organization/settings.html:248
 #: warehouse/templates/manage/project/documentation.html:27
 #: warehouse/templates/manage/project/release.html:182
 #: warehouse/templates/manage/project/settings.html:126
@@ -3186,7 +3186,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/manage/account.html:705
-#: warehouse/templates/manage/organization/settings.html:230
+#: warehouse/templates/manage/organization/settings.html:237
 #, python-format
 msgid ""
 "<a href=\"%(transfer_href)s\">transfer ownership</a> or <a "
@@ -3195,8 +3195,8 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:714
 #: warehouse/templates/manage/account/token.html:166
-#: warehouse/templates/manage/organization/settings.html:184
-#: warehouse/templates/manage/organization/settings.html:239
+#: warehouse/templates/manage/organization/settings.html:191
+#: warehouse/templates/manage/organization/settings.html:246
 #: warehouse/templates/manage/team/settings.html:75
 msgid "Proceed with caution!"
 msgstr ""
@@ -4308,55 +4308,64 @@ msgstr ""
 msgid "Date created"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:152
+#: warehouse/templates/manage/organization/settings.html:150
+#, python-format
+msgid ""
+"If you need to convert your organization account from a Company account "
+"to a Community account, you can email <a "
+"href=\"mailto:%(email)s\">%(email)s</a> to communicate with %(site)s "
+"administrators."
+msgstr ""
+
+#: warehouse/templates/manage/organization/settings.html:159
 msgid "Update organization"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:161
+#: warehouse/templates/manage/organization/settings.html:168
 msgid "Billing details"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:163
+#: warehouse/templates/manage/organization/settings.html:170
 msgid "Billing status"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:167
+#: warehouse/templates/manage/organization/settings.html:174
 msgid "Billing email"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:172
+#: warehouse/templates/manage/organization/settings.html:179
 msgid "Manage billing"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:182
-#: warehouse/templates/manage/organization/settings.html:203
+#: warehouse/templates/manage/organization/settings.html:189
+#: warehouse/templates/manage/organization/settings.html:210
 msgid "Change organization account name"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:187
+#: warehouse/templates/manage/organization/settings.html:194
 msgid ""
 "You will not be able to revert to your current account name after you "
 "rename your organization."
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:203
+#: warehouse/templates/manage/organization/settings.html:210
 msgid "Change organization account name for"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:203
+#: warehouse/templates/manage/organization/settings.html:210
 msgid "Current organization account name"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:210
-#: warehouse/templates/manage/organization/settings.html:244
+#: warehouse/templates/manage/organization/settings.html:217
+#: warehouse/templates/manage/organization/settings.html:251
 msgid "Delete organization"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:213
+#: warehouse/templates/manage/organization/settings.html:220
 msgid "Cannot delete organization"
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:215
+#: warehouse/templates/manage/organization/settings.html:222
 #, python-format
 msgid ""
 "\n"
@@ -4369,7 +4378,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/organization/settings.html:220
+#: warehouse/templates/manage/organization/settings.html:227
 msgid ""
 "\n"
 "          You must transfer ownership or delete this project before you "
@@ -4383,11 +4392,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/organization/settings.html:242
+#: warehouse/templates/manage/organization/settings.html:249
 msgid "You will not be able to recover your organization after you delete it."
 msgstr ""
 
-#: warehouse/templates/manage/organization/settings.html:244
+#: warehouse/templates/manage/organization/settings.html:251
 msgid "Organization Name"
 msgstr ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1734,6 +1734,7 @@ msgstr ""
 #: warehouse/templates/email/organization-project-added/body.html:24
 #: warehouse/templates/email/organization-project-removed/body.html:24
 #: warehouse/templates/email/organization-renamed/body.html:31
+#: warehouse/templates/email/organization-updated/body.html:69
 #, python-format
 msgid ""
 "If this was a mistake, you can email <a "
@@ -1786,6 +1787,7 @@ msgstr ""
 #: warehouse/templates/email/organization-member-removed/body.html:43
 #: warehouse/templates/email/organization-member-role-changed/body.html:44
 #: warehouse/templates/email/organization-renamed/body.html:37
+#: warehouse/templates/email/organization-updated/body.html:75
 msgid "You are receiving this because you are an owner of this organization."
 msgstr ""
 
@@ -1860,6 +1862,43 @@ msgstr ""
 msgid ""
 "The %(site)s project \"%(project_name)s\" has been removed from the "
 "\"%(organization_name)s\" organization."
+msgstr ""
+
+#: warehouse/templates/email/organization-updated/body.html:31
+#, python-format
+msgid "The %(site)s organization \"%(organization_name)s\" has been updated."
+msgstr ""
+
+#: warehouse/templates/email/organization-updated/body.html:36
+msgid "Old display name:"
+msgstr ""
+
+#: warehouse/templates/email/organization-updated/body.html:39
+msgid "New display name:"
+msgstr ""
+
+#: warehouse/templates/email/organization-updated/body.html:44
+msgid "Old URL:"
+msgstr ""
+
+#: warehouse/templates/email/organization-updated/body.html:47
+msgid "New URL:"
+msgstr ""
+
+#: warehouse/templates/email/organization-updated/body.html:52
+msgid "Old description:"
+msgstr ""
+
+#: warehouse/templates/email/organization-updated/body.html:55
+msgid "New description:"
+msgstr ""
+
+#: warehouse/templates/email/organization-updated/body.html:60
+msgid "Old organization type:"
+msgstr ""
+
+#: warehouse/templates/email/organization-updated/body.html:63
+msgid "New organization type:"
 msgstr ""
 
 #: warehouse/templates/email/password-change/body.html:18

--- a/warehouse/manage/forms.py
+++ b/warehouse/manage/forms.py
@@ -590,7 +590,6 @@ class SaveOrganizationForm(forms.Form):
         ]
     )
     orgtype = wtforms.SelectField(
-        # TODO: Map additional choices to "Company" and "Community".
         choices=[("Company", "Company"), ("Community", "Community")],
         coerce=OrganizationType,
         validators=[

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -1418,7 +1418,6 @@ class ManageOrganizationSettingsViews:
                 link_url=self.organization.link_url,
                 description=self.organization.description,
                 orgtype=self.organization.orgtype,
-                organization_service=self.organization_service,
             ),
             "save_organization_name_form": SaveOrganizationNameForm(
                 organization_service=self.organization_service,
@@ -1432,10 +1431,7 @@ class ManageOrganizationSettingsViews:
 
     @view_config(request_method="POST", request_param=SaveOrganizationForm.__params__)
     def save_organization(self):
-        form = SaveOrganizationForm(
-            self.request.POST,
-            organization_service=self.organization_service,
-        )
+        form = SaveOrganizationForm(self.request.POST)
 
         if form.validate():
             previous_organization_display_name = self.organization.display_name
@@ -1444,6 +1440,9 @@ class ManageOrganizationSettingsViews:
             previous_organization_orgtype = self.organization.orgtype
 
             data = form.data
+            if previous_organization_orgtype == OrganizationType.Company:
+                # Disable changing Company account to Community account.
+                data["orgtype"] = previous_organization_orgtype
             self.organization_service.update_organization(self.organization.id, **data)
 
             owner_users = set(organization_owners(self.request, self.organization))

--- a/warehouse/templates/email/organization-updated/body.html
+++ b/warehouse/templates/email/organization-updated/body.html
@@ -1,0 +1,76 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+{% set site = request.registry.settings["site.name"] %}
+
+{% block extra_style %}
+dl.update-details dt {
+  font-weight: bold;
+  margin-top: 0.5em;
+}
+dl.update-details dd {
+  margin-left: 0;
+}
+{% endblock %}
+
+
+{% block content %}
+<p>
+  {% trans organization_name=organization_name, site=site %}The {{ site }} organization "{{ organization_name }}" has been updated.{% endtrans %}
+</p>
+
+<dl class="update-details">
+{% if organization_display_name != previous_organization_display_name %}
+  <dt>{% trans %}Old display name:{% endtrans %}</dt>
+  <dd>{{ previous_organization_display_name }}</dd>
+
+  <dt>{% trans %}New display name:{% endtrans %}</dt>
+  <dd>{{ organization_display_name }}</dd>
+  {% endif %}
+
+{% if organization_link_url != previous_organization_link_url %}
+  <dt>{% trans %}Old URL:{% endtrans %}</dt>
+  <dd>{{ previous_organization_link_url }}</dd>
+
+  <dt>{% trans %}New URL:{% endtrans %}</dt>
+  <dd>{{ organization_link_url }}</dd>
+  {% endif %}
+
+{% if organization_description != previous_organization_description %}
+  <dt>{% trans %}Old description:{% endtrans %}</dt>
+  <dd>{{ previous_organization_description }}</dd>
+
+  <dt>{% trans %}New description:{% endtrans %}</dt>
+  <dd>{{ organization_description }}</dd>
+  {% endif %}
+
+{% if organization_orgtype != previous_organization_orgtype %}
+  <dt>{% trans %}Old organization type:{% endtrans %}</dt>
+  <dd>{{ previous_organization_orgtype }}</dd>
+
+  <dt>{% trans %}New organization type:{% endtrans %}</dt>
+  <dd>{{ organization_orgtype }}</dd>
+  {% endif %}
+</dl>
+
+<p>
+  {% trans email_address="admin@pypi.org", site=site %}If this was a mistake, you can email <a href="mailto:{{ email_address }}">{{ email_address }}</a> to communicate with the {{ site }} administrators.{% endtrans %}
+</p>
+{% endblock %}
+
+
+{% block reason %}
+{% trans %}You are receiving this because you are an owner of this organization.{% endtrans %}
+{% endblock %}

--- a/warehouse/templates/email/organization-updated/body.txt
+++ b/warehouse/templates/email/organization-updated/body.txt
@@ -1,0 +1,58 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+{% set site = request.registry.settings["site.name"] %}
+
+{% block content %}
+{% trans organization_name=organization_name, site=site %}The {{ site }} organization "{{ organization_name }}" has been updated.{% endtrans %}
+{% if organization_display_name != previous_organization_display_name %}
+
+{% trans %}Old display name:{% endtrans %}
+{{ previous_organization_display_name }}
+
+{% trans %}New display name:{% endtrans %}
+{{ organization_display_name }}
+{% endif %}
+{% if organization_link_url != previous_organization_link_url %}
+
+{% trans %}Old URL:{% endtrans %}
+{{ previous_organization_link_url }}
+
+{% trans %}New URL:{% endtrans %}
+{{ organization_link_url }}
+{% endif %}
+{% if organization_description != previous_organization_description %}
+
+{% trans %}Old description:{% endtrans %}
+{{ previous_organization_description }}
+
+{% trans %}New description:{% endtrans %}
+{{ organization_description }}
+{% endif %}
+{% if organization_orgtype != previous_organization_orgtype %}
+
+{% trans %}Old organization type:{% endtrans %}
+{{ previous_organization_orgtype }}
+
+{% trans %}New organization type:{% endtrans %}
+{{ organization_orgtype }}
+{% endif %}
+
+{% trans email_address="admin@pypi.org", site=site %}If this was a mistake, you can email {{ email_address }} to communicate with the {{ site }} administrators.{% endtrans %}
+{% endblock %}
+
+{% block reason %}
+{% trans %}You are receiving this because you are an owner of this organization.{% endtrans %}
+{% endblock %}

--- a/warehouse/templates/email/organization-updated/subject.txt
+++ b/warehouse/templates/email/organization-updated/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}{% trans organization_name=organization_name %}"{{ organization_name }}" organization updated{% endtrans %}{% endblock %}

--- a/warehouse/templates/manage/organization/settings.html
+++ b/warehouse/templates/manage/organization/settings.html
@@ -125,11 +125,11 @@
       <div class="form-group">
         <label class="form-group__label" for="orgtype">
           {% trans %}️Organization type{% endtrans %}
-          {% if request.has_permission("manage:organization") and save_organization_form.orgtype.flags.required %}
+          {% if request.has_permission("manage:organization") and organization.orgtype != OrganizationType.Company and save_organization_form.orgtype.flags.required %}
           <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
           {% endif %}
         </label>
-        {% if request.has_permission("manage:organization") %}
+        {% if request.has_permission("manage:organization") and organization.orgtype != OrganizationType.Company %}
         {{ save_organization_form.orgtype(class_="form-group__field", **{"aria-describedby":"orgtype-errors"}) }}
         {% else %}
         <p class="form-group__text">
@@ -142,9 +142,16 @@
         {% if request.has_permission("manage:organization") %}
         <p class="form-group__help-text">
           {% trans trimmed %}
-            Companies can create organization accounts as a paid service while community projects are granted complimentary access.
+          Companies can create organization accounts as a paid service while community projects are granted complimentary access.
           {% endtrans %}
         </p>
+        {% if organization.orgtype == OrganizationType.Company %}
+        <p class="form-group__help-text">
+          {% trans trimmed email="admin@pypi.org",site=request.registry.settings["site.name"] %}
+          If you need to convert your organization account from a Company account to a Community account, you can email <a href="mailto:{{ email }}">{{ email }}</a> to communicate with {{ site }} administrators.
+          {% endtrans %}
+        </p>
+        {% endif %}
         {% endif %}
       </div>
 

--- a/warehouse/templates/manage/organization/settings.html
+++ b/warehouse/templates/manage/organization/settings.html
@@ -45,7 +45,7 @@
       {{ form_errors(save_organization_form) }}
       <div class="form-group">
         <label for="display_name" class="form-group__label">
-          {% trans %}Organization name{% endtrans %}
+          {% trans %}Organization display name{% endtrans %}
           {% if request.has_permission("manage:organization") and save_organization_form.display_name.flags.required %}
           <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
           {% endif %}

--- a/warehouse/templates/manage/organizations.html
+++ b/warehouse/templates/manage/organizations.html
@@ -167,7 +167,7 @@
 
       <div class="form-group">
         <label for="display_name" class="form-group__label">
-          {% trans %}Organization name{% endtrans %}
+          {% trans %}Organization display name{% endtrans %}
           {% if create_organization_form.display_name.flags.required %}
           <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
           {% endif %}


### PR DESCRIPTION
- Relabel "Organization {name → display name}".
- Send "organization-updated" notification email.
- Disable changing organization from Company to Community.
- `303 See Other` instead of `404 Not Found` for inactive Company orgs.
- Closes #12043.
