### PR TITLE
fix(admin): style email details

### DIFF
--- a/warehouse/admin/templates/admin/emails/detail.html
+++ b/warehouse/admin/templates/admin/emails/detail.html
@@ -78,9 +78,10 @@
     <div class="col-md-12">
       <div class="card">
         <div class="card-header">
-          <i class="fa fa-envelope-open"></i>
-
-          <h3 class="card-title">Message</h3>
+          <h3 class="card-title">
+            <i class="fa fa-envelope-open"></i>
+            Message
+          </h3>
         </div>
 
         <div class="card-body">
@@ -112,17 +113,20 @@
 
   <div class="row">
     <div class="col-md-12">
-      <div class="card-solid">
+      <div class="card">
         <div class="card-header">
-          <i class="fa fa-exchange-alt"></i>
 
-          <h3 class="card-title">Events</h3>
+          <h3 class="card-title">
+            <i class="fa fa-exchange-alt"></i>
+            Events
+          </h3>
         </div>
 
         <div class="card-body">
-          <ul class="timeline">
+          <div class="timeline timeline-inverse">
             {% for event in email.events|reverse %}
-            <li>
+            <div>
+              {# Modify the icon and color based on the event type #}
               {% if event.event_type.value == "Delivery" %}
                 {% set event_icon = "envelope" %}
                 {% set event_color = "green" %}
@@ -150,21 +154,21 @@
                   {{ render_data(event.data) }}
                 </div>
               </div>
-            </li>
+            </div>
             {% endfor %}
 
-            <li>
+            <div>
               <i class="fa fa-check bg-blue"></i>
+
               <div class="timeline-item">
                 <span class="time"><i class="fa fa-clock"></i> {{ email.created|format_datetime }}</span>
                 <h3 class="timeline-header no-border">Accepted</h3>
               </div>
-            </li>
-
-            <li>
-              <i class="fa fa-clock-o bg-gray"></i>
-            </li>
-          </ul>
+            </div>
+            <div>
+              <i class="fas fa-clock bg-gray"></i>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
During the Admin UI refactor, this page was not restyled.

Refs: https://adminlte.io/docs/3.2/components/timeline.html

Signed-off-by: Mike Fiedler <miketheman@gmail.com>

Data is for demonstration purposes only, not fully real examples.

## Before

<img width="802" alt="Screenshot 2023-01-31 at 5 11 50 PM" src="https://user-images.githubusercontent.com/529516/215897055-2f14c33f-6660-490a-a595-1d070a234f1d.png">

## After

<img width="969" alt="Screenshot 2023-01-31 at 5 13 47 PM" src="https://user-images.githubusercontent.com/529516/215897076-811ac0ab-44b4-4334-a3cc-975baf09d32d.png">
