### PR TITLE
test: wrap resend test case with a time freeze

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -4445,6 +4445,7 @@ class TestManageOrganizationRoles:
 
 
 class TestResendOrganizationInvitations:
+    @freeze_time(datetime.datetime.utcnow())
     def test_resend_invitation(
         self, db_request, token_service, enable_organizations, monkeypatch
     ):


### PR DESCRIPTION
One of the newer test cases using the `token_service` fixture wasn't wrapped with the freeze decorator.
Other test cases in this module using the `token_service` **fixture** are already wrapped as such, this follows suit.

There are some tests that use a stub token_service with guaranteed `loads/dumps` behavior that don't use the fixture, so they don't need to be frozen.

Resolves: #13233