### PR TITLE
Allow closed beta participants to access org features

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -426,6 +426,7 @@ def db_request(pyramid_request, db_session):
     pyramid_request.db = db_session
     pyramid_request.flags = admin.flags.Flags(pyramid_request)
     pyramid_request.banned = admin.bans.Bans(pyramid_request)
+    pyramid_request.organization_access = True
     return pyramid_request
 
 

--- a/tests/functional/manage/test_views.py
+++ b/tests/functional/manage/test_views.py
@@ -65,6 +65,7 @@ class TestManageOrganizations:
         user = UserFactory.create(name="old name")
         EmailFactory.create(primary=True, verified=True, public=True, user=user)
         db_request.user = user
+        db_request.organization_access = True
         db_request.method = "POST"
         db_request.path = "/manage/organizations/"
         db_request.POST = MultiDict(

--- a/tests/unit/admin/views/test_organizations.py
+++ b/tests/unit/admin/views/test_organizations.py
@@ -221,10 +221,6 @@ class TestOrganizationList:
             "terms": ["is:not-actually-a-valid-query"],
         }
 
-    def test_disable_organizations(self, db_request):
-        with pytest.raises(HTTPNotFound):
-            views.organization_list(db_request)
-
 
 class TestOrganizationDetail:
     def test_detail(self, enable_organizations):
@@ -713,15 +709,3 @@ class TestOrganizationDetail:
 
         with pytest.raises(HTTPNotFound):
             views.organization_decline(request)
-
-    def test_detail_disable_organizations(self, db_request):
-        with pytest.raises(HTTPNotFound):
-            views.organization_detail(db_request)
-
-    def test_approve_disable_organizations(self, db_request):
-        with pytest.raises(HTTPNotFound):
-            views.organization_approve(db_request)
-
-    def test_decline_disable_organizations(self, db_request):
-        with pytest.raises(HTTPNotFound):
-            views.organization_decline(db_request)

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -2526,9 +2526,7 @@ class TestManageProjects:
 class TestManageProjectSettings:
     @pytest.mark.parametrize("enabled", [False, True])
     def test_manage_project_settings(self, enabled, monkeypatch):
-        request = pretend.stub(
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: enabled))
-        )
+        request = pretend.stub(organization_access=enabled)
         project = pretend.stub(organization=None)
         view = views.ManageProjectSettingsViews(project, request)
         form = pretend.stub()
@@ -2553,9 +2551,7 @@ class TestManageProjectSettings:
         }
 
     def test_manage_project_settings_in_organization_managed(self, monkeypatch):
-        request = pretend.stub(
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
-        )
+        request = pretend.stub(organization_access=True)
         organization_managed = pretend.stub(name="managed-org", is_active=True)
         organization_owned = pretend.stub(name="owned-org", is_active=True)
         project = pretend.stub(organization=organization_managed)
@@ -2587,9 +2583,7 @@ class TestManageProjectSettings:
         ]
 
     def test_manage_project_settings_in_organization_owned(self, monkeypatch):
-        request = pretend.stub(
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
-        )
+        request = pretend.stub(organization_access=True)
         organization_managed = pretend.stub(name="managed-org", is_active=True)
         organization_owned = pretend.stub(name="owned-org", is_active=True)
         project = pretend.stub(organization=organization_owned)
@@ -2763,7 +2757,7 @@ class TestManageProjectSettings:
         request = pretend.stub(
             POST={},
             user=user,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
+            organization_access=True,
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=lambda *a, **kw: "/foo/bar/",
         )
@@ -2773,9 +2767,6 @@ class TestManageProjectSettings:
             assert exc.value.status_code == 303
             assert exc.value.headers["Location"] == "/foo/bar/"
 
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ]
         assert request.session.flash.calls == [
             pretend.call("Confirm the request", queue="error")
         ]
@@ -2791,7 +2782,7 @@ class TestManageProjectSettings:
         request = pretend.stub(
             POST={"confirm_remove_organization_project_name": "FOO"},
             user=user,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
+            organization_access=True,
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=lambda *a, **kw: "/foo/bar/",
         )
