### PR TITLE
lint: include more file extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.curlylint]
+include = '\.(html|jinja|txt)$'
 # For jinja's i18n extension:
 template_tags = [['trans', 'pluralize', 'endtrans']]
 


### PR DESCRIPTION
Discovered when researching #13216

The cool defaults to only link `.html` files, and we use `.txt` for email templates.
Added `.jinja` for future template extensions that parse in IDEs.

To be clear: does not catch the error surfaced in the related issue.