### PR TITLE
Remove `record_event` from `UserService` and `OrganizationService`

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -212,11 +212,14 @@ class TestLogin:
         new_session = {}
 
         user_id = uuid.uuid4()
+        user = pretend.stub(
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
+        )
         user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda username: user_id),
             update_user=pretend.call_recorder(lambda *a, **kw: None),
+            get_user=pretend.call_recorder(lambda userid: user),
             has_two_factor=lambda userid: False,
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
             get_password_timestamp=lambda userid: 0,
         )
         breach_service = pretend.stub(check_password=lambda password, tags=None: False)
@@ -278,10 +281,10 @@ class TestLogin:
 
         assert user_service.find_userid.calls == [pretend.call("theuser")]
         assert user_service.update_user.calls == [pretend.call(user_id, last_login=now)]
-        assert user_service.record_event.calls == [
+        assert user.record_event.calls == [
             pretend.call(
-                user_id,
                 tag=EventTag.Account.LoginSuccess,
+                ip_address=pyramid_request.remote_addr,
                 additional={"two_factor_method": None, "two_factor_label": None},
             )
         ]
@@ -305,11 +308,14 @@ class TestLogin:
     def test_post_validate_no_redirects(
         self, pyramid_request, pyramid_services, expected_next_url, observed_next_url
     ):
+        user = pretend.stub(
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
+        )
         user_service = pretend.stub(
+            get_user=pretend.call_recorder(lambda userid: user),
             find_userid=pretend.call_recorder(lambda username: 1),
             update_user=lambda *a, **k: None,
             has_two_factor=lambda userid: False,
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
             get_password_timestamp=lambda userid: 0,
         )
         breach_service = pretend.stub(check_password=lambda password, tags=None: False)
@@ -338,10 +344,10 @@ class TestLogin:
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == observed_next_url
-        assert user_service.record_event.calls == [
+        assert user.record_event.calls == [
             pretend.call(
-                1,
                 tag=EventTag.Account.LoginSuccess,
+                ip_address=pyramid_request.remote_addr,
                 additional={"two_factor_method": None, "two_factor_label": None},
             )
         ]
@@ -400,7 +406,6 @@ class TestLogin:
             ("Content-Length", "0"),
             ("Location", "/account/two-factor"),
         ]
-        assert user_service.record_event.calls == []
 
 
 class TestTwoFactor:
@@ -636,6 +641,7 @@ class TestTwoFactor:
         user = pretend.stub(
             last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1)),
             has_recovery_codes=has_recovery_codes,
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda username: 1),
@@ -645,7 +651,6 @@ class TestTwoFactor:
             has_webauthn=lambda userid: False,
             has_recovery_codes=lambda userid: has_recovery_codes,
             check_totp_value=lambda userid, totp_value: True,
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
             get_password_timestamp=lambda userid: 0,
         )
 
@@ -702,10 +707,10 @@ class TestTwoFactor:
         assert remember.calls == [pretend.call(pyramid_request, str(1))]
         assert pyramid_request.session.invalidate.calls == [pretend.call()]
         assert pyramid_request.session.new_csrf_token.calls == [pretend.call()]
-        assert user_service.record_event.calls == [
+        assert user.record_event.calls == [
             pretend.call(
-                "1",
                 tag=EventTag.Account.LoginSuccess,
+                ip_address=pyramid_request.remote_addr,
                 additional={"two_factor_method": "totp", "two_factor_label": "totp"},
             )
         ]
@@ -1086,17 +1091,16 @@ class TestRecoveryCode:
             )
         )
 
+        user = pretend.stub(
+            last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1)),
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
+        )
         user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda username: 1),
-            get_user=pretend.call_recorder(
-                lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1))
-                )
-            ),
+            get_user=pretend.call_recorder(lambda userid: user),
             update_user=lambda *a, **k: None,
             has_recovery_codes=lambda userid: True,
             check_recovery_code=lambda userid, recovery_code_value: True,
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
             get_password_timestamp=lambda userid: 0,
         )
 
