### PR TITLE
fix: use `.key` to capture the logical keypress

### DIFF
--- a/warehouse/static/js/warehouse/controllers/search_focus_controller.js
+++ b/warehouse/static/js/warehouse/controllers/search_focus_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
   focusSearchField(event) {
     // When we receive a keydown event, check if it's `/` and that we're not
     // already focused on the search field, or any other input field.
-    if (event.code === "Slash" && event.target.tagName !== "INPUT") {
+    if (event.key === "/" && event.target.tagName !== "INPUT") {
       // Prevent the key from being handled as an actual input
       event.preventDefault();
       this.searchFieldTarget.focus();


### PR DESCRIPTION
The `.code` method maps to physical keys on a keyboard, and different layouts may place them somewhere else.

See: https://github.com/pypi/warehouse/issues/3462#issuecomment-1458672380