### PR TITLE
chore: add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
After working with the codebase for a while, it became easier with a config file in place.

Only used if the author uses the EditorConfig plugins for their editor.

Refs: https://editorconfig.org/

Signed-off-by: Mike Fiedler <miketheman@gmail.com>