### PR TITLE
Compose gardening

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ volumes:
 
 services:
   vault:
-    # NOTE: intentionally an older version, for consistency with cabotage
-    image: vault:1.3.4
+    # NOTE: pinned for consistency with whats available in our deployment
+    image: vault:1.12.3
     restart: on-failure
     entrypoint: /bin/sh
     command: ["/etc/vault/entry.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       interval: 1s
 
   stripe:
-    image: stripe/stripe-mock:v0.140.0
+    image: stripe/stripe-mock:v0.152.0
     ports:
       - "12111:12111"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
         DEVEL: "yes"
         IPYTHON: "no"
     image: warehouse:docker-compose
-    command: gunicorn --reload -b 0.0.0.0:8000 warehouse.wsgi:application
+    command: gunicorn --reload -b 0.0.0.0:8000 --access-logfile - --error-logfile - warehouse.wsgi:application
     env_file: dev/environment
     volumes:
       # We specify paths explicitly to only add what we need, and to avoid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,12 +46,13 @@ services:
     image: redis:4.0
 
   localstack:
-    image: localstack/localstack:0.12.19.1
+    image: localstack/localstack:1.4
     environment:
       SERVICES: "sqs"
       HOSTNAME: "localstack"
       HOSTNAME_EXTERNAL: "localstack"
       DEFAULT_REGION: "us-east-2"
+      LS_LOG: "error"
     ports:
       - "4566:4566"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       args:
         DEVEL: "yes"
         IPYTHON: "no"
+    image: warehouse:docker-compose
     command: gunicorn --reload -b 0.0.0.0:8000 warehouse.wsgi:application
     env_file: dev/environment
     volumes:
@@ -118,8 +119,7 @@ services:
         condition: service_started
 
   files:
-    build:
-      context: .
+    image: warehouse:docker-compose
     working_dir: /var/opt/warehouse
     command: python -m http.server 9001
     volumes:
@@ -128,12 +128,10 @@ services:
       - simple:/var/opt/warehouse/simple
     ports:
       - "9001:9001"
+    depends_on: [web]
 
   worker:
-    build:
-      context: .
-      args:
-        DEVEL: "yes"
+    image: warehouse:docker-compose
     command: hupper -m celery -A warehouse worker -B -S redbeat.RedBeatScheduler -l info
     volumes:
       - ./warehouse:/opt/warehouse/src/warehouse:z
@@ -142,11 +140,13 @@ services:
       C_FORCE_ROOT: "1"
       FILES_BACKEND: "warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files:9001/packages/{path}"
       SIMPLE_BACKEND: "warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://files:9001/simple/{path}"
+    depends_on: [web]
 
   static:
     build:
       context: .
       target: static-deps
+    image: warehouse:docker-compose-static
     environment:
       NODE_ENV: "development"
     command: bash -c "npm run watch"
@@ -166,10 +166,7 @@ services:
       - "1025:1025"
 
   notdatadog:
-    build:
-      context: .
-      args:
-        DEVEL: "yes"
+    image: warehouse:docker-compose
     command: python /opt/warehouse/dev/notdatadog.py 0.0.0.0:8125
     environment:
       METRICS_OUTPUT: "false"
@@ -177,6 +174,7 @@ services:
       - "8125:8125/udp"
     volumes:
       - ./dev/notdatadog.py:/opt/warehouse/dev/notdatadog.py
+    depends_on: [web]
 
   notgithub:
     image: ewjoachim/notgithub-token-scanning

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,12 +67,14 @@ services:
         hard: 65536
 
   camo:
-    image: pypa/warehouse-camo:latest
+    image: pypa/warehouse-camo:2.0.0
+    command: /bin/go-camo --listen=0.0.0.0:9000
     ports:
       - "9000:9000"
     environment:
-      CAMO_KEY: "insecurecamokey"
-      PORT: 9000
+      GOCAMO_HMAC: "insecurecamokey"
+      GOCAMO_MAXSIZE: 10000
+      GOCAMO_MAXSIZEREDIRECT: "https://warehouse-camo.ingress.cmh1.psfhosted.org/d1e139dd79d95783a48690c79813071314e45a69/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f707970692d6173736574732f696d6167652d746f6f2d6c617267652d31306d622e706e67"
 
   web:
     build:


### PR DESCRIPTION
- biggest win: share built image from web with all the others
- upgrade to latest localstack image (adds arm64 support)
- update to latest vault
- update stripe-mock (hoping for arm64 support, but no dice https://github.com/stripe/stripe-mock/pull/380)
- update to use our new go-camo image
- log access/error from gunicorn to stdout