### PR TITLE
[WIP] feature admin 2fa reset

### DIFF
--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -47,6 +47,9 @@ def includeme(config):
         "admin.user.add_email", "/admin/users/{user_id}/add_email/", domain=warehouse
     )
     config.add_route(
+        "admin.user.reset_2fa", "/admin/users/{user_id}/reset_2fa/", domain=warehouse
+    )
+    config.add_route(
         "admin.user.delete", "/admin/users/{user_id}/delete/", domain=warehouse
     )
     config.add_route(

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -47,7 +47,9 @@ def includeme(config):
         "admin.user.add_email", "/admin/users/{user_id}/add_email/", domain=warehouse
     )
     config.add_route(
-        "admin.user.reset_2fa", "/admin/users/{user_id}/reset_2fa/", domain=warehouse
+        "admin.user.reset_2fa",
+        "/admin/users/{user_id}/reset_2fa/",
+        domain=warehouse,
     )
     config.add_route(
         "admin.user.delete", "/admin/users/{user_id}/delete/", domain=warehouse

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -147,6 +147,40 @@
                 </div>
               </div>
             </li>
+            <li>
+              <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#reset2FA" {{ "disabled" if not request.has_permission('admin') }}>
+                <i class="icon fa fa-bomb"></i> Initiate 2FA Reset
+              </button>
+              <div class="modal fade" id="reset2FA" tabindex="-1" role="dialog">
+                <form method="POST" action="{{ request.route_path('admin.user.reset_2fa', user_id=user.id) }}">
+                  <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+                  <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h4 class="modal-title" id="exampleModalLabel">Initiate 2FA reset for {{ user.username }}?</h4>
+                        <button type="button" class="close" data-dismiss="modal">
+                          <span>&times;</span>
+                        </button>
+                      </div>
+                      <div class="modal-body">
+                        <p>
+                          This will initiate resetting the user's 2FA.
+                        </p>
+                        <hr>
+                        <p>
+                          Type the Gitub Issue URL to begin:
+                        </p>
+                        <input type="text" name="issue-url" width="100%" placeholder="Github Issue URL">
+                      </div>
+                      <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                          <button type="submit" class="btn btn-danger" title="Reset 2fa" if not request.has_permission('admin') }}" {{ "disabled" if not request.has_permission('admin') }}>Reset 2FA</button>
+                        </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </li>
           </ul>
         </div>
       </div>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -281,6 +281,35 @@
             </table>
           </div>
         </div>
+      </div>
+      <div class="box">
+        <div class="box-header with-border">
+          <h3 class="box-title">2FA - Reset</h3>
+        </div>
+        <div>
+          <div class="box-body">
+            <form class="form-horizontal" method="POST" action="{{ request.route_path('admin.user.reset_2fa', user_id=user.id) }}">
+                {{ render_field("Github Issue", form.name, "user-name", class="form-control", placeholder="Github Issue URL") }}
+                <table class="table table-hover">
+                <tr>
+                    <th>Project</th>
+                    <th>{% if user.has_recovery_codes %}<i class="fa fa-check text-green"></i>{% else %}<i class="fa fa-times text-red"></i>{% endif %}</th>
+                </tr>
+                <tr>
+                    <th>Token</th>
+                    <th>{% if user.has_recovery_codes %}<i class="fa fa-check text-green"></i>{% else %}<i class="fa fa-times text-red"></i>{% endif %}</th>
+                </tr>
+                <tr>
+                    <th>Reset 2FA</th>
+                    <th>
+                        <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+                        <button type="submit" class="btn btn-danger" title="Reset 2fa" if not request.has_permission('admin') }}" {{ "disabled" if not request.has_permission('admin') }}>Reset 2FA</button>
+                    </th>
+                </tr>
+                </table>
+            </form>
+          </div>
+        </div>
         {% if user.webauthn %}
         <div>
           <div class="box-header with-border">

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -195,7 +195,7 @@ def user_add_email(request):
 def user_reset_2fa(request):
     user = request.db.query(User).get(request.matchdict["user_id"])
     form = UserForm(request.POST if request.method == "POST" else None, user)
-    gh_link = form.data["name"]
+    gh_link = request.params.get("issue-url")
 
     if form.validate():
         valid_sites = set()
@@ -225,7 +225,7 @@ def user_reset_2fa(request):
             pass
 
     request.session.flash(
-        f"Reset 2FA for {user.username!r} on issue {gh_link}", queue="success"
+        f"Initiating Reset 2FA for {user.username!r} from issue '{gh_link}'.", queue="success"
     )
     return HTTPSeeOther(request.route_path("admin.user.detail", user_id=user.id))
 

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -238,6 +238,14 @@ def send_admin_organization_deleted_email(request, user, *, organization_name):
         "organization_name": organization_name,
     }
 
+@_email("admin-reset-2fa")
+def send_admin_reset_2fa_email(request, user, *, project_name, token, gh_link):
+    return {
+        "username": user.username,
+        "project_name": project_name,
+        "token": token,
+        "gh_link": gh_link,
+    }
 
 # Email templates for users.
 

--- a/warehouse/templates/email/admin-reset-2fa/body.html
+++ b/warehouse/templates/email/admin-reset-2fa/body.html
@@ -1,0 +1,27 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+{% block content %}
+
+<p>An account recovery request was filed at <a href="{{ gh_link }}">{{ gh_link }}</a> for the PyPI username "{{username}}".</p>
+
+<p>In order to verify the request, please push a branch with the name "{{token}}" to the public source code repository for the {{project_name}} project.</p>
+
+<p>The "{{token}}" branch does not need to include any commits or changes and can be deleted after it’s been verified.</p>
+
+<p>After verification, we’ll reset 2FA for your account and issue a password reset.</p>
+
+<p>For help, you can send an email to admin@pypi.org to communicate with the PyPI administrators.</p>
+{% endblock %}

--- a/warehouse/templates/email/admin-reset-2fa/body.txt
+++ b/warehouse/templates/email/admin-reset-2fa/body.txt
@@ -1,0 +1,27 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+
+{% block content %}
+An account recovery request was filed at {{gh_link}} for the PyPI username "{{username}}".
+
+In order to verify the request, please push a branch with the name "{{token}}" to the public source code repository for the {{project_name}} project.
+
+The "{{token}}" branch does not need to include any commits or changes and can be deleted after it’s been verified.
+
+After verification, we’ll reset 2FA for your account and issue a password reset.
+
+For help, you can send an email to admin@pypi.org to communicate with the PyPI administrators.
+{% endblock %}

--- a/warehouse/templates/email/admin-reset-2fa/subject.txt
+++ b/warehouse/templates/email/admin-reset-2fa/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}PyPI Account Recovery Request: {{username}}{% endblock %}


### PR DESCRIPTION
I recently had a 2fa issues with warehouse and i noticed a [pinned issue](https://github.com/pypa/pypi-support/issues/796) around the problem. 

I thought i would give it an initial attempt on realizing the feature, noticing there are 100's of request in the repository.

There are a few things, I have not tackled yet
* storing the generated token created (idea would be admin could press a button and "check" that branch was created)
* validating email message
* Completely validating the logic
* tests

I'm also not sure if that location of the reset is in the right correct location, or should it be in some other place.

![Screenshot from 2022-10-19 10-56-59](https://user-images.githubusercontent.com/618177/196743279-4a83fd56-735e-4967-8991-e51b7543932a.png)
