### PR TITLE
Origin Cache - Connect to a specific IP if configured

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ module = [
     "elasticsearch_dsl.*", # https://github.com/elastic/elasticsearch-dsl-py/issues/1533
     "github_reserved_names.*",
     "google.cloud.*",
+    "forcediphttpsadapter.*",
     "IPython.*",
     "mistune.*",
     "paginate.*",

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -14,6 +14,7 @@ disposable-email-domains
 elasticsearch>=7.0.0,<7.11.0
 elasticsearch_dsl>=7.0.0,<8.0.0
 first
+forcediphttpsadapter
 github-reserved-names>=1.0.0
 google-cloud-bigquery
 google-cloud-storage

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -480,6 +480,9 @@ first==2.0.2 \
     --hash=sha256:8d8e46e115ea8ac652c76123c0865e3ff18372aef6f03c22809ceefcea9dec86 \
     --hash=sha256:ff285b08c55f8c97ce4ea7012743af2495c9f1291785f163722bd36f6af6d3bf
     # via -r requirements/main.in
+forcediphttpsadapter==1.0.2 \
+    --hash=sha256:f7582b34aaa6ab6b17f69ab1abbfe67097b952ed0682b758b5e01e18fe24433e
+    # via -r requirements/main.in
 github-reserved-names==1.0.1 \
     --hash=sha256:c9acc3c8e573e303e962496308553241db6f306290a09be7d2c6d60cdcda0bb9 \
     --hash=sha256:f10b8df2b01d76022b144a17381782b63205b2f2cefdfc145c984d16cb4e9733
@@ -1346,6 +1349,7 @@ requests==2.28.2 \
     # via
     #   -r requirements/main.in
     #   datadog
+    #   forcediphttpsadapter
     #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-storage

--- a/tests/unit/cache/origin/test_fastly.py
+++ b/tests/unit/cache/origin/test_fastly.py
@@ -104,7 +104,7 @@ class TestFastlyCache:
         cacher = fastly.FastlyCache.create_service(None, request)
         assert isinstance(cacher, fastly.FastlyCache)
         assert cacher.api_endpoint == "https://api.example.com"
-        assert cacher.api_connect_via == None
+        assert cacher.api_connect_via is None
         assert cacher.api_key == "the api key"
         assert cacher.service_id == "the service id"
         assert cacher._purger is purge_key.delay
@@ -123,7 +123,7 @@ class TestFastlyCache:
         cacher = fastly.FastlyCache.create_service(None, request)
         assert isinstance(cacher, fastly.FastlyCache)
         assert cacher.api_endpoint == "https://api.fastly.com"
-        assert cacher.api_connect_via == None
+        assert cacher.api_connect_via is None
         assert cacher.api_key == "the api key"
         assert cacher.service_id == "the service id"
         assert cacher._purger is purge_key.delay
@@ -254,11 +254,14 @@ class TestFastlyCache:
             json=lambda: {"status": "ok"},
         )
         requests_post = pretend.call_recorder(lambda *a, **kw: response)
-        requests_Session = lambda *a, **kw: pretend.stub(
-            mount=requests_mount,
-            post=requests_post,
-        )
-        monkeypatch.setattr(requests, "Session", requests_Session)
+
+        def requests_session(*a, **kw):
+            return pretend.stub(
+                mount=requests_mount,
+                post=requests_post,
+            )
+
+        monkeypatch.setattr(requests, "Session", requests_session)
 
         cacher.purge_key("one")
 
@@ -302,11 +305,14 @@ class TestFastlyCache:
             json=lambda: {"status": "ok"},
         )
         requests_post = pretend.call_recorder(lambda *a, **kw: response)
-        requests_Session = lambda *a, **kw: pretend.stub(
-            mount=requests_mount,
-            post=requests_post,
-        )
-        monkeypatch.setattr(requests, "Session", requests_Session)
+
+        def requests_session(*a, **kw):
+            return pretend.stub(
+                mount=requests_mount,
+                post=requests_post,
+            )
+
+        monkeypatch.setattr(requests, "Session", requests_session)
 
         cacher.purge_key("one")
 
@@ -338,11 +344,14 @@ class TestFastlyCache:
             raise_for_status=pretend.call_recorder(lambda: None), json=lambda: result
         )
         requests_post = pretend.call_recorder(lambda *a, **kw: response)
-        requests_Session = lambda *a, **kw: pretend.stub(
-            mount=requests_mount,
-            post=requests_post,
-        )
-        monkeypatch.setattr(requests, "Session", requests_Session)
+
+        def requests_session(*a, **kw):
+            return pretend.stub(
+                mount=requests_mount,
+                post=requests_post,
+            )
+
+        monkeypatch.setattr(requests, "Session", requests_session)
 
         with pytest.raises(fastly.UnsuccessfulPurgeError):
             cacher.purge_key("one")


### PR DESCRIPTION
This implements an http client adapter for our Fastly client that directs requests for the configured api host (api.fastly.com by default) to a specific IP address.

Fastly has provided us a workaround for #12214 that allows us to direct purges to our shields first, which mitigates a known [race condition](https://developer.fastly.com/learning/concepts/purging/#race-conditions). In order to do this we need to issue valid requests for api.fastly.com to a specific ip address with valid TLS.

As a reliability feature, we fallback to the "purge twice" regime if anything goes wrong at the socket/TLS level connecting to this IP, and emit a metric. If the failure rate goes above some threshold we can contact Fastly (as the virtual IP may have been moved/reallocated/disabled).