### PR TITLE
Revert "chore(deps): pin packaging to upper boundary (#12664)"

### DIFF
--- a/requirements/deploy.in
+++ b/requirements/deploy.in
@@ -1,4 +1,2 @@
 gunicorn==20.1.0
 ddtrace==1.7.2
-# Until resolved https://github.com/googleapis/python-bigquery/issues/1435
-packaging<22.0

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -109,8 +109,6 @@ jsonschema==4.17.3 \
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
-    # via
-    #   -r requirements/deploy.in
     #   ddtrace
 protobuf==4.21.12 \
     --hash=sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30 \

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -106,10 +106,10 @@ jsonschema==4.17.3 \
     --hash=sha256:0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d \
     --hash=sha256:a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6
     # via ddtrace
-packaging==21.3 \
-    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
-    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
-    #   ddtrace
+packaging==23.0 \
+    --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2 \
+    --hash=sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97
+    # via ddtrace
 protobuf==4.21.12 \
     --hash=sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30 \
     --hash=sha256:237216c3326d46808a9f7c26fd1bd4b20015fb6867dc5d263a493ef9a539293b \
@@ -128,10 +128,6 @@ protobuf==4.21.12 \
     # via
     #   ddsketch
     #   ddtrace
-pyparsing==3.0.9 \
-    --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
-    --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
-    # via packaging
 pyrsistent==0.19.3 \
     --hash=sha256:016ad1afadf318eb7911baa24b049909f7f3bb2c5b1ed7b6a8f21db21ea3faa8 \
     --hash=sha256:1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440 \

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -2,5 +2,4 @@ furo
 Sphinx
 sphinxcontrib-httpdomain
 myst-parser
-# Until resolved https://github.com/googleapis/python-bigquery/issues/1435
-packaging<22.0
+docutils<0.19

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -204,20 +204,16 @@ myst-parser==0.18.1 \
     --hash=sha256:61b275b85d9f58aa327f370913ae1bec26ebad372cc99f3ab85c8ec3ee8d9fb8 \
     --hash=sha256:79317f4bb2c13053dd6e64f9da1ba1da6cd9c40c8a430c447a7b146a594c246d
     # via -r requirements/docs.in
-packaging==21.3 \
-    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
-    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
-    #   sphinx
+packaging==23.0 \
+    --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2 \
+    --hash=sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97
+    # via sphinx
 pygments==2.14.0 \
     --hash=sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297 \
     --hash=sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717
     # via
     #   furo
     #   sphinx
-pyparsing==3.0.9 \
-    --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
-    --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
-    # via packaging
 pytz==2022.7.1 \
     --hash=sha256:01a0681c4b9684a28304615eba55d1ab31ae00bf68ec157ec3708a8182dbbcd0 \
     --hash=sha256:78f4f37d8198e0627c5f1143240bb0206b8691d8d7ac6d78fee88b78733f8c4a

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -207,8 +207,6 @@ myst-parser==0.18.1 \
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
-    # via
-    #   -r requirements/docs.in
     #   sphinx
 pygments==2.14.0 \
     --hash=sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297 \

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -70,5 +70,3 @@ WTForms[email]>=2.0.0
 yara-python
 zope.sqlalchemy
 zxcvbn
-# Until resolved https://github.com/googleapis/python-bigquery/issues/1435
-packaging<22.0

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1089,9 +1089,9 @@ orjson==3.8.5 \
     --hash=sha256:f2be0025ca7e460bcacb250aba8ce0239be62957d58cf34045834cc9302611d3 \
     --hash=sha256:f5745ff473dd5c6718bf8c8d5bc183f638b4f3e03c7163ffcda4d4ef453f42ff
     # via -r requirements/main.in
-packaging==21.3 \
-    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
-    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+packaging==23.0 \
+    --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2 \
+    --hash=sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97
     # via
     #   -r requirements/main.in
     #   google-cloud-bigquery
@@ -1265,10 +1265,6 @@ pyopenssl==23.0.0 \
     --hash=sha256:c1cc5f86bcacefc84dada7d31175cae1b1518d5f60d3d0bb595a67822a868a6f \
     --hash=sha256:df5fc28af899e74e19fccb5510df423581047e10ab6f1f4ba1763ff5fde844c0
     # via webauthn
-pyparsing==3.0.9 \
-    --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
-    --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
-    # via packaging
 pyqrcode==1.2.1 \
     --hash=sha256:1b2812775fa6ff5c527977c4cd2ccb07051ca7d0bc0aecf937a43864abe5eff6 \
     --hash=sha256:fdbf7634733e56b72e27f9bce46e4550b75a3a2c420414035cae9d9d26b234d5

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -6,5 +6,3 @@ pytest>=3.0.0
 pytest-postgresql>=3.1.3,<4.0.0
 responses>=0.5.1
 webtest
