### PR TITLE
vulnerabilities: expose withdrawn state on vulnerabilities

### DIFF
--- a/docs/api-reference/json.rst
+++ b/docs/api-reference/json.rst
@@ -326,10 +326,10 @@ provided below, with unrelated fields collapsed for readability.
         ]
     }
 
-The ``withdrawn`` field is of particular interest: when non-``null``, it contains
-the RFC 3339 timestamp when the vulnerability was withdrawn by an upstream
-vulnerability reporting source. API consumers can use this field to retract
-vulnerability reports that are later determined to be invalid.
+The ``withdrawn`` field is of particular interest: when non-``null``, it
+contains the RFC 3339 timestamp when the vulnerability was withdrawn by an
+upstream vulnerability reporting source. API consumers can use this field to
+retract vulnerability reports that are later determined to be invalid.
 
 For example, here is what a withdrawn vulnerability might look like:
 

--- a/docs/api-reference/json.rst
+++ b/docs/api-reference/json.rst
@@ -326,7 +326,27 @@ provided below, with unrelated fields collapsed for readability.
         ]
     }
 
-The ``withdrawn`` field is of particular note: when non-``null``, it contains
+The ``withdrawn`` field is of particular interest: when non-``null``, it contains
 the RFC 3339 timestamp when the vulnerability was withdrawn by an upstream
 vulnerability reporting source. API consumers can use this field to retract
 vulnerability reports that are later determined to be invalid.
+
+For example, here is what a withdrawn vulnerability might look like:
+
+.. code:: json
+
+
+    {
+        "aliases": [
+            "CVE-2022-XXXXX"
+        ],
+        "details": "A long description.",
+        "summary": "A shorter summary.",
+        "fixed_in": [
+            "1.2.3"
+        ],
+        "id": "PYSEC-2022-XXX",
+        "link": "https://osv.dev/vulnerability/PYSEC-2022-XXX",
+        "source": "osv",
+        "withdrawn": "2022-06-28T16:39:06Z"
+    }

--- a/docs/api-reference/json.rst
+++ b/docs/api-reference/json.rst
@@ -312,6 +312,7 @@ provided below, with unrelated fields collapsed for readability.
                     "CVE-2021-3281"
                 ],
                 "details": "In Django 2.2 before 2.2.18, 3.0 before 3.0.12, and 3.1 before 3.1.6, the django.utils.archive.extract method (used by \"startapp --template\" and \"startproject --template\") allows directory traversal via an archive with absolute paths or relative paths with dot segments.",
+                "summary": "A shorter summary of the vulnerability",
                 "fixed_in": [
                     "2.2.18",
                     "3.0.12",
@@ -319,7 +320,13 @@ provided below, with unrelated fields collapsed for readability.
                 ],
                 "id": "PYSEC-2021-9",
                 "link": "https://osv.dev/vulnerability/PYSEC-2021-9",
-                "source": "osv"
+                "source": "osv",
+                "withdrawn": null
             },
         ]
     }
+
+The ``withdrawn`` field is of particular note: when non-``null``, it contains
+the RFC 3339 timestamp when the vulnerability was withdrawn by an upstream
+vulnerability reporting source. API consumers can use this field to retract
+vulnerability reports that are later determined to be invalid.

--- a/tests/unit/integration/vulnerabilities/test_package.py
+++ b/tests/unit/integration/vulnerabilities/test_package.py
@@ -48,6 +48,7 @@ def test_vulnerability_report_request_from_api_request():
             "aliases": ["vuln_alias"],
             "details": "some details",
             "events": [{"introduced": "1.0.0"}, {"fixed": "1.0.1"}, {"fixed": "2.0.0"}],
+            "withdrawn": "some-timestamp",
         }
     )
 
@@ -58,6 +59,7 @@ def test_vulnerability_report_request_from_api_request():
     assert request.aliases == ["vuln_alias"]
     assert request.details == "some details"
     assert request.fixed_in == ["1.0.1", "2.0.0"]
+    assert request.withdrawn == "some-timestamp"
 
 
 def test_invalid_vulnerability_report():

--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -669,7 +669,8 @@ class TestJSONRelease:
             "vulnerabilities": [],
         }
 
-    def test_vulnerabilities_renders(self, pyramid_config, db_request):
+    @pytest.mark.parametrize("withdrawn", (None, "2022-06-28T16:39:06Z"))
+    def test_vulnerabilities_renders(self, pyramid_config, db_request, withdrawn):
         project = ProjectFactory.create(has_docs=False)
         release = ReleaseFactory.create(project=project, version="0.1")
         VulnerabilityRecordFactory.create(
@@ -681,6 +682,7 @@ class TestJSONRelease:
             summary="some summary",
             fixed_in=["3.3.2"],
             releases=[release],
+            withdrawn=withdrawn,
         )
 
         url = "/the/fake/url/"
@@ -701,6 +703,7 @@ class TestJSONRelease:
                 "details": "some details",
                 "summary": "some summary",
                 "fixed_in": ["3.3.2"],
+                "withdrawn": withdrawn,
             },
         ]
 

--- a/warehouse/integrations/vulnerabilities/__init__.py
+++ b/warehouse/integrations/vulnerabilities/__init__.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 
-from typing import List
+from typing import List, Optional
 
 from warehouse import integrations
 
@@ -33,6 +33,7 @@ class VulnerabilityReportRequest:
         details: str,
         summary: str,
         fixed_in: List[str],
+        withdrawn: Optional[str],
     ):
         self.project = project
         self.versions = versions
