### PR TITLE
Ordering API tokens by date created

### DIFF
--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -109,7 +109,11 @@ class User(SitemapMixin, HasEvents, db.Model):
     )
 
     macaroons = orm.relationship(
-        "Macaroon", backref="user", cascade="all, delete-orphan", lazy=True
+        "Macaroon",
+        backref="user",
+        cascade="all, delete-orphan",
+        lazy=True,
+        order_by="Macaroon.created.desc()",
     )
 
     pending_oidc_providers = orm.relationship(


### PR DESCRIPTION
This change will make the API tokens on the Account Settings page be displayed in descending order of when they were created. That ordering makes the most sense to me, and that is how GitHub orders personal access tokens (as best I can tell).

Here's a screenshot of how the new ordering will look:
![image](https://user-images.githubusercontent.com/8961650/210583537-3ccec074-e224-4d30-a998-da6f0bb6a5d2.png)

Closes https://github.com/pypi/warehouse/issues/9674