-# Until resolved https://github.com/googleapis/python-bigquery/issues/1435
-packaging<22.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -186,9 +186,7 @@ mirakuru==2.4.2 \
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
-    # via
-    #   -r requirements/tests.in
-    #   pytest
+    # via pytest
 pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -183,9 +183,9 @@ mirakuru==2.4.2 \
     --hash=sha256:ec84d4d81b4bca96cb0e598c6b3d198a92f036a0c1223c881482c02a98508226 \
     --hash=sha256:fdb67d141cc9f7abd485a515d618daf3272c3e6ff48380749997ff8e8c5f2cb2
     # via pytest-postgresql
-packaging==21.3 \
-    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
-    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+packaging==23.0 \
+    --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2 \
+    --hash=sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97
     # via pytest
 pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
@@ -213,10 +213,6 @@ psutil==5.9.4 \
     --hash=sha256:c1ca331af862803a42677c120aff8a814a804e09832f166f226bfd22b56feee8 \
     --hash=sha256:efeae04f9516907be44904cc7ce08defb6b665128992a56957abc9b61dca94b7
     # via mirakuru
-pyparsing==3.0.9 \
-    --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
-    --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
-    # via packaging
 pytest==7.2.1 \
     --hash=sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5 \
     --hash=sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -106,12 +106,21 @@ class TestValidation:
         form, field = pretend.stub(), pretend.stub(data=version)
         legacy._validate_pep440_version(form, field)
 
-    @pytest.mark.filterwarnings("ignore:Creating a LegacyVersion.*:DeprecationWarning")
-    @pytest.mark.parametrize("version", ["dog", "1.0.dev.a1", "1.0+local"])
+    @pytest.mark.parametrize("version", ["dog", "1.0.dev.a1"])
     def test_validates_invalid_pep440_version(self, version):
         form, field = pretend.stub(), pretend.stub(data=version)
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as e:
             legacy._validate_pep440_version(form, field)
+
+        assert str(e.value) == "Invalid PEP 440 version."
+
+    @pytest.mark.parametrize("version", ["1.0+local"])
+    def test_validates_local_pep440_version(self, version):
+        form, field = pretend.stub(), pretend.stub(data=version)
+        with pytest.raises(ValidationError) as e:
+            legacy._validate_pep440_version(form, field)
+
+        assert str(e.value) == "Can't use PEP 440 local versions."
 
     @pytest.mark.parametrize(
         ("requirement", "expected"),
@@ -868,11 +877,9 @@ class TestFileUpload:
             (
                 {"metadata_version": "1.2", "name": "example", "version": "dog"},
                 "'dog' is an invalid value for Version. "
-                "Error: Start and end with a letter or numeral "
-                "containing only ASCII numeric and '.', '_' and '-'. "
-                "See "
-                "https://packaging.python.org/specifications/core-metadata"
-                " for more information.",
+                "Error: Invalid PEP 440 version. See "
+                "https://packaging.python.org/specifications/core-metadata for "
+                "more information.",
             ),
             # filetype/pyversion errors.
             (
@@ -994,7 +1001,6 @@ class TestFileUpload:
             ),
         ],
     )
-    @pytest.mark.filterwarnings("ignore:Creating a LegacyVersion.*:DeprecationWarning")
     def test_fails_invalid_post_data(
         self, pyramid_config, db_request, post_data, message
     ):

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -215,14 +215,10 @@ def _exc_with_message(exc, message, **kwargs):
 
 
 def _validate_pep440_version(form, field):
-    parsed = packaging.version.parse(field.data)
-
-    # Check that this version is a valid PEP 440 version at all.
-    if not isinstance(parsed, packaging.version.Version):
-        raise wtforms.validators.ValidationError(
-            "Start and end with a letter or numeral containing only "
-            "ASCII numeric and '.', '_' and '-'."
-        )
+    try:
+        parsed = packaging.version.parse(field.data)
+    except packaging.version.InvalidVersion:
+        raise wtforms.validators.ValidationError("Invalid PEP 440 version.")
 
     # Check that this version does not have a PEP 440 local segment attached
     # to it.


### PR DESCRIPTION
This reverts commit 48502f9c894d36c0466ff0d4c258f6ab662ad2d1.

Issue was resolved in https://github.com/googleapis/python-bigquery/pull/1440.

This also bumps to `packaging==23.0` to avoid dependency check failures and updates our usage to match changes there.