### PR TITLE
Guard against invalid UUIDs in token scanning endpoint

### DIFF
--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -57,7 +57,10 @@ class TestDatabaseMacaroonService:
     def test_extract_raw_macaroon(self, macaroon_service, raw_macaroon, result):
         assert macaroon_service._extract_raw_macaroon(raw_macaroon) == result
 
-    def test_find_macaroon_invalid_macaroon(self, macaroon_service):
+    def test_find_macaroon_invalid_uuid(self, macaroon_service):
+        assert macaroon_service.find_macaroon("foobar") is None
+
+    def test_find_macaroon_missing_macaroon(self, macaroon_service):
         assert macaroon_service.find_macaroon(str(uuid4())) is None
 
     def test_find_macaroon(self, user_service, macaroon_service):

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import datetime
+import uuid
 
 import pymacaroons
 
@@ -52,6 +53,11 @@ class DatabaseMacaroonService:
         Returns a macaroon model from the DB by its identifier.
         Returns None if no macaroon has the given ID.
         """
+        try:
+            uuid.UUID(macaroon_id)
+        except ValueError:
+            return None
+
         return self.db.get(
             Macaroon, macaroon_id, (joinedload("user"), joinedload("oidc_provider"))
         )


### PR DESCRIPTION
Fixes https://sentry.io/organizations/python-software-foundation/issues/3755844370/.