### PR TITLE
Skip non-user URLs when autodetecting a GitHub repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ module = [
     "citext.*",
     "disposable_email_domains.*",
     "elasticsearch_dsl.*", # https://github.com/elastic/elasticsearch-dsl-py/issues/1533
+    "github_reserved_names.*",
     "google.cloud.*",
     "IPython.*",
     "mistune.*",

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -14,6 +14,7 @@ disposable-email-domains
 elasticsearch>=7.0.0,<7.11.0
 elasticsearch_dsl>=7.0.0,<8.0.0
 first
+github-reserved-names>=1.0.0
 google-cloud-bigquery
 google-cloud-storage
 hiredis

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -394,6 +394,10 @@ first==2.0.2 \
     --hash=sha256:8d8e46e115ea8ac652c76123c0865e3ff18372aef6f03c22809ceefcea9dec86 \
     --hash=sha256:ff285b08c55f8c97ce4ea7012743af2495c9f1291785f163722bd36f6af6d3bf
     # via -r requirements/main.in
+github-reserved-names==1.0.1 \
+    --hash=sha256:c9acc3c8e573e303e962496308553241db6f306290a09be7d2c6d60cdcda0bb9 \
+    --hash=sha256:f10b8df2b01d76022b144a17381782b63205b2f2cefdfc145c984d16cb4e9733
+    # via -r requirements/main.in
 google-api-core[grpc]==2.8.2 \
     --hash=sha256:06f7244c640322b508b125903bb5701bebabce8832f85aba9335ec00b3d02edc \
     --hash=sha256:93c6a91ccac79079ac6bbf8b74ee75db970cc899278b97d53bc012f35908cf50
@@ -1012,6 +1016,10 @@ pastedeploy==3.0.1 \
     --hash=sha256:5f4b4d5fddd39b8947ea727161e366bf55b90efc60a4d1dd7976b9031d0b4e5f \
     --hash=sha256:6195c921b1c3ed9722e4e3e6aa29b70deebb2429b4ca3ff3d49185c8e80003bb
     # via plaster-pastedeploy
+pip==22.3.1 \
+    --hash=sha256:65fd48317359f3af8e593943e6ae1506b66325085ea64b706a998c6e83eeaf38 \
+    --hash=sha256:908c78e6bc29b676ede1c4d57981d490cb892eb45cd8c214ab6298125119e077
+    # via pip-api
 pip-api==0.0.30 \
     --hash=sha256:2a0314bd31522eb9ffe8a99668b0d07fee34ebc537931e7b6483001dbedcbdc9 \
     --hash=sha256:a05df2c7aa9b7157374bcf4273544201a0c7bae60a9c65bcf84f3959ef3896f3
@@ -1267,6 +1275,17 @@ sentry-sdk==1.12.1 \
     --hash=sha256:5bbe4b72de22f9ac1e67f2a4e6efe8fbd595bb59b7b223443f50fe5802a5551c \
     --hash=sha256:9f0b960694e2d8bb04db4ba6ac2a645040caef4e762c65937998ff06064f10d6
     # via -r requirements/main.in
+setuptools==65.6.3 \
+    --hash=sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54 \
+    --hash=sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75
+    # via
+    #   -r requirements/main.in
+    #   limits
+    #   pyramid
+    #   repoze-sendmail
+    #   zope-deprecation
+    #   zope-interface
+    #   zope-sqlalchemy
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
@@ -1574,20 +1593,3 @@ zope-sqlalchemy==1.6 \
 zxcvbn==4.4.28 \
     --hash=sha256:151bd816817e645e9064c354b13544f85137ea3320ca3be1fb6873ea75ef7dc1
     # via -r requirements/main.in
-
-# The following packages are considered to be unsafe in a requirements file:
-pip==22.3.1 \
-    --hash=sha256:65fd48317359f3af8e593943e6ae1506b66325085ea64b706a998c6e83eeaf38 \
-    --hash=sha256:908c78e6bc29b676ede1c4d57981d490cb892eb45cd8c214ab6298125119e077
-    # via pip-api
-setuptools==65.6.3 \
-    --hash=sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54 \
-    --hash=sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75
-    # via
-    #   -r requirements/main.in
-    #   limits
-    #   pyramid
-    #   repoze-sendmail
-    #   zope-deprecation
-    #   zope-interface
-    #   zope-sqlalchemy

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -427,6 +427,7 @@ class TestRelease:
                 "https://api.github.com/repos/pypi/warehouse",
             ),
             ("https://github.com/pypa/", None),
+            ("https://github.com/sponsors/pypa/", None),
             ("https://google.com/pypi/warehouse/tree/main", None),
             ("https://google.com", None),
             ("incorrect url", None),

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 import packaging.utils
 
 from citext import CIText
+from github_reserved_names import ALL as GITHUB_RESERVED_NAMES
 from pyramid.authorization import Allow
 from pyramid.threadlocal import get_current_request
 from sqlalchemy import (
@@ -591,6 +592,8 @@ class Release(db.Model):
             segments = parsed.path.strip("/").split("/")
             if parsed.netloc in {"github.com", "www.github.com"} and len(segments) >= 2:
                 user_name, repo_name = segments[:2]
+                if user_name in GITHUB_RESERVED_NAMES:
+                    continue
                 if repo_name.endswith(".git"):
                     repo_name = repo_name.removesuffix(".git")
                 return f"https://api.github.com/repos/{user_name}/{repo_name}"


### PR DESCRIPTION
Uses a hardcoded list of known examples (from a new dependency).

Closes: #12725