### PR TITLE
fix(dev): update ignore for doc8

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -15,6 +15,6 @@ find . -name '*.py' -exec python -m pyupgrade --py311-plus {} +
 python -m flake8 .
 python -m black --check *.py warehouse/ tests/
 python -m isort --check *.py warehouse/ tests/
-python -m doc8 --allow-long-titles README.rst CONTRIBUTING.rst docs/ --ignore-path docs/_build/
+python -m doc8 --allow-long-titles README.rst CONTRIBUTING.rst docs/ --ignore-path "docs/**/_build/"
 python -m curlylint ./warehouse/templates
 python -m mypy -p warehouse


### PR DESCRIPTION
With the changes in #12953, the existing path is no longer valid, and new doc builds surface linter errors.