### PR TITLE
fix: allow code block contents to be scrollable

### DIFF
--- a/warehouse/static/sass/blocks/_code-block.scss
+++ b/warehouse/static/sass/blocks/_code-block.scss
@@ -30,4 +30,5 @@ A custom styled code block.
   margin-bottom: $spacing-unit / 2;
   word-break: break-all;
   direction: ltr;
+  overflow-x: auto;
 }


### PR DESCRIPTION
Use same `overflow-x` behavior we have in `project-description`.

`code-block` classes are only used in the `token.html` template today.

Fixes #12529

Looks a little something like this (don't worry, that token is on my dev env and not worth anything):


https://user-images.githubusercontent.com/529516/201366510-b756eb94-b411-446c-98b6-2c08f5d85a5c.mov



