### PR TITLE
Migrate keywords data structure to Postgres ARRAY type

### DIFF
--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -298,7 +298,7 @@ def test_release_data(db_request):
         "summary": release.summary,
         "description": release.description.raw,
         "license": release.license,
-        "keywords": release.keywords,
+        "keywords": release.keywords_csv,
         "platform": release.platform,
         "classifiers": list(release.classifiers),
         "requires": list(release.requires),

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -201,7 +201,7 @@ class TestReleaseURL:
 
 class TestRelease:
     def test_has_meta_true_with_keywords(self, db_session):
-        release = DBReleaseFactory.create(keywords="foo, bar")
+        release = DBReleaseFactory.create(keywords_array=["foo", "bar"])
         assert release.has_meta
 
     def test_has_meta_true_with_author(self, db_session):

--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -31,7 +31,7 @@ def test_build_search():
         maintainer_email="joe.maintainer@example.com",
         home_page="https://example.com/foobar/",
         download_url="https://example.com/foobar/downloads/",
-        keywords="the, keywords, lol",
+        keywords_array=["the", "keywords", "lol"],
         platform="any platform",
         created=datetime.datetime(1956, 1, 31),
         classifiers=["Alpha", "Beta"],
@@ -50,7 +50,32 @@ def test_build_search():
     assert obj["maintainer_email"] == "joe.maintainer@example.com"
     assert obj["home_page"] == "https://example.com/foobar/"
     assert obj["download_url"] == "https://example.com/foobar/downloads/"
-    assert obj["keywords"] == "the, keywords, lol"
+    assert obj["keywords"] == "the,keywords,lol"
     assert obj["platform"] == "any platform"
     assert obj["created"] == datetime.datetime(1956, 1, 31)
     assert obj["classifiers"] == ["Alpha", "Beta"]
+
+
+def test_build_search_no_keywords():
+    release = pretend.stub(
+        name="Foobar",
+        normalized_name="foobar",
+        all_versions=["5.0.dev0", "4.0", "3.0", "2.0", "1.0"],
+        latest_version="4.0",
+        summary="This is my summary",
+        description="This is my description",
+        author="Jane Author",
+        author_email="jane.author@example.com",
+        maintainer="Joe Maintainer",
+        maintainer_email="joe.maintainer@example.com",
+        home_page="https://example.com/foobar/",
+        download_url="https://example.com/foobar/downloads/",
+        platform="any platform",
+        created=datetime.datetime(1956, 1, 31),
+        classifiers=["Alpha", "Beta"],
+        keywords_array=None,
+    )
+
+    obj = Project.from_db(release)
+
+    assert obj["keywords"] is None

--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -433,7 +433,7 @@ class TestSyncBigQueryMetadata:
                         "maintainer": release.maintainer or None,
                         "maintainer_email": release.maintainer_email or None,
                         "license": release.license or None,
-                        "keywords": release.keywords or None,
+                        "keywords": release.keywords_csv or None,
                         "classifiers": release.classifiers or [],
                         "platform": [release.platform] or [],
                         "home_page": release.home_page or None,

--- a/tests/unit/utils/test_release.py
+++ b/tests/unit/utils/test_release.py
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from warehouse.utils.release import split_and_strip_keywords
+
+
+@pytest.mark.parametrize(
+    ("keyword_input", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("foo, bar", ["foo", "bar"]),
+        ("foo,bar", ["foo", "bar"]),
+        ("foo bar baz", ["foo bar baz"]),
+        ("foo, bar baz, ", ["foo", "bar baz"]),
+        ("foo, bar, baz, ,", ["foo", "bar", "baz"]),
+    ],
+)
+def test_split_and_strip_keywords(keyword_input, expected):
+    assert split_and_strip_keywords(keyword_input) == expected

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -64,6 +64,7 @@ from warehouse.packaging.models import (
 from warehouse.packaging.tasks import update_bigquery_release_files
 from warehouse.utils import http, readme
 from warehouse.utils.project import PROJECT_NAME_RE, add_project, validate_project_name
+from warehouse.utils.release import split_and_strip_keywords
 from warehouse.utils.security_policy import AuthenticationMethod
 
 ONE_MB = 1 * 1024 * 1024
@@ -1091,13 +1092,13 @@ def file_upload(request):
                     "author_email",
                     "maintainer",
                     "maintainer_email",
-                    "keywords",
                     "platform",
                     "home_page",
                     "download_url",
                     "requires_python",
                 }
             },
