### PR TITLE
feat(ci): exclude any pulls that are `blocked`

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -71,7 +71,7 @@ jobs:
                     }
                   }
                 }
-                if(${{ github.event.inputs.mustBeUnblocked }}) {
+                if(${{ github.event.inputs.mustBeUnblocked && statusOK }}) {
                   console.log('Checking blocked status: ' + pull['number']);
                   const labels = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/labels', {
                     owner: context.repo.owner,

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -71,7 +71,7 @@ jobs:
                     }
                   }
                 }
-                if(${{ github.event.inputs.mustBeUnblocked && statusOK }}) {
+                if(${{ github.event.inputs.mustBeUnblocked }} && statusOK) {
                   console.log('Checking blocked status: ' + pull['number']);
                   const labels = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/labels', {
                     owner: context.repo.owner,

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -9,6 +9,11 @@ on:
         type: boolean
         required: true
         default: true
+      mustBeUnblocked:
+        description: 'Exclude PRs that have the `blocked` label'
+        type: boolean
+        required: true
+        default: true
       combineBranchName:
         description: 'Name of the branch to combine PRs into'
         type: string
@@ -61,6 +66,24 @@ jobs:
                       console.log('Validating conclusion: ' + latest_conclusion);
                       if(latest_conclusion == 'failure') {
                         console.log('Discarding ' + branch + ' with failed check');
+                        statusOK = false;
+                      }
+                    }
+                  }
+                }
+                if(${{ github.event.inputs.mustBeUnblocked }}) {
+                  console.log('Checking blocked status: ' + pull['number']);
+                  const labels = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/labels', {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pull['number']
+                  });
+                  if(labels.length > 0) {
+                    for (const label of labels) {
+                      const label_name = label['name'];
+                      console.log('Validating label: ' + label_name);
+                      if(label_name == 'blocked') {
+                        console.log('Discarding ' + branch + ' with blocked label on PR');
                         statusOK = false;
                       }
                     }


### PR DESCRIPTION
We currently block dependencies if they fail checks, but we also occasionally apply a `blocked` label to mark a passing PR for exclusion.