### PR TITLE
Add unverified `environment_node_id` claim for GitHub publisher

### DIFF
--- a/tests/unit/oidc/test_models.py
+++ b/tests/unit/oidc/test_models.py
@@ -71,6 +71,7 @@ class TestGitHubPublisher:
             "job_workflow_sha",
             "workflow_ref",
             "runner_environment",
+            "environment_node_id",
         }
 
     def test_github_publisher_computed_properties(self):

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -267,6 +267,7 @@ class GitHubPublisherMixin:
         "job_workflow_sha",
         "workflow_ref",
         "runner_environment",
+        "environment_node_id",
     }
 
     @property


### PR DESCRIPTION
Fixes https://python-software-foundation.sentry.io/issues/4025352730/