### PR TITLE
Audit/comment all uses of db.flush() and session.flush()

### DIFF
--- a/bin/flushes
+++ b/bin/flushes
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+EXIT_CODE=0
+
+MISSING_COMMENTS=$(egrep -nr 'db.flush()|session.flush()' ./warehouse | grep -v '  #.*$')
+if [ $? -ne 1 ]; then
+  echo "Missing comments for use of flush():"
+  echo "$MISSING_COMMENTS"
+  echo ""
+  cat <<EOF
+Use of flush() is _often_ unnecessary and should be annotated with a comment:
+
+    my_object = MyObject(
+        name=name,
+        display_name=display_name,
+    )
+    self.db.add(my_object)
+    self.db.flush()  # flush the db now so my_object.id is available
+    method_that_depends_on_id(my_object)
+
+is a common pattern when auto-generated ids are needed.
+
+Parts of the warehouse codebase (namely our cache_key/purge_key machinery)
+react to flushes and may have unintended side-effects as a result of calls to
+flush().
+
+EOF
+  EXIT_CODE=1
+fi
+
+exit $EXIT_CODE

--- a/bin/lint
+++ b/bin/lint
@@ -12,6 +12,7 @@ set -x
 
 # Actually run our tests.
 find . -name '*.py' -exec python -m pyupgrade --py311-plus {} +
+./bin/flushes
 python -m flake8 .
 python -m black --check *.py warehouse/ tests/
 python -m isort --check *.py warehouse/ tests/

--- a/tests/unit/organizations/test_services.py
+++ b/tests/unit/organizations/test_services.py
@@ -304,6 +304,7 @@ class TestDatabaseOrganizationService:
         organization_invite = OrganizationInvitationFactory.create()
 
         organization_service.delete_organization_invite(organization_invite.id)
