### PR TITLE
Add dark theme to docs and Blog

### DIFF
--- a/bin/rtd-docs
+++ b/bin/rtd-docs
@@ -14,13 +14,13 @@ fi
 if [ "${READTHEDOCS_PROJECT}" = "docspypiorg" ]; then
   pip install -r requirements/docs/user.txt
   asdf reshim
-  mkdocs build -f mkdocs-user-docs.yml
+  mkdocs build -f docs/mkdocs-user-docs.yml
   mkdir _readthedocs && mv docs/user-site _readthedocs/html
 fi
 
 if [ "${READTHEDOCS_PROJECT}" = "blogpypiorg" ]; then
   pip install -r requirements/docs/blog.txt
   asdf reshim
-  mkdocs build -f docs/blog.yml
+  mkdocs build -f docs/mkdocs-blog.yml
   mkdir _readthedocs && mv docs/blog-site _readthedocs/html
 fi

--- a/bin/user-docs
+++ b/bin/user-docs
@@ -10,4 +10,4 @@ export LANG="${ENCODING:-en_US.UTF-8}"
 # Print all the following commands
 set -x
 
-mkdocs build -f mkdocs-user-docs.yml
+mkdocs build -f docs/mkdocs-user-docs.yml

--- a/docs/mkdocs-blog.yml
+++ b/docs/mkdocs-blog.yml
@@ -8,6 +8,17 @@ theme:
   favicon: assets/favicon.ico
   homepage: https://pypi.org
   custom_dir: blog/overrides
+  palette:
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      toggle:
+        icon: material/weather-night
+        name: Switch to Dark mode
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to Light mode
 markdown_extensions:
   - footnotes
 extra_css:

--- a/docs/mkdocs-user-docs.yml
+++ b/docs/mkdocs-user-docs.yml
@@ -1,9 +1,9 @@
 site_name: PyPI Docs
-docs_dir: docs/user
-site_dir: docs/user-site
+docs_dir: user
+site_dir: user-site
 plugins:
   - macros:
-      module_name: docs/user/main
+      module_name: user/main
 markdown_extensions: 
   - admonition 
   - pymdownx.details 
@@ -16,6 +16,17 @@ theme:
   homepage: https://pypi.org
   features:
     - content.action.edit
+  palette:
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      toggle:
+        icon: material/weather-night
+        name: Switch to Dark mode
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to Light mode
 extra_css:
   - stylesheets/extra.css
 extra:


### PR DESCRIPTION
Makes the following changes:

- Moves `mkdocs-user-docs.yml` into the `docs/` directory
- Renames `docs/blog.yml` to `docs/mkdocs-blog.yml` for better consistency with file names used.
- Updated `bin/rtd-docs` to use new file name and locations.
- Added a dark theme and theme toggle to documentation.

See #13294 for context and any extra info.