### PR TITLE
chore: update sqlalchemy exception imports

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -25,7 +25,7 @@ from pyramid.httpexceptions import (
     HTTPSeeOther,
     HTTPTooManyRequests,
 )
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from webauthn.authentication.verify_authentication_response import (
     VerifiedAuthentication,
 )

--- a/tests/unit/admin/views/test_banners.py
+++ b/tests/unit/admin/views/test_banners.py
@@ -16,7 +16,7 @@ import pretend
 import pytest
 
 from pyramid.httpexceptions import HTTPNotFound
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from webob.multidict import MultiDict
 
 from warehouse.admin.views import banners as views

--- a/tests/unit/admin/views/test_sponsors.py
+++ b/tests/unit/admin/views/test_sponsors.py
@@ -20,7 +20,7 @@ import pretend
 import pytest
 
 from pyramid.httpexceptions import HTTPNotFound
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from webob.multidict import MultiDict
 
 from warehouse.admin.interfaces import ISponsorLogoStorage

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -16,7 +16,7 @@ import celery.exceptions
 import pretend
 import pytest
 
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse import email
 from warehouse.accounts.interfaces import IUserService

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -27,7 +27,7 @@ from pyramid.httpexceptions import (
 )
 from pyramid.response import Response
 from sqlalchemy.orm import joinedload
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from webauthn.helpers import bytes_to_base64url
 from webob.multidict import MultiDict
 

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -26,8 +26,8 @@ from pyramid.httpexceptions import (
     HTTPTooManyRequests,
 )
 from pyramid.response import Response
-from sqlalchemy.orm import joinedload
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import joinedload
 from webauthn.helpers import bytes_to_base64url
 from webob.multidict import MultiDict
 

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -33,8 +33,8 @@ from sqlalchemy import (
     sql,
 )
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from warehouse import db
 from warehouse.events.models import HasEvents

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -34,7 +34,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse import db
 from warehouse.events.models import HasEvents

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -24,7 +24,7 @@ import requests
 
 from passlib.context import CryptContext
 from sqlalchemy.orm import joinedload
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.sql import exists
 from webauthn.helpers import bytes_to_base64url
 from zope.interface import implementer

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -23,8 +23,8 @@ import urllib.parse
 import requests
 
 from passlib.context import CryptContext
-from sqlalchemy.orm import joinedload
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import exists
 from webauthn.helpers import bytes_to_base64url
 from zope.interface import implementer

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -26,7 +26,7 @@ from pyramid.httpexceptions import (
 )
 from pyramid.security import forget, remember
 from pyramid.view import view_config, view_defaults
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from webauthn.helpers import bytes_to_base64url
 
 from warehouse.accounts import REDIRECT_FIELD_NAME

--- a/warehouse/admin/views/banners.py
+++ b/warehouse/admin/views/banners.py
@@ -14,7 +14,7 @@ import wtforms
 
 from pyramid.httpexceptions import HTTPNotFound, HTTPSeeOther
 from pyramid.view import view_config
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse.banners.models import Banner
 from warehouse.forms import Form, URIValidator

--- a/warehouse/admin/views/checks.py
+++ b/warehouse/admin/views/checks.py
@@ -12,7 +12,7 @@
 
 from pyramid.httpexceptions import HTTPNotFound, HTTPSeeOther
 from pyramid.view import view_config
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse.malware.models import MalwareCheck, MalwareCheckState, MalwareCheckType
 from warehouse.malware.tasks import backfill, remove_verdicts, run_scheduled_check

--- a/warehouse/admin/views/emails.py
+++ b/warehouse/admin/views/emails.py
@@ -18,7 +18,7 @@ from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound, HTTPSeeOther
 from pyramid.view import view_config
 from sqlalchemy import String, cast, or_
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse.accounts.models import User
 from warehouse.email import send_email

