### PR TITLE
Use `raise NotImplementedError` instead of `return NotImplemented`

### DIFF
--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -35,11 +35,10 @@ class TestBasicAuthSecurityPolicy:
 
     def test_noops(self):
         policy = security_policy.BasicAuthSecurityPolicy()
-        assert policy.authenticated_userid(pretend.stub()) == NotImplemented
-        assert (
+        with pytest.raises(NotImplementedError):
+            policy.authenticated_userid(pretend.stub())
+        with pytest.raises(NotImplementedError):
             policy.permits(pretend.stub(), pretend.stub(), pretend.stub())
-            == NotImplemented
-        )
 
     def test_forget_and_remember(self):
         policy = security_policy.BasicAuthSecurityPolicy()
@@ -220,11 +219,10 @@ class TestSessionSecurityPolicy:
 
     def test_noops(self):
         policy = security_policy.SessionSecurityPolicy()
-        assert policy.authenticated_userid(pretend.stub()) == NotImplemented
-        assert (
+        with pytest.raises(NotImplementedError):
+            policy.authenticated_userid(pretend.stub())
+        with pytest.raises(NotImplementedError):
             policy.permits(pretend.stub(), pretend.stub(), pretend.stub())
-            == NotImplemented
-        )
 
     def test_forget_and_remember(self, monkeypatch):
         request = pretend.stub()

--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -64,11 +64,10 @@ class TestMacaroonSecurityPolicy:
 
     def test_noops(self):
         policy = security_policy.MacaroonSecurityPolicy()
-        assert policy.authenticated_userid(pretend.stub()) == NotImplemented
-        assert (
+        with pytest.raises(NotImplementedError):
+            policy.authenticated_userid(pretend.stub())
+        with pytest.raises(NotImplementedError):
             policy.permits(pretend.stub(), pretend.stub(), pretend.stub())
-            == NotImplemented
-        )
 
     def test_forget_and_remember(self):
         policy = security_policy.MacaroonSecurityPolicy()

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -179,11 +179,11 @@ class SessionSecurityPolicy:
 
     def authenticated_userid(self, request):
         # Handled by MultiSecurityPolicy
-        return NotImplemented
+        raise NotImplementedError
 
     def permits(self, request, context, permission):
         # Handled by MultiSecurityPolicy
-        return NotImplemented
+        raise NotImplementedError
 
 
 @implementer(ISecurityPolicy)
@@ -220,11 +220,11 @@ class BasicAuthSecurityPolicy:
 
     def authenticated_userid(self, request):
         # Handled by MultiSecurityPolicy
-        return NotImplemented
+        raise NotImplementedError
 
     def permits(self, request, context, permission):
         # Handled by MultiSecurityPolicy
-        return NotImplemented
+        raise NotImplementedError
 
 
 @implementer(IAuthorizationPolicy)

--- a/warehouse/macaroons/security_policy.py
+++ b/warehouse/macaroons/security_policy.py
@@ -112,11 +112,11 @@ class MacaroonSecurityPolicy:
 
     def authenticated_userid(self, request):
         # Handled by MultiSecurityPolicy
-        return NotImplemented
+        raise NotImplementedError
 
     def permits(self, request, context, permission):
         # Handled by MultiSecurityPolicy
-        return NotImplemented
+        raise NotImplementedError
 
 
 @implementer(IAuthorizationPolicy)

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -214,12 +214,12 @@ class OIDCPublisherMixin:
     @property
     def publisher_name(self):  # pragma: no cover
         # Only concrete subclasses are constructed.
-        return NotImplemented
+        raise NotImplementedError
 
     @property
     def publisher_url(self):  # pragma: no cover
         # Only concrete subclasses are constructed.
-        return NotImplemented
+        raise NotImplementedError
 
 
 class OIDCPublisher(OIDCPublisherMixin, db.Model):
@@ -265,7 +265,7 @@ class PendingOIDCPublisher(OIDCPublisherMixin, db.Model):
         """
 
         # Only concrete subclasses are constructed.
-        return NotImplemented
+        raise NotImplementedError
 
 
 class GitHubPublisherMixin:


### PR DESCRIPTION
Fixing a few places where we `return NotImplemented` where we should be `raise NotImplementedError`:

[_exception_ `NotImplementedError`](https://docs.python.org/3.6/library/exceptions.html#NotImplementedError):

> In user defined base classes, abstract methods should raise this exception when they require derived classes to override the method, or while the class is being developed to indicate that the real implementation still needs to be added.

[`NotImplemented`](https://docs.python.org/3.6/library/constants.html#NotImplemented):

> Special value which should be returned by the binary special methods (e.g. [`__eq__()`](https://docs.python.org/3.6/reference/datamodel.html#object.__eq__), [`__lt__()`](https://docs.python.org/3.6/reference/datamodel.html#object.__lt__), [`__add__()`](https://docs.python.org/3.6/reference/datamodel.html#object.__add__), [`__rsub__()`](https://docs.python.org/3.6/reference/datamodel.html#object.__rsub__), etc.) to indicate that the operation is not implemented with respect to the other type

(cc @woodruffw)
