### PR TITLE
warehouse/packaging: initial ProjectService

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,8 @@ from warehouse.macaroons import services as macaroon_services
 from warehouse.metrics import IMetricsService
 from warehouse.organizations import services as organization_services
 from warehouse.organizations.interfaces import IOrganizationService
+from warehouse.packaging import services as packaging_services
+from warehouse.packaging.interfaces import IProjectService
 from warehouse.subscriptions import services as subscription_services
 from warehouse.subscriptions.interfaces import IBillingService, ISubscriptionService
 
@@ -133,6 +135,7 @@ def pyramid_services(
     subscription_service,
     token_service,
     user_service,
+    project_service,
 ):
     services = _Services()
 
@@ -145,6 +148,7 @@ def pyramid_services(
     services.register_service(token_service, ITokenService, None, name="password")
     services.register_service(token_service, ITokenService, None, name="email")
     services.register_service(user_service, IUserService, None, name="")
+    services.register_service(project_service, IProjectService, None, name="")
 
     return services
 
@@ -307,6 +311,11 @@ def user_service(db_session, metrics, remote_addr):
     return account_services.DatabaseUserService(
         db_session, metrics=metrics, remote_addr=remote_addr
     )
+
+
+@pytest.fixture
+def project_service(db_session, remote_addr):
+    return packaging_services.ProjectService(db_session, remote_addr)
 
 
 @pytest.fixture

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -37,7 +37,7 @@ from warehouse.admin.flags import AdminFlag, AdminFlagValue
 from warehouse.classifiers.models import Classifier
 from warehouse.forklift import legacy
 from warehouse.metrics import IMetricsService
-from warehouse.packaging.interfaces import IFileStorage
+from warehouse.packaging.interfaces import IFileStorage, IProjectService
 from warehouse.packaging.models import (
     Dependency,
     DependencyKind,
@@ -1918,8 +1918,9 @@ class TestFileUpload:
         assert resp.status_code == 400
         assert resp.status == "400 Invalid distribution file."
 
-    def test_upload_fails_end_of_file_error(self, pyramid_config, db_request, metrics):
-
+    def test_upload_fails_end_of_file_error(
+        self, pyramid_config, db_request, metrics, project_service
+    ):
         user = UserFactory.create()
         EmailFactory.create(user=user)
         project = ProjectFactory.create(name="Package-Name")
@@ -1951,6 +1952,7 @@ class TestFileUpload:
         db_request.find_service = lambda svc, name=None, context=None: {
             IFileStorage: storage_service,
             IMetricsService: metrics,
+            IProjectService: project_service,
         }.get(svc)
         db_request.user_agent = "warehouse-tests/6.6.6"
 
@@ -2100,7 +2102,11 @@ class TestFileUpload:
         )
 
     def test_upload_succeeds_custom_project_size_limit(
-        self, pyramid_config, db_request, metrics
+        self,
+        pyramid_config,
+        db_request,
+        metrics,
+        project_service,
     ):
 
         user = UserFactory.create()
@@ -2139,6 +2145,7 @@ class TestFileUpload:
         db_request.find_service = lambda svc, name=None, context=None: {
             IFileStorage: storage_service,
             IMetricsService: metrics,
+            IProjectService: project_service,
         }.get(svc)
         db_request.user_agent = "warehouse-tests/6.6.6"
 
@@ -3312,7 +3319,9 @@ class TestFileUpload:
             "configure the project to use OpenID Connect."
         )
 
-    def test_upload_succeeds_creates_project(self, pyramid_config, db_request, metrics):
+    def test_upload_succeeds_creates_project(
+        self, pyramid_config, db_request, metrics, project_service
+    ):
 
         user = UserFactory.create()
         EmailFactory.create(user=user)
@@ -3340,6 +3349,7 @@ class TestFileUpload:
         db_request.find_service = lambda svc, name=None, context=None: {
             IFileStorage: storage_service,
             IMetricsService: metrics,
+            IProjectService: project_service,
         }.get(svc)
         db_request.user_agent = "warehouse-tests/6.6.6"
 
