### PR TITLE
tests, warehouse: drop Macaroon desc length DB constraint

### DIFF
--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
 import json
 
 import pretend
@@ -438,7 +439,7 @@ def test_mint_token_from_oidc_no_pending_publisher_ok(monkeypatch):
     assert macaroon_service.create_macaroon.calls == [
         pretend.call(
             "fakedomain",
-            "OpenID token: https://fake/url (0)",
+            f"OpenID token: https://fake/url ({datetime.fromtimestamp(0).isoformat()})",
             [
                 caveats.OIDCPublisher(oidc_publisher_id="fakepublisherid"),
                 caveats.ProjectID(project_ids=["fakeprojectid"]),

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -438,7 +438,7 @@ def test_mint_token_from_oidc_no_pending_publisher_ok(monkeypatch):
     assert macaroon_service.create_macaroon.calls == [
         pretend.call(
             "fakedomain",
-            "OpenID (fakepublishername) (0)",
+            "OpenID token: https://fake/url (0)",
             [
                 caveats.OIDCPublisher(oidc_publisher_id="fakepublisherid"),
                 caveats.ProjectID(project_ids=["fakeprojectid"]),

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -10,8 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
 import json
+
+from datetime import datetime
 
 import pretend
 import pytest

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -438,7 +438,7 @@ def test_mint_token_from_oidc_no_pending_publisher_ok(monkeypatch):
     assert macaroon_service.create_macaroon.calls == [
         pretend.call(
             "fakedomain",
-            "OpenID token: https://fake/url (0)",
+            "OpenID (fakepublishername) (0)",
             [
                 caveats.OIDCPublisher(oidc_publisher_id="fakepublisherid"),
                 caveats.ProjectID(project_ids=["fakeprojectid"]),

--- a/warehouse/macaroons/models.py
+++ b/warehouse/macaroons/models.py
@@ -61,7 +61,7 @@ class Macaroon(db.Model):
 
     # Store some information about the Macaroon to give users some mechanism
     # to differentiate between them.
-    description = Column(String(256), nullable=False)
+    description = Column(String, nullable=False)
     created = Column(DateTime, nullable=False, server_default=sql.func.now())
     last_used = Column(DateTime, nullable=True)
 

--- a/warehouse/macaroons/models.py
+++ b/warehouse/macaroons/models.py
@@ -61,7 +61,7 @@ class Macaroon(db.Model):
 
     # Store some information about the Macaroon to give users some mechanism
     # to differentiate between them.
-    description = Column(String(100), nullable=False)
+    description = Column(String(256), nullable=False)
     created = Column(DateTime, nullable=False, server_default=sql.func.now())
     last_used = Column(DateTime, nullable=True)
 

--- a/warehouse/migrations/versions/eb736cb3236d_drop_macaroon_description_limit.py
+++ b/warehouse/migrations/versions/eb736cb3236d_drop_macaroon_description_limit.py
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Drop Macaroon description limit
+
+Revision ID: eb736cb3236d
+Revises: cc06bd67a61b
+Create Date: 2023-03-07 21:29:53.314390
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "eb736cb3236d"
+down_revision = "cc06bd67a61b"
+
+
+def upgrade():
+    op.alter_column(
+        "macaroons",
+        "description",
+        existing_type=sa.VARCHAR(length=100),
+        type_=sa.String(),
+        existing_nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "macaroons",
+        "description",
+        existing_type=sa.String(),
+        type_=sa.VARCHAR(length=100),
+        existing_nullable=False,
+    )

--- a/warehouse/migrations/versions/eb736cb3236d_drop_macaroon_description_limit.py
+++ b/warehouse/migrations/versions/eb736cb3236d_drop_macaroon_description_limit.py
@@ -36,10 +36,4 @@ def upgrade():
 
 
 def downgrade():
-    op.alter_column(
-        "macaroons",
-        "description",
-        existing_type=sa.String(),
-        type_=sa.VARCHAR(length=100),
-        existing_nullable=False,
-    )
+    raise RuntimeError("Order No. 227 - Ни шагу назад!")

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -184,7 +184,7 @@ def mint_token_from_oidc(request):
     expires_at = not_before + 900
     serialized, dm = macaroon_service.create_macaroon(
         request.domain,
-        f"OpenID token: {publisher.publisher_url} ({not_before})",
+        f"OpenID ({publisher.publisher_name}) ({not_before})",
         [
             caveats.OIDCPublisher(oidc_publisher_id=str(publisher.id)),
             caveats.ProjectID(project_ids=[str(p.id) for p in publisher.projects]),

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -10,8 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
 import time
+
+from datetime import datetime
 
 from pydantic import BaseModel, StrictStr, ValidationError
 from pyramid.response import Response

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
 import time
 
 from pydantic import BaseModel, StrictStr, ValidationError
@@ -184,7 +185,10 @@ def mint_token_from_oidc(request):
     expires_at = not_before + 900
     serialized, dm = macaroon_service.create_macaroon(
         request.domain,
-        f"OpenID token: {publisher.publisher_url} ({not_before})",
+        (
+            f"OpenID token: {publisher.publisher_url} "
+            f"({datetime.fromtimestamp(not_before).isoformat()})"
+        ),
         [
             caveats.OIDCPublisher(oidc_publisher_id=str(publisher.id)),
             caveats.ProjectID(project_ids=[str(p.id) for p in publisher.projects]),

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -184,7 +184,7 @@ def mint_token_from_oidc(request):
     expires_at = not_before + 900
     serialized, dm = macaroon_service.create_macaroon(
         request.domain,
-        f"OpenID ({publisher.publisher_name}) ({not_before})",
+        f"OpenID token: {publisher.publisher_url} ({not_before})",
         [
             caveats.OIDCPublisher(oidc_publisher_id=str(publisher.id)),
             caveats.ProjectID(project_ids=[str(p.id) for p in publisher.projects]),


### PR DESCRIPTION
This is still enforced at the form validation layer, but isn't relevant for Macaroons we create explicitly (e.g. via OIDC).