### PR TITLE
Revert "chore: add tracing to celery"

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
 release: bin/release
 web: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-prod.conf.py warehouse.wsgi:application
 web-uploads: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
-worker: bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
-worker-malware: bin/start-worker ddtrace-run celery -A warehouse worker -Q malware -l info --max-tasks-per-child 32
-worker-beat: bin/start-worker ddtrace-run celery -A warehouse beat -S redbeat.RedBeatScheduler -l info
+worker: bin/start-worker celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
+worker-malware: bin/start-worker celery -A warehouse worker -Q malware -l info --max-tasks-per-child 32
+worker-beat: bin/start-worker celery -A warehouse beat -S redbeat.RedBeatScheduler -l info


### PR DESCRIPTION
Reverts pypi/warehouse#12981

This seems to have caused our celery workers to freeze up occasionally with

```
[2023-02-14 01:26:19,433: WARNING/MainProcess] Unexpected error
Traceback (most recent call last):
  File "/opt/warehouse/lib/python3.11/site-packages/ddtrace/internal/remoteconfig/client.py", line 425, in request
    response = self._send_request(payload)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/warehouse/lib/python3.11/site-packages/ddtrace/internal/remoteconfig/client.py", line 266, in _send_request
    self._conn.request("POST", "v0.7/config", payload, self._headers)
  File "/usr/local/lib/python3.11/http/client.py", line 1282, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/local/lib/python3.11/http/client.py", line 1328, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.11/http/client.py", line 1277, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.11/http/client.py", line 1037, in _send_output
    self.send(msg)
  File "/usr/local/lib/python3.11/http/client.py", line 975, in send
    self.connect()
  File "/usr/local/lib/python3.11/http/client.py", line 941, in connect
    self.sock = self._create_connection(
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/socket.py", line 851, in create_connection
    raise exceptions[0]
  File "/usr/local/lib/python3.11/socket.py", line 836, in create_connection
    sock.connect(sa)
OSError: [Errno 99] Cannot assign requested address
```