### PR TITLE
Fixing deprecations in notdatadog service

### DIFF
--- a/dev/notdatadog.py
+++ b/dev/notdatadog.py
@@ -13,7 +13,7 @@
 import asyncore
 import os
 import socket
-import smtpd
+import sys
 
 
 class AsyncoreSocketUDP(asyncore.dispatcher):
@@ -40,10 +40,16 @@ class AsyncoreSocketUDP(asyncore.dispatcher):
 
 
 if __name__ == "__main__":
-    options = smtpd.parseargs()
+    try:
+        host, port = sys.argv[1].split(":")
+        port = int(port)
+    except (ValueError, IndexError):
+        print("Usage: python3 notdatadog.py <host>:<port>")
+        sys.exit(1)
+
     AsyncoreSocketUDP(
-        options.localhost,
-        options.localport,
+        host,
+        port,
         os.environ.get("METRICS_OUTPUT", "").lower() == "true",
     )
     asyncore.loop()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,8 @@ services:
   notdatadog:
     build:
       context: .
+      args:
+        DEVEL: "yes"
     command: python /opt/warehouse/dev/notdatadog.py 0.0.0.0:8125
     environment:
       METRICS_OUTPUT: "false"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
+asyncudp>=0.7
 hupper>=1.9
 pip-tools>=1.0
 pyramid_debugtoolbar>=2.5


### PR DESCRIPTION
This is to remove two modules that will be deprecated in Python 3.12: `smptd` and `asyncore`.

`asyncio` is the recommended replacement for `asyncore`. I tried implementing a UDP server using just `asyncio`, but it would crash after working for a while, and I really wasn't sure if I was using the library correctly. So I broke down and introduced a dependency on `asyncudp`. This is a pretty small library really only maintained by 1 person. I think this is fine for a library that's only installed in development, but if you disagree, let me know, and I can rework this PR to not use it.

With these changes, these are some example logs from the `notdatadog` container (when `METRICS_OUTPUT='true'`):
```
warehouse.2fa.total_users_with_totp_enabled:0|g
warehouse.2fa.total_users_with_webauthn_enabled:0|g
warehouse.2fa.total_users_with_two_factor_enabled:0|g
warehouse.task.complete:1|c|#task:warehouse.packaging.tasks.compute_2fa_metrics
warehouse.task.run:36|ms|#task:warehouse.packaging.tasks.compute_2fa_metrics
warehouse.db.session.finished:1|c
pyramid.request.duration.route_match:0.134033203125|ms
pyramid.request.duration.traversal:1.874267578125|ms
warehouse.db.session.start:1|c
pyramid.request.duration.view:6.902587890625|ms|#route:admin.sponsor.list
pyramid.view.duration:23|ms|#route:admin.sponsor.list,view:warehouse.admin.views.sponsors.sponsor_list
pyramid.request.duration.template_render:32.0166015625|ms|#route:admin.sponsor.list
pyramid.request.duration.total:40.794921875|ms|#route:admin.sponsor.list,status_code:200,status_type:2xx
warehouse.db.session.finished:1|c
pyramid.request.duration.route_match:0.199951171875|ms
pyramid.request.duration.traversal:0.9560546875|ms
```

Closes https://github.com/pypi/warehouse/issues/12779