### PR TITLE
email, help: more "trusted publisher" language

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -598,46 +598,46 @@ msgstr ""
 #: warehouse/templates/pages/help.html:445
 #: warehouse/templates/pages/help.html:451
 #: warehouse/templates/pages/help.html:509
-#: warehouse/templates/pages/help.html:551
-#: warehouse/templates/pages/help.html:557
+#: warehouse/templates/pages/help.html:549
+#: warehouse/templates/pages/help.html:555
+#: warehouse/templates/pages/help.html:558
 #: warehouse/templates/pages/help.html:560
-#: warehouse/templates/pages/help.html:562
-#: warehouse/templates/pages/help.html:571
-#: warehouse/templates/pages/help.html:593
-#: warehouse/templates/pages/help.html:600
-#: warehouse/templates/pages/help.html:612
-#: warehouse/templates/pages/help.html:613
-#: warehouse/templates/pages/help.html:618
-#: warehouse/templates/pages/help.html:643
-#: warehouse/templates/pages/help.html:656
-#: warehouse/templates/pages/help.html:661
-#: warehouse/templates/pages/help.html:673
-#: warehouse/templates/pages/help.html:694
-#: warehouse/templates/pages/help.html:718
-#: warehouse/templates/pages/help.html:725
-#: warehouse/templates/pages/help.html:737
-#: warehouse/templates/pages/help.html:748
-#: warehouse/templates/pages/help.html:753
-#: warehouse/templates/pages/help.html:761
-#: warehouse/templates/pages/help.html:772
-#: warehouse/templates/pages/help.html:817
-#: warehouse/templates/pages/help.html:825
-#: warehouse/templates/pages/help.html:841
-#: warehouse/templates/pages/help.html:846
-#: warehouse/templates/pages/help.html:851
-#: warehouse/templates/pages/help.html:861
-#: warehouse/templates/pages/help.html:870
-#: warehouse/templates/pages/help.html:884
-#: warehouse/templates/pages/help.html:892
-#: warehouse/templates/pages/help.html:900
-#: warehouse/templates/pages/help.html:908
-#: warehouse/templates/pages/help.html:917
-#: warehouse/templates/pages/help.html:937
+#: warehouse/templates/pages/help.html:569
+#: warehouse/templates/pages/help.html:591
+#: warehouse/templates/pages/help.html:598
+#: warehouse/templates/pages/help.html:610
+#: warehouse/templates/pages/help.html:611
+#: warehouse/templates/pages/help.html:616
+#: warehouse/templates/pages/help.html:641
+#: warehouse/templates/pages/help.html:654
+#: warehouse/templates/pages/help.html:659
+#: warehouse/templates/pages/help.html:671
+#: warehouse/templates/pages/help.html:692
+#: warehouse/templates/pages/help.html:716
+#: warehouse/templates/pages/help.html:723
+#: warehouse/templates/pages/help.html:735
+#: warehouse/templates/pages/help.html:746
+#: warehouse/templates/pages/help.html:751
+#: warehouse/templates/pages/help.html:759
+#: warehouse/templates/pages/help.html:770
+#: warehouse/templates/pages/help.html:815
+#: warehouse/templates/pages/help.html:823
+#: warehouse/templates/pages/help.html:839
+#: warehouse/templates/pages/help.html:844
+#: warehouse/templates/pages/help.html:849
+#: warehouse/templates/pages/help.html:859
+#: warehouse/templates/pages/help.html:868
+#: warehouse/templates/pages/help.html:882
+#: warehouse/templates/pages/help.html:890
+#: warehouse/templates/pages/help.html:898
+#: warehouse/templates/pages/help.html:906
+#: warehouse/templates/pages/help.html:915
+#: warehouse/templates/pages/help.html:935
+#: warehouse/templates/pages/help.html:950
+#: warehouse/templates/pages/help.html:951
 #: warehouse/templates/pages/help.html:952
 #: warehouse/templates/pages/help.html:953
-#: warehouse/templates/pages/help.html:954
-#: warehouse/templates/pages/help.html:955
-#: warehouse/templates/pages/help.html:960
+#: warehouse/templates/pages/help.html:958
 #: warehouse/templates/pages/sponsors.html:33
 #: warehouse/templates/pages/sponsors.html:37
 #: warehouse/templates/pages/sponsors.html:41
@@ -1737,10 +1737,10 @@ msgstr ""
 #: warehouse/templates/email/oidc-publisher-added/body.html:19
 #, python-format
 msgid ""
