### PR TITLE
chore: remove vestiges of selenium testing

### DIFF
--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,4 +1,3 @@
-bok-choy>=0.6.0
 coverage
 factory_boy
 freezegun

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -12,10 +12,6 @@ beautifulsoup4==4.11.1 \
     --hash=sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30 \
     --hash=sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693
     # via webtest
-bok-choy==1.1.1 \
-    --hash=sha256:67e8a868d645d68cfc0d1d14fe2bf522f1508655242333a1161d748af1d02650 \
-    --hash=sha256:aa807f7cd704699743761921c453df42fbb2f5424709b796e76246c27fdd018a
-    # via -r requirements/tests.in
 certifi==2022.12.7 \
     --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
     --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
@@ -97,10 +93,6 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
-lazy==1.5 \
-    --hash=sha256:7b8bc7e0136f96722bf9e41eec7472495059526bfa1195db61d43e8da6bbe604 \
-    --hash=sha256:cb3d8612aa895a48afe8f08860573ba8ef5ee4fdbe1b3cd606c5f50a16152186
-    # via bok-choy
 mirakuru==2.4.2 \
     --hash=sha256:ec84d4d81b4bca96cb0e598c6b3d198a92f036a0c1223c881482c02a98508226 \
     --hash=sha256:fdb67d141cc9f7abd485a515d618daf3272c3e6ff48380749997ff8e8c5f2cb2
@@ -165,16 +157,10 @@ responses==0.22.0 \
     --hash=sha256:396acb2a13d25297789a5866b4881cf4e46ffd49cc26c43ab1117f40b973102e \
     --hash=sha256:dcf294d204d14c436fddcc74caefdbc5764795a40ff4e6a7740ed8ddbf3294be
     # via -r requirements/tests.in
-selenium==3.141.0 \
-    --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \
-    --hash=sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d
-    # via bok-choy
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-    # via
-    #   bok-choy
-    #   python-dateutil
+    # via python-dateutil
 soupsieve==2.3.2.post1 \
     --hash=sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759 \
     --hash=sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d
@@ -193,7 +179,6 @@ urllib3==1.26.13 \
     # via
     #   requests
     #   responses
-    #   selenium
 waitress==2.1.2 \
     --hash=sha256:7500c9625927c8ec60f54377d590f67b30c8e70ef4b8894214ac6e4cad233d2a \
     --hash=sha256:780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -462,26 +462,6 @@ def webtest(app_config):
         app_config.registry["sqlalchemy.engine"].dispose()
 
 
-@pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    # execute all other hooks to obtain the report object
-    outcome = yield
-    rep = outcome.get_result()
-
-    # we only look at actual failing test calls, not setup/teardown
-    if rep.when == "call" and rep.failed:
-        if "browser" in item.fixturenames:
-            browser = item.funcargs["browser"]
-            for log_type in set(browser.log_types) - {"har"}:
-                data = "\n\n".join(
-                    filter(
-                        None, (log.get("message") for log in browser.get_log(log_type))
-                    )
-                )
-                if data:
-                    rep.sections.append(("Captured {} log".format(log_type), data))
-
-
 @pytest.fixture(scope="session")
 def monkeypatch_session():
     # NOTE: This is a minor hack to avoid duplicate monkeypatching


### PR DESCRIPTION
In #2481 Selenium testing was dropped.
Remove some of the leftovers from that era.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>