### PR TITLE
Remove superuser exclusion for read-only mode

### DIFF
--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -164,7 +164,11 @@ def test_create_session(monkeypatch, pyramid_services):
         (None, False, []),
         (pretend.stub(enabled=False), True, []),
         (pretend.stub(enabled=False), False, []),
-        (pretend.stub(enabled=True, description="flag description"), True, []),
+        (
+            pretend.stub(enabled=True, description="flag description"),
+            True,
+            [pretend.call()],
+        ),
         (
             pretend.stub(enabled=True, description="flag description"),
             False,

--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -152,7 +152,7 @@ def _create_session(request):
     from warehouse.admin.flags import AdminFlag, AdminFlagValue
 
     flag = session.query(AdminFlag).get(AdminFlagValue.READ_ONLY.value)
-    if flag and flag.enabled and not request.user.is_superuser:
+    if flag and flag.enabled:
         request.tm.doom()
 
     # Return our session now that it's created and registered


### PR DESCRIPTION
This is the 'quick fix' for #12422. Admins can still make changes (including unsetting the `read-only` flag) via the DB or shell.

Fixes https://github.com/pypi/warehouse/issues/12422, closes #12427.