### PR TITLE
Don't specify webauthn transports

### DIFF
--- a/warehouse/utils/webauthn.py
+++ b/warehouse/utils/webauthn.py
@@ -25,7 +25,6 @@ from webauthn.helpers.structs import (
     AttestationConveyancePreference,
     AuthenticationCredential,
     AuthenticatorSelectionCriteria,
-    AuthenticatorTransport,
     PublicKeyCredentialDescriptor,
     RegistrationCredential,
     UserVerificationRequirement,
@@ -47,15 +46,7 @@ def _get_webauthn_user_public_key_credential_descriptors(user, *, rp_id):
     usage within the webauthn API.
     """
     return [
-        PublicKeyCredentialDescriptor(
-            id=base64url_to_bytes(credential.credential_id),
-            transports=[
-                AuthenticatorTransport.USB,
-                AuthenticatorTransport.NFC,
-                AuthenticatorTransport.BLE,
-                AuthenticatorTransport.INTERNAL,
-            ],
-        )
+        PublicKeyCredentialDescriptor(id=base64url_to_bytes(credential.credential_id))
         for credential in user.webauthn
     ]
 


### PR DESCRIPTION
Fixes #13062.

Since we're not restricting the transport options at registration time, or storing the transport used during registration, we don't actually know what transports should be used at assertion time. Instead, we should just omit this restriction and allow all transport types.

Per https://github.com/duo-labs/py_webauthn/blob/c3c6c21f76937b08aed089897fe595f8b9232cdf/webauthn/helpers/structs.py#L271 these are optional.