+        organization_service.db.flush()
 
         assert (
             organization_service.get_organization_invite(organization_invite.id) is None
@@ -387,6 +388,7 @@ class TestDatabaseOrganizationService:
         db_organization = organization_service.get_organization(organization.id)
         assert db_organization.name == "some_new_name"
 
+        organization_service.db.flush()
         assert (
             db_request.db.query(OrganizationNameCatalog)
             .filter(
@@ -413,6 +415,7 @@ class TestDatabaseOrganizationService:
         assert db_organization.display_name == "Some New Name"
         assert db_organization.orgtype == OrganizationType.Company
 
+        organization_service.db.flush()
         assert (
             db_request.db.query(OrganizationNameCatalog)
             .filter(
@@ -667,6 +670,7 @@ class TestDatabaseOrganizationService:
         team_role_id = team_role.id
 
         organization_service.delete_team_role(team_role.id)
+        organization_service.db.flush()
         assert organization_service.get_team_role(team_role_id) is None
 
     def test_get_team_project_role(self, organization_service):

--- a/tests/unit/subscriptions/test_services.py
+++ b/tests/unit/subscriptions/test_services.py
@@ -507,6 +507,7 @@ class TestStripeSubscriptionService:
         )
 
         subscription_service.delete_subscription(subscription.id)
+        subscription_service.db.flush()
 
         assert subscription_service.get_subscription(subscription.id) is None
         assert not (
@@ -647,6 +648,7 @@ class TestStripeSubscriptionService:
         subscription_product = StripeSubscriptionProductFactory.create()
 
         subscription_service.delete_subscription_product(subscription_product.id)
+        subscription_service.db.flush()
 
         assert (
             subscription_service.get_subscription_product(subscription_product.id)
@@ -730,6 +732,7 @@ class TestStripeSubscriptionService:
         assert db_request.db.query(StripeSubscriptionPrice).get(subscription_price.id)
 
         subscription_service.delete_subscription_price(subscription_price.id)
+        subscription_service.db.flush()
 
         assert not (
             db_request.db.query(StripeSubscriptionPrice).get(subscription_price.id)

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -589,8 +589,6 @@ class DatabaseUserService:
         for recovery_code in recovery_codes:
             self.db.add(RecoveryCode(user=user, code=self.hasher.hash(recovery_code)))
 
-        self.db.flush()
-
         return recovery_codes
 
     def check_recovery_code(self, user_id, code):
@@ -613,7 +611,6 @@ class DatabaseUserService:
 
         # The code is valid and not burned. Mark it as burned
         stored_recovery_code.burned = datetime.datetime.now()
-        self.db.flush()
         self._metrics.increment("warehouse.authentication.recovery_code.ok")
         return True
 

--- a/warehouse/admin/views/prohibited_project_names.py
+++ b/warehouse/admin/views/prohibited_project_names.py
@@ -199,7 +199,7 @@ def release_prohibited_project_name(request):
         f"{project.name!r} released to {user.username!r}.", queue="success"
     )
 
-    request.db.flush()
+    request.db.flush()  # flush db now so project.normalized_name is available
 
     return HTTPSeeOther(
         request.route_path("admin.project.detail", project_name=project.normalized_name)

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -122,6 +122,5 @@ class HasEvents:
             additional=additional,
         )
         session.add(event)
-        session.flush()
 
         return event

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1387,10 +1387,7 @@ def file_upload(request):
                 },
             )
 
-    # We are flushing the database requests so that we
-    # can access the server default values when initiating celery
-    # tasks.
-    request.db.flush()
+    request.db.flush()  # flush db now so server default values are populated for celery
 
     # Push updates to BigQuery
     dist_metadata = {

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -268,7 +268,7 @@ msgstr ""
 msgid "You can't register more than 3 pending OpenID Connect publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1438 warehouse/manage/views.py:3125
+#: warehouse/accounts/views.py:1438 warehouse/manage/views.py:3124
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
@@ -378,45 +378,45 @@ msgid ""
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views.py:2043 warehouse/manage/views.py:4391
+#: warehouse/manage/views.py:2043 warehouse/manage/views.py:4390
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:2109 warehouse/manage/views.py:4458
+#: warehouse/manage/views.py:2108 warehouse/manage/views.py:4456
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:2155
+#: warehouse/manage/views.py:2154
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2169 warehouse/manage/views.py:4502
+#: warehouse/manage/views.py:2168 warehouse/manage/views.py:4500
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2211 warehouse/manage/views.py:4535
+#: warehouse/manage/views.py:2210 warehouse/manage/views.py:4533
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views.py:4168
+#: warehouse/manage/views.py:4167
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4276
+#: warehouse/manage/views.py:4275
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4345
+#: warehouse/manage/views.py:4344
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views.py:4378
+#: warehouse/manage/views.py:4377
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:4491
+#: warehouse/manage/views.py:4489
 msgid "Could not find role invitation."
 msgstr ""
 

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -172,7 +172,7 @@ class DatabaseMacaroonService:
             permissions_caveat={"permissions": permissions},
         )
         self.db.add(dm)
-        self.db.flush()
+        self.db.flush()  # flush db now so dm.id is available
 
         m = pymacaroons.Macaroon(
             location=location,
@@ -191,7 +191,6 @@ class DatabaseMacaroonService:
         """
         dm = self.find_macaroon(macaroon_id)
         self.db.delete(dm)
-        self.db.flush()
 
     def get_macaroon_by_description(self, user_id, description):
         """

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -525,7 +525,7 @@ class ManageAccountViews:
                 tag=EventTag.Account.PasswordChange,
             )
             send_password_change_email(self.request, self.request.user)
-            self.request.db.flush()  # Ensure changes are persisted to DB
+            self.request.db.flush()  # ensure password_date is available
             self.request.db.refresh(self.request.user)  # Pickup new password_date
             self.request.session.record_password_timestamp(
                 self.user_service.get_password_timestamp(self.request.user.id)
@@ -2084,7 +2084,6 @@ def manage_organization_roles(
                     "role_name": role_name.value,
                 },
             )
-            request.db.flush()  # in order to get id
             owner_users = set(organization_owners(request, organization))
             send_organization_member_invited_email(
                 request,
@@ -4453,7 +4452,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                     "role_name": role_name,
                 },
             )
-            request.db.flush()  # in order to get id
             request.session.flash(
                 request._(
                     "Invitation sent to '${username}'",

--- a/warehouse/organizations/services.py
+++ b/warehouse/organizations/services.py
@@ -119,7 +119,7 @@ class DatabaseOrganizationService:
             description=description,
         )
         self.db.add(organization)
-        self.db.flush()
+        self.db.flush()  # flush the db now so organization.id is available
 
         self.add_catalog_entry(organization.id)
 
@@ -147,7 +147,6 @@ class DatabaseOrganizationService:
             )
         except NoResultFound:
             self.db.add(catalog_entry)
-            self.db.flush()
 
         return catalog_entry
 
@@ -198,7 +197,6 @@ class DatabaseOrganizationService:
         )
 
         self.db.add(role)
-        self.db.flush()
 
         return role
 
@@ -209,7 +207,6 @@ class DatabaseOrganizationService:
         role = self.get_organization_role(organization_role_id)
 
         self.db.delete(role)
-        self.db.flush()
 
     def get_organization_invite(self, organization_invite_id):
         """
@@ -274,7 +271,6 @@ class DatabaseOrganizationService:
         )
 
         self.db.add(organization_invite)
-        self.db.flush()
 
         return organization_invite
 
@@ -285,7 +281,6 @@ class DatabaseOrganizationService:
         organization_invite = self.get_organization_invite(organization_invite_id)
 
         self.db.delete(organization_invite)
-        self.db.flush()
 
     def approve_organization(self, organization_id):
         """
@@ -295,7 +290,6 @@ class DatabaseOrganizationService:
         organization.is_active = True
         organization.is_approved = True
         organization.date_approved = datetime.datetime.now()
-        # self.db.flush()
 
         return organization
 
@@ -307,7 +301,6 @@ class DatabaseOrganizationService:
         organization.is_active = False
         organization.is_approved = False
         organization.date_approved = datetime.datetime.now()
-        # self.db.flush()
 
         return organization
 
@@ -352,17 +345,15 @@ class DatabaseOrganizationService:
         self.delete_teams_by_organization(organization_id)
         # Delete organization
         self.db.delete(organization)
-        self.db.flush()
 
     def rename_organization(self, organization_id, name):
         """
         Performs operations necessary to rename an Organization
         """
         organization = self.get_organization(organization_id)
-
         organization.name = name
-        self.db.flush()
 
+        self.db.flush()  # flush db now so organization.normalized_name available
         self.add_catalog_entry(organization_id)
 
         return organization
@@ -405,7 +396,6 @@ class DatabaseOrganizationService:
         )
 
         self.db.add(organization_project)
-        self.db.flush()
 
         return organization_project
 
@@ -418,7 +408,6 @@ class DatabaseOrganizationService:
         )
 
         self.db.delete(organization_project)
-        self.db.flush()
 
     def get_organization_subscription(self, organization_id, subscription_id):
         """
@@ -444,7 +433,6 @@ class DatabaseOrganizationService:
         )
 
         self.db.add(organization_subscription)
-        self.db.flush()
 
         return organization_subscription
 
@@ -457,7 +445,6 @@ class DatabaseOrganizationService:
         )
 
         self.db.delete(organization_subscription)
-        self.db.flush()
 
     def get_organization_stripe_customer(self, organization_id):
         """
@@ -482,7 +469,6 @@ class DatabaseOrganizationService:
         )
 
         self.db.add(organization_stripe_customer)
-        self.db.flush()
 
         return organization_stripe_customer
 
@@ -540,7 +526,6 @@ class DatabaseOrganizationService:
             organization_id=organization_id,
         )
         self.db.add(team)
-        self.db.flush()
 
         return team
 
@@ -551,7 +536,6 @@ class DatabaseOrganizationService:
         team = self.get_team(team_id)
 
         team.name = name
-        self.db.flush()
 
         return team
 
@@ -566,7 +550,6 @@ class DatabaseOrganizationService:
         self.db.query(TeamProjectRole).filter_by(team=team).delete()
         # Delete team
         self.db.delete(team)
-        self.db.flush()
 
     def delete_teams_by_organization(self, organization_id):
         """
@@ -601,7 +584,6 @@ class DatabaseOrganizationService:
         )
 
         self.db.add(member)
-        self.db.flush()
 
         return member
 
@@ -612,7 +594,6 @@ class DatabaseOrganizationService:
         member = self.get_team_role(team_role_id)
 
         self.db.delete(member)
-        self.db.flush()
 
     def get_team_project_role(self, team_project_role_id):
         """
