### PR TITLE
chore: upgrade nodejs runtime to latest LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: ${{ matrix.needs-node }}
         with:
-          node-version: 16.17.1
+          node-version: 18.13.0
           cache: 'npm'
       - name: Install Node dependencies
         if: ${{ matrix.needs-node }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # First things first, we build an image which is where we're going to compile
 # our static assets with. We use this stage in development.
-FROM node:16.17.1-bullseye as static-deps
+FROM node:18.13.0-bullseye as static-deps
 
 WORKDIR /opt/warehouse/src/
 


### PR DESCRIPTION
Node 18 was released in April 2022, and became LTS in October 2022. Node 16 is now in maintenance-only mode.

Refs: https://nodejs.org/de/blog/announcements/v18-release-announce/ Refs: https://github.com/nodejs/release

Signed-off-by: Mike Fiedler <miketheman@gmail.com>