### PR TITLE
Partial revert of pypi/warehouse#12733

### DIFF
--- a/tests/unit/api/test_simple.py
+++ b/tests/unit/api/test_simple.py
@@ -186,11 +186,11 @@ class TestSimpleDetail:
         user = UserFactory.create()
         JournalEntryFactory.create(submitted_by=user)
 
-        result = simple.simple_detail(project, db_request)
-
-        assert result["meta"] == {"_last-serial": 0, "api-version": "1.0"}
-        assert result["name"] == project.normalized_name
-        assert result["files"] == []
+        assert simple.simple_detail(project, db_request) == {
+            "meta": {"_last-serial": 0, "api-version": "1.0"},
+            "name": project.normalized_name,
+            "files": [],
+        }
 
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
         assert db_request.response.content_type == content_type
@@ -209,11 +209,11 @@ class TestSimpleDetail:
         user = UserFactory.create()
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
 
-        result = simple.simple_detail(project, db_request)
-
-        assert result["meta"] == {"_last-serial": je.id, "api-version": "1.0"}
-        assert result["name"] == project.normalized_name
-        assert result["files"] == []
+        assert simple.simple_detail(project, db_request) == {
+            "meta": {"_last-serial": je.id, "api-version": "1.0"},
+            "name": project.normalized_name,
+            "files": [],
+        }
 
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
         assert db_request.response.content_type == content_type
@@ -241,19 +241,20 @@ class TestSimpleDetail:
         user = UserFactory.create()
         JournalEntryFactory.create(submitted_by=user)
 
-        result = simple.simple_detail(project, db_request)
-
-        assert result["meta"] == {"_last-serial": 0, "api-version": "1.0"}
-        assert result["name"] == project.normalized_name
-
-        for f in files:
-            assert {
-                "filename": f.filename,
-                "url": f"/file/{f.filename}",
-                "hashes": {"sha256": f.sha256_digest},
-                "requires-python": f.requires_python,
-                "yanked": False,
-            } in result["files"]
+        assert simple.simple_detail(project, db_request) == {
+            "meta": {"_last-serial": 0, "api-version": "1.0"},
+            "name": project.normalized_name,
+            "files": [
+                {
+                    "filename": f.filename,
+                    "url": f"/file/{f.filename}",
+                    "hashes": {"sha256": f.sha256_digest},
+                    "requires-python": f.requires_python,
+                    "yanked": False,
+                }
+                for f in files
+            ],
+        }
 
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
         assert db_request.response.content_type == content_type
@@ -281,19 +282,20 @@ class TestSimpleDetail:
         user = UserFactory.create()
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
 
-        result = simple.simple_detail(project, db_request)
-
-        assert result["meta"] == {"_last-serial": je.id, "api-version": "1.0"}
-        assert result["name"] == project.normalized_name
-
-        for f in files:
-            assert {
-                "filename": f.filename,
-                "url": f"/file/{f.filename}",
-                "hashes": {"sha256": f.sha256_digest},
-                "requires-python": f.requires_python,
-                "yanked": False,
-            } in result["files"]
+        assert simple.simple_detail(project, db_request) == {
+            "meta": {"_last-serial": je.id, "api-version": "1.0"},
+            "name": project.normalized_name,
+            "files": [
+                {
+                    "filename": f.filename,
+                    "url": f"/file/{f.filename}",
+                    "hashes": {"sha256": f.sha256_digest},
+                    "requires-python": f.requires_python,
+                    "yanked": False,
+                }
+                for f in files
+            ],
+        }
 
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
         assert db_request.response.content_type == content_type
@@ -358,19 +360,20 @@ class TestSimpleDetail:
         user = UserFactory.create()
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
 
-        result = simple.simple_detail(project, db_request)
-
-        assert result["meta"] == {"_last-serial": je.id, "api-version": "1.0"}
-        assert result["name"] == project.normalized_name
-
-        for f in files:
-            assert {
-                "filename": f.filename,
-                "url": f"/file/{f.filename}",
-                "hashes": {"sha256": f.sha256_digest},
-                "requires-python": f.requires_python,
-                "yanked": False,
-            } in result["files"]
+        assert simple.simple_detail(project, db_request) == {
+            "meta": {"_last-serial": je.id, "api-version": "1.0"},
+            "name": project.normalized_name,
+            "files": [
+                {
+                    "filename": f.filename,
+                    "url": f"/file/{f.filename}",
+                    "hashes": {"sha256": f.sha256_digest},
+                    "requires-python": f.requires_python,
+                    "yanked": False,
+                }
+                for f in files
+            ],
+        }
 
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
         assert db_request.response.content_type == content_type


### PR DESCRIPTION
In pypi/warehouse#12733, a number of the tests for the simple API were adjusted to fix pytest-randomly.

However, the changes to those simple API tests are wrong. They boil down to allowing extra things to exist in the result that we didn't expect, which suggests that some other test is leaking state, and our solution was to make these tests worse rather than stop that test from leaking state.

This ends up being important because the way that these tests *used* to be written (and are written again with this PR) is that they ensured that no extra keys were being emitted into the result that we didn't expect, and they ensured that no extra files were being emitted into the result that we didn't expect.

However, the way the tests are *currently* written, extra files that are not intended to be in the simple response are allowed (and in fact, that was explicitly the point of the change, presumably because some other test leaked state to cause there to be extra files), which is something that we want our tests to ensure doesn't happen.