@@ -1146,18 +1150,18 @@ class TestRecoveryCode:
         assert remember.calls == [pretend.call(pyramid_request, str(1))]
         assert pyramid_request.session.invalidate.calls == [pretend.call()]
         assert pyramid_request.session.new_csrf_token.calls == [pretend.call()]
-        assert user_service.record_event.calls == [
+        assert user.record_event.calls == [
             pretend.call(
-                "1",
                 tag=EventTag.Account.LoginSuccess,
+                ip_address=pyramid_request.remote_addr,
                 additional={
                     "two_factor_method": "recovery-code",
                     "two_factor_label": None,
                 },
             ),
             pretend.call(
-                "1",
                 tag=EventTag.Account.RecoveryCodesUsed,
+                ip_address=pyramid_request.remote_addr,
             ),
         ]
         assert pyramid_request.session.flash.calls == [
@@ -1338,11 +1342,14 @@ class TestRegister:
     def test_register_redirect(self, db_request, monkeypatch):
         db_request.method = "POST"
 
-        user = pretend.stub(id=pretend.stub())
+        record_event = pretend.call_recorder(lambda *a, **kw: None)
+        user = pretend.stub(
+            id=pretend.stub(),
+            record_event=record_event,
+        )
         email = pretend.stub()
         create_user = pretend.call_recorder(lambda *args, **kwargs: user)
         add_email = pretend.call_recorder(lambda *args, **kwargs: email)
-        record_event = pretend.call_recorder(lambda *a, **kw: None)
         db_request.session.record_auth_timestamp = pretend.call_recorder(
             lambda *args: None
         )
@@ -1357,9 +1364,9 @@ class TestRegister:
                     find_userid_by_email=pretend.call_recorder(lambda _: None),
                     update_user=lambda *args, **kwargs: None,
                     create_user=create_user,
+                    get_user=lambda userid: user,
                     add_email=add_email,
                     check_password=lambda pw, tags=None: False,
-                    record_event=record_event,
                     get_password_timestamp=lambda uid: 0,
                 ),
                 IPasswordBreachedService: pretend.stub(
@@ -1399,13 +1406,13 @@ class TestRegister:
         assert send_email.calls == [pretend.call(db_request, (user, email))]
         assert record_event.calls == [
             pretend.call(
-                user.id,
                 tag=EventTag.Account.AccountCreate,
+                ip_address=db_request.remote_addr,
                 additional={"email": "foo@bar.com"},
             ),
             pretend.call(
-                user.id,
                 tag=EventTag.Account.LoginSuccess,
+                ip_address=db_request.remote_addr,
                 additional={"two_factor_method": None, "two_factor_label": None},
             ),
         ]
@@ -1467,12 +1474,14 @@ class TestRequestPasswordReset:
     ):
 
         stub_user = pretend.stub(
-            id=pretend.stub(), username=pretend.stub(), can_reset_password=True
+            id=pretend.stub(),
+            username=pretend.stub(),
+            can_reset_password=True,
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         pyramid_request.method = "POST"
         token_service.dumps = pretend.call_recorder(lambda a: "TOK")
         user_service.get_user_by_username = pretend.call_recorder(lambda a: stub_user)
-        user_service.record_event = pretend.call_recorder(lambda *a, **kw: None)
         pyramid_request.find_service = pretend.call_recorder(
             lambda interface, **kw: {
                 IUserService: user_service,
@@ -1509,10 +1518,10 @@ class TestRequestPasswordReset:
         assert send_password_reset_email.calls == [
             pretend.call(pyramid_request, (stub_user, None))
         ]
-        assert user_service.record_event.calls == [
+        assert stub_user.record_event.calls == [
             pretend.call(
-                stub_user.id,
                 tag=EventTag.Account.PasswordResetRequest,
+                ip_address=pyramid_request.remote_addr,
             )
         ]
 
@@ -1525,12 +1534,12 @@ class TestRequestPasswordReset:
             email="foo@example.com",
             emails=[pretend.stub(email="foo@example.com")],
             can_reset_password=True,
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         pyramid_request.method = "POST"
         token_service.dumps = pretend.call_recorder(lambda a: "TOK")
         user_service.get_user_by_username = pretend.call_recorder(lambda a: None)
         user_service.get_user_by_email = pretend.call_recorder(lambda a: stub_user)
-        user_service.record_event = pretend.call_recorder(lambda *a, **kw: None)
         user_service.ratelimiters = {
             "password.reset": pretend.stub(
                 test=pretend.call_recorder(lambda *a, **kw: True),
@@ -1574,10 +1583,10 @@ class TestRequestPasswordReset:
         assert send_password_reset_email.calls == [
             pretend.call(pyramid_request, (stub_user, stub_user.emails[0]))
         ]
-        assert user_service.record_event.calls == [
+        assert stub_user.record_event.calls == [
             pretend.call(
-                stub_user.id,
                 tag=EventTag.Account.PasswordResetRequest,
+                ip_address=pyramid_request.remote_addr,
             )
         ]
         assert user_service.ratelimiters["password.reset"].test.calls == [
@@ -1599,12 +1608,12 @@ class TestRequestPasswordReset:
                 pretend.stub(email="other@example.com"),
             ],
             can_reset_password=True,
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         pyramid_request.method = "POST"
         token_service.dumps = pretend.call_recorder(lambda a: "TOK")
         user_service.get_user_by_username = pretend.call_recorder(lambda a: None)
         user_service.get_user_by_email = pretend.call_recorder(lambda a: stub_user)
-        user_service.record_event = pretend.call_recorder(lambda *a, **kw: None)
         user_service.ratelimiters = {
             "password.reset": pretend.stub(
                 test=pretend.call_recorder(lambda *a, **kw: True),
@@ -1650,10 +1659,10 @@ class TestRequestPasswordReset:
         assert send_password_reset_email.calls == [
             pretend.call(pyramid_request, (stub_user, stub_user.emails[1]))
         ]
-        assert user_service.record_event.calls == [
+        assert stub_user.record_event.calls == [
             pretend.call(
-                stub_user.id,
                 tag=EventTag.Account.PasswordResetRequest,
+                ip_address=pyramid_request.remote_addr,
             )
         ]
         assert user_service.ratelimiters["password.reset"].test.calls == [
@@ -1676,11 +1685,11 @@ class TestRequestPasswordReset:
             email="foo@example.com",
             emails=[pretend.stub(email="foo@example.com")],
             can_reset_password=True,
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         pyramid_request.method = "POST"
         user_service.get_user_by_username = pretend.call_recorder(lambda a: None)
         user_service.get_user_by_email = pretend.call_recorder(lambda a: stub_user)
-        user_service.record_event = pretend.call_recorder(lambda *a, **kw: None)
         user_service.ratelimiters = {
             "password.reset": pretend.stub(
                 test=pretend.call_recorder(lambda *a, **kw: False),
@@ -1723,12 +1732,14 @@ class TestRequestPasswordReset:
         self, monkeypatch, pyramid_request, pyramid_config, user_service
     ):
         stub_user = pretend.stub(
-            id=pretend.stub(), username=pretend.stub(), can_reset_password=False
+            id=pretend.stub(),
+            username=pretend.stub(),
+            can_reset_password=False,
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         pyramid_request.method = "POST"
         pyramid_request.route_path = pretend.call_recorder(lambda a: "/the-redirect")
         user_service.get_user_by_username = pretend.call_recorder(lambda a: stub_user)
-        user_service.record_event = pretend.call_recorder(lambda *a, **kw: None)
         pyramid_request.find_service = pretend.call_recorder(
             lambda interface, **kw: {
                 IUserService: user_service,
@@ -1748,10 +1759,10 @@ class TestRequestPasswordReset:
         ]
         assert result.headers["Location"] == "/the-redirect"
 
-        assert user_service.record_event.calls == [
+        assert stub_user.record_event.calls == [
             pretend.call(
-                stub_user.id,
                 tag=EventTag.Account.PasswordResetAttempt,
+                ip_address=pyramid_request.remote_addr,
             )
         ]
 

--- a/tests/unit/admin/views/test_organizations.py
+++ b/tests/unit/admin/views/test_organizations.py
@@ -460,11 +460,11 @@ class TestOrganizationDetail:
                     ),
                 ),
             ),
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         organization_service = pretend.stub(
             get_organization=lambda *a, **kw: organization,
             approve_organization=pretend.call_recorder(lambda *a, **kw: None),
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         organization_detail_location = (f"/admin/organizations/{organization.id}/",)
         message = pretend.stub()
@@ -480,6 +480,7 @@ class TestOrganizationDetail:
             session=pretend.stub(
                 flash=pretend.call_recorder(lambda *a, **kw: None),
             ),
+            remote_addr="0.0.0.0",
             user=admin,
         )
         send_email = pretend.call_recorder(lambda *a, **kw: None)
@@ -493,10 +494,10 @@ class TestOrganizationDetail:
         assert organization_service.approve_organization.calls == [
             pretend.call(organization.id),
         ]
-        assert organization_service.record_event.calls == [
+        assert organization.record_event.calls == [
             pretend.call(
-                organization.id,
                 tag=EventTag.Organization.OrganizationApprove,
+                ip_address=request.remote_addr,
                 additional={"approved_by_user_id": str(admin.id)},
             ),
         ]
@@ -606,11 +607,11 @@ class TestOrganizationDetail:
                     ),
                 ),
             ),
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         organization_service = pretend.stub(
             get_organization=lambda *a, **kw: organization,
             decline_organization=pretend.call_recorder(lambda *a, **kw: None),
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         organization_detail_location = (f"/admin/organizations/{organization.id}/",)
         message = pretend.stub()
@@ -626,6 +627,7 @@ class TestOrganizationDetail:
             session=pretend.stub(
                 flash=pretend.call_recorder(lambda *a, **kw: None),
             ),
+            remote_addr="0.0.0.0",
             user=admin,
         )
         send_email = pretend.call_recorder(lambda *a, **kw: None)
@@ -639,10 +641,10 @@ class TestOrganizationDetail:
         assert organization_service.decline_organization.calls == [
             pretend.call(organization.id),
         ]
-        assert organization_service.record_event.calls == [
+        assert organization.record_event.calls == [
             pretend.call(
-                organization.id,
                 tag=EventTag.Organization.OrganizationDecline,
+                ip_address=request.remote_addr,
                 additional={"declined_by_user_id": str(admin.id)},
             ),
         ]

--- a/tests/unit/manage/views/test_organizations.py
+++ b/tests/unit/manage/views/test_organizations.py
@@ -131,7 +131,6 @@ class TestManageOrganizations:
         admins = []
         user_service = pretend.stub(
             get_admins=pretend.call_recorder(lambda *a, **kw: admins),
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
 
         organization = pretend.stub(
@@ -147,6 +146,7 @@ class TestManageOrganizations:
             ),
             is_active=False,
             is_approved=None,
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         catalog_entry = pretend.stub()
         role = pretend.stub()
@@ -154,7 +154,6 @@ class TestManageOrganizations:
             add_organization=pretend.call_recorder(lambda *a, **kw: organization),
             add_catalog_entry=pretend.call_recorder(lambda *a, **kw: catalog_entry),
             add_organization_role=pretend.call_recorder(lambda *a, **kw: role),
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
 
         request = pretend.stub(
@@ -170,6 +169,7 @@ class TestManageOrganizations:
                 id=pretend.stub(),
                 username=pretend.stub(),
                 has_primary_verified_email=True,
+                record_event=pretend.call_recorder(lambda *a, **kw: None),
             ),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             find_service=lambda interface, **kw: {
@@ -228,20 +228,20 @@ class TestManageOrganizations:
                 OrganizationRoleType.Owner,
             )
         ]
-        assert organization_service.record_event.calls == [
+        assert organization.record_event.calls == [
             pretend.call(
-                organization.id,
                 tag=EventTag.Organization.CatalogEntryAdd,
+                ip_address=request.remote_addr,
                 additional={"submitted_by_user_id": str(request.user.id)},
             ),
             pretend.call(
-                organization.id,
                 tag=EventTag.Organization.OrganizationCreate,
+                ip_address=request.remote_addr,
                 additional={"created_by_user_id": str(request.user.id)},
             ),
             pretend.call(
-                organization.id,
                 tag=EventTag.Organization.OrganizationRoleAdd,
+                ip_address=request.remote_addr,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
                     "role_name": "Owner",
@@ -249,10 +249,10 @@ class TestManageOrganizations:
                 },
             ),
         ]
-        assert user_service.record_event.calls == [
+        assert request.user.record_event.calls == [
             pretend.call(
-                request.user.id,
                 tag=EventTag.Account.OrganizationRoleAdd,
+                ip_address=request.remote_addr,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
                     "organization_name": organization.name,
@@ -282,7 +282,6 @@ class TestManageOrganizations:
         admins = []
         user_service = pretend.stub(
             get_admins=pretend.call_recorder(lambda *a, **kw: admins),
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
 
         organization = pretend.stub(
@@ -299,6 +298,7 @@ class TestManageOrganizations:
             ),
             is_active=False,
             is_approved=None,
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         catalog_entry = pretend.stub()
         role = pretend.stub()
@@ -306,7 +306,6 @@ class TestManageOrganizations:
             add_organization=pretend.call_recorder(lambda *a, **kw: organization),
             add_catalog_entry=pretend.call_recorder(lambda *a, **kw: catalog_entry),
             add_organization_role=pretend.call_recorder(lambda *a, **kw: role),
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
 
         request = pretend.stub(
@@ -322,6 +321,7 @@ class TestManageOrganizations:
                 id=pretend.stub(),
                 username=pretend.stub(),
                 has_primary_verified_email=True,
+                record_event=pretend.call_recorder(lambda *a, **kw: None),
             ),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             find_service=lambda interface, **kw: {
@@ -380,20 +380,20 @@ class TestManageOrganizations:
                 OrganizationRoleType.Owner,
             )
         ]
-        assert organization_service.record_event.calls == [
+        assert organization.record_event.calls == [
             pretend.call(
-                organization.id,
                 tag=EventTag.Organization.CatalogEntryAdd,
+                ip_address=request.remote_addr,
                 additional={"submitted_by_user_id": str(request.user.id)},
             ),
             pretend.call(
-                organization.id,
                 tag=EventTag.Organization.OrganizationCreate,
+                ip_address=request.remote_addr,
                 additional={"created_by_user_id": str(request.user.id)},
             ),
             pretend.call(
-                organization.id,
                 tag=EventTag.Organization.OrganizationRoleAdd,
+                ip_address=request.remote_addr,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
                     "role_name": "Owner",
@@ -401,10 +401,10 @@ class TestManageOrganizations:
                 },
             ),
         ]
-        assert user_service.record_event.calls == [
+        assert request.user.record_event.calls == [
             pretend.call(
-                request.user.id,
                 tag=EventTag.Account.OrganizationRoleAdd,
+                ip_address=request.remote_addr,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
                     "organization_name": organization.name,
@@ -433,17 +433,17 @@ class TestManageOrganizations:
         admins = []
         user_service = pretend.stub(
             get_admins=pretend.call_recorder(lambda *a, **kw: admins),
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
 
-        organization = pretend.stub()
+        organization = pretend.stub(
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
+        )
         catalog_entry = pretend.stub()
         role = pretend.stub()
         organization_service = pretend.stub(
             add_organization=pretend.call_recorder(lambda *a, **kw: organization),
             add_catalog_entry=pretend.call_recorder(lambda *a, **kw: catalog_entry),
             add_organization_role=pretend.call_recorder(lambda *a, **kw: role),
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
 
         request = pretend.stub(
@@ -494,7 +494,7 @@ class TestManageOrganizations:
         assert organization_service.add_organization.calls == []
         assert organization_service.add_catalog_entry.calls == []
         assert organization_service.add_organization_role.calls == []
-        assert organization_service.record_event.calls == []
+        assert organization.record_event.calls == []
         assert send_email.calls == []
         assert result == {"create_organization_form": create_organization_obj}
 

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -224,14 +224,6 @@ class IUserService(Interface):
         or None of the user doesn't have a credential with this ID.
         """
 
-    def record_event(user_id, *, tag, additional=None):
-        """
-        Creates a new UserEvent for the given user with the given
-        tag, IP address, and additional metadata.
-
-        Returns the event.
-        """
-
     def generate_recovery_codes(user_id):
         """
         Generates RecoveryCode objects for the given user.

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -565,18 +565,6 @@ class DatabaseUserService:
             None,
         )
 
-    def record_event(self, user_id, *, tag, additional=None):
-        """
-        Creates a new UserEvent for the given user with the given
-        tag, IP address, and additional metadata.
-
-        Returns the event.
-        """
-        user = self.get_user(user_id)
-        return user.record_event(
-            tag=tag, ip_address=self.remote_addr, additional=additional
-        )
-
     def generate_recovery_codes(self, user_id):
         user = self.get_user(user_id)
 

--- a/warehouse/admin/views/organizations.py
+++ b/warehouse/admin/views/organizations.py
@@ -234,9 +234,9 @@ def organization_approve(request):
     message = request.params.get("message", "")
 
     organization_service.approve_organization(organization.id)
-    organization_service.record_event(
-        organization.id,
+    organization.record_event(
         tag=EventTag.Organization.OrganizationApprove,
+        ip_address=request.remote_addr,
         additional={"approved_by_user_id": str(request.user.id)},
     )
     send_admin_new_organization_approved_email(
@@ -302,9 +302,9 @@ def organization_decline(request):
     message = request.params.get("message", "")
 
     organization_service.decline_organization(organization.id)
-    organization_service.record_event(
-        organization.id,
+    organization.record_event(
         tag=EventTag.Organization.OrganizationDecline,
+        ip_address=request.remote_addr,
         additional={"declined_by_user_id": str(request.user.id)},
     )
     send_admin_new_organization_declined_email(

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -67,9 +67,9 @@ def send_email(task, request, recipient, msg, success_event):
 
     try:
         sender.send(recipient, msg)
-
         user_service = request.find_service(IUserService, context=None)
-        user_service.record_event(**success_event)
+        user = user_service.get_user(success_event.pop("user_id"))
+        user.record_event(**success_event)
     except (BadHeaders, EncodingError, InvalidMessage) as exc:
         raise exc
     except Exception as exc:

--- a/warehouse/integrations/github/utils.py
+++ b/warehouse/integrations/github/utils.py
@@ -17,7 +17,6 @@ import time
 import requests
 
 from warehouse import integrations
-from warehouse.accounts.interfaces import IUserService
 from warehouse.email import send_token_compromised_email_leak
 from warehouse.events.tags import EventTag
 from warehouse.macaroons import InvalidMacaroonError
@@ -245,11 +244,10 @@ def _analyze_disclosure(request, disclosure_record, origin):
         public_url=disclosure.public_url,
         origin=origin,
     )
-    user_service = request.find_service(IUserService, context=None)
 
-    user_service.record_event(
-        database_macaroon.user.id,
+    database_macaroon.user.record_event(
         tag=EventTag.Account.APITokenRemovedLeak,
+        ip_address=request.remote_addr,
         additional={
             "macaroon_id": str(database_macaroon.id),
             "public_url": disclosure.public_url,

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -41,60 +41,60 @@ msgid ""
 "different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:142 warehouse/accounts/forms.py:186
-#: warehouse/accounts/forms.py:199
+#: warehouse/accounts/forms.py:142 warehouse/accounts/forms.py:187
+#: warehouse/accounts/forms.py:200
 msgid "Password too long."
 msgstr ""
 
-#: warehouse/accounts/forms.py:172 warehouse/accounts/views.py:95
+#: warehouse/accounts/forms.py:173 warehouse/accounts/views.py:95
 msgid "There have been too many unsuccessful login attempts. Try again later."
 msgstr ""
 
-#: warehouse/accounts/forms.py:202
+#: warehouse/accounts/forms.py:203
 msgid "Your passwords don't match. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:233 warehouse/accounts/forms.py:244
+#: warehouse/accounts/forms.py:234 warehouse/accounts/forms.py:245
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:252
+#: warehouse/accounts/forms.py:253
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:263
+#: warehouse/accounts/forms.py:264
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:270
+#: warehouse/accounts/forms.py:271
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:292 warehouse/manage/forms.py:143
+#: warehouse/accounts/forms.py:293 warehouse/manage/forms.py:143
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:380
+#: warehouse/accounts/forms.py:382
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:397
+#: warehouse/accounts/forms.py:399
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:455
+#: warehouse/accounts/forms.py:459
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:463
+#: warehouse/accounts/forms.py:468
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:482
+#: warehouse/accounts/forms.py:487
 msgid "No user found with that username or email"
 msgstr ""
 
@@ -143,8 +143,8 @@ msgstr ""
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:674 warehouse/accounts/views.py:773
-#: warehouse/accounts/views.py:872 warehouse/accounts/views.py:1041
+#: warehouse/accounts/views.py:674 warehouse/accounts/views.py:775
+#: warehouse/accounts/views.py:874 warehouse/accounts/views.py:1043
 msgid "Invalid token: no token supplied"
 msgstr ""
 
@@ -166,115 +166,115 @@ msgid ""
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:741
+#: warehouse/accounts/views.py:743
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:769
+#: warehouse/accounts/views.py:771
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:771
+#: warehouse/accounts/views.py:773
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:777
+#: warehouse/accounts/views.py:779
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:786
+#: warehouse/accounts/views.py:788
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:789
+#: warehouse/accounts/views.py:791
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:806
+#: warehouse/accounts/views.py:808
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:810
+#: warehouse/accounts/views.py:812
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:815
+#: warehouse/accounts/views.py:817
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:868
+#: warehouse/accounts/views.py:870
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:870
+#: warehouse/accounts/views.py:872
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:876
+#: warehouse/accounts/views.py:878
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:880
+#: warehouse/accounts/views.py:882
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:889
+#: warehouse/accounts/views.py:891
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:940
+#: warehouse/accounts/views.py:942
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1003
+#: warehouse/accounts/views.py:1005
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1037
+#: warehouse/accounts/views.py:1039
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1039
+#: warehouse/accounts/views.py:1041
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1045
+#: warehouse/accounts/views.py:1047
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1049
+#: warehouse/accounts/views.py:1051
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1064
+#: warehouse/accounts/views.py:1066
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1095
+#: warehouse/accounts/views.py:1097
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1162
+#: warehouse/accounts/views.py:1164
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1418
+#: warehouse/accounts/views.py:1421
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1431
+#: warehouse/accounts/views.py:1434
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1447 warehouse/manage/views/__init__.py:1244
+#: warehouse/accounts/views.py:1450 warehouse/manage/views/__init__.py:1244
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1475
+#: warehouse/accounts/views.py:1478
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -205,14 +205,14 @@ class ManageOrganizationsViews:
         if form.validate():
             data = form.data
             organization = self.organization_service.add_organization(**data)
-            self.organization_service.record_event(
-                organization.id,
+            organization.record_event(
                 tag=EventTag.Organization.CatalogEntryAdd,
+                ip_address=self.request.remote_addr,
                 additional={"submitted_by_user_id": str(self.request.user.id)},
             )
-            self.organization_service.record_event(
-                organization.id,
+            organization.record_event(
                 tag=EventTag.Organization.OrganizationCreate,
+                ip_address=self.request.remote_addr,
                 additional={"created_by_user_id": str(self.request.user.id)},
             )
             self.organization_service.add_organization_role(
@@ -220,18 +220,18 @@ class ManageOrganizationsViews:
                 self.request.user.id,
                 OrganizationRoleType.Owner,
             )
-            self.organization_service.record_event(
-                organization.id,
+            organization.record_event(
                 tag=EventTag.Organization.OrganizationRoleAdd,
+                ip_address=self.request.remote_addr,
                 additional={
                     "submitted_by_user_id": str(self.request.user.id),
                     "role_name": "Owner",
                     "target_user_id": str(self.request.user.id),
                 },
             )
-            self.user_service.record_event(
-                self.request.user.id,
+            self.request.user.record_event(
                 tag=EventTag.Account.OrganizationRoleAdd,
+                ip_address=self.request.remote_addr,
                 additional={
                     "submitted_by_user_id": str(self.request.user.id),
                     "organization_name": organization.name,

--- a/warehouse/organizations/interfaces.py
+++ b/warehouse/organizations/interfaces.py
@@ -256,11 +256,3 @@ class IOrganizationService(Interface):
         """
         Delete an team project role for a specified team project role id
         """
-
-    def record_event(organization_id, *, tag, additional=None):
-        """
-        Creates a new Organization.Event for the given organization with the given
-        tag, IP address, and additional metadata.
-
-        Returns the event.
-        """

--- a/warehouse/organizations/services.py
+++ b/warehouse/organizations/services.py
@@ -624,18 +624,6 @@ class DatabaseOrganizationService:
 
         self.db.delete(team_project_role)
 
-    def record_event(self, organization_id, *, tag, additional=None):
-        """
-        Creates a new Organization.Event for the given organization with the given
-        tag, IP address, and additional metadata.
-
-        Returns the event.
-        """
-        organization = self.get_organization(organization_id)
-        return organization.record_event(
-            tag=tag, ip_address=self.remote_addr, additional=additional
-        )
-
 
 def database_organization_factory(context, request):
     return DatabaseOrganizationService(request.db, remote_addr=request.remote_addr)

--- a/warehouse/organizations/tasks.py
+++ b/warehouse/organizations/tasks.py
@@ -74,9 +74,9 @@ def delete_declined_organizations(request):
     for organization in organizations:
         organization_service = request.find_service(IOrganizationService, context=None)
         # TODO: Cannot call this after deletion so how exactly do we handle this?
-        organization_service.record_event(
-            organization.id,
+        organization.record_event(
             tag=EventTag.Organization.OrganizationDelete,
+            ip_address=request.remote_addr,
             additional={"deleted_by": "CRON"},
         )
         organization_service.delete_organization(organization.id)


### PR DESCRIPTION
This removes the vestigial `record_event` function from the `UserService` and `OrganizationService` in favor of `User.record_event` and `Organization.record_event` functions provided by`HasEvents`.

This brings some additional consistency to how we record events, and also in _most_ cases, this saves us from having to do an unnecessary `UserService.get_user()` call to get the user by ID. 