@@ -2801,9 +2792,6 @@ class TestManageProjectSettings:
             assert exc.value.status_code == 303
             assert exc.value.headers["Location"] == "/foo/bar/"
 
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ]
         assert request.session.flash.calls == [
             pretend.call(
                 (
@@ -2817,7 +2805,7 @@ class TestManageProjectSettings:
     def test_remove_organization_project_disable_organizations(self):
         project = pretend.stub(name="foo", normalized_name="foo")
         request = pretend.stub(
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: True)),
+            organization_access=False,
             route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
         )
@@ -2826,9 +2814,6 @@ class TestManageProjectSettings:
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ]
         assert request.session.flash.calls == [
             pretend.call("Organizations are disabled", queue="error")
         ]
@@ -2890,7 +2875,7 @@ class TestManageProjectSettings:
         request = pretend.stub(
             POST={},
             user=user,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
+            organization_access=True,
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=lambda *a, **kw: "/foo/bar/",
         )
@@ -2899,9 +2884,6 @@ class TestManageProjectSettings:
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/foo/bar/"
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ]
         assert request.session.flash.calls == [
             pretend.call(
                 (
@@ -2940,9 +2922,6 @@ class TestManageProjectSettings:
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
-        assert db_request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ]
         assert db_request.session.flash.calls == [
             pretend.call(
                 (
@@ -3020,7 +2999,7 @@ class TestManageProjectSettings:
         request = pretend.stub(
             POST={},
             user=user,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
+            organization_access=True,
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=lambda *a, **kw: "/foo/bar/",
         )
@@ -3030,9 +3009,6 @@ class TestManageProjectSettings:
             assert exc.value.status_code == 303
             assert exc.value.headers["Location"] == "/foo/bar/"
 
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ]
         assert request.session.flash.calls == [
             pretend.call("Confirm the request", queue="error")
         ]
@@ -3047,7 +3023,7 @@ class TestManageProjectSettings:
         request = pretend.stub(
             POST={"confirm_transfer_organization_project_name": "FOO"},
             user=user,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
+            organization_access=True,
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=lambda *a, **kw: "/foo/bar/",
         )
@@ -3057,9 +3033,6 @@ class TestManageProjectSettings:
             assert exc.value.status_code == 303
             assert exc.value.headers["Location"] == "/foo/bar/"
 
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ]
         assert request.session.flash.calls == [
             pretend.call(
                 "Could not transfer project - 'FOO' is not the same as 'foo'",
@@ -3070,7 +3043,7 @@ class TestManageProjectSettings:
     def test_transfer_organization_project_disable_organizations(self):
         project = pretend.stub(name="foo", normalized_name="foo")
         request = pretend.stub(
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: True)),
+            organization_access=False,
             route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
         )
@@ -3078,10 +3051,6 @@ class TestManageProjectSettings:
         result = org_views.transfer_organization_project(project, request)
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
-
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ]
 
         assert request.session.flash.calls == [
             pretend.call("Organizations are disabled", queue="error")
@@ -3163,7 +3132,7 @@ class TestManageProjectSettings:
         request = pretend.stub(
             POST={},
             user=user,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
+            organization_access=True,
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=lambda *a, **kw: "/foo/bar/",
         )
@@ -3172,9 +3141,6 @@ class TestManageProjectSettings:
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/foo/bar/"
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ]
         assert request.session.flash.calls == [
             pretend.call(
                 (

--- a/tests/unit/manage/views/test_organizations.py
+++ b/tests/unit/manage/views/test_organizations.py
@@ -103,7 +103,7 @@ class TestManageOrganizations:
     def test_manage_organizations(self, monkeypatch):
         request = pretend.stub(
             find_service=lambda *a, **kw: pretend.stub(),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
+            organization_access=True,
         )
 
         default_response = {"default": "response"}
@@ -120,7 +120,7 @@ class TestManageOrganizations:
     def test_manage_organizations_disable_organizations(self):
         request = pretend.stub(
             find_service=lambda *a, **kw: pretend.stub(),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: True)),
+            organization_access=False,
         )
 
         view = org_views.ManageOrganizationsViews(request)
@@ -176,7 +176,7 @@ class TestManageOrganizations:
                 IUserService: user_service,
                 IOrganizationService: organization_service,
             }[interface],
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
+            organization_access=True,
             remote_addr="0.0.0.0",
             path="request-path",
         )
@@ -328,7 +328,7 @@ class TestManageOrganizations:
                 IUserService: user_service,
                 IOrganizationService: organization_service,
             }[interface],
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
+            organization_access=True,
             remote_addr="0.0.0.0",
             route_path=lambda *a, **kw: "manage-subscription-url",
         )
