### PR TITLE
dev UX fixups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,61 @@ RUN NODE_ENV=production npm run build
 
 
 
+# We'll build a light-weight layer along the way with just docs stuff
+FROM python:3.11.2-slim-bullseye as docs
+
+# Install System level build requirements, this is done before
+# everything else because these are rarely ever going to change.
+RUN set -x \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential git libffi-dev libcairo2-dev libfreetype6-dev libpq-dev
+
+# We create an /opt directory with a virtual environment in it to store our
+# application in.
+RUN set -x \
+    && python3 -m venv /opt/warehouse
+
+# Now that we've created our virtual environment, we'll go ahead and update
+# our $PATH to refer to it first.
+ENV PATH="/opt/warehouse/bin:${PATH}"
+
+# Next, we want to update pip, setuptools, and wheel inside of this virtual
+# environment to ensure that we have the latest versions of them.
+# TODO: We use --require-hashes in our requirements files, but not here, making
+#       the ones in the requirements files kind of a moot point. We should
+#       probably pin these too, and update them as we do anything else.
+RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip setuptools wheel
+
+# We copy this into the docker container prior to copying in the rest of our
+# application so that we can skip installing requirements if the only thing
+# that has changed is the Warehouse code itself.
+COPY requirements /tmp/requirements
+
+# Install the Python level Warehouse requirements, this is done after copying
+# the requirements but prior to copying Warehouse itself into the container so
+# that code changes don't require triggering an entire install of all of
+# Warehouse's dependencies.
+RUN set -x \
+    && pip --no-cache-dir --disable-pip-version-check \
+            install --no-deps \
+            -r /tmp/requirements/docs/dev.txt \
+            -r /tmp/requirements/docs/user.txt \
+            -r /tmp/requirements/docs/blog.txt \
+    && pip check \
+    && find /opt/warehouse -name '*.pyc' -delete
+
+WORKDIR /opt/warehouse/src/
+
+ARG USER_ID
+ARG GROUP_ID
+RUN groupadd -o -g $GROUP_ID -r docs
+RUN useradd -o -m -u $USER_ID -g $GROUP_ID docs
+RUN chown docs /opt/warehouse/src
+USER docs
+
+
+
 
 # Now we're going to build our actual application, but not the actual production
 # image that it gets deployed into.
@@ -61,7 +116,6 @@ RUN set -x \
 # application in.
 RUN set -x \
     && python3 -m venv /opt/warehouse
-
 
 # Now that we've created our virtual environment, we'll go ahead and update
 # our $PATH to refer to it first.
@@ -96,10 +150,9 @@ RUN set -x \
             install --no-deps \
                     -r /tmp/requirements/deploy.txt \
                     -r /tmp/requirements/main.txt \
-                    $(if [ "$DEVEL" = "yes" ]; then echo '-r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt -r /tmp/requirements/docs/dev.txt -r /tmp/requirements/docs/user.txt -r /tmp/requirements/docs/blog.txt'; fi) \
+                    $(if [ "$DEVEL" = "yes" ]; then echo '-r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt'; fi) \
     && pip check \
     && find /opt/warehouse -name '*.pyc' -delete
-
 
 
 
@@ -132,7 +185,7 @@ RUN set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         libpq5 libxml2 libxslt1.1 libcurl4  \
-        $(if [ "$DEVEL" = "yes" ]; then echo 'bash libjpeg62 postgresql-client build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev libcurl4-openssl-dev libssl-dev git libcairo2-dev libfreetype6-dev libjpeg-dev libpng-dev libz-dev'; fi) \
+        $(if [ "$DEVEL" = "yes" ]; then echo 'bash libjpeg62 postgresql-client build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev libcurl4-openssl-dev libssl-dev git libjpeg-dev libpng-dev libz-dev'; fi) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ FROM python:3.11.2-slim-bullseye as docs
 RUN set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
-        build-essential git libffi-dev libcairo2-dev libfreetype6-dev libpq-dev
+        build-essential git libcairo2-dev libfreetype6-dev libjpeg-dev libpng-dev libz-dev
 
 # We create an /opt directory with a virtual environment in it to store our
 # application in.
