### PR TITLE
Improve the autodetection of GitHub URLs slightly

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -428,6 +428,10 @@ class TestRelease:
             ),
             ("https://github.com/pypa/", None),
             ("https://google.com/pypi/warehouse/tree/main", None),
+            (
+                "https://www.github.com/pypi/warehouse.git",
+                "https://www.github.com/pypi/warehouse",
+            ),
             ("https://google.com", None),
             ("incorrect url", None),
         ],

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -591,6 +591,8 @@ class Release(db.Model):
             segments = parsed.path.strip("/").split("/")
             if parsed.netloc in {"github.com", "www.github.com"} and len(segments) >= 2:
                 user_name, repo_name = segments[:2]
+                if repo_name.endswith(".git"):
+                    repo_name = repo_name[:-4]
                 return f"https://api.github.com/repos/{user_name}/{repo_name}"
 
     @property


### PR DESCRIPTION
- [x] strip off `.git` from the ends of any detected URL (#12753)
- [ ] skip URLs which aren't real repository links (e.g. `github.com/sponsors/`) when trying to find one in the list of links