-"PyPI user <strong>%(username)s</strong> has added a new OpenID Connect "
-"publisher to a project (<strong>%(project_name)s</strong>) that you "
-"manage. OpenID Connect publishers act as trusted users and can create "
-"project releases automatically."
+"PyPI user <strong>%(username)s</strong> has added a new trusted publisher"
+" to a project (<strong>%(project_name)s</strong>) that you manage. "
+"Trusted publishers behave similarly to API tokens and can create project "
+"releases automatically."
 msgstr ""
 
 #: warehouse/templates/email/oidc-publisher-added/body.html:28
@@ -1777,9 +1777,8 @@ msgstr ""
 #: warehouse/templates/email/oidc-publisher-removed/body.html:19
 #, python-format
 msgid ""
-"PyPI user <strong>%(username)s</strong> has removed an OpenID Connect "
-"publisher from a project (<strong>%(project_name)s</strong>) that you "
-"manage."
+"PyPI user <strong>%(username)s</strong> has removed a trusted publisher "
+"from a project (<strong>%(project_name)s</strong>) that you manage."
 msgstr ""
 
 #: warehouse/templates/email/oidc-publisher-removed/body.html:34
@@ -2649,7 +2648,7 @@ msgstr ""
 
 #: warehouse/templates/includes/packaging/project-data.html:92
 #: warehouse/templates/includes/packaging/project-data.html:94
-#: warehouse/templates/pages/help.html:604
+#: warehouse/templates/pages/help.html:602
 msgid "Maintainer:"
 msgstr ""
 
@@ -5452,7 +5451,7 @@ msgid "Project Roles"
 msgstr ""
 
 #: warehouse/templates/manage/project/roles.html:46
-#: warehouse/templates/pages/help.html:603
+#: warehouse/templates/pages/help.html:601
 msgid "There are two possible roles for collaborators:"
 msgstr ""
 
@@ -6206,7 +6205,7 @@ msgid "How do I change my PyPI username?"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:70
-msgid "How can I use OpenID connect to authenticate with PyPI?"
+msgid "How can I use trusted publishing to authenticate with PyPI?"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:72
@@ -6369,22 +6368,22 @@ msgid "My Account"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:149
-#: warehouse/templates/pages/help.html:548
+#: warehouse/templates/pages/help.html:546
 msgid "Integrating"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:160
-#: warehouse/templates/pages/help.html:585
+#: warehouse/templates/pages/help.html:583
 msgid "Administration of projects on PyPI"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:175
-#: warehouse/templates/pages/help.html:669
+#: warehouse/templates/pages/help.html:667
 msgid "Troubleshooting"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:192
-#: warehouse/templates/pages/help.html:837
+#: warehouse/templates/pages/help.html:835
 msgid "About"
 msgstr ""
 
@@ -6928,31 +6927,29 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:530
-#, python-format
 msgid ""
-"PyPI users and projects can use <a href=\"%(openid)s\">OpenID Connect</a>"
-" (OIDC) to delegate publishing authority for a PyPI package to a trusted "
-"third party service, eliminating the need to use API tokens or passwords."
+"PyPI users and projects can use \"trusted publishing\" to delegate "
+"publishing authority for a PyPI package to a trusted third party service,"
+" eliminating the need to use manually configured API tokens or passwords."
 msgstr ""
 
 #: warehouse/templates/pages/help.html:537
+#, python-format
 msgid ""
-"Using OIDC to authenticate when publishing is done by registering "
-"\"publishers,\" which correspond to services with OIDC identities like "
-"GitHub Actions. Existing projects can add or remove OIDC publishers at "
-"any time. OIDC publishers can also be created in advance for projects "
-"that don't exist yet."
+"You can read more about how trusted publishing works (including its "
+"implementation details) in the <a href=\"%(docs)s\">PyPI "
+"documentation</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:551
+#: warehouse/templates/pages/help.html:549
 msgid "Yes, including RSS feeds of new packages and new releases."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:551
+#: warehouse/templates/pages/help.html:549
 msgid "See the API reference."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:554
+#: warehouse/templates/pages/help.html:552
 #, python-format
 msgid ""
 "If you need to run your own mirror of PyPI, the <a "
@@ -6961,7 +6958,7 @@ msgid ""
 "terabyte—and growing!"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:557
+#: warehouse/templates/pages/help.html:555
 #, python-format
 msgid ""
 "You can subscribe to the <a href=\"%(rss_href)s\" title=\"%(title)s\" "
