### PR TITLE
chore: discourage crawlers from using search

### DIFF
--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -34,6 +34,7 @@ def test_robots_txt(app_config, domain, indexable):
             "Disallow: /pypi/*/json\n"
             "Disallow: /pypi/*/*/json\n"
             "Disallow: /pypi*?\n"
+            "Disallow: /search*\n"
         )
     else:
         assert body == (

--- a/warehouse/templates/robots.txt
+++ b/warehouse/templates/robots.txt
@@ -10,5 +10,6 @@ Disallow: /_includes/
 Disallow: /pypi/*/json
 Disallow: /pypi/*/*/json
 Disallow: /pypi*?
+Disallow: /search*
 {%- endif %}
 


### PR DESCRIPTION
It's common practice to guide bots away from the search interface. Refs: https://github.com/search?q=%22Disallow%3A+%2Fsearch%22+language%3AText&type=code&l=Text

Signed-off-by: Mike Fiedler <miketheman@gmail.com>