@@ -465,7 +465,7 @@ class TestManageOrganizations:
                 IUserService: user_service,
                 IOrganizationService: organization_service,
             }[interface],
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
+            organization_access=True,
             remote_addr="0.0.0.0",
         )
 
@@ -501,7 +501,7 @@ class TestManageOrganizations:
     def test_create_organization_disable_organizations(self):
         request = pretend.stub(
             find_service=lambda *a, **kw: pretend.stub(),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: True)),
+            organization_access=False,
         )
 
         view = org_views.ManageOrganizationsViews(request)
@@ -1051,6 +1051,7 @@ class TestManageOrganizationBillingViews:
         subscription_service,
         organization,
     ):
+        db_request.organization_access = False
         view = org_views.ManageOrganizationBillingViews(organization, db_request)
 
         with pytest.raises(HTTPNotFound):

--- a/warehouse/admin/templates/admin/base.html
+++ b/warehouse/admin/templates/admin/base.html
@@ -109,13 +109,11 @@
       <nav class="mt-2">
         <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
           {% if request.has_permission('moderator') %}
-          {% if not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS) %}
           <li class="nav-item">
             <a href="{{ request.route_path('admin.organization.list') }}" class="nav-link">
               <i class="fa fa-sitemap nav-icon"></i> <p>Organizations <span class="right badge badge-danger">New</span></p>
             </a>
           </li>
-          {% endif %}
           <li class="nav-item">
             <a href="{{ request.route_path('admin.user.list') }}" class="nav-link">
               <i class="fa fa-user nav-icon"></i> <p>Users</p>

--- a/warehouse/admin/views/organizations.py
+++ b/warehouse/admin/views/organizations.py
@@ -18,7 +18,6 @@ from pyramid.view import view_config
 from sqlalchemy import or_
 
 from warehouse.accounts.interfaces import IUserService
-from warehouse.admin.flags import AdminFlagValue
 from warehouse.email import (
     send_admin_new_organization_approved_email,
     send_admin_new_organization_declined_email,
@@ -38,9 +37,6 @@ from warehouse.utils.paginate import paginate_url_factory
     uses_session=True,
 )
 def organization_list(request):
-    if request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
-        raise HTTPNotFound
-
     q = request.params.get("q", "")
     terms = shlex.split(q)
 
@@ -145,9 +141,6 @@ def organization_list(request):
     require_reauth=True,
 )
 def organization_detail(request):
-    if request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
-        raise HTTPNotFound
-
     organization_service = request.find_service(IOrganizationService, context=None)
     user_service = request.find_service(IUserService, context=None)
 
@@ -204,9 +197,6 @@ def organization_detail(request):
     require_reauth=True,
 )
 def organization_approve(request):
-    if request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
-        raise HTTPNotFound
-
     organization_service = request.find_service(IOrganizationService, context=None)
     user_service = request.find_service(IUserService, context=None)
 
@@ -272,9 +262,6 @@ def organization_approve(request):
     require_reauth=True,
 )
 def organization_decline(request):
-    if request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
-        raise HTTPNotFound
-
     organization_service = request.find_service(IOrganizationService, context=None)
     user_service = request.find_service(IUserService, context=None)
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -368,67 +368,67 @@ msgstr ""
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2033
+#: warehouse/manage/views/__init__.py:2032
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2141
+#: warehouse/manage/views/__init__.py:2140
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2209
+#: warehouse/manage/views/__init__.py:2208
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2241
+#: warehouse/manage/views/__init__.py:2240
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2254
-#: warehouse/manage/views/organizations.py:891
+#: warehouse/manage/views/__init__.py:2253
+#: warehouse/manage/views/organizations.py:890
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2320
-#: warehouse/manage/views/organizations.py:956
+#: warehouse/manage/views/__init__.py:2319
+#: warehouse/manage/views/organizations.py:955
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2353
+#: warehouse/manage/views/__init__.py:2352
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2364
+#: warehouse/manage/views/__init__.py:2363
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2397
-#: warehouse/manage/views/organizations.py:1143
+#: warehouse/manage/views/__init__.py:2396
+#: warehouse/manage/views/organizations.py:1142
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:867
+#: warehouse/manage/views/organizations.py:866
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:878
+#: warehouse/manage/views/organizations.py:877
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1039
-#: warehouse/manage/views/organizations.py:1081
+#: warehouse/manage/views/organizations.py:1038
+#: warehouse/manage/views/organizations.py:1080
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1049
+#: warehouse/manage/views/organizations.py:1048
 msgid "Organization invitation could not be re-sent."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1096