@@ -6972,7 +6969,7 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">GitHub apps</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:560
+#: warehouse/templates/pages/help.html:558
 #, python-format
 msgid ""
 "You can analyze PyPI project/package metadata and <a href=\"%(href)s\" "
@@ -6980,7 +6977,7 @@ msgid ""
 "statistics</a> via our public dataset on Google BigQuery."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:562
+#: warehouse/templates/pages/help.html:560
 #, python-format
 msgid ""
 "<a href=\"%(libs_io_href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -6995,7 +6992,7 @@ msgid ""
 "rel=\"noopener\">other relevant factors</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:571
+#: warehouse/templates/pages/help.html:569
 #, python-format
 msgid ""
 "For recent statistics on uptime and performance, see <a href=\"%(href)s\""
@@ -7003,7 +7000,7 @@ msgid ""
 "page</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:574
+#: warehouse/templates/pages/help.html:572
 msgid ""
 "For each package hosted on PyPI, there are corresponding hashes for that "
 "file. These hashes can be used to verify that the file you are "
@@ -7013,7 +7010,7 @@ msgid ""
 "from the JSON API. Here is an example of generating the hashes:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:581
+#: warehouse/templates/pages/help.html:579
 msgid ""
 "In practice, it would only be necessary to verify one of the hashes. It "
 "is not recommended to use the MD5 hash because of known security issues "
@@ -7021,7 +7018,7 @@ msgid ""
 " only."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:588
+#: warehouse/templates/pages/help.html:586
 #, python-format
 msgid ""
 "PyPI does not support publishing private packages. If you need to publish"
@@ -7029,7 +7026,7 @@ msgid ""
 "run your own deployment of the <a href=\"%(href)s\">devpi project</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:591
+#: warehouse/templates/pages/help.html:589
 msgid ""
 "Your publishing tool may return an error that your new project can't be "
 "created with your desired name, despite no evidence of a project or "
@@ -7037,7 +7034,7 @@ msgid ""
 "reasons this may occur:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:593
+#: warehouse/templates/pages/help.html:591
 #, python-format
 msgid ""
 "The project name conflicts with a <a href=\"%(href)s\" "
@@ -7045,13 +7042,13 @@ msgid ""
 "Library</a> module from any major version from 2.5 to present."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:594
+#: warehouse/templates/pages/help.html:592
 msgid ""
 "The project name is too similar to an existing project and may be "
 "confusable."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:595
+#: warehouse/templates/pages/help.html:593
 #, python-format
 msgid ""
 "The project name has been explicitly prohibited by the PyPI "
@@ -7060,18 +7057,18 @@ msgid ""
 "with a malicious package."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:596
+#: warehouse/templates/pages/help.html:594
 msgid ""
 "The project name has been registered by another user, but no releases "
 "have been created."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:596
+#: warehouse/templates/pages/help.html:594
 #, python-format
 msgid "See <a href=\"%(href)s\">%(anchor_text)s</a>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:600
+#: warehouse/templates/pages/help.html:598
 #, python-format
 msgid ""
 "Follow the <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -7079,23 +7076,23 @@ msgid ""
 "title=\"Python enhancement proposal\">PEP</abbr> 541."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:604
+#: warehouse/templates/pages/help.html:602
 msgid ""
 "Can upload releases for a package. Cannot add collaborators. Cannot "
 "delete files, releases, or the project."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:605
+#: warehouse/templates/pages/help.html:603
 msgid "Owner:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:605
+#: warehouse/templates/pages/help.html:603
 msgid ""
 "Can upload releases. Can add other collaborators. Can delete files, "
 "releases, or the entire project."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:608
+#: warehouse/templates/pages/help.html:606
 msgid ""
 "Only the current owners of a project have the ability to add new owners "
 "or maintainers. If you need to request ownership, you should contact the "
@@ -7104,12 +7101,12 @@ msgid ""
 "project page."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:609
+#: warehouse/templates/pages/help.html:607
 #, python-format
 msgid "If the owner is unresponsive, see <a href=\"%(href)s\">%(anchor_text)s</a>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:612
+#: warehouse/templates/pages/help.html:610
 #, python-format
 msgid ""
 "By default, an upload's description will render with <a href=\"%(href)s\""
@@ -7120,7 +7117,7 @@ msgid ""
 "the alternate format."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:613
+#: warehouse/templates/pages/help.html:611
 #, python-format
 msgid ""
 "Refer to the <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -7128,7 +7125,7 @@ msgid ""
 "available formats."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:618
