### PR TITLE
disable dynamic_context for coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
-dynamic_context = test_function
+# TODO: Re-Enable when https://github.com/nedbat/coveragepy/issues/1527 is resolved
+# dynamic_context = test_function
 
 source =
     warehouse


### PR DESCRIPTION
Introduced in https://github.com/pypi/warehouse/pull/10816/commits/89a2c0da1bf1cfffc5dfc9b230653f78430c1c5d.

Currently performance impact of this with current version of coverage is _bad_:

Without this change:

```
=============================== 3231 passed, 483 warnings in 1249.00s (0:20:49) ==============================
```

With this change:

```
=============================== 3231 passed, 483 warnings in 100.98s (0:01:40) ===============================
```