### PR TITLE
Strip newlines from email subjects

### DIFF
--- a/tests/unit/email/test_services.py
+++ b/tests/unit/email/test_services.py
@@ -94,6 +94,24 @@ class TestEmailMessage:
             "<html>\n<head></head>\n<body><p>Email HTML Body</p></body>\n</html>\n"
         )
 
+    def test_strips_newlines_from_subject(self, pyramid_config, pyramid_request):
+        subject_renderer = pyramid_config.testing_add_renderer("email/foo/subject.txt")
+        subject_renderer.string_response = "Email Subject\n"
+
+        body_renderer = pyramid_config.testing_add_renderer("email/foo/body.txt")
+        body_renderer.string_response = "Email Body"
+
+        html_renderer = pyramid_config.testing_add_renderer("email/foo/body.html")
+        html_renderer.string_response = "<p>Email HTML Body</p>"
+
+        msg = EmailMessage.from_template(
+            "foo", {"my_var": "my value"}, request=pyramid_request
+        )
+
+        subject_renderer.assert_(my_var="my value")
+
+        assert msg.subject == "Email Subject"
+
 
 @pytest.mark.parametrize("sender_class", [SMTPEmailSender, ConsoleAndSMTPEmailSender])
 class TestSMTPEmailSender:

--- a/warehouse/email/services.py
+++ b/warehouse/email/services.py
@@ -39,7 +39,9 @@ class EmailMessage:
 
     @classmethod
     def from_template(cls, email_name, context, *, request):
-        subject = render(f"email/{email_name}/subject.txt", context, request=request)
+        subject = render(
+            f"email/{email_name}/subject.txt", context, request=request
+        ).replace("\n", "")
         body_text = render(f"email/{email_name}/body.txt", context, request=request)
 
         try:


### PR DESCRIPTION
This makes currently failing jobs (due to #13215) pass to clear the job queue.