+#: warehouse/templates/pages/help.html:616
 #, python-format
 msgid ""
 "If you can't upload your project's release to PyPI because you're hitting"
@@ -7141,34 +7138,34 @@ msgid ""
 "rel=\"noopener\">file an issue</a> and tell us:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:627
-#: warehouse/templates/pages/help.html:648
+#: warehouse/templates/pages/help.html:625
+#: warehouse/templates/pages/help.html:646
 msgid "A link to your project on PyPI (or Test PyPI)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:628
+#: warehouse/templates/pages/help.html:626
 msgid "The size of your release, in megabytes"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:629
+#: warehouse/templates/pages/help.html:627
 msgid "Which index/indexes you need the increase for (PyPI, Test PyPI, or both)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:630
-#: warehouse/templates/pages/help.html:650
+#: warehouse/templates/pages/help.html:628
+#: warehouse/templates/pages/help.html:648
 msgid ""
 "A brief description of your project, including the reason for the "
 "additional size."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:636
+#: warehouse/templates/pages/help.html:634
 msgid ""
 "If you can't upload your project's release to PyPI because you're hitting"
 " the project size limit, first remove any unnecessary releases or "
 "individual files to lower your overall project size."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:643
+#: warehouse/templates/pages/help.html:641
 #, python-format
 msgid ""
 "If that is not possible, we can sometimes increase your limit. <a "
@@ -7176,11 +7173,11 @@ msgid ""
 "rel=\"noopener\">File an issue</a> and tell us:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:649
+#: warehouse/templates/pages/help.html:647
 msgid "The total size of your project, in gigabytes"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:656
+#: warehouse/templates/pages/help.html:654
 #, python-format
 msgid ""
 "PyPI receives reports on vulnerabilities in the packages hosted on it "
@@ -7191,7 +7188,7 @@ msgid ""
 "Advisory Database</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:661
+#: warehouse/templates/pages/help.html:659
 #, python-format
 msgid ""
 "If you believe vulnerability data for your project is invalid or "
@@ -7199,7 +7196,7 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">file an issue</a> with details."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:673
+#: warehouse/templates/pages/help.html:671
 #, python-format
 msgid ""
 "PyPI will reject uploads if the package description fails to render. You "
@@ -7207,41 +7204,41 @@ msgid ""
 "command</a> to locally check a description for validity."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:679
+#: warehouse/templates/pages/help.html:677
 msgid ""
 "If you've forgotten your PyPI password but you remember your email "
 "address or username, follow these steps to reset your password:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:681
+#: warehouse/templates/pages/help.html:679
 #, python-format
 msgid "Go to <a href=\"%(href)s\">reset your password</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:682
+#: warehouse/templates/pages/help.html:680
 msgid "Enter the email address or username you used for PyPI and submit the form."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:683
+#: warehouse/templates/pages/help.html:681
 msgid "You'll receive an email with a password reset link."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:688
+#: warehouse/templates/pages/help.html:686
 msgid "If you've lost access to your PyPI account due to:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:690
+#: warehouse/templates/pages/help.html:688
 msgid "Lost access to the email address associated with your account"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:691
+#: warehouse/templates/pages/help.html:689
 msgid ""
 "Lost two factor authentication <a href=\"#totp\">application</a>, <a "
 "href=\"#utfkey\">device</a>, and <a href=\"#recoverycodes\">recovery "
 "codes</a>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:694
+#: warehouse/templates/pages/help.html:692
 #, python-format
 msgid ""
 "You can proceed to <a href=\"%(href)s\" title=\"%(title)s\" "
@@ -7249,46 +7246,46 @@ msgid ""
 "request assistance with account recovery."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:701
+#: warehouse/templates/pages/help.html:699
 msgid "If you are using a username and password for uploads:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:703
+#: warehouse/templates/pages/help.html:701
 msgid "Ensure that your username and password are correct."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:704
+#: warehouse/templates/pages/help.html:702
 msgid ""
 "Ensure that your username and password do not contain any trailing "
 "characters such as newlines."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:706
+#: warehouse/templates/pages/help.html:704
 msgid "If you are using an <a href=\"#apitoken\">API Token</a> for uploads:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:708
+#: warehouse/templates/pages/help.html:706
 msgid "Ensure that your API Token is valid and has not been revoked."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:709
