### PR TITLE
Enable BQ jobs to quit early if env var is None

### DIFF
--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -319,6 +319,14 @@ class TestUpdateBigQueryMetadata:
             for table in release_files_table.split()
         ]
 
+    def test_var_is_none(self):
+        request = pretend.stub(
+            registry=pretend.stub(settings={"warehouse.release_files_table": None})
+        )
+        task = pretend.stub()
+        dist_metadata = pretend.stub()
+        update_bigquery_release_files(task, request, dist_metadata)
+
 
 class TestSyncBigQueryMetadata:
     @pytest.mark.filterwarnings(
@@ -501,6 +509,12 @@ class TestSyncBigQueryMetadata:
             )
             for first, second in product("fedcba9876543210", repeat=2)
         ]
+
+    def test_var_is_none(self):
+        request = pretend.stub(
+            registry=pretend.stub(settings={"warehouse.release_files_table": None})
+        )
+        sync_bigquery_release_files(request)
 
 
 def test_compute_2fa_mandate(db_request, monkeypatch):

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -219,9 +219,14 @@ def update_bigquery_release_files(task, request, dist_metadata):
     """
     Adds release file metadata to public BigQuery database
     """
+    release_files_table = request.registry.settings.get("warehouse.release_files_table")
+    if release_files_table is None:
+        return
+
     bq = request.find_service(name="gcloud.bigquery")
+
     # Multiple table names can be specified by separating them with whitespace
-    table_names = request.registry.settings["warehouse.release_files_table"].split()
+    table_names = release_files_table.split()
 
     for table_name in table_names:
         table_schema = bq.get_table(table_name).schema
@@ -263,9 +268,14 @@ def update_bigquery_release_files(task, request, dist_metadata):
 
 @tasks.task(ignore_result=True, acks_late=True)
 def sync_bigquery_release_files(request):
+    release_files_table = request.registry.settings.get("warehouse.release_files_table")
+    if release_files_table is None:
+        return
+
     bq = request.find_service(name="gcloud.bigquery")
+
     # Multiple table names can be specified by separating them with whitespace
-    table_names = request.registry.settings["warehouse.release_files_table"].split()
+    table_names = release_files_table.split()
 
     for table_name in table_names:
         table_schema = bq.get_table(table_name).schema


### PR DESCRIPTION
Currently disabling the env var will cause failures here. Fix this if we need to shut these off in the future while jobs are still in the queue.