### PR TITLE
Truncate long licenses that lack newlines

### DIFF
--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -400,6 +400,20 @@ class TestReleaseDetail:
 
         assert result["license"] == "BSD License, MIT License"
 
+    def test_long_singleline_license(self, db_request):
+        """When license metadata contains no newlines, it gets truncated"""
+        release = ReleaseFactory.create(
+            license="Multiline License is very long, so long that it is far longer than"
+            " 100 characters, it's really so long, how terrible"
+        )
+
+        result = views.release_detail(release, db_request)
+
+        assert result["license"] == (
+            "Multiline License is very long, so long that it is far longer than 100 "
+            "characters, it's really so lo..."
+        )
+
 
 class TestEditProjectButton:
     def test_edit_project_button_returns_project(self):

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -117,6 +117,10 @@ def release_detail(release, request):
     # first line only.
     short_license = release.license.split("\n")[0] if release.license else None
 
+    # Truncate the short license if we were unable to shorten it with newlines
+    if short_license and len(short_license) > 100 and short_license == release.license:
+        short_license = short_license[:100] + "..."
+
     if license_classifiers and short_license:
         license = f"{license_classifiers} ({short_license})"
     else:


### PR DESCRIPTION
Fixes #12392 until we have more sane license metadata with [PEP 639](https://peps.python.org/pep-0639/).