+            keywords_array=split_and_strip_keywords(form.keywords.data),
             uploader=request.user if request.user else None,
             uploaded_via=request.user_agent,
         )

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -149,7 +149,7 @@ def _json_data(request, project, release, *, all_releases):
             "summary": release.summary,
             "description_content_type": release.description.content_type,
             "description": release.description.raw,
-            "keywords": release.keywords,
+            "keywords": release.keywords_csv,
             "license": release.license,
             "classifiers": list(release.classifiers),
             "author": release.author,

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -352,7 +352,7 @@ def release_data(request, package_name: str, version: str):
         "summary": _clean_for_xml(release.summary),
         "description": _clean_for_xml(release.description.raw),
         "license": _clean_for_xml(release.license),
-        "keywords": _clean_for_xml(release.keywords),
+        "keywords": _clean_for_xml(release.keywords_csv),
         "platform": release.platform,
         "classifiers": list(release.classifiers),
         "requires": list(release.requires),

--- a/warehouse/migrations/versions/677b8c232e17_add_release_keywords_array_column.py
+++ b/warehouse/migrations/versions/677b8c232e17_add_release_keywords_array_column.py
@@ -1,0 +1,54 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add Release.keywords_array column
+
+Revision ID: 677b8c232e17
+Revises: f93cf2d43974
+Create Date: 2023-02-14 19:32:12.553294
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "677b8c232e17"
+down_revision = "f93cf2d43974"
+
+
+def upgrade():
+    op.add_column(
+        "releases",
+        sa.Column("keywords_array", postgresql.ARRAY(sa.Text()), nullable=True),
+    )
+    # Fill the new column with the data from the keywords column
+    # Splits the keywords column on commas and trims the whitespace
+    op.execute(
+        """
+        UPDATE releases
+        SET keywords_array = (
+            SELECT ARRAY(
+                SELECT TRIM(
+                    UNNEST(
+                        STRING_TO_ARRAY(keywords, ',')
+                    )
+                )
+            )
+        )
+        WHERE keywords IS NOT NULL AND keywords != ''
+        """
+    )
+
+
+def downgrade():
+    op.drop_column("releases", "keywords_array")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -455,7 +455,6 @@ class Release(db.Model):
     home_page = Column(Text)
     license = Column(Text)
     summary = Column(Text)
-    keywords = Column(Text)
     keywords_array = Column(ARRAY(Text))
     platform = Column(Text)
     download_url = Column(Text)

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -619,7 +619,7 @@ class Release(db.Model):
         return any(
             [
                 self.license,
-                self.keywords,
+                self.keywords_array,
                 self.author,
                 self.author_email,
                 self.maintainer,

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import enum
+import warnings
 
 from collections import OrderedDict
 from urllib.parse import urlparse
@@ -455,7 +456,7 @@ class Release(db.Model):
     home_page = Column(Text)
     license = Column(Text)
     summary = Column(Text)
-    keywords = Column(Text)
+    _keywords = Column("keywords", Text)  # deprecated, see `keywords()`
     keywords_array = Column(ARRAY(Text))
     platform = Column(Text)
     download_url = Column(Text)
@@ -630,6 +631,22 @@ class Release(db.Model):
     @property
     def keywords_csv(self) -> str | None:
         return ",".join(self.keywords_array) if self.keywords_array else None
+
+    @property
+    def keywords(self):
+        warnings.warn(
+            "The keywords attribute is deprecated, use keywords_array instead",
+            DeprecationWarning,
+        )
+        return self._keywords
+
+    @keywords.setter
+    def keywords(self, value):
+        warnings.warn(
+            "The keywords attribute is deprecated, use keywords_array instead",
+            DeprecationWarning,
+        )
+        self._keywords = value
 
 
 class File(db.Model):

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -627,6 +627,10 @@ class Release(db.Model):
             ]
         )
 