+#: warehouse/manage/views/organizations.py:1095
 msgid "Expired invitation for '${username}' deleted."
 msgstr ""
 

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -1045,7 +1045,7 @@ class ManageProjectSettingsViews:
 
     @view_config(request_method="GET")
     def manage_project_settings(self):
-        if self.request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
+        if not self.request.organization_access:
             # Disable transfer of project to any organization.
             organization_choices = set()
         else:
@@ -1965,8 +1965,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
 
     # Team project roles and add internal collaborator form for organization projects.
     enable_internal_collaborator = bool(
-        not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        and project.organization
+        request.organization_access and project.organization
     )
     if enable_internal_collaborator:
         team_project_roles = set(

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -22,7 +22,6 @@ from pyramid.view import view_config, view_defaults
 
 from warehouse.accounts.interfaces import ITokenService, IUserService, TokenExpired
 from warehouse.accounts.models import User
-from warehouse.admin.flags import AdminFlagValue
 from warehouse.email import (
     send_admin_new_organization_requested_email,
     send_admin_organization_deleted_email,
@@ -186,7 +185,7 @@ class ManageOrganizationsViews:
     @view_config(request_method="GET")
     def manage_organizations(self):
         # Organizations must be enabled.
-        if self.request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
+        if not self.request.organization_access:
             raise HTTPNotFound()
 
         return self.default_response
@@ -194,7 +193,7 @@ class ManageOrganizationsViews:
     @view_config(request_method="POST", request_param=CreateOrganizationForm.__params__)
     def create_organization(self):
         # Organizations must be enabled.
-        if self.request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
+        if not self.request.organization_access:
             raise HTTPNotFound()
 
         form = CreateOrganizationForm(
@@ -566,7 +565,7 @@ class ManageOrganizationBillingViews:
     @view_config(route_name="manage.organization.subscription")
     def create_or_manage_subscription(self):
         # Organizations must be enabled.
-        if self.request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
+        if not self.request.organization_access:
             raise HTTPNotFound()
 
         if not self.organization.subscriptions:
@@ -1370,7 +1369,7 @@ def manage_organization_history(organization, request):
     require_reauth=True,
 )
 def remove_organization_project(project, request):
-    if request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
+    if not request.organization_access:
         request.session.flash("Organizations are disabled", queue="error")
         return HTTPSeeOther(
             request.route_path("manage.project.settings", project_name=project.name)
@@ -1464,7 +1463,7 @@ def remove_organization_project(project, request):
     require_reauth=True,
 )
 def transfer_organization_project(project, request):
-    if request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS):
+    if not request.organization_access:
         request.session.flash("Organizations are disabled", queue="error")
         return HTTPSeeOther(
             request.route_path("manage.project.settings", project_name=project.name)

--- a/warehouse/predicates.py
+++ b/warehouse/predicates.py
@@ -82,11 +82,6 @@ class ActiveOrganizationPredicate:
         )
 
         if (
-            # Organization accounts are disabled.
-            request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS)
-        ):
-            return False
-        elif (
             # Organization is active.
             organization.is_active
             # Organization has active subscription if it is a Company.
@@ -96,6 +91,11 @@ class ActiveOrganizationPredicate:
             )
         ):
             return True
+        elif (
+            # Organization accounts are disabled.
+            request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS)
+        ):
+            return False
         else:
             raise HTTPSeeOther(request.route_path("manage.organizations"))
 

--- a/warehouse/templates/includes/current-user-indicator.html
+++ b/warehouse/templates/includes/current-user-indicator.html
@@ -37,7 +37,7 @@
             {% trans %}Your projects{% endtrans %}
           </a>
         </li>
-        {% if not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS) %}
+        {% if request.organization_access %}
         <li>
           <a href="{{ request.route_path('manage.organizations') }}" class="dropdown__link">
             <i class="fa fa-sitemap" aria-hidden="true"></i>

