### PR TITLE
Implementation of a Primary/Archive setup for object storage.

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -31,6 +31,7 @@ HIBP_API_KEY="something-not-real"
 DOCS_URL="https://pythonhosted.org/{project}/"
 
 FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://localhost:9001/packages/{path}
+ARCHIVE_FILES_BACKEND=warehouse.packaging.services.LocalArchiveFileStorage path=/var/opt/warehouse/packages-archive/ url=http://localhost:9001/packages-archive/{path}
 SIMPLE_BACKEND=warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://localhost:9001/simple/{path}
 DOCS_BACKEND=warehouse.packaging.services.LocalDocsStorage path=/var/opt/warehouse/docs/
 SPONSORLOGOS_BACKEND=warehouse.admin.services.LocalSponsorLogoStorage path=/var/opt/warehouse/sponsorlogos/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.9'
 volumes:
   simple:
   packages:
+  packages-archive:
   sponsorlogos:
   policies:
   vault:
@@ -98,6 +99,7 @@ services:
       - ./pyproject.toml:/opt/warehouse/src/pyproject.toml:z
       - .coveragerc:/opt/warehouse/src/.coveragerc:z
       - packages:/var/opt/warehouse/packages
+      - packages-archive:/var/opt/warehouse/packages-archive
       - sponsorlogos:/var/opt/warehouse/sponsorlogos
       - policies:/var/opt/warehouse/policies
       - simple:/var/opt/warehouse/simple
@@ -128,6 +130,7 @@ services:
     command: python -m http.server 9001
     volumes:
       - packages:/var/opt/warehouse/packages
+      - packages-archive:/var/opt/warehouse/packages-archive
       - sponsorlogos:/var/opt/warehouse/sponsorlogos
       - simple:/var/opt/warehouse/simple
     ports:
@@ -139,10 +142,13 @@ services:
     command: hupper -m celery -A warehouse worker -B -S redbeat.RedBeatScheduler -l info
     volumes:
       - ./warehouse:/opt/warehouse/src/warehouse:z
+      - packages:/var/opt/warehouse/packages
+      - packages-archive:/var/opt/warehouse/packages-archive
     env_file: dev/environment
     environment:
       C_FORCE_ROOT: "1"
       FILES_BACKEND: "warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files:9001/packages/{path}"