+    @property
+    def keywords_csv(self) -> str | None:
+        return ",".join(self.keywords_array) if self.keywords_array else None
+
 
 class File(db.Model):
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -40,7 +40,7 @@ from sqlalchemy import (
     orm,
     sql,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr  # type: ignore
@@ -456,6 +456,7 @@ class Release(db.Model):
     license = Column(Text)
     summary = Column(Text)
     keywords = Column(Text)
+    keywords_array = Column(ARRAY(Text))
     platform = Column(Text)
     download_url = Column(Text)
     _pypi_ordering = Column(Integer)

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 import enum
-import warnings
 
 from collections import OrderedDict
 from urllib.parse import urlparse
@@ -456,7 +455,7 @@ class Release(db.Model):
     home_page = Column(Text)
     license = Column(Text)
     summary = Column(Text)
-    _keywords = Column("keywords", Text)  # deprecated, see `keywords()`
+    keywords = Column(Text)
     keywords_array = Column(ARRAY(Text))
     platform = Column(Text)
     download_url = Column(Text)
@@ -631,22 +630,6 @@ class Release(db.Model):
     @property
     def keywords_csv(self) -> str | None:
         return ",".join(self.keywords_array) if self.keywords_array else None
-
-    @property
-    def keywords(self):
-        warnings.warn(
-            "The keywords attribute is deprecated, use keywords_array instead",
-            DeprecationWarning,
-        )
-        return self._keywords
-
-    @keywords.setter
-    def keywords(self, value):
-        warnings.warn(
-            "The keywords attribute is deprecated, use keywords_array instead",
-            DeprecationWarning,
-        )
-        self._keywords = value
 
 
 class File(db.Model):

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -67,7 +67,12 @@ class Project(Document):
         obj["maintainer_email"] = release.maintainer_email
         obj["home_page"] = release.home_page
         obj["download_url"] = release.download_url
-        obj["keywords"] = release.keywords
+        obj["keywords"] = (
+            # can't use `release.keywords_csv` because it's a property
+            ",".join(release.keywords_array)
+            if release.keywords_array
+            else None
+        )
         obj["platform"] = release.platform
         obj["created"] = release.created
         obj["classifiers"] = release.classifiers

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -86,7 +86,7 @@ def _project_docs(db, project_name=None):
             Release.maintainer_email,
             Release.home_page,
             Release.summary,
-            Release.keywords,
+            Release.keywords_array,
             Release.platform,
             Release.download_url,
             Release.created,

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -97,7 +97,7 @@
   <p class="tags">
     <i class="fa fa-tags" aria-hidden="true"></i>
     <span class="sr-only">{% trans %}Tags{% endtrans %}</span>
-    {% for keyword in release.keywords | format_tags %}
+    {% for keyword in release.keywords_csv | format_tags %}
     <span class="package-keyword">
       {{ keyword }}{% if not loop.last %},{% endif %}
     </span>

--- a/warehouse/utils/release.py
+++ b/warehouse/utils/release.py
@@ -1,0 +1,27 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def split_and_strip_keywords(keyword_input: str) -> list[str] | None:
+    """
+    Split keywords on commas and strip whitespace, remove empties.
+    Useful to cleanse user input prior to storing in Release.keywords_array.
+    """
+    try:
+        split_keywords = keyword_input.split(",")
+    except AttributeError:
+        return None
+
+    stripped_keywords = [keyword.strip() for keyword in split_keywords]
+    slimmed_keywords = [keyword for keyword in stripped_keywords if keyword]
+
+    return slimmed_keywords if slimmed_keywords else None


### PR DESCRIPTION
🚨 **Note**: Data migration contained within

Does not drop existing column, but removes references to it.

Once merged, no new Releases will populate their `keywords` column, only the `keywords_array` column will be filled.