+#: warehouse/templates/pages/help.html:707
 msgid ""
 "Ensure that your API Token is <a href=\"#apitoken\">properly "
 "formatted</a> and does not contain any trailing characters such as "
 "newlines."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:710
+#: warehouse/templates/pages/help.html:708
 msgid "Ensure that the username you are using is <code>__token__</code>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:712
+#: warehouse/templates/pages/help.html:710
 msgid ""
 "In both cases, remember that PyPI and TestPyPI each require you to create"
 " an account, so your credentials may be different."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:714
+#: warehouse/templates/pages/help.html:712
 msgid ""
 "If you're using Windows and trying to paste your password or token in the"
 " Command Prompt or PowerShell, note that Ctrl-V and Shift+Insert won't "
@@ -7296,7 +7293,7 @@ msgid ""
 "enable \"Use Ctrl+Shift+C/V as Copy/Paste\" in \"Properties\"."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:718
+#: warehouse/templates/pages/help.html:716
 #, python-format
 msgid ""
 "This is a <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -7304,7 +7301,7 @@ msgid ""
 "module."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:725
+#: warehouse/templates/pages/help.html:723
 #, python-format
 msgid ""
 "Transport Layer Security, or TLS, is part of how we make sure connections"
@@ -7316,7 +7313,7 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">Learn why on the PSF blog</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:732
+#: warehouse/templates/pages/help.html:730
 #, python-format
 msgid ""
 "If you are having trouble with <code>%(command)s</code> and get a "
@@ -7325,7 +7322,7 @@ msgid ""
 "information:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:734
+#: warehouse/templates/pages/help.html:732
 msgid ""
 "If you see an error like <code>There was a problem confirming the ssl "
 "certificate</code> or <code>tlsv1 alert protocol version</code> or "
@@ -7333,7 +7330,7 @@ msgid ""
 "PyPI with a newer TLS support library."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:735
+#: warehouse/templates/pages/help.html:733
 msgid ""
 "The specific steps you need to take will depend on your operating system "
 "version, where your installation of Python originated (python.org, your "
@@ -7341,7 +7338,7 @@ msgid ""
 " Python, <code>setuptools</code>, and <code>pip</code>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:737
+#: warehouse/templates/pages/help.html:735
 #, python-format
 msgid ""
 "For help, go to <a href=\"%(irc_href)s\" title=\"%(title)s\" "
@@ -7354,7 +7351,7 @@ msgid ""
 "of <code>%(command)s</code>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:748
+#: warehouse/templates/pages/help.html:746
 #, python-format
 msgid ""
 "We take <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -7362,7 +7359,7 @@ msgid ""
 "website easy to use for everyone."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:753
+#: warehouse/templates/pages/help.html:751
 #, python-format
 msgid ""
 "If you are experiencing an accessibility problem, <a href=\"%(href)s\" "
@@ -7370,7 +7367,7 @@ msgid ""
 " GitHub</a>, so we can try to fix the problem, for you and others."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:761
+#: warehouse/templates/pages/help.html:759
 #, python-format
 msgid ""
 "In a previous version of PyPI, it used to be possible for maintainers to "
@@ -7380,7 +7377,7 @@ msgid ""
 "rel=\"noopener\">use twine to upload your project to PyPI</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:770
+#: warehouse/templates/pages/help.html:768
 msgid ""
 "Spammers return to PyPI with some regularity hoping to place their Search"
 " Engine Optimized phishing, scam, and click-farming content on the site. "
@@ -7389,7 +7386,7 @@ msgid ""
 "prime target."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:772
+#: warehouse/templates/pages/help.html:770
 #, python-format
 msgid ""
 "When the PyPI administrators are overwhelmed by spam <strong>or</strong> "
@@ -7400,35 +7397,35 @@ msgid ""
 "have updated it with reasoning for the intervention."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:781
+#: warehouse/templates/pages/help.html:779
 msgid "PyPI will return these errors for one of these reasons:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:783
+#: warehouse/templates/pages/help.html:781
 msgid "Filename has been used and file exists"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:784
+#: warehouse/templates/pages/help.html:782
 msgid "Filename has been used but file no longer exists"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:785
+#: warehouse/templates/pages/help.html:783
 msgid "A file with the exact same content exists"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:788
+#: warehouse/templates/pages/help.html:786
 msgid ""
 "PyPI does not allow for a filename to be reused, even once a project has "
 "been deleted and recreated."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:794
+#: warehouse/templates/pages/help.html:792
 msgid ""
 "A distribution filename on PyPI consists of the combination of project "
 "name, version number, and distribution type."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:800
