### PR TITLE
fix: add gstatic.cn domain for recaptcha

### DIFF
--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -243,6 +243,7 @@ class TestCSPPolicy:
             "script-src": [
                 "{request.scheme}://www.recaptcha.net/recaptcha/",
                 "{request.scheme}://www.gstatic.com/recaptcha/",
+                "{request.scheme}://www.gstatic.cn/recaptcha/",
             ],
             "frame-src": ["{request.scheme}://www.recaptcha.net/recaptcha/"],
             "style-src": ["'unsafe-inline'"],

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -68,6 +68,7 @@ class Service:
             "script-src": [
                 "{request.scheme}://www.recaptcha.net/recaptcha/",
                 "{request.scheme}://www.gstatic.com/recaptcha/",
+                "{request.scheme}://www.gstatic.cn/recaptcha/",
             ],
             "frame-src": [
                 "{request.scheme}://www.recaptcha.net/recaptcha/",


### PR DESCRIPTION
Thanks to some extra debugging details, we can see that the script is being loaded via a different Google Static domain in China.

Refs: #3174, #13232, #13350