@@ -42,6 +43,7 @@ class VulnerabilityReportRequest:
         self.details = details
         self.summary = summary
         self.fixed_in = fixed_in
+        self.withdrawn = withdrawn
 
     @classmethod
     def from_api_request(cls, request):
@@ -73,6 +75,7 @@ class VulnerabilityReportRequest:
                 for event_type, version in event.items()
                 if event_type == "fixed"
             ],
+            withdrawn=request.get("withdrawn"),
         )
 
 

--- a/warehouse/integrations/vulnerabilities/models.py
+++ b/warehouse/integrations/vulnerabilities/models.py
@@ -12,7 +12,7 @@
 
 
 from sqlalchemy import Column, ForeignKey, ForeignKeyConstraint, String, Table, orm
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY, TIMESTAMP
 
 from warehouse import db
 
@@ -67,6 +67,9 @@ class VulnerabilityRecord(db.Model):
 
     # Events of introduced/fixed versions
     fixed_in = Column(ARRAY(String))
+
+    # When the vulnerability was withdrawn, if it has been withdrawn.
+    withdrawn = Column(TIMESTAMP, nullable=True)
 
     releases = orm.relationship(
         "Release",

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -74,9 +74,9 @@ def _analyze_vulnerability(request, vulnerability_report, origin, metrics):
     try:
         vulnerability_record = _get_vuln_record(request, report, origin)
 
-        if not report.versions or report.withdrawn is not None:
-            # No versions or a withdrawn date indicates the vulnerability is no
-            # longer considered valid, so delete it.
+        if not report.versions:
+            # No versions indicates the vulnerability is no longer considered
+            # valid, so delete it.
             _delete_vuln_record(request, vulnerability_record)
             return
 
@@ -92,6 +92,7 @@ def _analyze_vulnerability(request, vulnerability_report, origin, metrics):
             details=report.details,
             summary=report.summary,
             fixed_in=report.fixed_in,
+            withdrawn=report.withdrawn,
         )
         _add_vuln_record(request, vulnerability_record)
 

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -74,9 +74,9 @@ def _analyze_vulnerability(request, vulnerability_report, origin, metrics):
     try:
         vulnerability_record = _get_vuln_record(request, report, origin)
 
-        if not report.versions:
-            # No versions indicates the vulnerability is no longer considered
-            # valid, so delete it.
+        if not report.versions or report.withdrawn is not None:
+            # No versions or a withdrawn date indicates the vulnerability is no
+            # longer considered valid, so delete it.
             _delete_vuln_record(request, vulnerability_record)
             return
 

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -129,9 +129,11 @@ def _json_data(request, project, release, *, all_releases):
             "details": vulnerability_record.details,
             "summary": vulnerability_record.summary,
             "fixed_in": vulnerability_record.fixed_in,
-            "withdrawn": (vulnerability_record.withdrawn.strftime("%Y-%m-%dT%H:%M:%SZ")
-                          if vulnerability_record.withdrawn
-                          else None),
+            "withdrawn": (
+                vulnerability_record.withdrawn.strftime("%Y-%m-%dT%H:%M:%SZ")
+                if vulnerability_record.withdrawn
+                else None
+            ),
         }
         for vulnerability_record in release.vulnerabilities
     ]

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -119,7 +119,7 @@ def _json_data(request, project, release, *, all_releases):
         for r, fs in releases.items()
     }
 
-    # Serialize a list of vulnerabilties for this release
+    # Serialize a list of vulnerabilities for this release
     vulnerabilities = [
         {
             "id": vulnerability_record.id,
@@ -129,6 +129,9 @@ def _json_data(request, project, release, *, all_releases):
             "details": vulnerability_record.details,
             "summary": vulnerability_record.summary,
             "fixed_in": vulnerability_record.fixed_in,
+            "withdrawn": vulnerability_record.withdrawn.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if vulnerability_record.withdrawn
+            else None,
         }
         for vulnerability_record in release.vulnerabilities
     ]

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -129,9 +129,9 @@ def _json_data(request, project, release, *, all_releases):
             "details": vulnerability_record.details,
             "summary": vulnerability_record.summary,
             "fixed_in": vulnerability_record.fixed_in,
-            "withdrawn": vulnerability_record.withdrawn.strftime("%Y-%m-%dT%H:%M:%SZ")
-            if vulnerability_record.withdrawn
-            else None,
+            "withdrawn": (vulnerability_record.withdrawn.strftime("%Y-%m-%dT%H:%M:%SZ")
+                          if vulnerability_record.withdrawn
+                          else None),
         }
         for vulnerability_record in release.vulnerabilities
     ]

--- a/warehouse/migrations/versions/bd71566c2877_add_withdrawn_field.py
+++ b/warehouse/migrations/versions/bd71566c2877_add_withdrawn_field.py
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add withdrawn field
+
+Revision ID: bd71566c2877
+Revises: 90f6ee9298db
+Create Date: 2022-10-26 19:54:21.291985
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "bd71566c2877"
+down_revision = "90f6ee9298db"
+
+
+def upgrade():
+    op.add_column(
+        "vulnerabilities", sa.Column("withdrawn", postgresql.TIMESTAMP(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("vulnerabilities", "withdrawn")


### PR DESCRIPTION
See https://github.com/pypa/pip-audit/issues/388. This exposes the underlying "withdrawn" field provided by OSV, allowing tools like `pip-audit` to filter on it.

Signed-off-by: William Woodruff <william@trailofbits.com>