### PR TITLE
fix(ci): invert condition for check-runs

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -64,7 +64,7 @@ jobs:
                     for (const check of checks) {
                       const latest_conclusion = check['conclusion'];
                       console.log('Validating conclusion: ' + latest_conclusion);
-                      if(latest_conclusion == 'failure') {
+                      if(latest_conclusion != 'success') {
                         console.log('Discarding ' + branch + ' with failed check');
                         statusOK = false;
                       }


### PR DESCRIPTION
With the condition being `failed`, we will include in-flight PRs that have not succeeded, which is counter to the messaging we surface to the user.