### PR TITLE
refactor(dev): include missing files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,29 +82,19 @@ services:
     command: gunicorn --reload -b 0.0.0.0:8000 warehouse.wsgi:application
     env_file: dev/environment
     volumes:
-      # We specify all of these directories instead of just . because we want to
-      # avoid having ./node_modules from the host OS being shared with the docker
-      # container, and since there's no way to exclude a directory, the only way
-      # to make this work is to share multiple, smaller directories. These cover
-      # the important things that we want to share, but changes to requirements
-      # or any file not in these directories will require a rebuild.
       # The :z option fixes permission issues with SELinux by setting a
       # permissive security context.
-      - ./dev:/opt/warehouse/src/dev:z
-      - ./docs:/opt/warehouse/src/docs:z
-      - ./warehouse:/opt/warehouse/src/warehouse:z
-      - ./tests:/opt/warehouse/src/tests:z
-      - ./htmlcov:/opt/warehouse/src/htmlcov:z
-      - .coveragerc:/opt/warehouse/src/.coveragerc:z
+      - .:/opt/warehouse/src:z
       - packages:/var/opt/warehouse/packages
       - sponsorlogos:/var/opt/warehouse/sponsorlogos
       - policies:/var/opt/warehouse/policies
       - simple:/var/opt/warehouse/simple
-      - ./bin:/opt/warehouse/src/bin:z
-      - ./requirements:/opt/warehouse/src/requirements:z
       - caches:/root/.cache
       - caches:/opt/warehouse/src/.mypy_cache
       - caches:/opt/warehouse/src/.pytest_cache
+      # We want to avoid having ./node_modules from the host OS being shared, so
+      # we mount an anonymous volume instead. Keep anonymous volumes last.
+      - /opt/warehouse/src/node_modules
     ports:
       - "${WEB_PORT:-80}:8000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,19 +82,29 @@ services:
     command: gunicorn --reload -b 0.0.0.0:8000 warehouse.wsgi:application
     env_file: dev/environment
     volumes:
+      # We specify all of these directories instead of just . because we want to
+      # avoid having ./node_modules from the host OS being shared with the docker
+      # container, and since there's no way to exclude a directory, the only way
+      # to make this work is to share multiple, smaller directories. These cover
+      # the important things that we want to share, but changes to requirements
+      # or any file not in these directories will require a rebuild.
       # The :z option fixes permission issues with SELinux by setting a
       # permissive security context.
-      - .:/opt/warehouse/src:z
+      - ./dev:/opt/warehouse/src/dev:z
+      - ./docs:/opt/warehouse/src/docs:z
+      - ./warehouse:/opt/warehouse/src/warehouse:z
+      - ./tests:/opt/warehouse/src/tests:z
+      - ./htmlcov:/opt/warehouse/src/htmlcov:z
+      - .coveragerc:/opt/warehouse/src/.coveragerc:z
       - packages:/var/opt/warehouse/packages
       - sponsorlogos:/var/opt/warehouse/sponsorlogos
       - policies:/var/opt/warehouse/policies
       - simple:/var/opt/warehouse/simple
+      - ./bin:/opt/warehouse/src/bin:z
+      - ./requirements:/opt/warehouse/src/requirements:z
       - caches:/root/.cache
       - caches:/opt/warehouse/src/.mypy_cache
       - caches:/opt/warehouse/src/.pytest_cache
-      # We want to avoid having ./node_modules from the host OS being shared, so
-      # we mount an anonymous volume instead. Keep anonymous volumes last.
-      - /opt/warehouse/src/node_modules
     ports:
       - "${WEB_PORT:-80}:8000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,12 +82,8 @@ services:
     command: gunicorn --reload -b 0.0.0.0:8000 warehouse.wsgi:application
     env_file: dev/environment
     volumes:
-      # We specify all of these directories instead of just . because we want to
-      # avoid having ./node_modules from the host OS being shared with the docker
-      # container, and since there's no way to exclude a directory, the only way
-      # to make this work is to share multiple, smaller directories. These cover
-      # the important things that we want to share, but changes to requirements
-      # or any file not in these directories will require a rebuild.
+      # We specify paths explicitly to only add what we need, and to avoid
+      # adding the entire repository.
       # The :z option fixes permission issues with SELinux by setting a
       # permissive security context.
       - ./dev:/opt/warehouse/src/dev:z
@@ -95,6 +91,7 @@ services:
       - ./warehouse:/opt/warehouse/src/warehouse:z
       - ./tests:/opt/warehouse/src/tests:z
       - ./htmlcov:/opt/warehouse/src/htmlcov:z
+      - ./pyproject.toml:/opt/warehouse/src/pyproject.toml:z
       - .coveragerc:/opt/warehouse/src/.coveragerc:z
       - packages:/var/opt/warehouse/packages
       - sponsorlogos:/var/opt/warehouse/sponsorlogos
@@ -105,6 +102,9 @@ services:
       - caches:/root/.cache
       - caches:/opt/warehouse/src/.mypy_cache
       - caches:/opt/warehouse/src/.pytest_cache
+      # Included to support linters during development
+      - ./gunicorn-prod.conf.py:/opt/warehouse/src/gunicorn-prod.conf.py:z
+      - ./gunicorn-uploads.conf.py:/opt/warehouse/src/gunicorn-uploads.conf.py:z
     ports:
       - "${WEB_PORT:-80}:8000"
     depends_on:


### PR DESCRIPTION
When modifying `pyproject.toml` the changes are not included unless a full rebuild is run.

I could have added another entry for the specific file, however I figured it was better to take advantage of anonymous volumes and be explicit about the behavior we want to prevent instead.