### PR TITLE
[oidc] Unify publisher removal messages

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -3884,7 +3884,8 @@ class TestManageAccountPublishingViews:
         assert delete_publisher_form_obj.validate.calls == [pretend.call()]
         assert request.session.flash.calls == [
             pretend.call(
-                "Removed publisher for project 'some-project-name'", queue="success"
+                "Removed trusted publisher for project 'some-project-name'",
+                queue="success",
             )
         ]
         assert request.user.record_event.calls == [

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -6603,7 +6603,9 @@ class TestManageOIDCPublisherViews:
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
         assert request.session.flash.calls == [
-            pretend.call("Removed fakespecifier from fakeproject", queue="success")
+            pretend.call(
+                "Removed trusted publisher for project 'fakeproject'", queue="success"
+            )
         ]
         # The publisher is not actually removed entirely from the DB, since it's
         # registered to other projects that haven't removed it.
@@ -6708,7 +6710,9 @@ class TestManageOIDCPublisherViews:
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
         assert request.session.flash.calls == [
-            pretend.call("Removed fakespecifier from fakeproject", queue="success")
+            pretend.call(
+                "Removed trusted publisher for project 'fakeproject'", queue="success"
+            )
         ]
         assert request.db.delete.calls == [pretend.call(publisher)]
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1559,7 +1559,8 @@ class ManageAccountPublishingViews:
                 return self.default_response
 
             self.request.session.flash(
-                f"Removed publisher for project '{pending_publisher.project_name}'",
+                "Removed trusted publisher for project "
+                f"{pending_publisher.project_name!r}",
                 queue="success",
             )
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -368,43 +368,43 @@ msgstr ""
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2032
+#: warehouse/manage/views/__init__.py:2033
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2140
+#: warehouse/manage/views/__init__.py:2141
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2208
+#: warehouse/manage/views/__init__.py:2209
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2240
+#: warehouse/manage/views/__init__.py:2241
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2253
+#: warehouse/manage/views/__init__.py:2254
 #: warehouse/manage/views/organizations.py:896
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2319
+#: warehouse/manage/views/__init__.py:2320
 #: warehouse/manage/views/organizations.py:961
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2352
+#: warehouse/manage/views/__init__.py:2353
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2363
+#: warehouse/manage/views/__init__.py:2364
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2396
+#: warehouse/manage/views/__init__.py:2397
 #: warehouse/manage/views/organizations.py:1148
 msgid "Invitation revoked from '${username}'."
 msgstr ""

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -1384,7 +1384,8 @@ class ManageOIDCPublisherViews:
             )
 
             self.request.session.flash(
-                f"Removed {publisher} from {self.project.name}", queue="success"
+                f"Removed trusted publisher for project {self.project.name!r}",
+                queue="success",
             )
 
             self.metrics.increment(


### PR DESCRIPTION
This was originally printing the `Publisher` repr for one message, which was including a lot of unnecessary information in the flash mesage. Instead, we unify the message to be the same for both pending and established publishers.