### PR TITLE
Improve metrics coverage on origin cache purges and retries

### DIFF
--- a/tests/unit/cache/origin/test_fastly.py
+++ b/tests/unit/cache/origin/test_fastly.py
@@ -506,7 +506,7 @@ class TestFastlyCache:
                 [
                     pretend.call(
                         "warehouse.cache.origin.fastly.connect_via.failed",
-                        tags="ip_address:172.16.0.1",
+                        tags=["ip_address:172.16.0.1"],
                     )
                 ],
             ),
@@ -521,7 +521,7 @@ class TestFastlyCache:
                 [
                     pretend.call(
                         "warehouse.cache.origin.fastly.connect_via.failed",
-                        tags="ip_address:172.16.0.1",
+                        tags=["ip_address:172.16.0.1"],
                     )
                 ],
             ),

--- a/warehouse/cache/origin/fastly.py
+++ b/warehouse/cache/origin/fastly.py
@@ -140,6 +140,6 @@ class FastlyCache:
             else:
                 metrics.increment(
                     "warehouse.cache.origin.fastly.connect_via.failed",
-                    tags=f"ip_address:{self.api_connect_via}",
+                    tags=[f"ip_address:{self.api_connect_via}"],
                 )
                 self._double_purge_key(key)  # Do not connect via on fallback

--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -122,6 +122,12 @@ class WarehouseTask(celery.Task):
             self._after_commit_hook, args=args, kws=kwargs
         )
 
+    def retry(self, *args, **kwargs):
+        request = get_current_request()
+        metrics = request.find_service(IMetricsService, context=None)
+        metrics.increment("warehouse.task.retried", tags=[f"task:{self.name}"])
+        return super().retry(*args, **kwargs)
+
     def _after_commit_hook(self, success, *args, **kwargs):
         if success:
             super().apply_async(*args, **kwargs)


### PR DESCRIPTION
- correct a small error in tagging on metric for origin cache purge failures
- *nearly all* of our retries are explicitly called via `raise self.retry(exc=...`, so instrument that and not just the auto retries from https://github.com/pypi/warehouse/blob/af5fb7108af1ddd4ab89aff6fb04a7a406887202/warehouse/tasks.py#L75-L79