### PR TITLE
oidc/forms: turn empty environments into None

### DIFF
--- a/warehouse/oidc/forms.py
+++ b/warehouse/oidc/forms.py
@@ -53,7 +53,7 @@ class GitHubPublisherBase(forms.Form):
     # Environment names are not case sensitive. An environment name may not
     # exceed 255 characters and must be unique within the repository.
     # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
-    environment = wtforms.StringField()
+    environment = wtforms.StringField(validators=[wtforms.validators.Optional()])
 
     def __init__(self, *args, api_token, **kwargs):
         super().__init__(*args, **kwargs)
@@ -155,9 +155,9 @@ class GitHubPublisherBase(forms.Form):
 
     @property
     def normalized_environment(self):
-        return (
-            self.environment.data.lower() if self.environment.data is not None else None
-        )
+        # NOTE: We explicitly do not compare `self.environment.data` to None,
+        # since it might also be falsey via an empty string.
+        return self.environment.data.lower() if self.environment.data else None
 
 
 class PendingGitHubPublisherForm(GitHubPublisherBase):


### PR DESCRIPTION
This fixes the immediate bug (which was caused by a comparison that began failing due to dual state between `''` and `None` columns), but should be further improved: the unique constraint between `GitHubProvider`s needs to be expanded to include the environment name as well.