### PR TITLE
Faster dev environment startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust  # never do this in production!
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres", "-d", "postgres"]
+      interval: 1s
 
   stripe:
     image: stripe/stripe-mock:v0.140.0


### PR DESCRIPTION
run db healthcheck every 1s

default is 30, which leads to excess delay before first opportunity for dependent containers to start