### PR TITLE
Fix typo in trusted-publishers docs

### DIFF
--- a/docs/user/trusted-publishers/adding-a-publisher.md
+++ b/docs/user/trusted-publishers/adding-a-publisher.md
@@ -27,7 +27,7 @@ providing the repository owner's name, the repository's name, and the
 filename of the GitHub Actions workflow that's authorized to upload to
 PyPI.
 
-For example, if you have a project at `https://github.com/pypa/sampleproject`
+For example, if you have a project at `https://github.com/octo-org/sampleproject`
 that uses a publishing workflow defined in `.github/workflows/release.yml`,
 then you'd do the following:
 

--- a/docs/user/trusted-publishers/adding-a-publisher.md
+++ b/docs/user/trusted-publishers/adding-a-publisher.md
@@ -38,7 +38,7 @@ at the top of the page:
 
 ![](/assets/project-publisher-registered.png)
 
-From this point onwards, the `release.yml` workflow on `pypa/sampleproject` will
+From this point onwards, the `release.yml` workflow on `octo-org/sampleproject` will
 be able to generate short-lived API tokens from PyPI for the project you've registered
 it against.
 


### PR DESCRIPTION
Fixes sample github URL to use `octo-org` instead `pypa` for the github organization, so it matches the screenshots on the page.