### PR TITLE
chore: update to Node 18.15

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.13.0
+          node-version: 18.15.0
           cache: 'npm'
       - name: Install Node dependencies
         run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # First things first, we build an image which is where we're going to compile
 # our static assets with. We use this stage in development.
-FROM node:18.13.0-bullseye as static-deps
+FROM node:18.15.0-bullseye as static-deps
 
 WORKDIR /opt/warehouse/src/
 


### PR DESCRIPTION
Includes some fixes, but most notable an update to `npm` binary.

Changelogs:
- https://nodejs.org/en/blog/release/v18.14.0
- https://nodejs.org/en/blog/release/v18.15.0