--- a/warehouse/admin/views/prohibited_project_names.py
+++ b/warehouse/admin/views/prohibited_project_names.py
@@ -19,7 +19,7 @@ from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound, HTTPSeeOther
 from pyramid.view import view_config
 from sqlalchemy import func, literal, or_
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse.accounts.models import User
 from warehouse.packaging.models import (

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -17,7 +17,7 @@ from pyramid.httpexceptions import HTTPBadRequest, HTTPMovedPermanently, HTTPSee
 from pyramid.view import view_config
 from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse.accounts.models import User
 from warehouse.forklift.legacy import MAX_FILESIZE, MAX_PROJECT_SIZE

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -16,8 +16,8 @@ from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
 from pyramid.httpexceptions import HTTPBadRequest, HTTPMovedPermanently, HTTPSeeOther
 from pyramid.view import view_config
 from sqlalchemy import func, or_
-from sqlalchemy.orm import joinedload
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import joinedload
 
 from warehouse.accounts.models import User
 from warehouse.forklift.legacy import MAX_FILESIZE, MAX_PROJECT_SIZE

--- a/warehouse/admin/views/sponsors.py
+++ b/warehouse/admin/views/sponsors.py
@@ -19,7 +19,7 @@ import wtforms
 from pyramid.httpexceptions import HTTPNotFound, HTTPSeeOther
 from pyramid.view import view_config
 from slugify import slugify
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse.admin.interfaces import ISponsorLogoStorage
 from warehouse.forms import Form, URIValidator

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -19,7 +19,7 @@ import pytz
 
 from celery.schedules import crontab
 from first import first
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse import tasks
 from warehouse.accounts.interfaces import ITokenService, IUserService

--- a/warehouse/email/ses/views.py
+++ b/warehouse/email/ses/views.py
@@ -17,7 +17,7 @@ import requests
 from pyramid.httpexceptions import HTTPBadRequest, HTTPServiceUnavailable
 from pyramid.response import Response
 from pyramid.view import view_config
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.sql import exists
 
 from warehouse.email.ses.models import EmailMessage, EmailStatus, Event, EventTypes

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -12,9 +12,9 @@
 
 from sqlalchemy import Column, DateTime, ForeignKey, Index, String, orm, sql
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.declarative import AbstractConcreteBase, declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.exc import NoResultFound
 
 from warehouse import db
 from warehouse.ip_addresses.models import IpAddress

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -14,7 +14,7 @@ from sqlalchemy import Column, DateTime, ForeignKey, Index, String, orm, sql
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.ext.declarative import AbstractConcreteBase, declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse import db
 from warehouse.ip_addresses.models import IpAddress

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -40,7 +40,7 @@ from pyramid.httpexceptions import (
 from pyramid.response import Response
 from pyramid.view import view_config
 from sqlalchemy import func, orm
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from trove_classifiers import classifiers, deprecated_classifiers
 
 from warehouse import forms

--- a/warehouse/integrations/vulnerabilities/tasks.py
+++ b/warehouse/integrations/vulnerabilities/tasks.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 from sqlalchemy import func, orm
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse import tasks
 from warehouse.integrations import vulnerabilities

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -13,8 +13,8 @@
 from packaging.utils import canonicalize_name, canonicalize_version
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
-from sqlalchemy.orm import Load, contains_eager, joinedload
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.orm import Load, contains_eager, joinedload
 
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -14,7 +14,7 @@ from packaging.utils import canonicalize_name, canonicalize_version
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
 from sqlalchemy.orm import Load, contains_eager, joinedload
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -31,7 +31,7 @@ from pyramid_rpc.xmlrpc import (
     xmlrpc_method as _xmlrpc_method,
 )
 from sqlalchemy import func, orm, select
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse.accounts.models import User
 from warehouse.classifiers.models import Classifier

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -16,8 +16,8 @@ import uuid
 import pymacaroons
 
 from pymacaroons.exceptions import MacaroonDeserializationException
-from sqlalchemy.orm import joinedload
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import joinedload
 from zope.interface import implementer
 
 from warehouse.macaroons import caveats

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -17,7 +17,7 @@ import pymacaroons
 
 from pymacaroons.exceptions import MacaroonDeserializationException
 from sqlalchemy.orm import joinedload
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from zope.interface import implementer
 
 from warehouse.macaroons import caveats

--- a/warehouse/malware/tasks.py
+++ b/warehouse/malware/tasks.py
@@ -12,7 +12,7 @@
 
 import inspect
 
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 import warehouse.malware.checks as checks
 import warehouse.packaging.models as packaging_models

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -29,7 +29,7 @@ from pyramid.response import Response
 from pyramid.view import view_config, view_defaults
 from sqlalchemy import func
 from sqlalchemy.orm import Load, joinedload
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from webauthn.helpers import bytes_to_base64url
 
 import warehouse.utils.otp as otp

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -28,8 +28,8 @@ from pyramid.httpexceptions import (
 from pyramid.response import Response
 from pyramid.view import view_config, view_defaults
 from sqlalchemy import func
-from sqlalchemy.orm import Load, joinedload
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import Load, joinedload
 from webauthn.helpers import bytes_to_base64url
 
 import warehouse.utils.otp as otp

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -29,7 +29,7 @@ from sqlalchemy import (
     sql,
 )
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy_utils.types.url import URLType
 
 from warehouse import db

--- a/warehouse/organizations/services.py
+++ b/warehouse/organizations/services.py
@@ -13,7 +13,7 @@
 import datetime
 
 from sqlalchemy import func
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from zope.interface import implementer
 
 from warehouse.accounts.models import User

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -41,12 +41,12 @@ from sqlalchemy import (
     sql,
 )
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr  # type: ignore
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import validates
 from sqlalchemy.orm.collections import attribute_mapped_collection
-from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 
 from warehouse import db
 from warehouse.accounts.models import User

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -46,7 +46,7 @@ from sqlalchemy.ext.declarative import declared_attr  # type: ignore
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import validates
 from sqlalchemy.orm.collections import attribute_mapped_collection
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 
 from warehouse import db
 from warehouse.accounts.models import User

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -13,7 +13,7 @@
 from natsort import natsorted
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse.accounts.models import User
 from warehouse.cache.origin import origin_cache

--- a/warehouse/subscriptions/services.py
+++ b/warehouse/subscriptions/services.py
@@ -17,7 +17,7 @@ from string import ascii_letters, digits
 import stripe
 
 from sqlalchemy import or_
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from zope.interface import implementer
 
 from warehouse.organizations.models import (

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -24,7 +24,7 @@ from pyramid.httpexceptions import (
     HTTPSeeOther,
 )
 from sqlalchemy import exists, func
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from warehouse.admin.flags import AdminFlagValue
 from warehouse.events.tags import EventTag


### PR DESCRIPTION
Changed in 1.4, and a proxy import was left in place. Update references to quiet down IDE warnings and use the current location.

Refs: https://github.com/sqlalchemy/sqlalchemy/commit/aded39f68c29e44a50c85be1ddb370d3d1affe9d#diff-2772b7fba8928afe87d08ebadd2f805fdce83b3ffc638ed705cbedc7fd67ce41

Signed-off-by: Mike Fiedler <miketheman@gmail.com>