### PR TITLE
chore(ci): cache the entire python env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,8 @@ jobs:
           path: |
             .cache
             .mypy_cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements/lint.txt') }}
+            ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
       - name: Install Python dependencies
         run: |
           pip install -U pip setuptools wheel


### PR DESCRIPTION
Since each step downloads the package cache and installs the packages, we are subject to any sdists needing to be built to wheels spending more time on the same operation.

If the Operating System, Python version, or any of the requirements files change, the cache will be recreated.