### PR TITLE
feat(admin): surface email breach counts in UI

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -26,6 +26,8 @@ BILLING_BACKEND=warehouse.subscriptions.services.MockStripeBillingService api_ba
 CAMO_URL={request.scheme}://{request.domain}:9000/
 CAMO_KEY=insecurecamokey
 
+HIBP_API_KEY="something-not-real"
+
 DOCS_URL="https://pythonhosted.org/{project}/"
 
 FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://localhost:9001/packages/{path}

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -21,6 +21,7 @@ from pyramid.httpexceptions import HTTPUnauthorized
 from warehouse import accounts
 from warehouse.accounts import security_policy
 from warehouse.accounts.interfaces import (
+    IEmailBreachedService,
     IPasswordBreachedService,
     ITokenService,
     IUserService,
@@ -28,6 +29,7 @@ from warehouse.accounts.interfaces import (
 from warehouse.accounts.models import DisableReason
 from warehouse.accounts.security_policy import _basic_auth_check
 from warehouse.accounts.services import (
+    HaveIBeenPwnedEmailBreachedService,
     HaveIBeenPwnedPasswordBreachedService,
     TokenServiceFactory,
     database_login_factory,
@@ -384,6 +386,10 @@ def test_includeme(monkeypatch):
         pretend.call(
             HaveIBeenPwnedPasswordBreachedService.create_service,
             IPasswordBreachedService,
+        ),
+        pretend.call(
+            HaveIBeenPwnedEmailBreachedService.create_service,
+            IEmailBreachedService,
         ),
         pretend.call(RateLimit("10 per 5 minutes"), IRateLimiter, name="user.login"),
         pretend.call(RateLimit("10 per 5 minutes"), IRateLimiter, name="ip.login"),

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -1348,7 +1348,7 @@ class TestHaveIBeenPwnedEmailBreachedService:
 
     def test_no_api_key(self):
         svc = services.HaveIBeenPwnedEmailBreachedService(session=pretend.stub())
-        assert svc.get_email_breach_count("anything") == "!!!"
+        assert svc.get_email_breach_count("anything") is None
 
     def test_successful_breach_count(self):
         response = pretend.stub(
@@ -1401,7 +1401,7 @@ class TestHaveIBeenPwnedEmailBreachedService:
             session=session, api_key="blowhole"
         )
 
-        assert svc.get_email_breach_count("invalid-address") == "?"
+        assert svc.get_email_breach_count("invalid-address") == -1
 
     def test_factory(self):
         context = pretend.stub()

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -31,6 +31,7 @@ import warehouse.utils.webauthn as webauthn
 from warehouse.accounts import services
 from warehouse.accounts.interfaces import (
     BurnedRecoveryCode,
+    IEmailBreachedService,
     InvalidRecoveryCode,
     IPasswordBreachedService,
     ITokenService,
@@ -1337,3 +1338,12 @@ class TestNullPasswordBreachedService:
 
         assert isinstance(svc, services.NullPasswordBreachedService)
         assert not svc.check_password("hunter2")
+
+
+class TestNullEmailBreachedService:
+    def test_verify_service(self):
+        assert verifyClass(IEmailBreachedService, services.NullEmailBreachedService)
+
+    def test_check_email(self):
+        svc = services.NullEmailBreachedService()
+        assert svc.get_email_breach_count("foo@example.com") == 0

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -1346,6 +1346,10 @@ class TestHaveIBeenPwnedEmailBreachedService:
             IEmailBreachedService, services.HaveIBeenPwnedEmailBreachedService
         )
 
+    def test_no_api_key(self):
+        svc = services.HaveIBeenPwnedEmailBreachedService(session=pretend.stub())
+        assert svc.get_email_breach_count("anything") == "!!!"
+
     def test_successful_breach_count(self):
         response = pretend.stub(
             json=lambda: [{"LinkedIn"}], raise_for_status=lambda: None

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -1351,13 +1351,15 @@ class TestHaveIBeenPwnedEmailBreachedService:
             json=lambda: [{"LinkedIn"}], raise_for_status=lambda: None
         )
         session = pretend.stub(get=pretend.call_recorder(lambda *a, **kw: response))
-        svc = services.HaveIBeenPwnedEmailBreachedService(session=session)
+        svc = services.HaveIBeenPwnedEmailBreachedService(
+            session=session, api_key="blowhole"
+        )
 
         assert svc.get_email_breach_count("foo@example.com") == 1
         assert session.get.calls == [
             pretend.call(
                 "https://haveibeenpwned.com/api/v3/breachedaccount/foo@example.com",
-                headers={"User-Agent": "PyPI.org", "hibp-api-key": None},
+                headers={"User-Agent": "PyPI.org", "hibp-api-key": "blowhole"},
             )
         ]
 
@@ -1370,13 +1372,15 @@ class TestHaveIBeenPwnedEmailBreachedService:
         session = pretend.stub(
             get=pretend.call_recorder(lambda *a, **kw: response),
         )
-        svc = services.HaveIBeenPwnedEmailBreachedService(session=session)
+        svc = services.HaveIBeenPwnedEmailBreachedService(
+            session=session, api_key="blowhole"
+        )
 
         assert svc.get_email_breach_count("new-email@gmail.com") == 0
         assert session.get.calls == [
             pretend.call(
                 "https://haveibeenpwned.com/api/v3/breachedaccount/new-email@gmail.com",
-                headers={"User-Agent": "PyPI.org", "hibp-api-key": None},
+                headers={"User-Agent": "PyPI.org", "hibp-api-key": "blowhole"},
             )
         ]
 
@@ -1389,13 +1393,15 @@ class TestHaveIBeenPwnedEmailBreachedService:
         session = pretend.stub(
             get=pretend.call_recorder(lambda *a, **kw: response),
         )
-        svc = services.HaveIBeenPwnedEmailBreachedService(session=session)
+        svc = services.HaveIBeenPwnedEmailBreachedService(
+            session=session, api_key="blowhole"
+        )
 
         assert svc.get_email_breach_count("invalid-address") == "?"
 
     def test_factory(self):
         context = pretend.stub()
-        hibp_api_key = "something-super-secret"
+        hibp_api_key = "blowhole"
         request = pretend.stub(
             http=pretend.stub(),
             registry=pretend.stub(settings={"hibp.api_key": hibp_api_key}),

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -280,3 +280,10 @@ class IPasswordBreachedService(Interface):
         May have an optional list of tags, which allows identifying the purpose of
         checking the password.
         """
+
+
+class IEmailBreachedService(Interface):
+    def get_email_breach_count(email: str) -> int | str:
+        """
+        Returns count of times the email appears in verified breaches.
+        """

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -283,7 +283,7 @@ class IPasswordBreachedService(Interface):
 
 
 class IEmailBreachedService(Interface):
-    def get_email_breach_count(email: str) -> int | str:
+    def get_email_breach_count(email: str) -> int | None:
         """
         Returns count of times the email appears in verified breaches.
         """

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -840,6 +840,10 @@ class HaveIBeenPwnedEmailBreachedService:
         See https://haveibeenpwned.com/API/v3#BreachesForAccount
         """
 
+        # bail early if no api key is set, so we don't send failing requests
+        if not self.api_key:
+            return "!!!"
+
         try:
             resp = self._http.get(
                 urllib.parse.urljoin(self._api_base, email),

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -834,7 +834,7 @@ class HaveIBeenPwnedEmailBreachedService:
         hibp_api_key = request.registry.settings.get("hibp.api_key")
         return cls(session=request.http, api_key=hibp_api_key)
 
-    def get_email_breach_count(self, email: str) -> int | str:
+    def get_email_breach_count(self, email: str) -> int | None:
         """
         Check if an email has been breached, return the number of breaches.
         See https://haveibeenpwned.com/API/v3#BreachesForAccount
@@ -842,7 +842,7 @@ class HaveIBeenPwnedEmailBreachedService:
 
         # bail early if no api key is set, so we don't send failing requests
         if not self.api_key:
-            return "!!!"
+            return None
 
         try:
             resp = self._http.get(
@@ -855,7 +855,7 @@ class HaveIBeenPwnedEmailBreachedService:
             if exc.response.status_code == http.HTTPStatus.NOT_FOUND:
                 return 0
             logger.warning("Error contacting HaveIBeenPwned: %r", exc)
-            return "?"
+            return -1
 
         return len(resp.json())
 

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -259,6 +259,9 @@
                   <div class="col">
                     {{ render_checkbox("Public", field.public, "email-public-" ~ loop.index0) }}
                   </div>
+                  <div class="col">
+                    Breaches: {{ breached_email_count[field.email.data] }}
+                  </div>
                 </div>
                 {% endfor %}
               </div>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -259,9 +259,11 @@
                   <div class="col">
                     {{ render_checkbox("Public", field.public, "email-public-" ~ loop.index0) }}
                   </div>
+                  {% if breached_email_count[field.email.data] %}
                   <div class="col">
                     Breaches: {{ breached_email_count[field.email.data] }}
                   </div>
+                  {% endif %}
                 </div>
                 {% endfor %}
               </div>

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -196,6 +196,7 @@ def configure(settings=None):
     maybe_set(settings, "ga.tracking_id", "GA_TRACKING_ID")
     maybe_set(settings, "ga4.tracking_id", "GA4_TRACKING_ID")
     maybe_set(settings, "statuspage.url", "STATUSPAGE_URL")
+    maybe_set(settings, "hibp.api_key", "HIBP_API_KEY")
     maybe_set(settings, "token.password.secret", "TOKEN_PASSWORD_SECRET")
     maybe_set(settings, "token.email.secret", "TOKEN_EMAIL_SECRET")
     maybe_set(settings, "token.two_factor.secret", "TOKEN_TWO_FACTOR_SECRET")


### PR DESCRIPTION
Based on https://www.troyhunt.com/pwned-or-bot/

Implement interface and service to retrieve breach counts for emails.

Previous HIBP API usage did not require an API Key, but the search by email account functionality requires both an API key and a custom header.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>