### PR TITLE
chore: add tracing to celery

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
 release: bin/release
 web: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-prod.conf.py warehouse.wsgi:application
 web-uploads: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
-worker: bin/start-worker celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
-worker-malware: bin/start-worker celery -A warehouse worker -Q malware -l info --max-tasks-per-child 32
-worker-beat: bin/start-worker celery -A warehouse beat -S redbeat.RedBeatScheduler -l info
+worker: bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
+worker-malware: bin/start-worker ddtrace-run celery -A warehouse worker -Q malware -l info --max-tasks-per-child 32
+worker-beat: bin/start-worker ddtrace-run celery -A warehouse beat -S redbeat.RedBeatScheduler -l info


### PR DESCRIPTION
We don't get APM-level visibility on background workers today.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>