### PR TITLE
Add some checkboxes to the "Delete Project" modal

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3318,7 +3318,7 @@ msgstr ""
 
 #: warehouse/templates/manage/manage_base.html:64
 #: warehouse/templates/manage/manage_base.html:78
-#: warehouse/templates/manage/manage_base.html:513
+#: warehouse/templates/manage/manage_base.html:514
 #: warehouse/templates/manage/organization/roles.html:123
 #: warehouse/templates/manage/organization/roles.html:125
 #: warehouse/templates/manage/organization/roles.html:130
@@ -3478,24 +3478,24 @@ msgstr ""
 msgid "Enter your password to continue."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:460
+#: warehouse/templates/manage/manage_base.html:461
 msgid "OpenID Connect Publisher Management"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:465
+#: warehouse/templates/manage/manage_base.html:466
 msgid ""
 "OpenID Connect (OIDC) provides a flexible, credential-free mechanism for "
 "delegating publishing authority for a PyPI package to a third party "
 "service, like GitHub Actions."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:473
+#: warehouse/templates/manage/manage_base.html:474
 msgid ""
 "PyPI users and projects can use trusted publishers to automate their "
 "release processes, without needing to use API tokens or passwords."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:480
+#: warehouse/templates/manage/manage_base.html:481
 #, python-format
 msgid ""
 "You can read more about OpenID Connect and how to use it <a "
@@ -5585,7 +5585,7 @@ msgstr ""
 
 #: warehouse/templates/manage/project/settings.html:147
 #: warehouse/templates/manage/project/settings.html:211
-#: warehouse/templates/manage/project/settings.html:269
+#: warehouse/templates/manage/project/settings.html:275
 msgid "Project Name"
 msgstr ""
 
@@ -5657,7 +5657,7 @@ msgid "You are not an owner or manager of any organizations."
 msgstr ""
 
 #: warehouse/templates/manage/project/settings.html:238
-#: warehouse/templates/manage/project/settings.html:269
+#: warehouse/templates/manage/project/settings.html:275
 msgid "Delete project"
 msgstr ""
 

--- a/warehouse/static/js/warehouse/controllers/delete_confirm_controller.js
+++ b/warehouse/static/js/warehouse/controllers/delete_confirm_controller.js
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = [ "input", "button" ];
+
+  connect() {
+    this.buttonTarget.setAttribute("disabled", "");
+  }
+
+  check() {
+    if (this.inputTargets.every(input => input.checked)) {
+      this.buttonTarget.removeAttribute("disabled");
+    } else {
+      this.buttonTarget.setAttribute("disabled", "");
+    }
+  }
+}

--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -113,6 +113,7 @@
     border-color: darken($background-color, 5%);
     color: darken($background-color, 12%);
     text-decoration: line-through;
+    pointer-events: none;
 
     &:focus,
     &:hover,

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -344,3 +344,8 @@ time {
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
+
+// Class for unstyled lists
+.no-bullets {
+  list-style-type: none;
+}

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -408,10 +408,11 @@
   warning=True,
   confirm_string_in_title=True,
   modifier="--danger",
-  tooltip=None)
+  tooltip=None,
+  additional_attributes=None)
 %}
   {% set slug = confirm_name.lower().replace(' ', '-') + '-modal' %}
-  <a href="#{{ slug }}" class="button button{{ modifier }}" {% if tooltip != None %}title="{{ tooltip }}"{% endif %}>
+  <a href="#{{ slug }}" class="button button{{ modifier }}" {% if tooltip != None %}title="{{ tooltip }}"{% endif %} {{ additional_attributes or '' }}>
     {{ confirm_button_label if confirm_button_label else title }}
   </a>
   {{ confirm_modal(title, label, confirm_name, confirm_string, slug, confirm_button_label=confirm_button_label, extra_fields=extra_fields, extra_description=extra_description, action=action, warning=warning, confirm_string_in_title=confirm_string_in_title, modifier=modifier) }}

--- a/warehouse/templates/manage/project/settings.html
+++ b/warehouse/templates/manage/project/settings.html
@@ -234,7 +234,7 @@
   <hr>
   {% endif %}
 
-  <div class="callout-block callout-block--danger">
+  <div class="callout-block callout-block--danger" data-controller="delete-confirm">
     <h3>{% trans %}Delete project{% endtrans %}</h3>
     <p>
       <i class="fa fa-exclamation-triangle" aria-hidden="true"><span class="sr-only">{% trans %}Warning{% endtrans %}</span></i>
@@ -265,7 +265,13 @@
         </small>
       </li>
     </ul>
+    <ul class="no-bullets">
+      <li><input type="checkbox" data-action="input->delete-confirm#check" data-delete-confirm-target="input"> I understand that I will not be able to re-upload any deleted versions.</li>
+      <li><input type="checkbox" data-action="input->delete-confirm#check" data-delete-confirm-target="input"> I understand that I am permanently deleting all releases for this project.</li>
+      <li><input type="checkbox" data-action="input->delete-confirm#check" data-delete-confirm-target="input"> I understand that I am releasing this project name for use by any other PyPI user.</li>
+      <li><input type="checkbox" data-action="input->delete-confirm#check" data-delete-confirm-target="input"> I understand that I cannot undo this.</li>
+    </ul>
     {% set action = request.route_path('manage.project.delete_project', project_name=project.normalized_name) %}
-    {{ confirm_button(gettext("Delete project"), gettext("Project Name"), "project_name", project.name, action=action) }}
+    {{ confirm_button(gettext("Delete project"), gettext("Project Name"), "project_name", project.name, action=action, additional_attributes="data-delete-confirm-target=button") }}
   </div>
 {% endblock %}


### PR DESCRIPTION
With any luck, this will slow down users who usually blow by the warning text here and then ask us to un-delete.

<img width="812" alt="image" src="https://user-images.githubusercontent.com/294415/222002158-25df7b0e-7a9a-44b6-965e-49f6b11ab29c.png">
