### PR TITLE
Add support for macOS 13 Ventura

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2914,7 +2914,7 @@ class TestFileUpload:
             "linux_x86_64",
             "linux_x86_64.win32",
             "macosx_9_2_x86_64",
-            "macosx_13_2_arm64",
+            "macosx_14_2_arm64",
             "macosx_10_15_amd64",
         ],
     )

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -130,6 +130,7 @@ _macosx_major_versions = {
     "10",
     "11",
     "12",
+    "13",
 }
 
 # manylinux pep600 and musllinux pep656 are a little more complicated:


### PR DESCRIPTION
https://www.apple.com/newsroom/2022/10/macos-ventura-is-now-available/