### PR TITLE
Normalize prohibited project name when looking for dupes

### DIFF
--- a/warehouse/admin/views/prohibited_project_names.py
+++ b/warehouse/admin/views/prohibited_project_names.py
@@ -237,7 +237,9 @@ def add_prohibited_project_names(request):
         request.db.query(literal(True))
         .filter(
             request.db.query(ProhibitedProjectName)
-            .filter(ProhibitedProjectName.name == project_name)
+            .filter(
+                ProhibitedProjectName.name == func.normalize_pep426_name(project_name)
+            )
             .exists()
         )
         .scalar()


### PR DESCRIPTION
Fixes https://sentry.io/organizations/python-software-foundation/issues/3758698961/.