@@ -187,7 +187,7 @@ RUN set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         libpq5 libxml2 libxslt1.1 libcurl4  \
-        $(if [ "$DEVEL" = "yes" ]; then echo 'bash libjpeg62 postgresql-client build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev libcurl4-openssl-dev libssl-dev git libjpeg-dev libpng-dev libz-dev'; fi) \
+        $(if [ "$DEVEL" = "yes" ]; then echo 'bash libjpeg62 postgresql-client build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev libcurl4-openssl-dev libssl-dev'; fi) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,8 @@ RUN set -x \
 
 WORKDIR /opt/warehouse/src/
 
+# We'll make the docs container run as a non-root user, ensure that the built
+# documentation belongs to the same user on the host machine.
 ARG USER_ID
 ARG GROUP_ID
 RUN groupadd -o -g $GROUP_ID -r docs

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ default:
 	@echo
 	@exit 1
 
-.state/docker-build-web: Dockerfile package.json package-lock.json requirements/main.txt requirements/deploy.txt requirements/lint.txt requirements/docs/dev.txt requirements/docs/user.txt requirements/dev.txt requirements/tests.txt
+.state/docker-build-web: Dockerfile package.json package-lock.json requirements/main.txt requirements/deploy.txt requirements/lint.txt requirements/tests.txt
 	# Build our web container for this project.
 	docker compose build --build-arg IPYTHON=$(IPYTHON) --force-rm web
 
@@ -33,7 +33,15 @@ default:
 	mkdir -p .state
 	touch .state/docker-build-static
 
-.state/docker-build: .state/docker-build-web .state/docker-build-static
+.state/docker-build-docs: Dockerfile requirements/docs/dev.txt requirements/docs/blog.txt requirements/docs/user.txt
+	# Build the worker container for this project
+	docker compose build --build-arg  USER_ID=$(shell id -u)  --build-arg GROUP_ID=$(shell id -g) --force-rm dev-docs
+
+        # Mark the state so we don't rebuild this needlessly.
+	mkdir -p .state
+	touch .state/docker-build-docs
+
+.state/docker-build: .state/docker-build-web .state/docker-build-static .state/docker-build-docs
 	# Build the worker container for this project
 	docker compose build --force-rm worker
 
@@ -68,14 +76,14 @@ lint: .state/docker-build-web
 	docker compose run --rm web bin/lint
 	docker compose run --rm static bin/static_lint
 
-dev-docs: .state/docker-build-web
-	docker compose run --rm web bin/dev-docs
+dev-docs: .state/docker-build-docs
+	docker compose run --rm dev-docs bin/dev-docs
 
-user-docs: .state/docker-build-web
-	docker compose run --rm web bin/user-docs
+user-docs: .state/docker-build-docs
+	docker compose run --rm user-docs bin/user-docs
 
-blog: .state/docker-build-web
-	docker compose run --rm web bin/blog
+blog: .state/docker-build-docs
+	docker compose run --rm blog bin/blog
 
 licenses: .state/docker-build-web
 	docker compose run --rm web bin/licenses

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,10 @@ dev-docs: .state/docker-build-web
 	docker compose run --rm web bin/dev-docs
 
 user-docs: .state/docker-build-web
-	docker-compose run --rm web bin/user-docs
+	docker compose run --rm web bin/user-docs
 
 blog: .state/docker-build-web
-	docker-compose run --rm web bin/blog
+	docker compose run --rm web bin/blog
 
 licenses: .state/docker-build-web
 	docker compose run --rm web bin/licenses

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ default:
 	# Build the worker container for this project
 	docker compose build --build-arg  USER_ID=$(shell id -u)  --build-arg GROUP_ID=$(shell id -g) --force-rm dev-docs
 
-        # Mark the state so we don't rebuild this needlessly.
+	# Mark the state so we don't rebuild this needlessly.
 	mkdir -p .state
 	touch .state/docker-build-docs
 
@@ -119,9 +119,10 @@ clean:
 
 purge: stop clean
 	rm -rf .state
+	docker compose down -v
 	docker compose rm --force
 
 stop:
-	docker compose down -v
+	docker compose stop
 
 .PHONY: default build serve initdb shell tests dev-docs user-docs deps clean purge debug stop compile-pot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,7 +211,8 @@ services:
     pull_policy: never
     command: mkdocs serve -a 0.0.0.0:8000 -f docs/blog.yml
     volumes:
-      - ./.git:/opt/warehouse/src/.git:z
+      # we mount git because rss, thanks feed nerds
+      - ./.git:/opt/warehouse/src/.git:ro
       - ./bin:/opt/warehouse/src/bin:z
       - ./docs:/opt/warehouse/src/docs:z
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,22 +186,33 @@ services:
     ports:
       - "8964:8000"
 
+  dev-docs:
+    build:
+      context: .
+      target: docs
+    image: warehouse:docker-compose-docs
+    volumes:
+      - ./bin:/opt/warehouse/src/bin:z
+      - ./docs:/opt/warehouse/src/docs:z
+
   user-docs:
-    image: warehouse:docker-compose
+    image: warehouse:docker-compose-docs
+    pull_policy: never
     command: mkdocs serve -a 0.0.0.0:8000 -f mkdocs-user-docs.yml
     volumes:
+      - ./bin:/opt/warehouse/src/bin:z
       - ./mkdocs-user-docs.yml:/opt/warehouse/src/mkdocs-user-docs.yml:z
-      - ./docs/user:/opt/warehouse/src/docs/user:z
+      - ./docs:/opt/warehouse/src/docs:z
     ports:
       - "10000:8000"
-    depends_on: [web]
 
   blog:
-    image: warehouse:docker-compose
+    image: warehouse:docker-compose-docs
+    pull_policy: never
     command: mkdocs serve -a 0.0.0.0:8000 -f docs/blog.yml
     volumes:
-      - ./docs/blog.yml:/opt/warehouse/src/docs/blog.yml:z
-      - ./docs/blog:/opt/warehouse/src/docs/blog:z
+      - ./.git:/opt/warehouse/src/.git:z
+      - ./bin:/opt/warehouse/src/bin:z
+      - ./docs:/opt/warehouse/src/docs:z
     ports:
       - "10001:8000"
-    depends_on: [web]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,7 @@ services:
 
   files:
     image: warehouse:docker-compose
+    pull_policy: never
     working_dir: /var/opt/warehouse
     command: python -m http.server 9001
     volumes:
@@ -131,10 +132,10 @@ services:
       - simple:/var/opt/warehouse/simple
     ports:
       - "9001:9001"
-    depends_on: [web]
 
   worker:
     image: warehouse:docker-compose
+    pull_policy: never
     command: hupper -m celery -A warehouse worker -B -S redbeat.RedBeatScheduler -l info
     volumes:
       - ./warehouse:/opt/warehouse/src/warehouse:z
@@ -143,7 +144,6 @@ services:
       C_FORCE_ROOT: "1"
       FILES_BACKEND: "warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files:9001/packages/{path}"
       SIMPLE_BACKEND: "warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://files:9001/simple/{path}"
-    depends_on: [web]
 
   static:
     build:
@@ -170,6 +170,7 @@ services:
 
   notdatadog:
     image: warehouse:docker-compose
+    pull_policy: never
     command: python /opt/warehouse/dev/notdatadog.py 0.0.0.0:8125
     environment:
       METRICS_OUTPUT: "false"
@@ -177,7 +178,6 @@ services:
       - "8125:8125/udp"
     volumes:
       - ./dev/notdatadog.py:/opt/warehouse/dev/notdatadog.py
-    depends_on: [web]
 
   notgithub:
     image: ewjoachim/notgithub-token-scanning

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       interval: 1s
 
   stripe:
-    image: stripe/stripe-mock:v0.152.0
+    image: stripe/stripe-mock:v0.158.0
     ports:
       - "12111:12111"
 

--- a/docs/dev/Makefile
+++ b/docs/dev/Makefile
@@ -50,8 +50,6 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
-	$(shell which pip)
-	$(shell which python)
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."


### PR DESCRIPTION
- A couple missed `docker-compose` -> `docker compose`
- stripe-mock now has arm builds! https://github.com/stripe/stripe-mock/issues/281
- Build/run our docs stuff in their own image
- Remove some stray debugging that was causing dev-docs to open a python REPL 🙃
- Better mechanism for sharing container images between services
- Don't delete compose volumes on `make stop`, rather do that only when `make purge` is called