### PR TITLE
configurable ratelimiting for project creation by user/ip

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,8 +322,10 @@ def user_service(db_session, metrics, remote_addr):
 
 
 @pytest.fixture
-def project_service(db_session, remote_addr):
-    return packaging_services.ProjectService(db_session, remote_addr)
+def project_service(db_session, remote_addr, metrics, ratelimiters=None):
+    return packaging_services.ProjectService(
+        db_session, remote_addr, metrics, ratelimiters=ratelimiters
+    )
 
 
 @pytest.fixture

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -671,7 +671,11 @@ class TestGenericLocalBlobStorage:
 def test_project_service_factory():
     db = pretend.stub()
     remote_addr = pretend.stub()
-    request = pretend.stub(db=db, remote_addr=remote_addr)
+    request = pretend.stub(
+        db=db,
+        remote_addr=remote_addr,
+        find_service=lambda iface, name=None, context=None: None,
+    )
 
     service = project_service_factory(pretend.stub(), request)
     assert service.db == db

--- a/tests/unit/rate_limiting/test_core.py
+++ b/tests/unit/rate_limiting/test_core.py
@@ -159,6 +159,12 @@ class TestRateLimit:
             )
         ]
 
+    def test_repr(self):
+        assert repr(RateLimit("one per hour")) == (
+            'RateLimit("one per hour", identifiers=None, '
+            "limiter_class=<class 'warehouse.rate_limiting.RateLimiter'>)"
+        )
+
     def test_eq(self):
         assert RateLimit("1 per 5 minutes", identifiers=["foo"]) == RateLimit(
             "1 per 5 minutes", identifiers=["foo"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -259,6 +259,8 @@ def test_configure(monkeypatch, settings, environment):
         "warehouse.account.password_reset_ratelimit_string": "5 per day",
         "warehouse.manage.oidc.user_registration_ratelimit_string": "20 per day",
         "warehouse.manage.oidc.ip_registration_ratelimit_string": "20 per day",
+        "warehouse.packaging.project_create_user_ratelimit_string": "20 per hour",
+        "warehouse.packaging.project_create_ip_ratelimit_string": "40 per hour",
         "warehouse.two_factor_requirement.enabled": False,
         "warehouse.two_factor_mandate.available": False,
         "warehouse.two_factor_mandate.enabled": False,

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -299,6 +299,18 @@ def configure(settings=None):
         "IP_OIDC_REGISTRATION_RATELIMIT_STRING",
         default="20 per day",
     )
+    maybe_set(
+        settings,
+        "warehouse.packaging.project_create_user_ratelimit_string",
+        "PROJECT_CREATE_USER_RATELIMIT_STRING",
+        default="20 per hour",
+    )
+    maybe_set(
+        settings,
+        "warehouse.packaging.project_create_ip_ratelimit_string",
+        "PROJECT_CREATE_IP_RATELIMIT_STRING",
+        default="40 per hour",
+    )
 
     # 2FA feature flags
     maybe_set(

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -268,7 +268,7 @@ msgstr ""
 msgid "You can't register more than 3 pending OpenID Connect publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1430 warehouse/manage/views.py:3113
+#: warehouse/accounts/views.py:1430 warehouse/manage/views.py:3116
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
@@ -368,55 +368,55 @@ msgstr ""
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:2015
+#: warehouse/manage/views.py:2018
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:2026
+#: warehouse/manage/views.py:2029
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:2040 warehouse/manage/views.py:4373
+#: warehouse/manage/views.py:2043 warehouse/manage/views.py:4376
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2106 warehouse/manage/views.py:4440
+#: warehouse/manage/views.py:2109 warehouse/manage/views.py:4443
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:2152
+#: warehouse/manage/views.py:2155
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2166 warehouse/manage/views.py:4484
+#: warehouse/manage/views.py:2169 warehouse/manage/views.py:4487
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2208 warehouse/manage/views.py:4517
+#: warehouse/manage/views.py:2211 warehouse/manage/views.py:4520
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views.py:4150
+#: warehouse/manage/views.py:4153
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4258
+#: warehouse/manage/views.py:4261
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4327
+#: warehouse/manage/views.py:4330
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4360
+#: warehouse/manage/views.py:4363
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4473
+#: warehouse/manage/views.py:4476
 msgid "Could not find role invitation."
 msgstr ""
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -1918,7 +1918,10 @@ class ManageOrganizationProjectsViews:
             # created is controlled by the organization and not the user creating it.
             project_service = self.request.find_service(IProjectService)
             project = project_service.create_project(
-                form.new_project_name.data, self.request.user, creator_is_owner=False
+                form.new_project_name.data,
+                self.request.user,
+                creator_is_owner=False,
+                ratelimited=False,
             )
 
         # Add project to organization.

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -109,7 +109,9 @@ def mint_token_from_oidc(request):
         # Create the new project, and reify the pending publisher against it.
         project_service = request.find_service(IProjectService)
         new_project = project_service.create_project(
-            pending_publisher.project_name, pending_publisher.added_by
+            pending_publisher.project_name,
+            pending_publisher.added_by,
+            ratelimited=False,
         )
         oidc_service.reify_pending_publisher(pending_publisher, new_project)
 

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -12,6 +12,12 @@
 
 from zope.interface import Interface
 
+from warehouse.rate_limiting.interfaces import RateLimiterException
+
+
+class TooManyProjectsCreated(RateLimiterException):
+    pass
+
 
 class IGenericFileStorage(Interface):
     def create_service(context, request):

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
+import logging
 import os.path
 import shutil
 import warnings
@@ -22,13 +24,18 @@ import sentry_sdk
 from zope.interface import implementer
 
 from warehouse.events.tags import EventTag
+from warehouse.metrics import IMetricsService
 from warehouse.packaging.interfaces import (
     IDocsStorage,
     IFileStorage,
     IProjectService,
     ISimpleStorage,
+    TooManyProjectsCreated,
 )
 from warehouse.packaging.models import JournalEntry, Project, Role
+from warehouse.rate_limiting import DummyRateLimiter, IRateLimiter
+
+logger = logging.getLogger(__name__)
 
 
 class InsecureStorageWarning(UserWarning):
@@ -259,11 +266,50 @@ class GCSSimpleStorage(GenericGCSBlobStorage):
 
 @implementer(IProjectService)
 class ProjectService:
-    def __init__(self, session, remote_addr) -> None:
+    def __init__(self, session, remote_addr, metrics=None, ratelimiters=None) -> None:
+        if ratelimiters is None:
+            ratelimiters = {}
+
         self.db = session
         self.remote_addr = remote_addr
+        self.ratelimiters = collections.defaultdict(DummyRateLimiter, ratelimiters)
+        self._metrics = metrics
+
+    def _check_ratelimits(self, creator):
+        # First we want to check if a single IP is exceeding our rate limiter.
+        print(self.ratelimiters)
+        if self.remote_addr is not None:
+            if not self.ratelimiters["project.create.ip"].test(self.remote_addr):
+                logger.warning("IP failed project create threshold reached.")
+                self._metrics.increment(
+                    "warehouse.project.create.ratelimited",
+                    tags=["ratelimiter:ip"],
+                )
+                raise TooManyProjectsCreated(
+                    resets_in=self.ratelimiters["project.create.ip"].resets_in(
+                        self.remote_addr
+                    )
+                )
+
+        if not self.ratelimiters["project.create.user"].test(creator.id):
+            logger.warning("User failed project create threshold reached.")
+            self._metrics.increment(
+                "warehouse.project.create.ratelimited",
+                tags=["ratelimiter:user"],
+            )
+            raise TooManyProjectsCreated(
+                resets_in=self.ratelimiters["project.create.user"].resets_in(
+                    self.remote_addr
+                )
+            )
+
+    def _hit_ratelimits(self, creator):
+        self.ratelimiters["project.create.user"].hit(creator.id)
+        self.ratelimiters["project.create.ip"].hit(self.remote_addr)
 
     def create_project(self, name, creator, *, creator_is_owner=True):
+        self._check_ratelimits(creator)
+
         project = Project(name=name)
         self.db.add(project)
 
@@ -308,8 +354,20 @@ class ProjectService:
                 },
             )
 
