### PR TITLE
oidc/models: unchecked claims, fix `sub` check

### DIFF
--- a/tests/unit/oidc/test_models.py
+++ b/tests/unit/oidc/test_models.py
@@ -215,13 +215,6 @@ class TestGitHubPublisher:
         assert check(publisher.job_workflow_ref, claim, {"ref": ref}) is valid
 
     def test_github_publisher_sub_claim(self):
-        publisher = models.GitHubPublisher(
-            repository_name="bar",
-            repository_owner="foo",
-            repository_owner_id=pretend.stub(),
-            workflow_filename="baz.yml",
-        )
-
         check = models.GitHubPublisher.__verifiable_claims__["sub"]
         assert check("repo:foo/bar", "repo:foo/bar:someotherstuff", pretend.stub())
         assert not check("repo:foo/bar:someotherstuff", "repo:foo/bar", pretend.stub())

--- a/tests/unit/oidc/test_models.py
+++ b/tests/unit/oidc/test_models.py
@@ -217,7 +217,10 @@ class TestGitHubPublisher:
     def test_github_publisher_sub_claim(self):
         check = models.GitHubPublisher.__verifiable_claims__["sub"]
         assert check("repo:foo/bar", "repo:foo/bar:someotherstuff", pretend.stub())
+        assert check("repo:foo/bar", "repo:foo/bar:", pretend.stub())
         assert not check("repo:foo/bar:someotherstuff", "repo:foo/bar", pretend.stub())
+        assert not check("repo:foo/bar-baz", "repo:foo/bar", pretend.stub())
+        assert not check("repo:foo/bar", "repo:foo/bar-baz", pretend.stub())
 
 
 class TestPendingGitHubPublisher:

--- a/tests/unit/oidc/test_models.py
+++ b/tests/unit/oidc/test_models.py
@@ -24,6 +24,15 @@ def test_check_claim_binary():
     assert wrapped("foo", "foo", pretend.stub()) is True
 
 
+def test_check_sub():
+    # Empty claims always fail.
+    assert models._check_sub(pretend.stub(), "", pretend.stub()) is False
+
+    # Malformed claims always fail.
+    assert models._check_sub(pretend.stub(), "repo", pretend.stub()) is False
+    assert models._check_sub(pretend.stub(), "repo:", pretend.stub()) is False
+
+
 class TestOIDCPublisher:
     def test_oidc_publisher_not_default_verifiable(self):
         publisher = models.OIDCPublisher(projects=[])

--- a/tests/unit/oidc/test_models.py
+++ b/tests/unit/oidc/test_models.py
@@ -35,6 +35,7 @@ class TestGitHubPublisher:
     def test_github_publisher_all_known_claims(self):
         assert models.GitHubPublisher.all_known_claims() == {
             # verifiable claims
+            "sub",
             "repository",
             "repository_owner",
             "repository_owner_id",
@@ -49,7 +50,6 @@ class TestGitHubPublisher:
             "actor",
             "actor_id",
             "jti",
-            "sub",
             "ref",
             "sha",
             "run_id",
@@ -61,6 +61,11 @@ class TestGitHubPublisher:
             "ref_type",
             "repository_id",
             "workflow",
+            "repository_visibility",
+            "workflow_sha",
+            "job_workflow_sha",
+            "workflow_ref",
+            "runner_environment",
         }
 
     def test_github_publisher_computed_properties(self):
@@ -208,6 +213,18 @@ class TestGitHubPublisher:
 
         check = models.GitHubPublisher.__verifiable_claims__["job_workflow_ref"]
         assert check(publisher.job_workflow_ref, claim, {"ref": ref}) is valid
+
+    def test_github_publisher_sub_claim(self):
+        publisher = models.GitHubPublisher(
+            repository_name="bar",
+            repository_owner="foo",
+            repository_owner_id=pretend.stub(),
+            workflow_filename="baz.yml",
+        )
+
+        check = models.GitHubPublisher.__verifiable_claims__["sub"]
+        assert check("repo:foo/bar", "repo:foo/bar:someotherstuff", pretend.stub())
+        assert not check("repo:foo/bar:someotherstuff", "repo:foo/bar", pretend.stub())
 
 
 class TestPendingGitHubPublisher:

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -57,6 +57,25 @@ def _check_job_workflow_ref(ground_truth, signed_claim, all_signed_claims):
     return f"{ground_truth}@{ref}" == signed_claim
 
 
+def _check_sub(ground_truth, signed_claim, _all_signed_claims):
+    # We expect a string formatted as follows:
+    #  repo:ORG/REPO[:OPTIONAL-STUFF]
+    # where :OPTIONAL-STUFF is a concatenation of other job context
+    # metadata. We currently lack the ground context to verify that
+    # additional metadata, so we limit our verification to just the ORG/REPO
+    # component.
+
+    # Defensive: GitHub should never give us an empty subject.
+    if not signed_claim:
+        return False
+
+    components = signed_claim.split(":")
+    if len(components) < 2:
+        return False
+
+    return f"{components[0]}:{components[1]}" == ground_truth
+
+
 class OIDCPublisherProjectAssociation(db.Model):
     __tablename__ = "oidc_publisher_project_association"
 
@@ -221,10 +240,7 @@ class GitHubPublisherMixin:
     workflow_filename = Column(String)
 
     __verifiable_claims__ = {
-        # NOTE: `sub` looks like `repo:org/name`, with some optional suffixes.
-        # We don't have the context to check those suffixes, so we check that
-        # the `repo:org/name` prefix matches.
-        "sub": _check_claim_binary(lambda truth, claim: claim.startswith(truth)),
+        "sub": _check_sub,
         "repository": _check_claim_binary(str.__eq__),
         "repository_owner": _check_claim_binary(str.__eq__),
         "repository_owner_id": _check_claim_binary(str.__eq__),

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -221,7 +221,7 @@ class GitHubPublisherMixin:
     workflow_filename = Column(String)
 
     __verifiable_claims__ = {
-        "sub": _check_claim_binary(str.__eq__),
+        "sub": _check_claim_binary(str.startswith),
         "repository": _check_claim_binary(str.__eq__),
         "repository_owner": _check_claim_binary(str.__eq__),
         "repository_owner_id": _check_claim_binary(str.__eq__),
@@ -243,6 +243,11 @@ class GitHubPublisherMixin:
         "ref_type",
         "repository_id",
         "workflow",
+        "repository_visibility",
+        "workflow_sha",
+        "job_workflow_sha",
+        "workflow_ref",
+        "runner_environment",
     }
 
     @property

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -221,7 +221,10 @@ class GitHubPublisherMixin:
     workflow_filename = Column(String)
 
     __verifiable_claims__ = {
-        "sub": _check_claim_binary(str.startswith),
+        # NOTE: `sub` looks like `repo:org/name`, with some optional suffixes.
+        # We don't have the context to check those suffixes, so we check that
+        # the `repo:org/name` prefix matches.
+        "sub": _check_claim_binary(lambda truth, claim: claim.startswith(truth)),
         "repository": _check_claim_binary(str.__eq__),
         "repository_owner": _check_claim_binary(str.__eq__),
         "repository_owner_id": _check_claim_binary(str.__eq__),


### PR DESCRIPTION
Per https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims: the `sub` claim is not always just `repo:org/repo`, but sometimes has additional suffixes (e.g. for branch names, PR events, environments, etc.). 

We don't currently check any of those, so we can relax the `sub` check to just the `repo:org/repo` prefix. This doesn't change the security model, since `repository` and `repository_owner` are already checked independently as separate claims.