+#: warehouse/templates/pages/help.html:798
 msgid ""
 "This ensures that a given distribution for a given release for a given "
 "project will always resolve to the same file, and cannot be "
@@ -7436,14 +7433,14 @@ msgid ""
 " party (it can only be removed)."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:808
+#: warehouse/templates/pages/help.html:806
 msgid ""
 "To avoid this situation in most cases, you will need to change the "
 "version number to one that you haven't previously uploaded to PyPI, "
 "rebuild the distribution, and then upload the new distribution."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:817
+#: warehouse/templates/pages/help.html:815
 #, python-format
 msgid ""
 "If you would like to request a new trove classifier file a pull request "
@@ -7452,7 +7449,7 @@ msgid ""
 " to include a brief justification of why it is important."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:825
+#: warehouse/templates/pages/help.html:823
 #, python-format
 msgid ""
 "If you're experiencing an issue with PyPI itself, we welcome "
@@ -7463,14 +7460,14 @@ msgid ""
 " first check that a similar issue does not already exist."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:832
+#: warehouse/templates/pages/help.html:830
 msgid ""
 "If you are having an issue is with a specific package installed from "
 "PyPI, you should reach out to the maintainers of that project directly "
 "instead."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:841
+#: warehouse/templates/pages/help.html:839
 #, python-format
 msgid ""
 "PyPI is powered by the Warehouse project; <a href=\"%(href)s\" "
@@ -7480,7 +7477,7 @@ msgid ""
 "Group (PackagingWG)."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:846
+#: warehouse/templates/pages/help.html:844
 #, python-format
 msgid ""
 "The <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -7489,7 +7486,7 @@ msgid ""
 "Python packaging."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:851
+#: warehouse/templates/pages/help.html:849
 #, python-format
 msgid ""
 "The <a href=\"%(packaging_wg_href)s\" title=\"%(title)s\" "
@@ -7502,7 +7499,7 @@ msgid ""
 "Warehouse's security and accessibility."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:861
+#: warehouse/templates/pages/help.html:859
 #, python-format
 msgid ""
 "PyPI is powered by <a href=\"%(warehouse_href)s\" title=\"%(title)s\" "
@@ -7511,14 +7508,14 @@ msgid ""
 " sponsors</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:868
+#: warehouse/templates/pages/help.html:866
 msgid ""
 "As of April 16, 2018, PyPI.org is at \"production\" status, meaning that "
 "it has moved out of beta and replaced the old site (pypi.python.org). It "
 "is now robust, tested, and ready for expected browser and API traffic."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:870
+#: warehouse/templates/pages/help.html:868
 #, python-format
 msgid ""
 "PyPI is heavily cached and distributed via <abbr title=\"content delivery"
@@ -7535,7 +7532,7 @@ msgid ""
 "href=\"%(private_index_href)s\">private index</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:884
+#: warehouse/templates/pages/help.html:882
 #, python-format
 msgid ""
 "We have a huge amount of work to do to continue to maintain and improve "
@@ -7543,22 +7540,22 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">the Warehouse project</a>)."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:889
+#: warehouse/templates/pages/help.html:887
 msgid "Financial:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:889
+#: warehouse/templates/pages/help.html:887
 #, python-format
 msgid ""
 "We would deeply appreciate <a href=\"%(href)s\">your donations to fund "
 "development and maintenance</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:890
+#: warehouse/templates/pages/help.html:888
 msgid "Development:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:890
+#: warehouse/templates/pages/help.html:888
 msgid ""
 "Warehouse is open source, and we would love to see some new faces working"
 " on the project. You <strong>do not</strong> need to be an experienced "
@@ -7566,7 +7563,7 @@ msgid ""
 " you make your first open source pull request!"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:892
+#: warehouse/templates/pages/help.html:890
 #, python-format
 msgid ""
 "If you have skills in Python, ElasticSearch, HTML, SCSS, JavaScript, or "
@@ -7580,7 +7577,7 @@ msgid ""
 "here."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:900
+#: warehouse/templates/pages/help.html:898
 #, python-format
 msgid ""
 "Issues are grouped into <a href=\"%(href)s\" title=\"%(title)s\" "
@@ -7590,11 +7587,11 @@ msgid ""
 "we can guide you through the contribution process."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:907
+#: warehouse/templates/pages/help.html:905
 msgid "Stay updated:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:908
+#: warehouse/templates/pages/help.html:906
 #, python-format
 msgid ""
 "You can also follow the ongoing development of the project on the <a "