@@ -3417,7 +3427,13 @@ class TestFileUpload:
         ],
     )
     def test_upload_requires_verified_email(
-        self, pyramid_config, db_request, emails_verified, expected_success, metrics
+        self,
+        pyramid_config,
+        db_request,
+        emails_verified,
+        expected_success,
+        metrics,
+        project_service,
     ):
 
         user = UserFactory.create()
@@ -3447,6 +3463,7 @@ class TestFileUpload:
         db_request.find_service = lambda svc, name=None, context=None: {
             IFileStorage: storage_service,
             IMetricsService: metrics,
+            IProjectService: project_service,
         }.get(svc)
         db_request.user_agent = "warehouse-tests/6.6.6"
 
@@ -3473,7 +3490,12 @@ class TestFileUpload:
             )
 
     def test_upload_purges_legacy(
-        self, pyramid_config, db_request, monkeypatch, metrics
+        self,
+        pyramid_config,
+        db_request,
+        monkeypatch,
+        metrics,
+        project_service,
     ):
 
         user = UserFactory.create()
@@ -3502,6 +3524,7 @@ class TestFileUpload:
         db_request.find_service = lambda svc, name=None, context=None: {
             IFileStorage: storage_service,
             IMetricsService: metrics,
+            IProjectService: project_service,
         }.get(svc)
         db_request.user_agent = "warehouse-tests/6.6.6"
 

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -60,7 +60,6 @@ from warehouse.organizations.models import (
     TeamProjectRoleType,
     TeamRoleType,
 )