+        self._hit_ratelimits(creator)
         return project
 
 
 def project_service_factory(context, request):
-    return ProjectService(request.db, request.remote_addr)
+    metrics = request.find_service(IMetricsService, context=None)
+    ratelimiters = {
+        "project.create.user": request.find_service(
+            IRateLimiter, name="project.create.user", context=None
+        ),
+        "project.create.ip": request.find_service(
+            IRateLimiter, name="project.create.ip", context=None
+        ),
+    }
+    return ProjectService(
+        request.db, request.remote_addr, metrics=metrics, ratelimiters=ratelimiters
+    )

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -307,8 +307,9 @@ class ProjectService:
         self.ratelimiters["project.create.user"].hit(creator.id)
         self.ratelimiters["project.create.ip"].hit(self.remote_addr)
 
-    def create_project(self, name, creator, *, creator_is_owner=True):
-        self._check_ratelimits(creator)
+    def create_project(self, name, creator, *, creator_is_owner=True, ratelimited=True):
+        if ratelimited:
+            self._check_ratelimits(creator)
 
         project = Project(name=name)
         self.db.add(project)
@@ -354,7 +355,8 @@ class ProjectService:
                 },
             )
 
-        self._hit_ratelimits(creator)
+        if ratelimited:
+            self._hit_ratelimits(creator)
         return project
 
 

--- a/warehouse/rate_limiting/__init__.py
+++ b/warehouse/rate_limiting/__init__.py
@@ -145,6 +145,12 @@ class RateLimit:
             metrics=request.find_service(IMetricsService, context=None),
         )
 
+    def __repr__(self):
+        return (
+            f'RateLimit("{self.limit}", identifiers={self.identifiers}, '
+            f"limiter_class={self.limiter_class})"
+        )
+
     def __eq__(self, other):
         if not isinstance(other, RateLimit):
             return NotImplemented


### PR DESCRIPTION
This gives us the ability to rate limit *new* project creation.

In general project creation is far less infrequent than uploads, so I think we could tune down the defaults significantly.

example output from twine:

```
ERROR    HTTPError: 429 Too Many Requests from http://localhost/legacy/                                                                 
         Too many new projects created    
```