@@ -7602,7 +7599,7 @@ msgid ""
 "rel=\"noopener\">Python packaging forum on Discourse</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:917
+#: warehouse/templates/pages/help.html:915
 #, python-format
 msgid ""
 "Changes to PyPI are generally announced on both the <a "
@@ -7616,21 +7613,21 @@ msgid ""
 "the \"pypi\" label."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:927
+#: warehouse/templates/pages/help.html:925
 #, python-format
 msgid ""
 "All traffic is routed through our global CDN, which lists their public IP"
 " addresses here: <a href=\"%(href)s\">%(href)s</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:928
+#: warehouse/templates/pages/help.html:926
 #, python-format
 msgid ""
 "More information about this list can be found here: <a "
 "href=\"%(href)s\">%(href)s</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:932
+#: warehouse/templates/pages/help.html:930
 msgid ""
 "When Warehouse's maintainers are deploying new features, at first we mark"
 " them with a small \"beta feature\" symbol to tell you: this should "
@@ -7638,11 +7635,11 @@ msgid ""
 "functionality."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:933
+#: warehouse/templates/pages/help.html:931
 msgid "Currently, no features are in beta."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:937
+#: warehouse/templates/pages/help.html:935
 #, python-format
 msgid ""
 "\"PyPI\" should be pronounced like \"pie pea eye\", specifically with the"
@@ -7652,39 +7649,39 @@ msgid ""
 "implementation of the Python language."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:949
+#: warehouse/templates/pages/help.html:947
 msgid "Resources"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:950
+#: warehouse/templates/pages/help.html:948
 msgid "Looking for something else? Perhaps these links will help:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:952
+#: warehouse/templates/pages/help.html:950
 msgid "Python Packaging User Guide"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:953
+#: warehouse/templates/pages/help.html:951
 msgid "Python documentation"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:954
+#: warehouse/templates/pages/help.html:952
 msgid "(main Python website)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:955
+#: warehouse/templates/pages/help.html:953
 msgid "Python community page"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:955
+#: warehouse/templates/pages/help.html:953
 msgid "(lists IRC channels, mailing lists, etc.)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:958
+#: warehouse/templates/pages/help.html:956
 msgid "Contact"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:960
+#: warehouse/templates/pages/help.html:958
 #, python-format
 msgid ""
 "The <a href=\"%(pypa_href)s\" title=\"%(title)s\" target=\"_blank\" "

--- a/warehouse/templates/email/oidc-publisher-added/body.html
+++ b/warehouse/templates/email/oidc-publisher-added/body.html
@@ -17,10 +17,10 @@
 {% block content %}
 <p>
   {% trans username=username, project_name=project_name %}
-  PyPI user <strong>{{ username }}</strong> has added a new OpenID Connect
+  PyPI user <strong>{{ username }}</strong> has added a new trusted
   publisher to a project (<strong>{{project_name}}</strong>) that you manage.
-  OpenID Connect publishers act as trusted users and can create project releases
-  automatically.
+  Trusted publishers behave similarly to API tokens and can create project
+  releases automatically.
   {% endtrans %}
 </p>
 

--- a/warehouse/templates/email/oidc-publisher-added/body.txt
+++ b/warehouse/templates/email/oidc-publisher-added/body.txt
@@ -15,9 +15,9 @@
 
 {% block content %}
 {% trans username=username, project_name=project_name %}
-PyPI user {{ username }} has added a new OpenID Connect publisher to a project
-({{ project_name }}) that you manage. OpenID Connect publishers act as trusted
-users and can create project releases automatically.
+PyPI user {{ username }} has added a new trusted publisher to a project
+({{ project_name }}) that you manage. Trusted publishers
+behave similarly to API tokens and can create project releases automatically.
 {% endtrans %}
 
 {% trans %}Publisher information{% endtrans %}:

--- a/warehouse/templates/email/oidc-publisher-added/subject.txt
+++ b/warehouse/templates/email/oidc-publisher-added/subject.txt
@@ -14,4 +14,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}{% trans project_name=project_name %}OpenID Connect publisher added to {{ project_name }}{% endtrans %}{% endblock %}
+{% block subject %}{% trans project_name=project_name %}Trusted publisher added to {{ project_name }}{% endtrans %}{% endblock %}

--- a/warehouse/templates/email/oidc-publisher-removed/body.html
+++ b/warehouse/templates/email/oidc-publisher-removed/body.html
@@ -17,7 +17,7 @@
 {% block content %}
 <p>
   {% trans username=username, project_name=project_name %}