@@ -632,7 +613,6 @@ class DatabaseOrganizationService:
         )
 
         self.db.add(team_project_role)
-        self.db.flush()
 
         return team_project_role
 
@@ -643,7 +623,6 @@ class DatabaseOrganizationService:
         team_project_role = self.get_team_project_role(team_project_role_id)
 
         self.db.delete(team_project_role)
-        self.db.flush()
 
     def record_event(self, organization_id, *, tag, additional=None):
         """

--- a/warehouse/subscriptions/services.py
+++ b/warehouse/subscriptions/services.py
@@ -433,7 +433,7 @@ class StripeSubscriptionService:
 
         self.db.add(subscription)
         self.db.add(organization_subscription)
-        self.db.flush()  # get back the subscription id
+        self.db.flush()  # flush db now so we have acccess to subscription.id
 
         # Create new subscription item.
         subscription_item = StripeSubscriptionItem(
@@ -444,7 +444,6 @@ class StripeSubscriptionService:
         )
 
         self.db.add(subscription_item)
-        self.db.flush()
 
         return subscription
 
@@ -473,7 +472,6 @@ class StripeSubscriptionService:
         ).delete()
 
         self.db.delete(subscription)
-        self.db.flush()
 
     def get_subscriptions_by_customer(self, customer_id):
         """
@@ -538,7 +536,7 @@ class StripeSubscriptionService:
         )
 
         self.db.add(stripe_customer)
-        self.db.flush()
+        self.db.flush()  # flush db now so we have access to stripe_customer.id
 
         return stripe_customer
 
@@ -600,7 +598,7 @@ class StripeSubscriptionService:
         )
 
         self.db.add(subscription_product)
-        self.db.flush()
+        self.db.flush()  # flush db now so we have access to subscription_product.id
 
         return subscription_product
 
@@ -622,7 +620,6 @@ class StripeSubscriptionService:
         subscription_product = self.get_subscription_product(subscription_product_id)
 
         self.db.delete(subscription_product)
-        self.db.flush()
 
     def get_or_create_default_subscription_price(self):
         """
@@ -709,7 +706,7 @@ class StripeSubscriptionService:
         )
 
         self.db.add(subscription_price)
-        self.db.flush()
+        self.db.flush()  # flush db now so we have access to subscription_price.id
 
         return subscription_price
 
@@ -731,7 +728,6 @@ class StripeSubscriptionService:
         subscription_price = self.get_subscription_price(subscription_price_id)
 
         self.db.delete(subscription_price)
-        self.db.flush()
 
 
 def subscription_factory(context, request):

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -197,9 +197,7 @@ def remove_project(project, request, flash=True):
     )
 
     request.db.delete(project)
-
-    # Flush so we can repeat this multiple times if necessary
-    request.db.flush()
+    request.db.flush()  # flush db now so we can repeat if necessary
 
     if flash:
         request.session.flash(f"Deleted the project {project.name!r}", queue="success")


### PR DESCRIPTION
Calling flush() is _often_ unnecessary and can have unintended side effects with some of our machinery. (Namely, I ran across confusing behavior when beginning to add purging for organization objects.)

I've removed as many of the flushes as I was able in the codebase here, and did my best to annotate the remaining ones.