### PR TITLE
fix: add CSS to style footnotes correctly

### DIFF
--- a/warehouse/static/sass/blocks/_project-description.scss
+++ b/warehouse/static/sass/blocks/_project-description.scss
@@ -263,6 +263,14 @@
     text-decoration: none;
   }
 
+  aside.footnote p {
+    display: inline;
+  }
+
+  aside.footnote {
+    padding-left: 2em;
+    text-indent: -2em;
+  }
 }
 
 


### PR DESCRIPTION
As noted in https://github.com/pypa/readme_renderer/issues/264

With these changes, the footnotes are styled in a more visually-pleasing manner.

# Examples

Using the output from https://github.com/pypa/readme_renderer/blob/da1a5a461c2cf668b83027e65b7d92b11a3f91d4/tests/fixtures/test_rst_footnotes.html as an example.

## Before
<img width="721" alt="Screenshot 2022-12-16 at 12 31 10 PM" src="https://user-images.githubusercontent.com/529516/208155309-98e37515-4aab-45d0-a74d-f2dd5315b404.png">

## After

<img width="752" alt="Screenshot 2022-12-16 at 12 30 47 PM" src="https://user-images.githubusercontent.com/529516/208155237-0cabd37f-e7d6-4abb-b020-c7fd8e7e2f4f.png">
