### PR TITLE
Use recaptcha.net instead of google.com

### DIFF
--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -241,10 +241,10 @@ class TestCSPPolicy:
         serv = recaptcha.Service(request)
         assert serv.csp_policy == {
             "script-src": [
-                "{request.scheme}://www.google.com/recaptcha/",
+                "{request.scheme}://www.recaptcha.net/recaptcha/",
                 "{request.scheme}://www.gstatic.com/recaptcha/",
             ],
-            "frame-src": ["{request.scheme}://www.google.com/recaptcha/"],
+            "frame-src": ["{request.scheme}://www.recaptcha.net/recaptcha/"],
             "style-src": ["'unsafe-inline'"],
         }
 

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -66,11 +66,11 @@ class Service:
         # be dynamic.
         return {
             "script-src": [
-                "{request.scheme}://www.google.com/recaptcha/",
+                "{request.scheme}://www.recaptcha.net/recaptcha/",
                 "{request.scheme}://www.gstatic.com/recaptcha/",
             ],
             "frame-src": [
-                "{request.scheme}://www.google.com/recaptcha/",
+                "{request.scheme}://www.recaptcha.net/recaptcha/",
             ],
             "style-src": [
                 "'unsafe-inline'",

--- a/warehouse/templates/includes/input-recaptcha.html
+++ b/warehouse/templates/includes/input-recaptcha.html
@@ -26,6 +26,6 @@
 
 {% macro recaptcha_src(request) -%}
   {% if request.find_service(name="recaptcha").enabled %}
-    <script src="//www.google.com/recaptcha/api.js" async defer></script>
+    <script src="//www.recaptcha.net/recaptcha/api.js" async defer></script>
   {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
This makes our reCAPTCHA more likely to work for a global user base, per https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally