### PR TITLE
Split translations into two sets/domains

### DIFF
--- a/warehouse/locale/Makefile
+++ b/warehouse/locale/Makefile
@@ -3,9 +3,14 @@ GITHUB_ACTIONS := $(shell echo "$${GITHUB_ACTIONS:-false}")
 compile-pot:
 	cd ../../; \
 	PYTHONPATH=$(PWD) pybabel extract \
-		-F babel.cfg \
+		-F warehouse/locale/babel.cfg \
 		--omit-header \
 		--output="warehouse/locale/messages.pot" \
+		warehouse; \
+	PYTHONPATH=$(PWD) pybabel extract \
+		-F warehouse/locale/babel-loggedin.cfg \
+		--omit-header \
+		--output="warehouse/locale/messages-loggedin.pot" \
 		warehouse
 
 init-po:

--- a/warehouse/locale/babel-loggedin.cfg
+++ b/warehouse/locale/babel-loggedin.cfg
@@ -1,0 +1,8 @@
+[ignore: views.py]
+[ignore: accounts/views.py]
+
+[python: **.py]
+[jinja2: **.html]
+encoding = utf-8
+extensions=warehouse.utils.html:ClientSideIncludeExtension,warehouse.i18n.extensions.TrimmedTranslatableTagsExtension
+silent=False

--- a/warehouse/locale/babel.cfg
+++ b/warehouse/locale/babel.cfg
@@ -1,3 +1,5 @@
+[ignore: subscriptions/*]
+
 [python: **.py]
 [jinja2: **.html]
 encoding = utf-8


### PR DESCRIPTION
Refs. #12901

To do:
* prepare final list of ignores,
* extend `init-po`, `update-po` and check in `translations` with new domain resource
* regenerate POTs
* migrate translations, preserve translated messages (some script)
* add/update tests