-  PyPI user <strong>{{ username }}</strong> has removed an OpenID Connect
+  PyPI user <strong>{{ username }}</strong> has removed a trusted
   publisher from a project (<strong>{{project_name}}</strong>) that you manage.
   {% endtrans %}
 </p>

--- a/warehouse/templates/email/oidc-publisher-removed/body.txt
+++ b/warehouse/templates/email/oidc-publisher-removed/body.txt
@@ -15,7 +15,7 @@
 
 {% block content %}
 {% trans username=username, project_name=project_name %}
-PyPI user {{ username }} has removed an OpenID Connect publisher from a project
+PyPI user {{ username }} has removed a trusted publisher from a project
 ({{ project_name }}) that you manage.
 {% endtrans %}
 

--- a/warehouse/templates/email/oidc-publisher-removed/subject.txt
+++ b/warehouse/templates/email/oidc-publisher-removed/subject.txt
@@ -14,4 +14,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}{% trans project_name=project_name %}OpenID Connect publisher removed from {{ project_name }}{% endtrans %}{% endblock %}
+{% block subject %}{% trans project_name=project_name %}Trusted publisher removed from {{ project_name }}{% endtrans %}{% endblock %}

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -67,7 +67,7 @@
 {% macro apitoken() %}{% trans %}How can I use API tokens to authenticate with PyPI?{% endtrans %}{% endmacro %}
 {% macro sensitiveactions() %}{% trans %}Why do certain actions require me to confirm my password?{% endtrans %}{% endmacro %}
 {% macro username_change() %}{% trans %}How do I change my PyPI username?{% endtrans %}{% endmacro %}
-{% macro openid_connect() %}{% trans %}How can I use OpenID connect to authenticate with PyPI?{% endtrans %}{% endmacro %}
+{% macro trusted_publishing() %}{% trans %}How can I use trusted publishing to authenticate with PyPI?{% endtrans %}{% endmacro %}
 
 {% macro mirroring() %}{% trans %}How can I run a mirror of PyPI?{% endtrans %}{% endmacro %}
 {% macro APIs() %}{% trans %}Does PyPI have APIs I can use?{% endtrans %}{% endmacro %}
@@ -140,7 +140,7 @@
           <li><a href="#sensitiveactions">{{ sensitiveactions() }}</a></li>
           <li><a href="#username-change">{{ username_change() }}</a></li>
           {% if request.registry.settings["warehouse.oidc.enabled"] %}
-          <li><a href="#openid-connect">{{ openid_connect() }}</a></li>
+          <li><a href="#trusted-publishing">{{ trusted_publishing() }}</a></li>
           {% endif %}
         </ul>
       </section>
@@ -525,20 +525,18 @@
         <p>{% trans %}Instead, you can create a new account with the desired username, add the new account as a maintainer of all the projects your old account owns, and then delete the old account, which will have the same effect.{% endtrans %}</p>
 
         {% if request.registry.settings["warehouse.oidc.enabled"] %}
-        <h3 id="openid-connect">{{ openid_connect() }}</h3>
+        <h3 id="trusted-publishing">{{ trusted_publishing() }}</h3>
         <p>
-          {% trans openid="https://openid.net/connect/", apitoken="#apitoken" %}
-          PyPI users and projects can use <a href="{{ openid }}">OpenID Connect</a> (OIDC) to delegate
+          {% trans %}
+          PyPI users and projects can use "trusted publishing" to delegate
           publishing authority for a PyPI package to a trusted third party service, eliminating
-          the need to use API tokens or passwords.
+          the need to use manually configured API tokens or passwords.
           {% endtrans %}
         </p>
         <p>
-          {% trans %}
-          Using OIDC to authenticate when publishing is done by registering "publishers,"
-          which correspond to services with OIDC identities like GitHub Actions.
-          Existing projects can add or remove OIDC publishers at any time. OIDC publishers
-          can also be created in advance for projects that don't exist yet.
+          {% trans docs="https://docs.pypi.org/trusted-publishers/" %}
+          You can read more about how trusted publishing works (including
+          its implementation details) in the <a href="{{ docs }}">PyPI documentation</a>.
           {% endtrans %}
         </p>
         {% endif %}


### PR DESCRIPTION
Removes references to OpenID Connect from the emails we send, as well as from the PyPI help page. The help links to the new PyPI docs, additionally.