### PR TITLE
fix: rename message to reflect what is removed

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -8860,7 +8860,7 @@ class TestDeleteProjectRole:
             pretend.call(db_request, user, submitter=user_2, project_name="foobar")
         ]
         assert db_request.session.flash.calls == [
-            pretend.call("Removed role", queue="success")
+            pretend.call("Removed collaborator", queue="success")
         ]
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
@@ -8956,7 +8956,7 @@ class TestDeleteProjectRole:
             pretend.call(db_request, user_2, submitter=user_2, project_name="foobar")
         ]
         assert db_request.session.flash.calls == [
-            pretend.call("Removed role", queue="success")
+            pretend.call("Removed collaborator", queue="success")
         ]
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -4667,7 +4667,7 @@ def delete_project_role(project, request):
                 request, role.user, submitter=request.user, project_name=project.name
             )
 
-            request.session.flash("Removed role", queue="success")
+            request.session.flash("Removed collaborator", queue="success")
             if removing_self:
                 return HTTPSeeOther(request.route_path("manage.projects"))
     except NoResultFound:


### PR DESCRIPTION
While the database object that is changed is indeed a role, the language may confuse the viewer, as they remove the collaborator from the project.

Resolves #12419

Signed-off-by: Mike Fiedler <miketheman@gmail.com>