### PR TITLE
OIDC: Fix JWT decode key type

### DIFF
--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -75,8 +75,9 @@ class TestOIDCPublisherService:
         token = pretend.stub()
         decoded = pretend.stub()
         jwt = pretend.stub(decode=pretend.call_recorder(lambda t, **kwargs: decoded))
+        key = pretend.stub(key="fake-key")
         monkeypatch.setattr(
-            service, "_get_key_for_token", pretend.call_recorder(lambda t: "fake-key")
+            service, "_get_key_for_token", pretend.call_recorder(lambda t: key)
         )
         monkeypatch.setattr(services, "jwt", jwt)
 
@@ -84,7 +85,7 @@ class TestOIDCPublisherService:
         assert jwt.decode.calls == [
             pretend.call(
                 token,
-                key="fake-key",
+                key=key.key,
                 algorithms=["RS256"],
                 options=dict(
                     verify_signature=True,

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -227,7 +227,7 @@ class OIDCPublisherService:
             # set them explicitly to assert the intended verification behavior.
             signed_payload = jwt.decode(
                 unverified_token,
-                key=key,
+                key=key.key,
                 algorithms=["RS256"],
                 options=dict(
                     verify_signature=True,


### PR DESCRIPTION
We've been passing in the `PyJWK` directly, when `pyjwt.decode(...)` doesn't support that -- it only supports PEM-encoded `str` or `bytes` objects, *or* a pre-constructed `cryptography` key type (like `_RSAPublicKey` from the OpenSSL backend).

The latter isn't included in the public type hints, but it's included in the library's official documentation.

xref https://github.com/jpadilla/pyjwt/issues/864