### PR TITLE
fix: naturally sort classifier values

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -146,6 +146,19 @@ def test_format_tags(inp, expected):
             ["Foo :: Bar :: Baz", "Vleep :: Foo", "Foo :: Bar :: Qux"],
             [("Foo", ["Bar :: Baz", "Bar :: Qux"]), ("Vleep", ["Foo"])],
         ),
+        (
+            [
+                "Programming Language :: Python :: 3.11",
+                "Programming Language :: Python :: 3.10",
+                "Programming Language :: Python :: 3.8",
+            ],
+            [
+                (
+                    "Programming Language",
+                    ["Python :: 3.8", "Python :: 3.10", "Python :: 3.11"],
+                )
+            ],
+        ),
     ],
 )
 def test_format_classifiers(inp, expected):

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -28,6 +28,7 @@ import jinja2
 import packaging.version
 import pytz
 
+from natsort import natsorted
 from pyramid.threadlocal import get_current_request
 
 from warehouse.utils.http import is_valid_uri
@@ -136,6 +137,10 @@ def format_classifiers(classifiers):
             if key not in structured:
                 structured[key] = []
             structured[key].append(value[0])
+
+    # Sort all the values in our data structure
+    for key, value in structured.items():
+        structured[key] = natsorted(value)
 
     return structured
 


### PR DESCRIPTION
Resolves #8843

Uses `natsort` which we use in other places already.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>