### PR TITLE
warehouse: add initial pending OIDC provider models

### DIFF
--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -112,6 +112,13 @@ class User(SitemapMixin, HasEvents, db.Model):
         "Macaroon", backref="user", cascade="all, delete-orphan", lazy=True
     )
 
+    pending_oidc_providers = orm.relationship(
+        "PendingOIDCProvider",
+        backref="added_by",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+
     @property
     def primary_email(self):
         primaries = [x for x in self.emails if x.primary]

--- a/warehouse/migrations/versions/aa3a4757f33a_add_pending_oidc_provider_hierarchy.py
+++ b/warehouse/migrations/versions/aa3a4757f33a_add_pending_oidc_provider_hierarchy.py
@@ -1,0 +1,80 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add pending OIDC provider hierarchy
+
+Revision ID: aa3a4757f33a
+Revises: 43bf0b6badcb
+Create Date: 2022-11-18 22:19:55.133681
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "aa3a4757f33a"
+down_revision = "43bf0b6badcb"
+
+
+def upgrade():
+    op.create_table(
+        "pending_oidc_providers",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("discriminator", sa.String(), nullable=True),
+        sa.Column("project_name", sa.String(), nullable=False),
+        sa.Column("added_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["added_by_id"],
+            ["users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_pending_oidc_providers_added_by_id"),
+        "pending_oidc_providers",
+        ["added_by_id"],
+        unique=False,
+    )
+    op.create_table(
+        "pending_github_oidc_providers",
+        sa.Column("repository_name", sa.String(), nullable=True),
+        sa.Column("repository_owner", sa.String(), nullable=True),
+        sa.Column("repository_owner_id", sa.String(), nullable=True),
+        sa.Column("workflow_filename", sa.String(), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["id"],
+            ["pending_oidc_providers.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "repository_name",
+            "repository_owner",
+            "workflow_filename",
+            name="_pending_github_oidc_provider_uc",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("pending_github_oidc_providers")
+    op.drop_index(
+        op.f("ix_pending_oidc_providers_added_by_id"),
+        table_name="pending_oidc_providers",
+    )
+    op.drop_table("pending_oidc_providers")

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -182,6 +182,7 @@ class PendingOIDCProvider(OIDCProviderMixin, db.Model):
     A "pending" OIDC provider, i.e. one that's been registered by a user
     but doesn't correspond to an existing PyPI project yet.
     """
+
     __tablename__ = "pending_oidc_providers"
 
     discriminator = Column(String)
@@ -284,4 +285,6 @@ class PendingGitHubProvider(GitHubProviderMixin, PendingOIDCProvider):
         ),
     )
 
-    id = Column(UUID(as_uuid=True), ForeignKey(PendingOIDCProvider.id), primary_key=True)
+    id = Column(
+        UUID(as_uuid=True), ForeignKey(PendingOIDCProvider.id), primary_key=True
+    )

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -17,8 +17,10 @@ import sentry_sdk
 
 from sqlalchemy import Column, ForeignKey, String, UniqueConstraint, orm
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.declarative import declared_attr
 
 from warehouse import db
+from warehouse.accounts.models import User
 from warehouse.macaroons.models import Macaroon
 from warehouse.oidc.interfaces import SignedClaims
 from warehouse.packaging.models import Project
@@ -70,23 +72,11 @@ class OIDCProviderProjectAssociation(db.Model):
     )
 
 
-class OIDCProvider(db.Model):
-    __tablename__ = "oidc_providers"
-
-    discriminator = Column(String)
-    projects = orm.relationship(
-        Project,
-        secondary=OIDCProviderProjectAssociation.__table__,  # type: ignore
-        backref="oidc_providers",
-    )
-    macaroons = orm.relationship(
-        Macaroon, backref="oidc_provider", cascade="all, delete-orphan", lazy=True
-    )
-
-    __mapper_args__ = {
-        "polymorphic_identity": "oidc_providers",
-        "polymorphic_on": discriminator,
-    }
+class OIDCProviderMixin:
+    """
+    A mixin for common functionality between all OIDC providers, including
+    "pending" providers that don't correspond to an extant project yet.
+    """
 
     # A map of claim names to "check" functions, each of which
     # has the signature `check(ground-truth, signed-claim, all-signed-claims) -> bool`.
@@ -161,28 +151,59 @@ class OIDCProvider(db.Model):
 
     @property
     def provider_name(self):  # pragma: no cover
-        # Only concrete subclasses of OIDCProvider are constructed.
+        # Only concrete subclasses are constructed.
         return NotImplemented
 
     @property
     def provider_url(self):  # pragma: no cover
-        # Only concrete subclasses of OIDCProvider are constructed.
+        # Only concrete subclasses are constructed.
         return NotImplemented
 
 
-class GitHubProvider(OIDCProvider):
-    __tablename__ = "github_oidc_providers"
-    __mapper_args__ = {"polymorphic_identity": "github_oidc_providers"}
-    __table_args__ = (
-        UniqueConstraint(
-            "repository_name",
-            "repository_owner",
-            "workflow_filename",
-            name="_github_oidc_provider_uc",
-        ),
+class OIDCProvider(OIDCProviderMixin, db.Model):
+    __tablename__ = "oidc_providers"
+
+    discriminator = Column(String)
+    projects = orm.relationship(
+        Project,
+        secondary=OIDCProviderProjectAssociation.__table__,  # type: ignore
+        backref="oidc_providers",
+    )
+    macaroons = orm.relationship(
+        Macaroon, backref="oidc_provider", cascade="all, delete-orphan", lazy=True
     )
 
-    id = Column(UUID(as_uuid=True), ForeignKey(OIDCProvider.id), primary_key=True)
+    __mapper_args__ = {
+        "polymorphic_identity": "oidc_providers",
+        "polymorphic_on": discriminator,
+    }
+
+
+class PendingOIDCProvider(OIDCProviderMixin, db.Model):
+    """
+    A "pending" OIDC provider, i.e. one that's been registered by a user
+    but doesn't correspond to an existing PyPI project yet.
+    """
+
+    __tablename__ = "pending_oidc_providers"
+
+    discriminator = Column(String)
+    project_name = Column(String, nullable=False)
+    added_by_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "pending_oidc_providers",
+        "polymorphic_on": discriminator,
+    }
+
+
+class GitHubProviderMixin:
+    """
+    Common functionality for both pending and concrete GitHub OIDC providers.
+    """
+
     repository_name = Column(String)
     repository_owner = Column(String)
     repository_owner_id = Column(String)
@@ -237,3 +258,35 @@ class GitHubProvider(OIDCProvider):
 
     def __str__(self):
         return f"{self.workflow_filename} @ {self.repository}"
+
+
+class GitHubProvider(GitHubProviderMixin, OIDCProvider):
+    __tablename__ = "github_oidc_providers"
+    __mapper_args__ = {"polymorphic_identity": "github_oidc_providers"}
+    __table_args__ = (
+        UniqueConstraint(
+            "repository_name",
+            "repository_owner",
+            "workflow_filename",
+            name="_github_oidc_provider_uc",
+        ),
+    )
+
+    id = Column(UUID(as_uuid=True), ForeignKey(OIDCProvider.id), primary_key=True)
+
+
+class PendingGitHubProvider(GitHubProviderMixin, PendingOIDCProvider):
+    __tablename__ = "pending_github_oidc_providers"
+    __mapper_args__ = {"polymorphic_identity": "pending_github_oidc_providers"}
+    __table_args__ = (
+        UniqueConstraint(
+            "repository_name",
+            "repository_owner",
+            "workflow_filename",
+            name="_pending_github_oidc_provider_uc",
+        ),
+    )
+
+    id = Column(
+        UUID(as_uuid=True), ForeignKey(PendingOIDCProvider.id), primary_key=True
+    )

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -17,10 +17,8 @@ import sentry_sdk
 
 from sqlalchemy import Column, ForeignKey, String, UniqueConstraint, orm
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.ext.declarative import declared_attr
 
 from warehouse import db
-from warehouse.accounts.models import User
 from warehouse.macaroons.models import Macaroon
 from warehouse.oidc.interfaces import SignedClaims
 from warehouse.packaging.models import Project
@@ -184,7 +182,6 @@ class PendingOIDCProvider(OIDCProviderMixin, db.Model):
     A "pending" OIDC provider, i.e. one that's been registered by a user
     but doesn't correspond to an existing PyPI project yet.
     """
-
     __tablename__ = "pending_oidc_providers"
 
     discriminator = Column(String)
@@ -287,6 +284,4 @@ class PendingGitHubProvider(GitHubProviderMixin, PendingOIDCProvider):
         ),
     )
 
-    id = Column(
-        UUID(as_uuid=True), ForeignKey(PendingOIDCProvider.id), primary_key=True
-    )
+    id = Column(UUID(as_uuid=True), ForeignKey(PendingOIDCProvider.id), primary_key=True)


### PR DESCRIPTION
See #11296.

This is going to be a relatively complex set of models (thanks to the mixins for shared functionality between "pending" and concrete OIDC providers), so I wanted to get them up and merged before beginning on actual routes/view logic.

~~Needs unit tests.~~

Signed-off-by: William Woodruff <william@trailofbits.com>