-from warehouse.packaging.interfaces import IProjectService
 from warehouse.packaging.models import (
     File,
     JournalEntry,
@@ -3893,11 +3892,6 @@ class TestManageOrganizationProjects:
         validate_project_name = pretend.call_recorder(lambda *a, **kw: True)
         monkeypatch.setattr(views, "validate_project_name", validate_project_name)
 
-        # project_service = pretend.stub(
-        #     create_project=pretend.call_recorder(lambda *a: None)
-        # )
-        # db_request.find_service = pretend.call_recorder(lambda *a: project_service)
-
         def add_organization_project(*args, **kwargs):
             OrganizationProjectFactory.create(
                 organization=organization, project=project
@@ -3922,10 +3916,6 @@ class TestManageOrganizationProjects:
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == db_request.path
         assert validate_project_name.calls == [pretend.call(project.name, db_request)]
-        # assert db_request.find_service.calls == [pretend.call(IProjectService)]
-        # assert project_service.create_project.calls == [
-        #     pretend.call(project.name, db_request.user)
-        # ]
         assert len(organization.projects) == 2
         assert send_organization_project_added_email.calls == [
             pretend.call(

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -3897,13 +3897,16 @@ class TestManageOrganizationProjects:
         view = views.ManageOrganizationProjectsViews(organization, db_request)
         result = view.add_organization_project()
 
-        # The project was created.
-        db_request.db.query(Project).filter_by(name="fakepackage").one_or_none() is not None
+        # The project was created, and belongs to the organization.
+        project = (
+            db_request.db.query(Project).filter_by(name="fakepackage").one_or_none()
+        )
+        assert project is not None
+        assert project.organization == organization
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == db_request.path
         assert validate_project_name.calls == [pretend.call("fakepackage", db_request)]
-        assert len(organization.projects) == 1
         assert send_organization_project_added_email.calls == [
             pretend.call(
                 db_request,

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -3901,7 +3901,7 @@ class TestManageOrganizationProjects:
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == db_request.path
         assert validate_project_name.calls == [pretend.call("fakepackage", db_request)]
-        assert len(organization.projects) == 2
+        assert len(organization.projects) == 1
         assert send_organization_project_added_email.calls == [
             pretend.call(
                 db_request,

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -60,6 +60,7 @@ from warehouse.organizations.models import (
     TeamProjectRoleType,
     TeamRoleType,
 )
+from warehouse.packaging.interfaces import IProjectService
 from warehouse.packaging.models import (
     File,
     JournalEntry,
@@ -3892,8 +3893,10 @@ class TestManageOrganizationProjects:
         validate_project_name = pretend.call_recorder(lambda *a, **kw: True)
         monkeypatch.setattr(views, "validate_project_name", validate_project_name)
 
-        add_project = pretend.call_recorder(lambda *a, **kw: project)
-        monkeypatch.setattr(views, "add_project", add_project)
+        # project_service = pretend.stub(
+        #     create_project=pretend.call_recorder(lambda *a: None)
+        # )
+        # db_request.find_service = pretend.call_recorder(lambda *a: project_service)
 
         def add_organization_project(*args, **kwargs):
             OrganizationProjectFactory.create(
@@ -3919,7 +3922,10 @@ class TestManageOrganizationProjects:
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == db_request.path
         assert validate_project_name.calls == [pretend.call(project.name, db_request)]
-        assert add_project.calls == [pretend.call(project.name, db_request)]
+        # assert db_request.find_service.calls == [pretend.call(IProjectService)]
+        # assert project_service.create_project.calls == [
+        #     pretend.call(project.name, db_request.user)
+        # ]
         assert len(organization.projects) == 2
         assert send_organization_project_added_email.calls == [
             pretend.call(

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -3859,7 +3859,6 @@ class TestManageOrganizationProjects:
         self,
         db_request,
         pyramid_user,
-        organization_service,
         enable_organizations,
         monkeypatch,
     ):
@@ -3897,6 +3896,9 @@ class TestManageOrganizationProjects:
 
         view = views.ManageOrganizationProjectsViews(organization, db_request)
         result = view.add_organization_project()
+
+        # The project was created.
+        db_request.db.query(Project).filter_by(name="fakepackage").one_or_none() is not None
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == db_request.path

--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -18,8 +18,14 @@ from celery.schedules import crontab
 from warehouse import packaging
 from warehouse.accounts.models import Email, User
 from warehouse.manage.tasks import update_role_invitation_status
-from warehouse.packaging.interfaces import IDocsStorage, IFileStorage, ISimpleStorage
+from warehouse.packaging.interfaces import (
+    IDocsStorage,
+    IFileStorage,
+    IProjectService,
+    ISimpleStorage,
+)
 from warehouse.packaging.models import File, Project, Release, Role
+from warehouse.packaging.services import project_service_factory
 from warehouse.packaging.tasks import (  # sync_bigquery_release_files,
     compute_2fa_mandate,
     update_description_html,
@@ -66,6 +72,7 @@ def test_includeme(monkeypatch, with_bq_sync, with_2fa_mandate):
         pretend.call(storage_class.create_service, IFileStorage),
         pretend.call(storage_class.create_service, ISimpleStorage),
         pretend.call(storage_class.create_service, IDocsStorage),
+        pretend.call(project_service_factory, IProjectService),
     ]
     assert config.register_origin_cache_keys.calls == [
         pretend.call(

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -32,6 +32,7 @@ from warehouse.packaging.services import (
     LocalSimpleStorage,
     S3DocsStorage,
     S3FileStorage,
+    project_service_factory,
 )
 
 
@@ -665,3 +666,13 @@ class TestGenericLocalBlobStorage:
     def test_notimplementederror(self):
         with pytest.raises(NotImplementedError):
             GenericLocalBlobStorage.create_service(pretend.stub(), pretend.stub())
+
+
+def test_project_service_factory():
+    db = pretend.stub()
+    remote_addr = pretend.stub()
+    request = pretend.stub(db=db, remote_addr=remote_addr)
+
+    service = project_service_factory(pretend.stub(), request)
+    assert service.db == db
+    assert service.remote_addr == remote_addr

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -59,7 +59,6 @@ from warehouse.packaging.models import (
     JournalEntry,
     Project,
     Release,
-    Role,
 )
 from warehouse.packaging.tasks import update_bigquery_release_files
 from warehouse.utils import http, readme

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -49,7 +49,7 @@ from warehouse.classifiers.models import Classifier
 from warehouse.email import send_basic_auth_with_two_factor_email
 from warehouse.events.tags import EventTag
 from warehouse.metrics import IMetricsService
-from warehouse.packaging.interfaces import IFileStorage
+from warehouse.packaging.interfaces import IFileStorage, IProjectService
 from warehouse.packaging.models import (
     Dependency,
     DependencyKind,
@@ -63,7 +63,7 @@ from warehouse.packaging.models import (
 )
 from warehouse.packaging.tasks import update_bigquery_release_files
 from warehouse.utils import http, readme
-from warehouse.utils.project import PROJECT_NAME_RE, add_project, validate_project_name
+from warehouse.utils.project import PROJECT_NAME_RE, validate_project_name
 from warehouse.utils.security_policy import AuthenticationMethod
 
 ONE_MB = 1 * 1024 * 1024
@@ -908,31 +908,9 @@ def file_upload(request):
             validate_project_name(form.name.data, request)
         except HTTPException as exc:
             raise _exc_with_message(exc.__class__, exc.detail) from None
-        project = add_project(form.name.data, request)
 
-        # Then we'll add a role setting the current user as the "Owner" of the
-        # project.
-        request.db.add(Role(user=request.user, project=project, role_name="Owner"))
-        # TODO: This should be handled by some sort of database trigger or a
-        #       SQLAlchemy hook or the like instead of doing it inline in this
-        #       view.
-        request.db.add(
-            JournalEntry(
-                name=project.name,
-                action=f"add Owner {request.user.username}",
-                submitted_by=request.user,
-                submitted_from=request.remote_addr,
-            )
-        )
-        project.record_event(
-            tag=EventTag.Project.RoleAdd,
-            ip_address=request.remote_addr,
-            additional={
-                "submitted_by": request.user.username,
-                "role_name": "Owner",
-                "target_user": request.user.username,
-            },
-        )
+        project_service = request.find_service(IProjectService)
+        project_service.create_project(form.name.data, request.user)
 
     # Check that the identity has permission to do things to this project, if this
     # is a new project this will act as a sanity check for the role we just

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -909,7 +909,7 @@ def file_upload(request):
             raise _exc_with_message(exc.__class__, exc.detail) from None
 
         project_service = request.find_service(IProjectService)
-        project_service.create_project(form.name.data, request.user)
+        project = project_service.create_project(form.name.data, request.user)
 
     # Check that the identity has permission to do things to this project, if this
     # is a new project this will act as a sanity check for the role we just

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -268,7 +268,7 @@ msgstr ""
 msgid "You can't register more than 3 pending OpenID Connect providers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1430 warehouse/manage/views.py:3111
+#: warehouse/accounts/views.py:1430 warehouse/manage/views.py:3113
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
@@ -368,55 +368,55 @@ msgstr ""
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:2013
+#: warehouse/manage/views.py:2015
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:2024
+#: warehouse/manage/views.py:2026
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:2038 warehouse/manage/views.py:4371
+#: warehouse/manage/views.py:2040 warehouse/manage/views.py:4373
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2104 warehouse/manage/views.py:4438
+#: warehouse/manage/views.py:2106 warehouse/manage/views.py:4440
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:2150
+#: warehouse/manage/views.py:2152
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2164 warehouse/manage/views.py:4482
+#: warehouse/manage/views.py:2166 warehouse/manage/views.py:4484
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2206 warehouse/manage/views.py:4515
+#: warehouse/manage/views.py:2208 warehouse/manage/views.py:4517
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views.py:4148
+#: warehouse/manage/views.py:4150
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4256
+#: warehouse/manage/views.py:4258
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4325
+#: warehouse/manage/views.py:4327
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4358
+#: warehouse/manage/views.py:4360
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4471
+#: warehouse/manage/views.py:4473
 msgid "Could not find role invitation."
 msgstr ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -268,7 +268,7 @@ msgstr ""
 msgid "You can't register more than 3 pending OpenID Connect providers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1430 warehouse/manage/views.py:3107
+#: warehouse/accounts/views.py:1430 warehouse/manage/views.py:3111
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
@@ -368,55 +368,55 @@ msgstr ""
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:2009
+#: warehouse/manage/views.py:2013
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:2020
+#: warehouse/manage/views.py:2024
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:2034 warehouse/manage/views.py:4367
+#: warehouse/manage/views.py:2038 warehouse/manage/views.py:4371
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2100 warehouse/manage/views.py:4434
+#: warehouse/manage/views.py:2104 warehouse/manage/views.py:4438
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:2146
+#: warehouse/manage/views.py:2150
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2160 warehouse/manage/views.py:4478
+#: warehouse/manage/views.py:2164 warehouse/manage/views.py:4482
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2202 warehouse/manage/views.py:4511
+#: warehouse/manage/views.py:2206 warehouse/manage/views.py:4515
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views.py:4144
+#: warehouse/manage/views.py:4148
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4252
+#: warehouse/manage/views.py:4256
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4321
+#: warehouse/manage/views.py:4325
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4354
+#: warehouse/manage/views.py:4358
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4467
+#: warehouse/manage/views.py:4471
 msgid "Could not find role invitation."
 msgstr ""
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -145,6 +145,7 @@ from warehouse.organizations.models import (
     TeamRole,
     TeamRoleType,
 )
+from warehouse.packaging.interfaces import IProjectService
 from warehouse.packaging.models import (
     File,
     JournalEntry,
@@ -162,7 +163,6 @@ from warehouse.utils.http import is_safe_url
 from warehouse.utils.organization import confirm_organization, confirm_team
 from warehouse.utils.paginate import paginate_url_factory
 from warehouse.utils.project import (
-    add_project,
     confirm_project,
     destroy_docs,
     remove_project,
@@ -1912,8 +1912,12 @@ class ManageOrganizationProjectsViews:
             except HTTPException as exc:
                 form.new_project_name.errors.append(exc.detail)
                 return default_response
+
             # Add new project.
-            project = add_project(form.new_project_name.data, self.request)
+            project_service = self.request.find_service(IProjectService)
+            project_service.create_project(
+                form.new_project_name.data, self.request.user
+            )
 
         # Add project to organization.
         self.organization_service.add_organization_project(

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -1914,9 +1914,11 @@ class ManageOrganizationProjectsViews:
                 return default_response
 
             # Add new project.
+            # Note that we pass `creator_is_owner=False`, since the project being
+            # created is controlled by the organization and not the user creating it.
             project_service = self.request.find_service(IProjectService)
-            project_service.create_project(
-                form.new_project_name.data, self.request.user
+            project = project_service.create_project(
+                form.new_project_name.data, self.request.user, creator_is_owner=False
             )
 
         # Add project to organization.

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -24,7 +24,7 @@ from warehouse.packaging.interfaces import (
     ISimpleStorage,
 )
 from warehouse.packaging.models import File, Project, Release, Role
-from warehouse.packaging.services import ProjectService
+from warehouse.packaging.services import ProjectService, project_service_factory
 from warehouse.packaging.tasks import (
     compute_2fa_mandate,
     compute_2fa_metrics,
@@ -58,7 +58,7 @@ def includeme(config):
     docs_storage_class = config.maybe_dotted(config.registry.settings["docs.backend"])
     config.register_service_factory(docs_storage_class.create_service, IDocsStorage)
 
-    config.register_service_factory(ProjectService.create_service, IProjectService)
+    config.register_service_factory(project_service_factory, IProjectService)
 
     # Register our origin cache keys
     config.register_origin_cache_keys(

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -24,7 +24,7 @@ from warehouse.packaging.interfaces import (
     ISimpleStorage,
 )
 from warehouse.packaging.models import File, Project, Release, Role
-from warehouse.packaging.services import ProjectService, project_service_factory
+from warehouse.packaging.services import project_service_factory
 from warehouse.packaging.tasks import (
     compute_2fa_mandate,
     compute_2fa_metrics,

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -17,8 +17,14 @@ from warehouse import db
 from warehouse.accounts.models import Email, User
 from warehouse.cache.origin import key_factory, receive_set
 from warehouse.manage.tasks import update_role_invitation_status
-from warehouse.packaging.interfaces import IDocsStorage, IFileStorage, ISimpleStorage
+from warehouse.packaging.interfaces import (
+    IDocsStorage,
+    IFileStorage,
+    IProjectService,
+    ISimpleStorage,
+)
 from warehouse.packaging.models import File, Project, Release, Role
+from warehouse.packaging.services import ProjectService
 from warehouse.packaging.tasks import (
     compute_2fa_mandate,
     compute_2fa_metrics,
@@ -51,6 +57,8 @@ def includeme(config):
 
     docs_storage_class = config.maybe_dotted(config.registry.settings["docs.backend"])
     config.register_service_factory(docs_storage_class.create_service, IDocsStorage)
+
+    config.register_service_factory(ProjectService.create_service, IProjectService)
 
     # Register our origin cache keys
     config.register_origin_cache_keys(

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -53,3 +53,16 @@ class IDocsStorage(Interface):
         """
         Remove all files matching the given prefix.
         """
+
+
+class IProjectService(Interface):
+    def create_service(context, request):
+        """
+        Create the service, given the context and request for which it
+        is being created.
+        """
+
+    def create_project(name, owner):
+        """
+        Creates a new project, associating it with a user as its owner.
+        """

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -56,12 +56,6 @@ class IDocsStorage(Interface):
 
 
 class IProjectService(Interface):
-    def create_service(context, request):
-        """
-        Create the service, given the context and request for which it
-        is being created.
-        """
-
     def create_project(name, owner):
         """
         Creates a new project, associating it with a user as its owner.

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -56,7 +56,10 @@ class IDocsStorage(Interface):
 
 
 class IProjectService(Interface):
-    def create_project(name, owner):
+    def create_project(name, creator, *, creator_is_owner=True):
         """
-        Creates a new project, associating it with a user as its owner.
+        Creates a new project, recording a user as its creator.
+
+        If `creator_is_owner`, a `Role` is also added to the project
+        marking `creator` as a project owner.
         """

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -263,10 +263,6 @@ class ProjectService:
         self.db = session
         self.remote_addr = remote_addr
 
-    @classmethod
-    def create_service(cls, context, request):
-        return cls(request.db, request.remote_addr)
-
     def create_project(self, name, owner):
         project = Project(name=name)
         self.db.add(project)
@@ -313,3 +309,7 @@ class ProjectService:
         )
 
         return project
+
+
+def project_service_factory(context, request):
+    return ProjectService(request.db, request.remote_addr)

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -153,33 +153,6 @@ def validate_project_name(name, request):
         return True
 
 
-def add_project(name, request):
-    """
-    Attempts to create a project with the given name.
-    """
-    project = Project(name=name)
-    request.db.add(project)
-
-    # TODO: This should be handled by some sort of database trigger or a
-    #       SQLAlchemy hook or the like instead of doing it inline in this
-    #       view.
-    request.db.add(
-        JournalEntry(
-            name=project.name,
-            action="create",
-            submitted_by=request.user,
-            submitted_from=request.remote_addr,
-        )
-    )
-    project.record_event(
-        tag=EventTag.Project.ProjectCreate,
-        ip_address=request.remote_addr,
-        additional={"created_by": request.user.username},
-    )
-
-    return project
-
-
 def confirm_project(
     project,
     request,

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -27,7 +27,6 @@ from sqlalchemy import exists, func
 from sqlalchemy.exc import NoResultFound
 
 from warehouse.admin.flags import AdminFlagValue
-from warehouse.events.tags import EventTag
 from warehouse.packaging.interfaces import IDocsStorage
 from warehouse.packaging.models import JournalEntry, ProhibitedProjectName, Project
 from warehouse.tasks import task


### PR DESCRIPTION
~~WIP; I need to remove the current `utils` code and update the tests.~~

Replaces the `add_project` helper with a new service `ProjectService` with constituent functionality. Also promotes some other functionality in the `file_upload` handler into `ProjectService.create_project`, like the role handling (since it's directly in-line with project creation).