### PR TITLE
fix: remove strikethrough from literal strings

### DIFF
--- a/warehouse/static/sass/blocks/_project-description.scss
+++ b/warehouse/static/sass/blocks/_project-description.scss
@@ -258,6 +258,11 @@
     margin-right: auto;
   }
 
+  s { /* pygments Literal.String */
+    /* Override browser default behavior */
+    text-decoration: none;
+  }
+
 }
 
 


### PR DESCRIPTION
When Pygments renders HTML, t uses the `<s>` tag for string literals, which most browsers will interpret as a Strikethrough, which is confusing.

Introduced during a fix for pypa/readme_renderer#262 and surfaced in project pages since.

Fixes: #12484

Signed-off-by: Mike Fiedler <miketheman@gmail.com>