### PR TITLE
Fix typo in welcome blog post

### DIFF
--- a/docs/blog/posts/2023-03-21-welcome-to-the-pypi-blog.md
+++ b/docs/blog/posts/2023-03-21-welcome-to-the-pypi-blog.md
@@ -46,7 +46,7 @@ secure since 2013._
 
 [^1]: We're thrifty and picky about what we run, but
 [Fastly](https://www.fastly.com/fast-forward) is the single most
-important factor allowing us to get by with comparitively few
+important factor allowing us to get by with comparatively few
 resources for our backends.
 [^2]: That was until we welcomed Mike Fiedler as an admin in 2023.
 [^3]: The PyPI Administrator team is


### PR DESCRIPTION
Congrats on the new blog! I noticed a wee typo, so I figured I'd put up a PR to fix it.

comparitively -> comparatively