### PR TITLE
fix(ci): use static branch name

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -165,7 +165,7 @@ jobs:
               repo: context.repo.repo,
               title: 'Combined PR',
               head: '${{ github.event.inputs.combineBranchName }}',
-              base: '${{ steps.fetch-branch-names.outputs.base-branch }}',
+              base: 'main',
               body: body
             });
       # Trigger downstream workflows


### PR DESCRIPTION
We don't care what the base branch emitted by previous steps is, we want to pull the changes into our `main` branch.

See https://github.com/pypi/warehouse/pull/13255#issuecomment-1478495896