### PR TITLE
style: brighten and make icon visible on all platforms

### DIFF
--- a/warehouse/static/sass/blocks/_notification-bar.scss
+++ b/warehouse/static/sass/blocks/_notification-bar.scss
@@ -113,6 +113,7 @@
   &__dismiss {
     @include dismiss-button;
     @include link-focus-state($white);
+    color: $white;
   }
 
   // Indicates that a notification is dismissable.


### PR DESCRIPTION
Instead of leaving the color up to the platform, set out desired color explicitly.

Chose `$white` to match the rest of the text in the bar.

Resolves #13138