--- a/warehouse/templates/includes/manage/manage-project-menu.html
+++ b/warehouse/templates/includes/manage/manage-project-menu.html
@@ -24,7 +24,7 @@
       <a href="{{ request.route_path('manage.project.roles', project_name=project.normalized_name)}}" class="vertical-tabs__tab vertical-tabs__tab--with-icon {% if active_tab == 'collaborators' %}vertical-tabs__tab--is-active{% endif %} {% if mode == 'mobile' %}vertical-tabs__tab--mobile{% endif %}" {% if active_tab == 'collaborators' %}aria-selected="true"{% endif %}>
         <i class="fa fa-user" aria-hidden="true"></i>
         {% trans %}Collaborators{% endtrans %}
-        {% if not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS) and project.organization %}
+        {% if request.organization_access and project.organization %}
         <span class="badge badge--neutral">{{ 1 + project.team_project_roles|length + project.roles|length }}</span>
         {% else %}
         <span class="badge badge--neutral">{{ project.roles|length }}</span>

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -216,7 +216,7 @@
                   {% trans %}Your projects{% endtrans %}
                 </a>
               </li>
-              {% if not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS) %}
+              {% if request.organization_access %}
               <li>
                 <a href="{{ request.route_path('manage.organizations') }}" class="vertical-tabs__tab vertical-tabs__tab--with-icon {% if active_tab == 'organizations' %}vertical-tabs__tab--is-active{% endif %}" {% if active_tab == 'organizations' %}aria-selected="true"{% endif %}>
                   <i class="fa fa-sitemap" aria-hidden="true"></i>
@@ -252,7 +252,7 @@
                 {% trans %}Your projects{% endtrans %}
               </a>
             </li>
-            {% if not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS) %}
+            {% if request.organization_access %}
             <li>
               <a href="{{ request.route_path('manage.organizations') }}" class="vertical-tabs__tab vertical-tabs__tab--mobile vertical-tabs__tab--with-icon vertical-tabs__tab--no-top-border {% if active_tab == 'organizations' %}vertical-tabs__tab--is-active{% endif %}" {% if active_tab == 'organizations' %}aria-selected="true"{% endif %}>
                 <i class="fa fa-sitemap" aria-hidden="true"></i>

--- a/warehouse/templates/manage/project/manage_project_base.html
+++ b/warehouse/templates/manage/project/manage_project_base.html
@@ -32,7 +32,7 @@
             {% trans %}Your account{% endtrans %}
           </a>
         </li>
-        {% if not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS) and project.organization and request.user in project.organization.users %}
+        {% if request.organization_access and project.organization and request.user in project.organization.users %}
         <li class="breadcrumbs__breadcrumb">
           <a href="{{ request.route_path('manage.organization.projects', organization_name=project.organization.normalized_name) }}">
             <i class="fa fa-sm fa-sitemap" aria-hidden="true"></i>
@@ -65,7 +65,7 @@
           {% trans %}Back to projects{% endtrans %}
         </a>
         <div class="vertical-tabs__content">
-          {% if not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS) and project.organization %}
+          {% if request.organization_access and project.organization %}
             <div class="organization-snippet organization-snippet--margin-bottom">
               <h1 class="organization-snippet__title organization-snippet__title--page-title">
                 <a href="{{ request.route_path('organizations.profile', organization=project.organization.name) }}">{{ project.organization.name }}</a>

--- a/warehouse/templates/manage/project/settings.html
+++ b/warehouse/templates/manage/project/settings.html
@@ -118,7 +118,7 @@
    # 1. User must be organization owner.
    # 2. There must be an individual project owner.
    #}
-  {% if not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS) and (project.organization and request.user in project.organization.owners) %}
+  {% if request.organization_access and (project.organization and request.user in project.organization.owners) %}
     {% if (project.owners|length) %}
     <div class="callout-block callout-block--danger">
       <h3>{% trans %}Remove project from organization{% endtrans %}</h3>
@@ -161,7 +161,7 @@
    # 1. If project is currently in an organization, the user must be organization owner.
    # 2. User must have an organization to transfer the project to.
    #}
-  {% if not request.flags.enabled(AdminFlagValue.DISABLE_ORGANIZATIONS) %}
+  {% if request.organization_access %}
     {% if (not project.organization or request.user in project.organization.owners) and (transfer_organization_project_form.organization.choices|length > 1) %}
     <div class="callout-block callout-block--danger">
       <h3>


### PR DESCRIPTION
This refactors the direct AdminFlag check to go through a request_method that allows access to org features if one has been assigned to them directly.

For closed-beta, we'll be onboarding users by creating an Organization object, and an OrganizationRole object directly, which will then enable access via this gate.