### PR TITLE
warehouse, tests: OIDC audience retrieval route

### DIFF
--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -46,6 +46,35 @@ def test_ratelimiters():
 @pytest.mark.parametrize(
     ("registry", "admin"), [(False, False), (False, True), (True, True)]
 )
+def test_oidc_audience_not_enabled(registry, admin):
+    request = pretend.stub(
+        registry=pretend.stub(settings={"warehouse.oidc.enabled": registry}),
+        flags=pretend.stub(enabled=lambda *a: admin),
+    )
+
+    response = views.oidc_audience(request)
+    assert response.status_code == 403
+    assert response.json == {"message": "OIDC functionality not enabled"}
+
+
+def test_oidc_audience():
+    request = pretend.stub(
+        registry=pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "warehouse.oidc.audience": "fakeaudience",
+            }
+        ),
+        flags=pretend.stub(enabled=lambda *a: False),
+    )
+
+    response = views.oidc_audience(request)
+    assert response == {"audience": "fakeaudience"}
+
+
+@pytest.mark.parametrize(
+    ("registry", "admin"), [(False, False), (False, True), (True, True)]
+)
 def test_mint_token_from_oidc_not_enabled(registry, admin):
     request = pretend.stub(
         response=pretend.stub(status=None),

--- a/warehouse/oidc/__init__.py
+++ b/warehouse/oidc/__init__.py
@@ -34,4 +34,5 @@ def includeme(config):
     # to simplify caching exclusion.
     auth = config.get_settings().get("auth.domain")
 
-    config.add_route("oidc.mint_token", "/_/oidc/github/mint-token", domain=auth)
+    config.add_route("oidc.audience", "/_/oidc/audience", domain=auth)
+    config.add_route("oidc.github.mint_token", "/_/oidc/github/mint-token", domain=auth)

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -13,6 +13,7 @@
 import time
 
 from pydantic import BaseModel, StrictStr, ValidationError
+from pyramid.response import Response
 from pyramid.view import view_config
 from sqlalchemy import func
 
@@ -44,7 +45,26 @@ def _ratelimiters(request):
 
 
 @view_config(
-    route_name="oidc.mint_token",
+    route_name="oidc.audience",
+    require_methods=["GET"],
+    renderer="json",
+    require_csrf=False,
+    has_translations=False,
+)
+def oidc_audience(request):
+    oidc_enabled = request.registry.settings[
+        "warehouse.oidc.enabled"
+    ] and not request.flags.enabled(AdminFlagValue.DISALLOW_OIDC)
+
+    if not oidc_enabled:
+        return Response(status=403, json={"message": "OIDC functionality not enabled"})
+
+    audience = request.registry.settings["warehouse.oidc.audience"]
+    return {"audience": audience}
+
+
+@view_config(
+    route_name="oidc.github.mint_token",
     require_methods=["POST"],
     renderer="json",
     require_csrf=False,


### PR DESCRIPTION
GETing this route returns a basic JSON payload containing just the Warehouse instance's expected OIDC audience.

An instance where OIDC has been disabled returns `403` instead. Other instances (i.e. ones that don't support OIDC) are expected to return 404, since they shouldn't have this route at all.

Closes #13141.