### PR TITLE
send gunicorn statsd to dogstatsd!

### DIFF
--- a/gunicorn-prod.conf.py
+++ b/gunicorn-prod.conf.py
@@ -25,6 +25,7 @@ loglevel = "info"
 accesslog = "-"
 access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 
+statsd_host="localhost:8125"
 
 def when_ready(server):
     open("/tmp/app-initialized", "w").close()

--- a/gunicorn-prod.conf.py
+++ b/gunicorn-prod.conf.py
@@ -25,7 +25,8 @@ loglevel = "info"
 accesslog = "-"
 access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 
-statsd_host="localhost:8125"
+statsd_host = "localhost:8125"
+
 
 def when_ready(server):
     open("/tmp/app-initialized", "w").close()

--- a/gunicorn-uploads.conf.py
+++ b/gunicorn-uploads.conf.py
@@ -25,6 +25,7 @@ loglevel = "info"
 accesslog = "-"
 access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 
+statsd_host="localhost:8125"
 
 def when_ready(server):
     open("/tmp/app-initialized", "w").close()

--- a/gunicorn-uploads.conf.py
+++ b/gunicorn-uploads.conf.py
@@ -25,7 +25,8 @@ loglevel = "info"
 accesslog = "-"
 access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 
-statsd_host="localhost:8125"
+statsd_host = "localhost:8125"
+
 
 def when_ready(server):
     open("/tmp/app-initialized", "w").close()


### PR DESCRIPTION
noticed this was available while i was in the datadog docs today.

this is nice because it should give us more granular insight into where an http status code originates from. i don't think the pyramid stats are emitted on error, cause i know they happen but i couldn't find a stat for them.