+      ARCHIVE_FILES_BACKEND: "warehouse.packaging.services.LocalArchiveFileStorage path=/var/opt/warehouse/packages-archive/ url=http://files:9001/packages-archive/{path}"
       SIMPLE_BACKEND: "warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://files:9001/simple/{path}"
 
   static:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = ["warehouse/locale/.*", "warehouse/migrations/versions.*"]
 module = [
     "automat.*",
     "bpython.*",  # https://github.com/bpython/bpython/issues/892
-    "b2sdk.*",
+    "b2sdk.*",  # https://github.com/Backblaze/b2-sdk-python/issues/148
     "celery.app.backends.*",
     "celery.backends.redis.*",
     "citext.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ exclude = ["warehouse/locale/.*", "warehouse/migrations/versions.*"]
 module = [
     "automat.*",
     "bpython.*",  # https://github.com/bpython/bpython/issues/892
+    "b2sdk.*",
     "celery.app.backends.*",
     "celery.backends.redis.*",
     "citext.*",

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -1,6 +1,7 @@
 alembic>=0.7.0
 Automat
 argon2-cffi
+b2sdk
 Babel
 bcrypt
 boto3

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -39,6 +39,10 @@ argon2-cffi-bindings==21.2.0 \
     --hash=sha256:f1152ac548bd5b8bcecfb0b0371f082037e47128653df2e8ba6e914d384f3c3e \
     --hash=sha256:f9f8b450ed0547e3d473fdc8612083fd08dd2120d6ac8f73828df9b7d45bb351
     # via argon2-cffi
+arrow==1.2.3 \
+    --hash=sha256:3934b30ca1b9f292376d9db15b19446088d12ec58629bc3f0da28fd55fb633a1 \
+    --hash=sha256:5a49ab92e3b7b71d96cd6bfcc4df14efefc9dfa96ea19045815914a6ab6b1fe2
+    # via b2sdk
 asn1crypto==1.5.1 \
     --hash=sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c \
     --hash=sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67
@@ -54,6 +58,9 @@ attrs==22.2.0 \
 automat==22.10.0 \
     --hash=sha256:c3164f8742b9dc440f3682482d32aaff7bb53f71740dd018533f9de286b64180 \
     --hash=sha256:e56beb84edad19dcc11d30e8d9b895f75deeb5ef5e96b84a467066b3b84bb04e
+    # via -r requirements/main.in
+b2sdk==1.20.0 \
+    --hash=sha256:b394d9fbdada1a4ffc0837cd6c930351f5fccc24cd0af23e41edd850d67fb687
     # via -r requirements/main.in
 babel==2.12.1 \
     --hash=sha256:b4246fb7677d3b98f501a39d43396d3cafdc8eadb045f4a31be01863f655c610 \
@@ -843,6 +850,10 @@ limits==3.3.1 \
     --hash=sha256:df8685b1aff349b5199628ecdf41a9f339a35233d8e4fcd9c3e10002e4419b45 \
     --hash=sha256:dfc59ed5b4847e33a33b88ec16033bed18ce444ce6a76287a4e054db9a683861
     # via -r requirements/main.in
+logfury==1.0.1 \
+    --hash=sha256:130a5daceab9ad534924252ddf70482aa2c96662b3a3825a7d30981d03b76a26 \
+    --hash=sha256:b4f04be1701a1df644afc3384d6167d64c899f8036b7eefc3b6c570c6a9b290b
+    # via b2sdk
 lxml==4.9.2 \
     --hash=sha256:01d36c05f4afb8f7c20fd9ed5badca32a2029b93b1750f571ccc0b142531caf7 \
     --hash=sha256:04876580c050a8c5341d706dd464ff04fd597095cc8c023252566a8826505726 \
@@ -1327,6 +1338,7 @@ python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
     # via
+    #   arrow
     #   botocore
     #   celery-redbeat
     #   elasticsearch-dsl
@@ -1358,6 +1370,7 @@ requests==2.28.2 \
     --hash=sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf
     # via
     #   -r requirements/main.in
+    #   b2sdk
     #   datadog
     #   forcediphttpsadapter
     #   google-api-core
@@ -1475,6 +1488,10 @@ text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
     --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93
     # via python-slugify
+tqdm==4.65.0 \
+    --hash=sha256:1871fb68a86b8fb3b59ca4cdd3dcccbc7e6d613eeed31f4c332531977b89beb5 \
+    --hash=sha256:c4f53a17fe37e132815abceec022631be8ffe1b9381c2e6e30aa70edc99e9671
+    # via b2sdk
 transaction==3.1.0 \
     --hash=sha256:65d0b1ea92dbe7c4e3b237fb6bd8b41dea23d7459e7bdd8c3880bffdaf912fa4 \
     --hash=sha256:8376a959aa71821df1bdd7d066858a3f9f34b7f5f1c0a0e1efbd11d626895449

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,6 +173,13 @@ def pyramid_request(pyramid_services, jinja, remote_addr):
 
     dummy_request.registry.registerUtility(jinja, IJinja2Environment, name=".jinja2")
 
+    dummy_request._task_stub = pretend.stub(
+        delay=pretend.call_recorder(lambda *a, **kw: None)
+    )
+    dummy_request.task = pretend.call_recorder(
+        lambda *a, **kw: dummy_request._task_stub
+    )
+
     def localize(message, **kwargs):
         ts = TranslationString(message, **kwargs)
         return ts.interpolate()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,7 @@ def metrics_timing(*args, **kwargs):
 def metrics():
     return pretend.stub(
         event=pretend.call_recorder(lambda *args, **kwargs: None),
+        gauge=pretend.call_recorder(lambda *args, **kwargs: None),
         increment=pretend.call_recorder(lambda *args, **kwargs: None),
         histogram=pretend.call_recorder(lambda *args, **kwargs: None),
         timing=pretend.call_recorder(lambda *args, **kwargs: None),
@@ -271,6 +272,7 @@ def app_config(database):
         "ratelimit.url": "memory://",
         "elasticsearch.url": "https://localhost/warehouse",
         "files.backend": "warehouse.packaging.services.LocalFileStorage",
+        "archive_files.backend": "warehouse.packaging.services.LocalArchiveFileStorage",
         "simple.backend": "warehouse.packaging.services.LocalSimpleStorage",
         "docs.backend": "warehouse.packaging.services.LocalDocsStorage",
         "sponsorlogos.backend": "warehouse.admin.services.LocalSponsorLogoStorage",
@@ -280,6 +282,7 @@ def app_config(database):
             "warehouse.malware.services.PrinterMalwareCheckService"
         ),
         "files.url": "http://localhost:7000/",
+        "archive_files.url": "http://localhost:7000/archive",
         "sessions.secret": "123456",
         "sessions.url": "redis://localhost:0/",
         "statuspage.url": "https://2p66nmmycsj3.statuspage.io",

--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -28,6 +28,7 @@ from warehouse.packaging.interfaces import (
 from warehouse.packaging.models import File, Project, Release, Role
 from warehouse.packaging.services import project_service_factory
 from warehouse.packaging.tasks import (  # sync_bigquery_release_files,
+    check_file_archive_tasks_outstanding,
     compute_2fa_mandate,
     update_description_html,
 )
@@ -49,6 +50,7 @@ def test_includeme(monkeypatch, with_bq_sync, with_2fa_mandate):
     monkeypatch.setattr(packaging, "key_factory", key_factory)
     settings = {
         "files.backend": "foo.bar",
+        "archive_files.backend": "peas.carrots",
         "simple.backend": "bread.butter",
         "docs.backend": "wu.tang",
         "warehouse.packaging.project_create_user_ratelimit_string": "20 per hour",
@@ -73,7 +75,8 @@ def test_includeme(monkeypatch, with_bq_sync, with_2fa_mandate):
     packaging.includeme(config)
 
     assert config.register_service_factory.calls == [
-        pretend.call(storage_class.create_service, IFileStorage),
+        pretend.call(storage_class.create_service, IFileStorage, name="primary"),
+        pretend.call(storage_class.create_service, IFileStorage, name="archive"),
         pretend.call(storage_class.create_service, ISimpleStorage),
         pretend.call(storage_class.create_service, IDocsStorage),
         pretend.call(
@@ -169,6 +172,10 @@ def test_includeme(monkeypatch, with_bq_sync, with_2fa_mandate):
             in config.add_periodic_task.calls
         )
 
+    assert (
+        pretend.call(crontab(minute="*/1"), check_file_archive_tasks_outstanding)
+        in config.add_periodic_task.calls
+    )
     assert (
         pretend.call(crontab(minute="*/5"), update_description_html)
         in config.add_periodic_task.calls

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -303,7 +303,7 @@ class TestB2FileStorage:
 
     def test_raises_when_key_non_existent(self):
         def raiser(path):
-            raise b2sdk.exception.FileNotPresent()
+            raise b2sdk.v2.exception.FileNotPresent()
 
         bucket_stub = pretend.stub(download_file_by_name=raiser)
         mock_b2_api = pretend.stub(get_bucket_by_name=lambda bucket_name: bucket_stub)
@@ -319,7 +319,7 @@ class TestB2FileStorage:
 
     def test_get_metadata_raises_when_key_non_existent(self):
         def raiser(path):
-            raise b2sdk.exception.FileNotPresent()
+            raise b2sdk.v2.exception.FileNotPresent()
 
         bucket_stub = pretend.stub(get_file_info_by_name=raiser)
         mock_b2_api = pretend.stub(get_bucket_by_name=lambda bucket_name: bucket_stub)

--- a/tests/unit/test_b2.py
+++ b/tests/unit/test_b2.py
@@ -1,0 +1,50 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import b2sdk.v2
+import pretend
+
+from warehouse import b2
+
+
+def test_b2_api_factory(monkeypatch):
+    mock_in_memory_account_info = pretend.call_recorder(lambda: "InMemoryAccountInfo")
+    monkeypatch.setattr(b2sdk.v2, "InMemoryAccountInfo", mock_in_memory_account_info)
+    mock_b2_api = pretend.stub(
+        authorize_account=pretend.call_recorder(lambda mode, key_id, key: None)
+    )
+    mock_b2_api_class = pretend.call_recorder(lambda account_info: mock_b2_api)
+    monkeypatch.setattr(b2sdk.v2, "B2Api", mock_b2_api_class)
+
+    request = pretend.stub(
+        registry=pretend.stub(
+            settings={"b2.application_key_id": "key_id", "b2.application_key": "key"}
+        )
+    )
+
+    assert b2.b2_api_factory(None, request) is mock_b2_api
+    assert mock_b2_api_class.calls == [pretend.call("InMemoryAccountInfo")]
+    assert mock_b2_api.authorize_account.calls == [
+        pretend.call("production", "key_id", "key")
+    ]
+
+
+def test_includeme():
+    config = pretend.stub(
+        register_service_factory=pretend.call_recorder(lambda factory, name: None)
+    )
+
+    b2.includeme(config)
+
+    assert config.register_service_factory.calls == [
+        pretend.call(b2.b2_api_factory, name="b2.api")
+    ]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -348,6 +348,7 @@ def test_configure(monkeypatch, settings, environment):
             pretend.call(".policy"),
             pretend.call(".search"),
             pretend.call(".aws"),
+            pretend.call(".b2"),
             pretend.call(".gcloud"),
             pretend.call(".sessions"),
             pretend.call(".cache.http"),

--- a/warehouse/b2.py
+++ b/warehouse/b2.py
@@ -10,11 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from b2sdk.v2 import B2Api, InMemoryAccountInfo
+import b2sdk.v2
 
 
 def b2_api_factory(context, request):
-    b2_api = B2Api(InMemoryAccountInfo())
+    b2_api = b2sdk.v2.B2Api(b2sdk.v2.InMemoryAccountInfo())
     b2_api.authorize_account(
         "production",
         request.registry.settings["b2.application_key_id"],

--- a/warehouse/b2.py
+++ b/warehouse/b2.py
@@ -1,0 +1,27 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from b2sdk.v2 import B2Api, InMemoryAccountInfo
+
+
+def b2_api_factory(context, request):
+    b2_api = B2Api(InMemoryAccountInfo())
+    b2_api.authorize_account(
+        "production",
+        request.registry.settings["b2.application_key_id"],
+        request.registry.settings["b2.application_key"],
+    )
+    return b2_api
+
+
+def includeme(config):
+    config.register_service_factory(b2_api_factory, name="b2.api")

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -231,6 +231,7 @@ def configure(settings=None):
     )
     maybe_set_compound(settings, "billing", "backend", "BILLING_BACKEND")
     maybe_set_compound(settings, "files", "backend", "FILES_BACKEND")
+    maybe_set_compound(settings, "archive_files", "backend", "ARCHIVE_FILES_BACKEND")
     maybe_set_compound(settings, "simple", "backend", "SIMPLE_BACKEND")
     maybe_set_compound(settings, "docs", "backend", "DOCS_BACKEND")
     maybe_set_compound(settings, "sponsorlogos", "backend", "SPONSORLOGOS_BACKEND")

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -162,6 +162,8 @@ def configure(settings=None):
     maybe_set(settings, "aws.key_id", "AWS_ACCESS_KEY_ID")
     maybe_set(settings, "aws.secret_key", "AWS_SECRET_ACCESS_KEY")
     maybe_set(settings, "aws.region", "AWS_REGION")
+    maybe_set(settings, "b2.application_key_id", "B2_APPLICATION_KEY_ID")
+    maybe_set(settings, "b2.application_key", "B2_APPLICATION_KEY")
     maybe_set(settings, "gcloud.credentials", "GCLOUD_CREDENTIALS")
     maybe_set(settings, "gcloud.project", "GCLOUD_PROJECT")
     maybe_set(
@@ -555,8 +557,9 @@ def configure(settings=None):
 
     config.include(".search")
 
-    # Register the support for AWS and Google Cloud
+    # Register the support for AWS, Backblaze,and Google Cloud
     config.include(".aws")
+    config.include(".b2")
     config.include(".gcloud")
 
     # Register our session support

--- a/warehouse/migrations/versions/360dc6a7eb7a_add_archived_column_to_files_table.py
+++ b/warehouse/migrations/versions/360dc6a7eb7a_add_archived_column_to_files_table.py
@@ -1,0 +1,42 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add archived column to files table
+
+Revision ID: 360dc6a7eb7a
+Revises: 203f1f8dcf92
+Create Date: 2023-04-09 15:03:39.717818
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "360dc6a7eb7a"
+down_revision = "203f1f8dcf92"
+
+
+def upgrade():
+    op.add_column(
+        "release_files",
+        sa.Column(
+            "archived", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+    )
+    op.create_index(
+        "release_files_archived_idx", "release_files", ["archived"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index("release_files_archived_idx", table_name="release_files")
+    op.drop_column("release_files", "archived")

--- a/warehouse/migrations/versions/d142f435bb39_add_archived_column_to_files.py
+++ b/warehouse/migrations/versions/d142f435bb39_add_archived_column_to_files.py
@@ -10,19 +10,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Add archived column to files
+add archived column to files
 
-Revision ID: e9de3397b71e
-Revises: 203f1f8dcf92
-Create Date: 2023-04-10 00:01:06.306182
+Revision ID: d142f435bb39
+Revises: 665b6f8fd9ac
+Create Date: 2023-04-11 10:11:22.602965
 """
 
 import sqlalchemy as sa
 
 from alembic import op
 
-revision = "e9de3397b71e"
-down_revision = "203f1f8dcf92"
+revision = "d142f435bb39"
+down_revision = "665b6f8fd9ac"
 
 
 def upgrade():

--- a/warehouse/migrations/versions/e9de3397b71e_add_archived_column_to_files.py
+++ b/warehouse/migrations/versions/e9de3397b71e_add_archived_column_to_files.py
@@ -10,18 +10,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-add archived column to files table
+Add archived column to files
 
-Revision ID: 360dc6a7eb7a
+Revision ID: e9de3397b71e
 Revises: 203f1f8dcf92
-Create Date: 2023-04-09 15:03:39.717818
+Create Date: 2023-04-10 00:01:06.306182
 """
 
 import sqlalchemy as sa
 
 from alembic import op
 
-revision = "360dc6a7eb7a"
+revision = "e9de3397b71e"
 down_revision = "203f1f8dcf92"
 
 
@@ -29,7 +29,11 @@ def upgrade():
     op.add_column(
         "release_files",
         sa.Column(
-            "archived", sa.Boolean(), server_default=sa.text("false"), nullable=False
+            "archived",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+            comment="Tracks if the associated object has been archived to our archival bucket.",
         ),
     )
     op.create_index(

--- a/warehouse/migrations/versions/e9de3397b71e_add_archived_column_to_files.py
+++ b/warehouse/migrations/versions/e9de3397b71e_add_archived_column_to_files.py
@@ -33,7 +33,7 @@ def upgrade():
             sa.Boolean(),
             server_default=sa.text("false"),
             nullable=False,
-            comment="Tracks if the associated object has been archived to our archival bucket.",
+            comment="If True, the object has been archived to our archival bucket.",
         ),
     )
     op.create_index(

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -32,6 +32,13 @@ class IGenericFileStorage(Interface):
         at the given path.
         """
 
+    def get_metadata(path):
+        """
+        Return a dictionary containing any user-created metadata associated
+        with the file at a given path. Implementations may or may not store
+        or provide such metadata.
+        """
+
     def store(path, file_path, *, meta=None):
         """
         Save the file located at file_path to the file storage at the location

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -647,6 +647,7 @@ class File(HasEvents, db.Model):
                 ),
             ),
             Index("release_files_release_id_idx", "release_id"),
+            Index("release_files_archived_idx", "archived"),
         )
 
     release_id = Column(
@@ -682,6 +683,8 @@ class File(HasEvents, db.Model):
     # sdists that exist in our database. Eventually we should try to get rid
     # of all of them and then remove this column.
     allow_multiple_sdist = Column(Boolean, nullable=False, server_default=sql.false())
+
+    archived = Column(Boolean, nullable=False, server_default=sql.false())
 
     @hybrid_property
     def pgp_path(self):

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -686,7 +686,7 @@ class File(HasEvents, db.Model):
 
     archived = Column(
         Boolean,
-        comment="Tracks if the associated object has been archived to our archival bucket.",
+        comment="If True, the object has been archived to our archival bucket.",
         nullable=False,
         server_default=sql.false(),
     )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -684,7 +684,12 @@ class File(HasEvents, db.Model):
     # of all of them and then remove this column.
     allow_multiple_sdist = Column(Boolean, nullable=False, server_default=sql.false())
 
-    archived = Column(Boolean, nullable=False, server_default=sql.false())
+    archived = Column(
+        Boolean,
+        comment="Tracks if the associated object has been archived to our archival bucket.",
+        nullable=False,
+        server_default=sql.false(),
+    )
 
     @hybrid_property
     def pgp_path(self):

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -147,6 +147,7 @@ class GenericBlobStorage:
 
 class GenericB2BlobStorage(GenericBlobStorage):
     def get(self, path):
+        path = self._get_path(path)
         try:
             file_obj = io.BytesIO()
             downloaded_file = self.bucket.download_file_by_name(path)
@@ -157,12 +158,14 @@ class GenericB2BlobStorage(GenericBlobStorage):
             raise FileNotFoundError(f"No such key: {path!r}") from None
 
     def get_metadata(self, path):
+        path = self._get_path(path)
         try:
             return self.bucket.get_file_info_by_name(path).file_info
         except b2sdk.exception.FileNotPresent:
             raise FileNotFoundError(f"No such key: {path!r}") from None
 
     def store(self, path, file_path, *, meta=None):
+        path = self._get_path(path)
         self.bucket.upload_local_file(
             local_file=file_path,
             file_name=path,

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import collections
+import io
 import json
 import logging
 import os.path
@@ -147,13 +148,17 @@ class GenericBlobStorage:
 class GenericB2BlobStorage(GenericBlobStorage):
     def get(self, path):
         try:
+            file_obj = io.BytesIO()
             downloaded_file = self.bucket.download_file_by_name(path)
+            downloaded_file.save(file_obj)
+            file_obj.seek(0)
+            return file_obj
         except b2sdk.exception.FileNotPresent:
             raise FileNotFoundError(f"No such key: {path!r}") from None
 
     def get_metadata(self, path):
         try:
-            file_info = self.bucket.get_file_info_by_name(path)
+            return self.bucket.get_file_info_by_name(path).file_info
         except b2sdk.exception.FileNotPresent:
             raise FileNotFoundError(f"No such key: {path!r}") from None
 

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -224,6 +224,17 @@ class S3FileStorage(GenericS3BlobStorage):
         return cls(bucket, prefix=prefix)
 
 
+@implementer(IFileStorage)
+class S3ArchiveFileStorage(GenericS3BlobStorage):
+    @classmethod
+    def create_service(cls, context, request):
+        session = request.find_service(name="aws.session")
+        s3 = session.resource("s3")
+        bucket = s3.Bucket(request.registry.settings["archive_files.bucket"])
+        prefix = request.registry.settings.get("archive_files.prefix")
+        return cls(bucket, prefix=prefix)
+
+
 @implementer(IDocsStorage)
 class S3DocsStorage:
     def __init__(self, s3_client, bucket_name, *, prefix=None):

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -154,14 +154,14 @@ class GenericB2BlobStorage(GenericBlobStorage):
             downloaded_file.save(file_obj)
             file_obj.seek(0)
             return file_obj
-        except b2sdk.exception.FileNotPresent:
+        except b2sdk.v2.exception.FileNotPresent:
             raise FileNotFoundError(f"No such key: {path!r}") from None
 
     def get_metadata(self, path):
         path = self._get_path(path)
         try:
             return self.bucket.get_file_info_by_name(path).file_info
-        except b2sdk.exception.FileNotPresent:
+        except b2sdk.v2.exception.FileNotPresent:
             raise FileNotFoundError(f"No such key: {path!r}") from None
 
     def store(self, path, file_path, *, meta=None):

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -11,11 +11,13 @@
 # limitations under the License.
 
 import collections
+import json
 import logging
 import os.path
 import shutil
 import warnings
 
+import b2sdk
 import botocore.exceptions
 import google.api_core.exceptions
 import google.api_core.retry
@@ -64,12 +66,18 @@ class GenericLocalBlobStorage:
     def get(self, path):
         return open(os.path.join(self.base, path), "rb")
 
+    def get_metadata(self, path):
+        return json.loads(open(os.path.join(self.base, path + ".meta")).read())
+
     def store(self, path, file_path, *, meta=None):
         destination = os.path.join(self.base, path)
         os.makedirs(os.path.dirname(destination), exist_ok=True)
         with open(destination, "wb") as dest_fp:
             with open(file_path, "rb") as src_fp:
                 dest_fp.write(src_fp.read())
+        if meta is not None:
+            with open(destination + ".meta", "w") as dest_fp:
+                dest_fp.write(json.dumps(meta))
 
 
 @implementer(IFileStorage)
@@ -77,6 +85,13 @@ class LocalFileStorage(GenericLocalBlobStorage):
     @classmethod
     def create_service(cls, context, request):
         return cls(request.registry.settings["files.path"])
+
+
+@implementer(IFileStorage)
+class LocalArchiveFileStorage(GenericLocalBlobStorage):
+    @classmethod
+    def create_service(cls, context, request):
+        return cls(request.registry.settings["archive_files.path"])
 
 
 @implementer(ISimpleStorage)
@@ -129,13 +144,52 @@ class GenericBlobStorage:
         return path
 
 
+class GenericB2BlobStorage(GenericBlobStorage):
+    def get(self, path):
+        try:
+            downloaded_file = self.bucket.download_file_by_name(path)
+        except b2sdk.exception.FileNotPresent:
+            raise FileNotFoundError(f"No such key: {path!r}") from None
+
+    def get_metadata(self, path):
+        try:
+            file_info = self.bucket.get_file_info_by_name(path)
+        except b2sdk.exception.FileNotPresent:
+            raise FileNotFoundError(f"No such key: {path!r}") from None
+
+    def store(self, path, file_path, *, meta=None):
+        self.bucket.upload_local_file(
+            local_file=file_path,
+            file_name=path,
+            file_infos=meta,
+        )
+
+
+@implementer(IFileStorage)
+class B2FileStorage(GenericB2BlobStorage):
+    @classmethod
+    def create_service(cls, context, request):
+        b2_api = request.find_service(name="b2.api")
+        bucket = b2_api.get_bucket_by_name(request.registry.settings["files.bucket"])
+        prefix = request.registry.settings.get("files.prefix")
+        return cls(bucket, prefix=prefix)
+
+
 class GenericS3BlobStorage(GenericBlobStorage):
     def get(self, path):
-        # Note: this is not actually used in production, instead our CDN is
+        # Note: this is not actually used to serve files, instead our CDN is
         # configured to connect directly to our storage bucket. See:
         # https://github.com/python/pypi-infra/blob/master/terraform/file-hosting/vcl/main.vcl
         try:
             return self.bucket.Object(self._get_path(path)).get()["Body"]
+        except botocore.exceptions.ClientError as exc:
+            if exc.response["Error"]["Code"] != "NoSuchKey":
+                raise
+            raise FileNotFoundError(f"No such key: {path!r}") from None
+
+    def get_metadata(self, path):
+        try:
+            return self.bucket.Object(self._get_path(path)).metadata
         except botocore.exceptions.ClientError as exc:
             if exc.response["Error"]["Code"] != "NoSuchKey":
                 raise
@@ -197,9 +251,12 @@ class S3DocsStorage:
 
 class GenericGCSBlobStorage(GenericBlobStorage):
     def get(self, path):
-        # Note: this is not actually used in production, instead our CDN is
+        # Note: this is not actually used in to serve files, instead our CDN is
         # configured to connect directly to our storage bucket. See:
         # https://github.com/python/pypi-infra/blob/master/terraform/file-hosting/vcl/main.vcl
+        raise NotImplementedError
+
+    def get_metadata(self, path):
         raise NotImplementedError
 
     @google.api_core.retry.Retry(

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -48,7 +48,9 @@ def sync_file_to_archive(request, file_id):
 def check_file_archive_tasks_outstanding(request):
     metrics = request.find_service(IMetricsService, context=None)
 
-    files_not_archived = request.db.query(File).filter(File.archived == False).count()
+    files_not_archived = (
+        request.db.query(File).filter(File.archived == False).count()  # noqa: E712
+    )
 
     metrics.gauge(
         "warehouse.packaging.files.not_archived",


### PR DESCRIPTION
This implements a Primary/Archive setup for our object storage.

Uploads are synchronously uploaded to the Primary object storage (namely Backblaze B2 as target) and then archived to Archive object store via task.

A task is implemented here which reports the number of files marked as having not been archived yet, by way of the new database column File.archived.

Additionally our CDN configuration is updated in https://github.com/pypi/infra/compare/2b101c5e942265c73bd398edd8a55a8580e134b9...6c0e47fb04a7b0a634129780c4cf60d798075394 to report a log event to our metrics provider whenever a file is fetched from Archival storage rather than Primary. This will be useful to determine if we missed any files in migration, but also in the long run to catch missed archive tasks.

One notable missing piece from design is a task to automatically reconcile the state between the two buckets. I plan to use the visibility from the task and logs to design something that handles real failure modes, rather than trying to preempt.