### PR TITLE
[oidc] More translated strings, and other fixups

### DIFF
--- a/tests/common/db/accounts.py
+++ b/tests/common/db/accounts.py
@@ -30,7 +30,6 @@ class UserFactory(WarehouseFactory):
     is_superuser = False
     is_moderator = False
     is_psf_staff = False
-    has_oidc_beta_access = True
     date_joined = factory.Faker(
         "date_time_between_dates",
         datetime_start=datetime.datetime(2005, 1, 1),

--- a/tests/common/db/accounts.py
+++ b/tests/common/db/accounts.py
@@ -30,6 +30,7 @@ class UserFactory(WarehouseFactory):
     is_superuser = False
     is_moderator = False
     is_psf_staff = False
+    has_oidc_beta_access = True
     date_joined = factory.Faker(
         "date_time_between_dates",
         datetime_start=datetime.datetime(2005, 1, 1),

--- a/tests/common/db/oidc.py
+++ b/tests/common/db/oidc.py
@@ -14,6 +14,7 @@ import factory
 
 from warehouse.oidc.models import GitHubPublisher, PendingGitHubPublisher
 
+from .accounts import UserFactory
 from .base import WarehouseFactory
 
 
@@ -40,3 +41,4 @@ class PendingGitHubPublisherFactory(WarehouseFactory):
     repository_owner_id = factory.Faker("pystr", max_chars=12)
     workflow_filename = "example.yml"
     environment = "production"
+    added_by = factory.SubFactory(UserFactory)

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -3278,7 +3278,7 @@ class TestManageAccountPublishingViews:
     def test_add_pending_github_oidc_publisher_too_many_already(
         self, monkeypatch, db_request
     ):
-        db_request.user = UserFactory.create()
+        db_request.user = UserFactory.create(has_oidc_beta_access=True)
         EmailFactory(user=db_request.user, verified=True, primary=True)
         for i in range(3):
             pending_publisher = PendingGitHubPublisher(
@@ -3460,7 +3460,7 @@ class TestManageAccountPublishingViews:
     def test_add_pending_github_oidc_publisher_already_exists(
         self, monkeypatch, db_request
     ):
-        db_request.user = UserFactory.create()
+        db_request.user = UserFactory.create(has_oidc_beta_access=True)
         EmailFactory(user=db_request.user, verified=True, primary=True)
         pending_publisher = PendingGitHubPublisher(
             project_name="some-project-name",
@@ -3534,7 +3534,7 @@ class TestManageAccountPublishingViews:
         ]
 
     def test_add_pending_github_oidc_publisher(self, monkeypatch, db_request):
-        db_request.user = UserFactory()
+        db_request.user = UserFactory(has_oidc_beta_access=True)
         db_request.user.record_event = pretend.call_recorder(lambda **kw: None)
         EmailFactory(user=db_request.user, verified=True, primary=True)
         db_request.registry = pretend.stub(
@@ -3735,7 +3735,7 @@ class TestManageAccountPublishingViews:
         ]
 
     def test_delete_pending_oidc_publisher_not_found(self, monkeypatch, db_request):
-        db_request.user = UserFactory.create()
+        db_request.user = UserFactory.create(has_oidc_beta_access=True)
         pending_publisher = PendingGitHubPublisher(
             project_name="some-project-name",
             repository_name="some-repository",
@@ -3816,7 +3816,7 @@ class TestManageAccountPublishingViews:
         assert db_request.db.query(PendingGitHubPublisher).all() == [pending_publisher]
 
     def test_delete_pending_oidc_publisher(self, monkeypatch, db_request):
-        db_request.user = UserFactory.create()
+        db_request.user = UserFactory.create(has_oidc_beta_access=True)
         pending_publisher = PendingGitHubPublisher(
             project_name="some-project-name",
             repository_name="some-repository",

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -30,6 +30,7 @@ from sqlalchemy.exc import NoResultFound
 from webauthn.authentication.verify_authentication_response import (
     VerifiedAuthentication,
 )
+from webob.multidict import MultiDict
 
 from warehouse.accounts import views
 from warehouse.accounts.interfaces import (
@@ -50,6 +51,7 @@ from warehouse.admin.flags import AdminFlag, AdminFlagValue
 from warehouse.events.tags import EventTag
 from warehouse.metrics.interfaces import IMetricsService
 from warehouse.oidc.interfaces import TooManyOIDCRegistrations
+from warehouse.oidc.models import PendingGitHubPublisher
 from warehouse.organizations.models import (
     OrganizationInvitation,
     OrganizationRole,
@@ -824,7 +826,7 @@ class TestTwoFactor:
 
 
 class TestWebAuthn:
-    def test_webauthn_get_options_already_authenticated(self, pyramid_request):
+    def test_webauthn_get_options_already_authenticated(self):
         request = pretend.stub(authenticated_userid=pretend.stub(), _=lambda a: a)
 
         result = views.webauthn_authentication_options(request)
@@ -3070,21 +3072,21 @@ class TestManageAccountPublishingViews:
         assert isinstance(resp, Response)
         assert resp.status_code == 403
 
-    def test_manage_publishing_admin_disabled(self, monkeypatch):
-        request = pretend.stub(
-            user=pretend.stub(
-                in_oidc_beta=True,
-            ),
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=pretend.call_recorder(lambda *a, **kw: None),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: True)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
+    def test_manage_publishing_admin_disabled(self, monkeypatch, pyramid_request):
+        pyramid_request.user = pretend.stub(
+            in_oidc_beta=True,
+        )
+        pyramid_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
+        )
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda f: True)
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
 
         project_factory = pretend.stub()
@@ -3099,17 +3101,17 @@ class TestManageAccountPublishingViews:
             views, "PendingGitHubPublisherForm", pending_github_publisher_form_cls
         )
 
-        view = views.ManageAccountPublishingViews(request)
+        view = views.ManageAccountPublishingViews(pyramid_request)
 
         assert view.manage_publishing() == {
             "oidc_enabled": True,
             "pending_github_publisher_form": pending_github_publisher_form_obj,
         }
 
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 (
                     "Trusted publishers are temporarily disabled. "
@@ -3120,7 +3122,7 @@ class TestManageAccountPublishingViews:
         ]
         assert pending_github_publisher_form_cls.calls == [
             pretend.call(
-                request.POST,
+                pyramid_request.POST,
                 api_token="fake-api-token",
                 project_factory=project_factory,
             )
@@ -3150,21 +3152,23 @@ class TestManageAccountPublishingViews:
         assert isinstance(resp, Response)
         assert resp.status_code == 403
 
-    def test_add_pending_github_oidc_publisher_admin_disabled(self, monkeypatch):
-        request = pretend.stub(
-            user=pretend.stub(
-                in_oidc_beta=True,
-            ),
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=pretend.call_recorder(lambda *a, **kw: None),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: True)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
+    def test_add_pending_github_oidc_publisher_admin_disabled(
+        self, monkeypatch, pyramid_request
+    ):
+        pyramid_request.user = pretend.stub(
+            in_oidc_beta=True,
+        )
+        pyramid_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
+        )
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda f: True)
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
 
         project_factory = pretend.stub()
@@ -3179,17 +3183,17 @@ class TestManageAccountPublishingViews:
             views, "PendingGitHubPublisherForm", pending_github_publisher_form_cls
         )
 
-        view = views.ManageAccountPublishingViews(request)
+        view = views.ManageAccountPublishingViews(pyramid_request)
 
         assert view.add_pending_github_oidc_publisher() == {
             "oidc_enabled": True,
             "pending_github_publisher_form": pending_github_publisher_form_obj,
         }
 
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 (
                     "Trusted publishers are temporarily disabled. "
@@ -3200,27 +3204,29 @@ class TestManageAccountPublishingViews:
         ]
         assert pending_github_publisher_form_cls.calls == [
             pretend.call(
-                request.POST,
+                pyramid_request.POST,
                 api_token="fake-api-token",
                 project_factory=project_factory,
             )
         ]
 
-    def test_add_pending_github_oidc_publisher_user_cannot_register(self, monkeypatch):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        request = pretend.stub(
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=pretend.call_recorder(lambda *a, **kw: metrics),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
-            user=pretend.stub(has_primary_verified_email=False, in_oidc_beta=True),
-            _=lambda s: s,
+    def test_add_pending_github_oidc_publisher_user_cannot_register(
+        self, monkeypatch, pyramid_request
+    ):
+        pyramid_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
+        )
+        pyramid_request.user = pretend.stub(
+            has_primary_verified_email=False, in_oidc_beta=True
+        )
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda f: False)
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
 
         project_factory = pretend.stub()
@@ -3235,14 +3241,14 @@ class TestManageAccountPublishingViews:
             views, "PendingGitHubPublisherForm", pending_github_publisher_form_cls
         )
 
-        view = views.ManageAccountPublishingViews(request)
+        view = views.ManageAccountPublishingViews(pyramid_request)
 
         assert view.add_pending_github_oidc_publisher() == {
             "oidc_enabled": True,
             "pending_github_publisher_form": pending_github_publisher_form_obj,
         }
 
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
         assert view.metrics.increment.calls == [
@@ -3251,7 +3257,7 @@ class TestManageAccountPublishingViews:
                 tags=["publisher:GitHub"],
             ),
         ]
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 (
                     "You must have a verified email in order to register a "
@@ -3263,57 +3269,56 @@ class TestManageAccountPublishingViews:
         ]
         assert pending_github_publisher_form_cls.calls == [
             pretend.call(
-                request.POST,
+                pyramid_request.POST,
                 api_token="fake-api-token",
                 project_factory=project_factory,
             )
         ]
 
-    def test_add_pending_github_oidc_publisher_too_many_already(self, monkeypatch):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        request = pretend.stub(
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=pretend.call_recorder(lambda *a, **kw: metrics),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
-            user=pretend.stub(
-                in_oidc_beta=True,
-                has_primary_verified_email=True,
-                pending_oidc_publishers=[
-                    pretend.stub(),
-                    pretend.stub(),
-                    pretend.stub(),
-                ],
-            ),
-            _=lambda s: s,
-        )
+    def test_add_pending_github_oidc_publisher_too_many_already(
+        self, monkeypatch, db_request
+    ):
+        db_request.user = UserFactory.create()
+        EmailFactory(user=db_request.user, verified=True, primary=True)
+        for i in range(3):
+            pending_publisher = PendingGitHubPublisher(
+                project_name="some-project-name-" + str(i),
+                repository_name="some-repository",
+                repository_owner="some-owner",
+                repository_owner_id="some-id",
+                workflow_filename="some-filename",
+                added_by_id=db_request.user.id,
+            )
+            db_request.db.add(pending_publisher)
 
-        project_factory = pretend.stub()
-        project_factory_cls = pretend.call_recorder(lambda r: project_factory)
-        monkeypatch.setattr(views, "ProjectFactory", project_factory_cls)
-
-        pending_github_publisher_form_obj = pretend.stub()
-        pending_github_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: pending_github_publisher_form_obj
+        db_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
         )
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda f: False))
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.POST = MultiDict(
+            {
+                "owner": "some-owner",
+                "repository": "some-repository",
+                "workflow_filename": "some-workflow-filename.yml",
+                "environment": "some-environment",
+                "project_name": "some-other-project-name",
+            }
+        )
+        default_response = pretend.stub()
         monkeypatch.setattr(
-            views, "PendingGitHubPublisherForm", pending_github_publisher_form_cls
+            views.ManageAccountPublishingViews, "default_response", default_response
         )
 
-        view = views.ManageAccountPublishingViews(request)
+        view = views.ManageAccountPublishingViews(db_request)
 
-        assert view.add_pending_github_oidc_publisher() == {
-            "oidc_enabled": True,
-            "pending_github_publisher_form": pending_github_publisher_form_obj,
-        }
-
-        assert request.flags.enabled.calls == [
+        assert view.add_pending_github_oidc_publisher() == view.default_response
+        assert db_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
         assert view.metrics.increment.calls == [
@@ -3322,7 +3327,7 @@ class TestManageAccountPublishingViews:
                 tags=["publisher:GitHub"],
             ),
         ]
-        assert request.session.flash.calls == [
+        assert db_request.session.flash.calls == [
             pretend.call(
                 (
                     "You can't register more than 3 pending trusted "
@@ -3331,48 +3336,39 @@ class TestManageAccountPublishingViews:
                 queue="error",
             )
         ]
-        assert pending_github_publisher_form_cls.calls == [
-            pretend.call(
-                request.POST,
-                api_token="fake-api-token",
-                project_factory=project_factory,
-            )
-        ]
+        assert len(db_request.db.query(PendingGitHubPublisher).all()) == 3
 
-    def test_add_pending_github_oidc_publisher_ratelimited(self, monkeypatch):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        request = pretend.stub(
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=pretend.call_recorder(lambda *a, **kw: metrics),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
-            user=pretend.stub(
-                in_oidc_beta=True,
-                has_primary_verified_email=True,
-                pending_oidc_publishers=[],
-            ),
-            _=lambda s: s,
+    def test_add_pending_github_oidc_publisher_ratelimited(
+        self, monkeypatch, pyramid_request
+    ):
+        pyramid_request.user = pretend.stub(
+            in_oidc_beta=True,
+            has_primary_verified_email=True,
+            pending_oidc_publishers=[],
+        )
+        pyramid_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
+        )
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda f: False)
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        pyramid_request.POST = MultiDict(
+            {
+                "owner": "some-owner",
+                "repository": "some-repository",
+                "workflow_filename": "some-workflow-filename.yml",
+                "environment": "some-environment",
+                "project_name": "some-other-project-name",
+            }
         )
 
-        project_factory = pretend.stub()
-        project_factory_cls = pretend.call_recorder(lambda r: project_factory)
-        monkeypatch.setattr(views, "ProjectFactory", project_factory_cls)
-
-        pending_github_publisher_form_obj = pretend.stub()
-        pending_github_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: pending_github_publisher_form_obj
-        )
-        monkeypatch.setattr(
-            views, "PendingGitHubPublisherForm", pending_github_publisher_form_cls
-        )
-
-        view = views.ManageAccountPublishingViews(request)
+        view = views.ManageAccountPublishingViews(pyramid_request)
         monkeypatch.setattr(
             view,
             "_check_ratelimits",
@@ -3385,7 +3381,7 @@ class TestManageAccountPublishingViews:
             ),
         )
 
-        assert view.add_pending_github_oidc_publisher().__class__ == HTTPTooManyRequests
+        assert isinstance(view.add_pending_github_oidc_publisher(), HTTPTooManyRequests)
         assert view.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.add_pending_publisher.attempt",
@@ -3397,117 +3393,52 @@ class TestManageAccountPublishingViews:
             ),
         ]
 
-    def test_add_pending_github_oidc_publisher_invalid_form(self, monkeypatch):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        request = pretend.stub(
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=pretend.call_recorder(lambda *a, **kw: metrics),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
-            user=pretend.stub(
-                in_oidc_beta=True,
-                has_primary_verified_email=True,
-                pending_oidc_publishers=[],
-            ),
-            _=lambda s: s,
+    def test_add_pending_github_oidc_publisher_invalid_form(
+        self, monkeypatch, pyramid_request
+    ):
+        pyramid_request.user = pretend.stub(
+            in_oidc_beta=True,
+            has_primary_verified_email=True,
+            pending_oidc_publishers=[],
+        )
+        pyramid_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
+        )
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda f: False)
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        pyramid_request.POST = MultiDict(
+            {
+                "owner": "some-owner",
+                "repository": "some-repository",
+                "workflow_filename": "some-workflow-filename-without-extension",  # Fail
+                "environment": "some-environment",
+                "project_name": "some-other-project-name",
+            }
         )
 
-        project_factory = pretend.stub()
-        project_factory_cls = pretend.call_recorder(lambda r: project_factory)
-        monkeypatch.setattr(views, "ProjectFactory", project_factory_cls)
+        view = views.ManageAccountPublishingViews(pyramid_request)
 
-        pending_github_publisher_form_obj = pretend.stub(
-            validate=pretend.call_recorder(lambda: False),
-        )
-        pending_github_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: pending_github_publisher_form_obj
+        monkeypatch.setattr(
+            views.ManageAccountPublishingViews,
+            "default_response",
+            view.default_response,
         )
         monkeypatch.setattr(
-            views, "PendingGitHubPublisherForm", pending_github_publisher_form_cls
-        )
-
-        view = views.ManageAccountPublishingViews(request)
-        default_response = {
-            "pending_github_publisher_form": pending_github_publisher_form_obj
-        }
-        monkeypatch.setattr(
-            views.ManageAccountPublishingViews, "default_response", default_response
+            views.PendingGitHubPublisherForm,
+            "_lookup_owner",
+            lambda *a: {"login": "some-owner", "id": "some-owner-id"},
         )
         monkeypatch.setattr(
-            view, "_check_ratelimits", pretend.call_recorder(lambda: None)
-        )
-        monkeypatch.setattr(
-            view, "_hit_ratelimits", pretend.call_recorder(lambda: None)
-        )
-
-        assert view.add_pending_github_oidc_publisher() == default_response
-        assert view.metrics.increment.calls == [
-            pretend.call(
-                "warehouse.oidc.add_pending_publisher.attempt",
-                tags=["publisher:GitHub"],
-            ),
-        ]
-        assert view._hit_ratelimits.calls == [pretend.call()]
-        assert view._check_ratelimits.calls == [pretend.call()]
-        assert pending_github_publisher_form_obj.validate.calls == [pretend.call()]
-
-    def test_add_pending_github_oidc_publisher_already_exists(self, monkeypatch):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        pending_publisher = pretend.stub()
-        request = pretend.stub(
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=pretend.call_recorder(lambda *a, **kw: metrics),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
-            user=pretend.stub(
-                in_oidc_beta=True,
-                has_primary_verified_email=True,
-                pending_oidc_publishers=[],
-            ),
-            _=lambda s: s,
-            db=pretend.stub(
-                query=lambda q: pretend.stub(
-                    filter_by=lambda **kw: pretend.stub(first=lambda: pending_publisher)
-                )
-            ),
-        )
-
-        project_factory = pretend.stub()
-        project_factory_cls = pretend.call_recorder(lambda r: project_factory)
-        monkeypatch.setattr(views, "ProjectFactory", project_factory_cls)
-
-        pending_github_publisher_form_obj = pretend.stub(
-            validate=pretend.call_recorder(lambda: True),
-            repository=pretend.stub(data="some-repo"),
-            normalized_owner="some-owner",
-            workflow_filename=pretend.stub(data="some-workflow.yml"),
-            normalized_environment="some-environment",
-        )
-        pending_github_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: pending_github_publisher_form_obj
-        )
-        monkeypatch.setattr(
-            views, "PendingGitHubPublisherForm", pending_github_publisher_form_cls
-        )
-
-        view = views.ManageAccountPublishingViews(request)
-        default_response = {
-            "pending_github_publisher_form": pending_github_publisher_form_obj
-        }
-        monkeypatch.setattr(
-            views.ManageAccountPublishingViews, "default_response", default_response
+            views.PendingGitHubPublisherForm,
+            "validate_project_name",
+            lambda *a: True,
         )
         monkeypatch.setattr(
             view, "_check_ratelimits", pretend.call_recorder(lambda: None)
@@ -3516,7 +3447,7 @@ class TestManageAccountPublishingViews:
             view, "_hit_ratelimits", pretend.call_recorder(lambda: None)
         )
 
-        assert view.add_pending_github_oidc_publisher() == default_response
+        assert view.add_pending_github_oidc_publisher() == view.default_response
         assert view.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.add_pending_publisher.attempt",
@@ -3525,8 +3456,74 @@ class TestManageAccountPublishingViews:
         ]
         assert view._hit_ratelimits.calls == [pretend.call()]
         assert view._check_ratelimits.calls == [pretend.call()]
-        assert pending_github_publisher_form_obj.validate.calls == [pretend.call()]
-        assert request.session.flash.calls == [
+
+    def test_add_pending_github_oidc_publisher_already_exists(
+        self, monkeypatch, db_request
+    ):
+        db_request.user = UserFactory.create()
+        EmailFactory(user=db_request.user, verified=True, primary=True)
+        pending_publisher = PendingGitHubPublisher(
+            project_name="some-project-name",
+            repository_name="some-repository",
+            repository_owner="some-owner",
+            repository_owner_id="some-id",
+            workflow_filename="some-workflow-filename.yml",
+            environment="some-environment",
+            added_by_id=db_request.user.id,
+        )
+        db_request.db.add(pending_publisher)
+        db_request.db.flush()  # To get it into the DB
+
+        db_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
+        )
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda f: False))
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.POST = MultiDict(
+            {
+                "owner": "some-owner",
+                "repository": "some-repository",
+                "workflow_filename": "some-workflow-filename.yml",
+                "environment": "some-environment",
+                "project_name": "some-project-name",
+            }
+        )
+
+        view = views.ManageAccountPublishingViews(db_request)
+
+        monkeypatch.setattr(
+            views.ManageAccountPublishingViews,
+            "default_response",
+            view.default_response,
+        )
+        monkeypatch.setattr(
+            views.PendingGitHubPublisherForm,
+            "_lookup_owner",
+            lambda *a: {"login": "some-owner", "id": "some-owner-id"},
+        )
+        monkeypatch.setattr(
+            view, "_check_ratelimits", pretend.call_recorder(lambda: None)
+        )
+        monkeypatch.setattr(
+            view, "_hit_ratelimits", pretend.call_recorder(lambda: None)
+        )
+
+        assert view.add_pending_github_oidc_publisher() == view.default_response
+
+        assert view.metrics.increment.calls == [
+            pretend.call(
+                "warehouse.oidc.add_pending_publisher.attempt",
+                tags=["publisher:GitHub"],
+            ),
+        ]
+        assert view._hit_ratelimits.calls == [pretend.call()]
+        assert view._check_ratelimits.calls == [pretend.call()]
+        assert db_request.session.flash.calls == [
             pretend.call(
                 (
                     "This trusted publisher has already been registered. "
@@ -3536,79 +3533,37 @@ class TestManageAccountPublishingViews:
             )
         ]
 
-    def test_add_pending_github_oidc_publisher(self, monkeypatch):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        request = pretend.stub(
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=pretend.call_recorder(lambda *a, **kw: metrics),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
-            user=pretend.stub(
-                in_oidc_beta=True,
-                has_primary_verified_email=True,
-                pending_oidc_publishers=[],
-                record_event=pretend.call_recorder(lambda **kw: None),
-                username="some-user",
-            ),
-            _=lambda s: s,
-            db=pretend.stub(
-                query=lambda q: pretend.stub(
-                    filter_by=lambda **kw: pretend.stub(first=lambda: None)
-                ),
-                add=pretend.call_recorder(lambda o: None),
-            ),
-            path="some-path",
-            remote_addr="0.0.0.0",
+    def test_add_pending_github_oidc_publisher(self, monkeypatch, db_request):
+        db_request.user = UserFactory()
+        db_request.user.record_event = pretend.call_recorder(lambda **kw: None)
+        EmailFactory(user=db_request.user, verified=True, primary=True)
+        db_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
         )
-
-        project_factory = pretend.stub()
-        project_factory_cls = pretend.call_recorder(lambda r: project_factory)
-        monkeypatch.setattr(views, "ProjectFactory", project_factory_cls)
-
-        pending_publisher = pretend.stub(
-            project_name="some-project-name",
-            publisher_name="some-publisher",
-            id=uuid.uuid4(),
-            publisher_url="some-url",
-            environment="some-environment",
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda f: False))
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        # NOTE: Can't set __str__ using pretend.stub()
-        monkeypatch.setattr(
-            pending_publisher.__class__, "__str__", lambda s: "fakespecifier"
-        )
-
-        pending_publisher_cls = pretend.call_recorder(lambda **kw: pending_publisher)
-        monkeypatch.setattr(views, "PendingGitHubPublisher", pending_publisher_cls)
-
-        pending_github_publisher_form_obj = pretend.stub(
-            validate=pretend.call_recorder(lambda: True),
-            project_name=pretend.stub(data="some-project-name"),
-            repository=pretend.stub(data="some-repo"),
-            normalized_owner="some-owner",
-            owner_id="some-owner-id",
-            workflow_filename=pretend.stub(data="some-workflow.yml"),
-            normalized_environment=pending_publisher.environment,
-        )
-        pending_github_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: pending_github_publisher_form_obj
+        db_request.POST = MultiDict(
+            {
+                "owner": "some-owner",
+                "repository": "some-repository",
+                "workflow_filename": "some-workflow-filename.yml",
+                "environment": "some-environment",
+                "project_name": "some-project-name",
+            }
         )
         monkeypatch.setattr(
-            views, "PendingGitHubPublisherForm", pending_github_publisher_form_cls
+            views.PendingGitHubPublisherForm,
+            "_lookup_owner",
+            lambda *a: {"login": "some-owner", "id": "some-owner-id"},
         )
 
-        view = views.ManageAccountPublishingViews(request)
-        default_response = {
-            "pending_github_publisher_form": pending_github_publisher_form_obj
-        }
-        monkeypatch.setattr(
-            views.ManageAccountPublishingViews, "default_response", default_response
-        )
+        view = views.ManageAccountPublishingViews(db_request)
+
         monkeypatch.setattr(
             view, "_check_ratelimits", pretend.call_recorder(lambda: None)
         )
@@ -3616,7 +3571,15 @@ class TestManageAccountPublishingViews:
             view, "_hit_ratelimits", pretend.call_recorder(lambda: None)
         )
 
-        assert view.add_pending_github_oidc_publisher().__class__ == HTTPSeeOther
+        resp = view.add_pending_github_oidc_publisher()
+
+        assert db_request.session.flash.calls == [
+            pretend.call(
+                "Registered a new publishing publisher to create "
+                "the project 'some-project-name'.",
+                queue="success",
+            )
+        ]
         assert view.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.add_pending_publisher.attempt",
@@ -3628,40 +3591,29 @@ class TestManageAccountPublishingViews:
         ]
         assert view._hit_ratelimits.calls == [pretend.call()]
         assert view._check_ratelimits.calls == [pretend.call()]
-        assert pending_github_publisher_form_obj.validate.calls == [pretend.call()]
+        assert isinstance(resp, HTTPSeeOther)
 
-        assert pending_publisher_cls.calls == [
-            pretend.call(
-                project_name="some-project-name",
-                added_by=request.user,
-                repository_name="some-repo",
-                repository_owner="some-owner",
-                repository_owner_id="some-owner-id",
-                workflow_filename="some-workflow.yml",
-                environment="some-environment",
-            )
-        ]
-        assert request.db.add.calls == [pretend.call(pending_publisher)]
-        assert request.user.record_event.calls == [
+        pending_publisher = db_request.db.query(PendingGitHubPublisher).one()
+        assert pending_publisher.project_name == "some-project-name"
+        assert pending_publisher.added_by_id == db_request.user.id
+        assert pending_publisher.repository_name == "some-repository"
+        assert pending_publisher.repository_owner == "some-owner"
+        assert pending_publisher.repository_owner_id == "some-owner-id"
+        assert pending_publisher.workflow_filename == "some-workflow-filename.yml"
+        assert pending_publisher.environment == "some-environment"
+
+        assert db_request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PendingOIDCPublisherAdded,
-                ip_address="0.0.0.0",
+                ip_address="1.2.3.4",
                 additional={
                     "project": "some-project-name",
-                    "publisher": "some-publisher",
+                    "publisher": pending_publisher.publisher_name,
                     "id": str(pending_publisher.id),
-                    "specifier": "fakespecifier",
-                    "url": "some-url",
-                    "submitted_by": "some-user",
+                    "specifier": str(pending_publisher),
+                    "url": pending_publisher.publisher_url,
+                    "submitted_by": db_request.user.username,
                 },
-            )
-        ]
-
-        assert request.session.flash.calls == [
-            pretend.call(
-                "Registered a new publishing publisher to create "
-                f"the project '{pending_publisher.project_name}'.",
-                queue="success",
             )
         ]
 
@@ -3689,21 +3641,23 @@ class TestManageAccountPublishingViews:
         assert isinstance(resp, Response)
         assert resp.status_code == 403
 
-    def test_delete_pending_oidc_publisher_admin_disabled(self, monkeypatch):
-        request = pretend.stub(
-            user=pretend.stub(
-                in_oidc_beta=True,
-            ),
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=pretend.call_recorder(lambda *a, **kw: None),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: True)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
+    def test_delete_pending_oidc_publisher_admin_disabled(
+        self, monkeypatch, pyramid_request
+    ):
+        pyramid_request.user = pretend.stub(
+            in_oidc_beta=True,
+        )
+        pyramid_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
+        )
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda f: True)
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
 
         project_factory = pretend.stub()
@@ -3718,17 +3672,17 @@ class TestManageAccountPublishingViews:
             views, "PendingGitHubPublisherForm", pending_github_publisher_form_cls
         )
 
-        view = views.ManageAccountPublishingViews(request)
+        view = views.ManageAccountPublishingViews(pyramid_request)
 
         assert view.delete_pending_oidc_publisher() == {
             "oidc_enabled": True,
             "pending_github_publisher_form": pending_github_publisher_form_obj,
         }
 
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 (
                     "Trusted publishers are temporarily disabled. "
@@ -3739,171 +3693,179 @@ class TestManageAccountPublishingViews:
         ]
         assert pending_github_publisher_form_cls.calls == [
             pretend.call(
-                request.POST,
+                pyramid_request.POST,
                 api_token="fake-api-token",
                 project_factory=project_factory,
             )
         ]
 
-    def test_delete_pending_oidc_publisher_invalid_form(self, monkeypatch):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        request = pretend.stub(
-            user=pretend.stub(
-                in_oidc_beta=True,
-            ),
-            registry=pretend.stub(settings={"warehouse.oidc.enabled": True}),
-            find_service=lambda *a, **kw: metrics,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            POST=pretend.stub(),
+    def test_delete_pending_oidc_publisher_invalid_form(
+        self, monkeypatch, pyramid_request
+    ):
+        pyramid_request.user = pretend.stub(
+            in_oidc_beta=True,
         )
+        pyramid_request.registry = pretend.stub(
+            settings={"warehouse.oidc.enabled": True}
+        )
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda f: False)
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        pyramid_request.POST = MultiDict({"publisher_id": None})
 
-        delete_publisher_form_obj = pretend.stub(
-            validate=pretend.call_recorder(lambda: False),
-        )
-        delete_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: delete_publisher_form_obj
-        )
-        monkeypatch.setattr(views, "DeletePublisherForm", delete_publisher_form_cls)
-
-        view = views.ManageAccountPublishingViews(request)
-        default_response = {"_": pretend.stub()}
+        view = views.ManageAccountPublishingViews(pyramid_request)
         monkeypatch.setattr(
-            views.ManageAccountPublishingViews, "default_response", default_response
+            views.ManageAccountPublishingViews, "default_response", pretend.stub()
         )
 
-        assert view.delete_pending_oidc_publisher() == default_response
-
+        assert view.delete_pending_oidc_publisher() == view.default_response
         assert view.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.delete_pending_publisher.attempt",
             ),
         ]
-
-        assert delete_publisher_form_cls.calls == [pretend.call(request.POST)]
-        assert delete_publisher_form_obj.validate.calls == [pretend.call()]
-
-    def test_delete_pending_oidc_publisher_not_found(self, monkeypatch):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        request = pretend.stub(
-            user=pretend.stub(
-                in_oidc_beta=True,
-            ),
-            registry=pretend.stub(settings={"warehouse.oidc.enabled": True}),
-            find_service=lambda *a, **kw: metrics,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            POST=pretend.stub(),
-            db=pretend.stub(query=lambda m: pretend.stub(get=lambda id: None)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-        )
-
-        delete_publisher_form_obj = pretend.stub(
-            validate=pretend.call_recorder(lambda: True),
-            publisher_id=pretend.stub(data="some-id"),
-        )
-        delete_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: delete_publisher_form_obj
-        )
-        monkeypatch.setattr(views, "DeletePublisherForm", delete_publisher_form_cls)
-
-        view = views.ManageAccountPublishingViews(request)
-        default_response = {"_": pretend.stub()}
-        monkeypatch.setattr(
-            views.ManageAccountPublishingViews, "default_response", default_response
-        )
-
-        assert view.delete_pending_oidc_publisher() == default_response
-
-        assert view.metrics.increment.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
-                "warehouse.oidc.delete_pending_publisher.attempt",
-            ),
-        ]
-        assert delete_publisher_form_cls.calls == [pretend.call(request.POST)]
-        assert delete_publisher_form_obj.validate.calls == [pretend.call()]
-        assert request.session.flash.calls == [
-            pretend.call(
-                "Invalid publisher for user",
+                "Invalid publisher ID",
                 queue="error",
             )
         ]
 
-    def test_delete_pending_oidc_publisher(self, monkeypatch):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        pending_publisher = pretend.stub(
+    def test_delete_pending_oidc_publisher_not_found(self, monkeypatch, db_request):
+        db_request.user = UserFactory.create()
+        pending_publisher = PendingGitHubPublisher(
             project_name="some-project-name",
-            publisher_name="some-publisher",
-            id=uuid.uuid4(),
-            publisher_url="some-url",
+            repository_name="some-repository",
+            repository_owner="some-owner",
+            repository_owner_id="some-id",
+            workflow_filename="some-filename",
+            added_by_id=db_request.user.id,
         )
-        # NOTE: Can't set __str__ using pretend.stub()
+        db_request.db.add(pending_publisher)
+
+        db_request.registry = pretend.stub(settings={"warehouse.oidc.enabled": True})
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda f: False))
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.POST = MultiDict({"publisher_id": str(uuid.uuid4())})
+
+        view = views.ManageAccountPublishingViews(db_request)
         monkeypatch.setattr(
-            pending_publisher.__class__, "__str__", lambda s: "fakespecifier"
-        )
-        request = pretend.stub(
-            registry=pretend.stub(settings={"warehouse.oidc.enabled": True}),
-            find_service=lambda *a, **kw: metrics,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            POST=pretend.stub(),
-            db=pretend.stub(
-                query=lambda m: pretend.stub(get=lambda id: pending_publisher),
-                delete=pretend.call_recorder(lambda m: None),
-            ),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            user=pretend.stub(
-                in_oidc_beta=True,
-                record_event=pretend.call_recorder(lambda **kw: None),
-                username="some-user",
-            ),
-            remote_addr="0.0.0.0",
-            path="some-path",
+            views.ManageAccountPublishingViews, "default_response", pretend.stub()
         )
 
-        delete_publisher_form_obj = pretend.stub(
-            validate=pretend.call_recorder(lambda: True),
-            publisher_id=pretend.stub(data="some-id"),
-        )
-        delete_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: delete_publisher_form_obj
-        )
-        monkeypatch.setattr(views, "DeletePublisherForm", delete_publisher_form_cls)
+        assert view.delete_pending_oidc_publisher() == view.default_response
+        assert view.metrics.increment.calls == [
+            pretend.call(
+                "warehouse.oidc.delete_pending_publisher.attempt",
+            ),
+        ]
+        assert db_request.session.flash.calls == [
+            pretend.call(
+                "Invalid publisher ID",
+                queue="error",
+            )
+        ]
+        assert db_request.db.query(PendingGitHubPublisher).all() == [pending_publisher]
 
-        view = views.ManageAccountPublishingViews(request)
-        default_response = {"_": pretend.stub()}
-        monkeypatch.setattr(
-            views.ManageAccountPublishingViews, "default_response", default_response
+    def test_delete_pending_oidc_publisher_no_access(self, monkeypatch, db_request):
+        db_request.user = UserFactory.create()
+        some_other_user = UserFactory.create()
+        pending_publisher = PendingGitHubPublisher(
+            project_name="some-project-name",
+            repository_name="some-repository",
+            repository_owner="some-owner",
+            repository_owner_id="some-id",
+            workflow_filename="some-filename",
+            added_by_id=some_other_user.id,
         )
+        db_request.db.add(pending_publisher)
+        db_request.db.flush()  # To get the id
+
+        db_request.user = pretend.stub(
+            in_oidc_beta=True,
+        )
+        db_request.registry = pretend.stub(settings={"warehouse.oidc.enabled": True})
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda f: False))
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.POST = MultiDict({"publisher_id": str(pending_publisher.id)})
+
+        view = views.ManageAccountPublishingViews(db_request)
+        monkeypatch.setattr(
+            views.ManageAccountPublishingViews, "default_response", pretend.stub()
+        )
+
+        assert view.delete_pending_oidc_publisher() == view.default_response
+        assert view.metrics.increment.calls == [
+            pretend.call(
+                "warehouse.oidc.delete_pending_publisher.attempt",
+            ),
+        ]
+        assert db_request.session.flash.calls == [
+            pretend.call(
+                "Invalid publisher ID",
+                queue="error",
+            )
+        ]
+        assert db_request.db.query(PendingGitHubPublisher).all() == [pending_publisher]
+
+    def test_delete_pending_oidc_publisher(self, monkeypatch, db_request):
+        db_request.user = UserFactory.create()
+        pending_publisher = PendingGitHubPublisher(
+            project_name="some-project-name",
+            repository_name="some-repository",
+            repository_owner="some-owner",
+            repository_owner_id="some-id",
+            workflow_filename="some-filename",
+            added_by_id=db_request.user.id,
+        )
+        db_request.db.add(pending_publisher)
+        db_request.db.flush()  # To get the id
+
+        db_request.registry = pretend.stub(settings={"warehouse.oidc.enabled": True})
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda f: False))
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.user.record_event = pretend.call_recorder(lambda **kw: None)
+        db_request.POST = MultiDict({"publisher_id": str(pending_publisher.id)})
+
+        view = views.ManageAccountPublishingViews(db_request)
 
         assert view.delete_pending_oidc_publisher().__class__ == HTTPSeeOther
-
         assert view.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.delete_pending_publisher.attempt",
             ),
             pretend.call(
                 "warehouse.oidc.delete_pending_publisher.ok",
-                tags=["publisher:some-publisher"],
+                tags=["publisher:GitHub"],
             ),
         ]
-        assert delete_publisher_form_cls.calls == [pretend.call(request.POST)]
-        assert delete_publisher_form_obj.validate.calls == [pretend.call()]
-        assert request.session.flash.calls == [
+        assert db_request.session.flash.calls == [
             pretend.call(
                 "Removed trusted publisher for project 'some-project-name'",
                 queue="success",
             )
         ]
-        assert request.user.record_event.calls == [
+        assert db_request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PendingOIDCPublisherRemoved,
-                ip_address="0.0.0.0",
+                ip_address="1.2.3.4",
                 additional={
                     "project": "some-project-name",
-                    "publisher": "some-publisher",
+                    "publisher": "GitHub",
                     "id": str(pending_publisher.id),
                     "specifier": str(pending_publisher),
-                    "url": "some-url",
-                    "submitted_by": "some-user",
+                    "url": pending_publisher.publisher_url,
+                    "submitted_by": db_request.user.username,
                 },
             )
         ]
-        assert request.db.delete.calls == [pretend.call(pending_publisher)]
+        assert db_request.db.query(PendingGitHubPublisher).all() == []

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -6284,7 +6284,7 @@ class TestManageOIDCPublisherViews:
     def test_add_github_oidc_publisher_already_registered_with_project(
         self, monkeypatch, db_request
     ):
-        db_request.user = UserFactory.create()
+        db_request.user = UserFactory.create(has_oidc_beta_access=True)
         EmailFactory(user=db_request.user, verified=True, primary=True)
         publisher = GitHubPublisher(
             repository_name="some-repository",
@@ -6503,7 +6503,7 @@ class TestManageOIDCPublisherViews:
     def test_delete_oidc_publisher_registered_to_multiple_projects(
         self, monkeypatch, db_request
     ):
-        db_request.user = UserFactory.create()
+        db_request.user = UserFactory.create(has_oidc_beta_access=True)
         EmailFactory(user=db_request.user, verified=True, primary=True)
         publisher = GitHubPublisher(
             repository_name="some-repository",
@@ -6595,7 +6595,7 @@ class TestManageOIDCPublisherViews:
         ]
 
     def test_delete_oidc_publisher_entirely(self, monkeypatch, db_request):
-        db_request.user = UserFactory.create()
+        db_request.user = UserFactory.create(has_oidc_beta_access=True)
         EmailFactory(user=db_request.user, verified=True, primary=True)
         publisher = GitHubPublisher(
             repository_name="some-repository",
@@ -6607,7 +6607,6 @@ class TestManageOIDCPublisherViews:
         db_request.db.add(publisher)
         db_request.db.flush()  # To get it in the DB
 
-        db_request.user = UserFactory.create()
         project = ProjectFactory.create(oidc_publishers=[publisher])
         project.record_event = pretend.call_recorder(lambda *a, **kw: None)
         RoleFactory.create(user=db_request.user, project=project, role_name="Owner")

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -47,6 +47,7 @@ from warehouse.manage import views
 from warehouse.manage.views import organizations as org_views
 from warehouse.metrics.interfaces import IMetricsService
 from warehouse.oidc.interfaces import TooManyOIDCRegistrations
+from warehouse.oidc.models import GitHubPublisher
 from warehouse.organizations.interfaces import IOrganizationService
 from warehouse.organizations.models import (
     OrganizationRoleType,
@@ -57,6 +58,7 @@ from warehouse.packaging.models import (
     File,
     JournalEntry,
     Project,
+    Release,
     Role,
     RoleInvitation,
     User,
@@ -194,36 +196,39 @@ class TestManageAccount:
         assert view.request == request
         assert view.user_service == user_service
 
-    def test_save_account(self, monkeypatch):
+    def test_save_account(self, monkeypatch, pyramid_request):
         update_user = pretend.call_recorder(lambda *a, **kw: None)
         user_service = pretend.stub(update_user=update_user)
-        request = pretend.stub(
-            POST={"name": "new name", "public_email": ""},
-            user=pretend.stub(
-                id=pretend.stub(),
-                name=pretend.stub(),
-                emails=[
-                    pretend.stub(
-                        primary=True, verified=True, public=True, email=pretend.stub()
-                    )
-                ],
-            ),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            find_service=lambda *a, **kw: user_service,
-            path="request-path",
+        pyramid_request.POST = {"name": "new name", "public_email": ""}
+        pyramid_request.user = pretend.stub(
+            id=pretend.stub(),
+            name=pretend.stub(),
+            emails=[
+                pretend.stub(
+                    primary=True, verified=True, public=True, email=pretend.stub()
+                )
+            ],
         )
-        save_account_obj = pretend.stub(validate=lambda: True, data=request.POST)
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        pyramid_request.find_service = lambda *a, **kw: user_service
+        save_account_obj = pretend.stub(
+            validate=lambda: True, data=pyramid_request.POST
+        )
         monkeypatch.setattr(views, "SaveAccountForm", lambda *a, **kw: save_account_obj)
         monkeypatch.setattr(
             views.ManageAccountViews, "default_response", {"_": pretend.stub()}
         )
-        view = views.ManageAccountViews(request)
+        view = views.ManageAccountViews(pyramid_request)
 
         assert isinstance(view.save_account(), HTTPSeeOther)
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Account details updated", queue="success")
         ]
-        assert update_user.calls == [pretend.call(request.user.id, **request.POST)]
+        assert update_user.calls == [
+            pretend.call(pyramid_request.user.id, **pyramid_request.POST)
+        ]
 
     def test_save_account_validation_fails(self, monkeypatch):
         update_user = pretend.call_recorder(lambda *a, **kw: None)
@@ -1943,19 +1948,19 @@ class TestProvisionMacaroonViews:
 
         assert result == default_response
 
-    def test_create_macaroon_not_allowed(self):
-        request = pretend.stub(
-            route_path=pretend.call_recorder(lambda x: "/foo/bar"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            user=pretend.stub(has_primary_verified_email=False),
-            find_service=lambda interface, **kw: pretend.stub(),
+    def test_create_macaroon_not_allowed(self, pyramid_request):
+        pyramid_request.route_path = pretend.call_recorder(lambda x: "/foo/bar")
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
+        pyramid_request.user = pretend.stub(has_primary_verified_email=False)
+        pyramid_request.find_service = lambda interface, **kw: pretend.stub()
 
-        view = views.ProvisionMacaroonViews(request)
+        view = views.ProvisionMacaroonViews(pyramid_request)
         result = view.create_macaroon()
 
-        assert request.route_path.calls == [pretend.call("manage.account")]
-        assert request.session.flash.calls == [
+        assert pyramid_request.route_path.calls == [pretend.call("manage.account")]
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Verify your email to create an API token.", queue="error")
         ]
         assert isinstance(result, HTTPSeeOther)
@@ -2191,21 +2196,24 @@ class TestProvisionMacaroonViews:
             ),
         ]
 
-    def test_delete_macaroon_invalid_form(self, monkeypatch):
+    def test_delete_macaroon_invalid_form(self, monkeypatch, pyramid_request):
         macaroon_service = pretend.stub(
             delete_macaroon=pretend.call_recorder(lambda id: pretend.stub())
         )
-        request = pretend.stub(
-            POST={"confirm_password": "password", "macaroon_id": "macaroon_id"},
-            route_path=pretend.call_recorder(lambda x: pretend.stub()),
-            find_service=lambda interface, **kw: {
-                IMacaroonService: macaroon_service,
-                IUserService: pretend.stub(),
-            }[interface],
-            referer="/fake/safe/route",
-            host=None,
-            user=pretend.stub(username=pretend.stub()),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.POST = {
+            "confirm_password": "password",
+            "macaroon_id": "macaroon_id",
+        }
+        pyramid_request.route_path = pretend.call_recorder(lambda x: pretend.stub())
+        pyramid_request.find_service = lambda interface, **kw: {
+            IMacaroonService: macaroon_service,
+            IUserService: pretend.stub(),
+        }[interface]
+        pyramid_request.referer = "/fake/safe/route"
+        pyramid_request.host = None
+        pyramid_request.user = pretend.stub(username=pretend.stub())
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
 
         delete_macaroon_obj = pretend.stub(validate=lambda: False)
@@ -2214,32 +2222,35 @@ class TestProvisionMacaroonViews:
         )
         monkeypatch.setattr(views, "DeleteMacaroonForm", delete_macaroon_cls)
 
-        view = views.ProvisionMacaroonViews(request)
+        view = views.ProvisionMacaroonViews(pyramid_request)
         result = view.delete_macaroon()
 
-        assert request.route_path.calls == []
+        assert pyramid_request.route_path.calls == []
         assert isinstance(result, HTTPSeeOther)
         assert result.location == "/fake/safe/route"
         assert macaroon_service.delete_macaroon.calls == []
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Invalid credentials. Try again", queue="error")
         ]
 
-    def test_delete_macaroon_dangerous_redirect(self, monkeypatch):
+    def test_delete_macaroon_dangerous_redirect(self, monkeypatch, pyramid_request):
         macaroon_service = pretend.stub(
             delete_macaroon=pretend.call_recorder(lambda id: pretend.stub())
         )
-        request = pretend.stub(
-            POST={"confirm_password": "password", "macaroon_id": "macaroon_id"},
-            route_path=pretend.call_recorder(lambda x: "/safe/route"),
-            find_service=lambda interface, **kw: {
-                IMacaroonService: macaroon_service,
-                IUserService: pretend.stub(),
-            }[interface],
-            referer="http://google.com/",
-            host=None,
-            user=pretend.stub(username=pretend.stub()),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.POST = {
+            "confirm_password": "password",
+            "macaroon_id": "macaroon_id",
+        }
+        pyramid_request.route_path = pretend.call_recorder(lambda x: "/safe/route")
+        pyramid_request.find_service = lambda interface, **kw: {
+            IMacaroonService: macaroon_service,
+            IUserService: pretend.stub(),
+        }[interface]
+        pyramid_request.referer = "http://google.com/"
+        pyramid_request.host = None
+        pyramid_request.user = pretend.stub(username=pretend.stub())
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
 
         delete_macaroon_obj = pretend.stub(validate=lambda: False)
@@ -2248,37 +2259,39 @@ class TestProvisionMacaroonViews:
         )
         monkeypatch.setattr(views, "DeleteMacaroonForm", delete_macaroon_cls)
 
-        view = views.ProvisionMacaroonViews(request)
+        view = views.ProvisionMacaroonViews(pyramid_request)
         result = view.delete_macaroon()
 
-        assert request.route_path.calls == [pretend.call("manage.account")]
+        assert pyramid_request.route_path.calls == [pretend.call("manage.account")]
         assert isinstance(result, HTTPSeeOther)
         assert result.location == "/safe/route"
         assert macaroon_service.delete_macaroon.calls == []
 
-    def test_delete_macaroon(self, monkeypatch):
+    def test_delete_macaroon(self, monkeypatch, pyramid_request):
         macaroon = pretend.stub(description="fake macaroon", permissions_caveat="user")
         macaroon_service = pretend.stub(
             delete_macaroon=pretend.call_recorder(lambda id: pretend.stub()),
             find_macaroon=pretend.call_recorder(lambda id: macaroon),
         )
         user_service = pretend.stub()
-        request = pretend.stub(
-            POST={"confirm_password": "password", "macaroon_id": "macaroon_id"},
-            route_path=pretend.call_recorder(lambda x: pretend.stub()),
-            find_service=lambda interface, **kw: {
-                IMacaroonService: macaroon_service,
-                IUserService: user_service,
-            }[interface],
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            referer="/fake/safe/route",
-            host=None,
-            user=pretend.stub(
-                id=pretend.stub(),
-                username=pretend.stub(),
-                record_event=pretend.call_recorder(lambda *a, **kw: None),
-            ),
-            remote_addr="0.0.0.0",
+        pyramid_request.POST = {
+            "confirm_password": "password",
+            "macaroon_id": "macaroon_id",
+        }
+        pyramid_request.route_path = pretend.call_recorder(lambda x: pretend.stub())
+        pyramid_request.find_service = lambda interface, **kw: {
+            IMacaroonService: macaroon_service,
+            IUserService: user_service,
+        }[interface]
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        pyramid_request.referer = "/fake/safe/route"
+        pyramid_request.host = None
+        pyramid_request.user = pretend.stub(
+            id=pretend.stub(),
+            username=pretend.stub(),
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
 
         delete_macaroon_obj = pretend.stub(
@@ -2289,10 +2302,10 @@ class TestProvisionMacaroonViews:
         )
         monkeypatch.setattr(views, "DeleteMacaroonForm", delete_macaroon_cls)
 
-        view = views.ProvisionMacaroonViews(request)
+        view = views.ProvisionMacaroonViews(pyramid_request)
         result = view.delete_macaroon()
 
-        assert request.route_path.calls == []
+        assert pyramid_request.route_path.calls == []
         assert isinstance(result, HTTPSeeOther)
         assert result.location == "/fake/safe/route"
         assert macaroon_service.delete_macaroon.calls == [
@@ -2301,18 +2314,20 @@ class TestProvisionMacaroonViews:
         assert macaroon_service.find_macaroon.calls == [
             pretend.call(delete_macaroon_obj.macaroon_id.data)
         ]
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Deleted API token 'fake macaroon'.", queue="success")
         ]
-        assert request.user.record_event.calls == [
+        assert pyramid_request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.APITokenRemoved,
-                ip_address=request.remote_addr,
+                ip_address=pyramid_request.remote_addr,
                 additional={"macaroon_id": delete_macaroon_obj.macaroon_id.data},
             )
         ]
 
-    def test_delete_macaroon_records_events_for_each_project(self, monkeypatch):
+    def test_delete_macaroon_records_events_for_each_project(
+        self, monkeypatch, pyramid_request
+    ):
         macaroon = pretend.stub(
             description="fake macaroon",
             permissions_caveat={"projects": ["foo", "bar"]},
@@ -2323,30 +2338,28 @@ class TestProvisionMacaroonViews:
         )
         record_project_event = pretend.call_recorder(lambda *a, **kw: None)
         user_service = pretend.stub()
-        request = pretend.stub(
-            POST={"confirm_password": pretend.stub(), "macaroon_id": pretend.stub()},
-            route_path=pretend.call_recorder(lambda x: pretend.stub()),
-            find_service=lambda interface, **kw: {
-                IMacaroonService: macaroon_service,
-                IUserService: user_service,
-            }[interface],
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            referer="/fake/safe/route",
-            host=None,
-            user=pretend.stub(
-                id=pretend.stub(),
-                username=pretend.stub(),
-                projects=[
-                    pretend.stub(
-                        normalized_name="foo", record_event=record_project_event
-                    ),
-                    pretend.stub(
-                        normalized_name="bar", record_event=record_project_event
-                    ),
-                ],
-                record_event=pretend.call_recorder(lambda *a, **kw: None),
-            ),
-            remote_addr="0.0.0.0",
+        pyramid_request.POST = {
+            "confirm_password": pretend.stub(),
+            "macaroon_id": pretend.stub(),
+        }
+        pyramid_request.route_path = pretend.call_recorder(lambda x: pretend.stub())
+        pyramid_request.find_service = lambda interface, **kw: {
+            IMacaroonService: macaroon_service,
+            IUserService: user_service,
+        }[interface]
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        pyramid_request.referer = "/fake/safe/route"
+        pyramid_request.host = None
+        pyramid_request.user = pretend.stub(
+            id=pretend.stub(),
+            username=pretend.stub(),
+            projects=[
+                pretend.stub(normalized_name="foo", record_event=record_project_event),
+                pretend.stub(normalized_name="bar", record_event=record_project_event),
+            ],
+            record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
 
         delete_macaroon_obj = pretend.stub(
@@ -2357,10 +2370,10 @@ class TestProvisionMacaroonViews:
         )
         monkeypatch.setattr(views, "DeleteMacaroonForm", delete_macaroon_cls)
 
-        view = views.ProvisionMacaroonViews(request)
+        view = views.ProvisionMacaroonViews(pyramid_request)
         result = view.delete_macaroon()
 
-        assert request.route_path.calls == []
+        assert pyramid_request.route_path.calls == []
         assert isinstance(result, HTTPSeeOther)
         assert result.location == "/fake/safe/route"
         assert macaroon_service.delete_macaroon.calls == [
@@ -2369,12 +2382,12 @@ class TestProvisionMacaroonViews:
         assert macaroon_service.find_macaroon.calls == [
             pretend.call(delete_macaroon_obj.macaroon_id.data)
         ]
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Deleted API token 'fake macaroon'.", queue="success")
         ]
-        assert request.user.record_event.calls == [
+        assert pyramid_request.user.record_event.calls == [
             pretend.call(
-                ip_address=request.remote_addr,
+                ip_address=pyramid_request.remote_addr,
                 tag=EventTag.Account.APITokenRemoved,
                 additional={"macaroon_id": delete_macaroon_obj.macaroon_id.data},
             )
@@ -2382,18 +2395,18 @@ class TestProvisionMacaroonViews:
         assert record_project_event.calls == [
             pretend.call(
                 tag=EventTag.Project.APITokenRemoved,
-                ip_address=request.remote_addr,
+                ip_address=pyramid_request.remote_addr,
                 additional={
                     "description": "fake macaroon",
-                    "user": request.user.username,
+                    "user": pyramid_request.user.username,
                 },
             ),
             pretend.call(
                 tag=EventTag.Project.APITokenRemoved,
-                ip_address=request.remote_addr,
+                ip_address=pyramid_request.remote_addr,
                 additional={
                     "description": "fake macaroon",
-                    "user": request.user.username,
+                    "user": pyramid_request.user.username,
                 },
             ),
         ]
@@ -3501,23 +3514,27 @@ class TestManageProjectSettings:
             )
         ]
 
-    def test_delete_project_disallow_deletion(self):
+    def test_delete_project_disallow_deletion(self, pyramid_request):
         project = pretend.stub(name="foo", normalized_name="foo")
-        request = pretend.stub(
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: True)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: True)
+        )
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
 
-        result = views.delete_project(project, request)
+        result = views.delete_project(project, pyramid_request)
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_DELETION)
         ]
 
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 (
                     "Project deletion temporarily disabled. "
@@ -3527,7 +3544,7 @@ class TestManageProjectSettings:
             )
         ]
 
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call("manage.project.settings", project_name="foo")
         ]
 
@@ -3834,7 +3851,9 @@ class TestManageProjectRelease:
             "files": files,
         }
 
-    def test_delete_project_release_disallow_deletion(self, monkeypatch):
+    def test_delete_project_release_disallow_deletion(
+        self, monkeypatch, pyramid_request
+    ):
         release = pretend.stub(
             version="1.2.3",
             canonical_version="1.2.3",
@@ -3842,23 +3861,28 @@ class TestManageProjectRelease:
                 name="foobar", record_event=pretend.call_recorder(lambda *a, **kw: None)
             ),
         )
-        request = pretend.stub(
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: True)),
-            method="POST",
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: True)
         )
-        view = views.ManageProjectRelease(release, request)
+        pyramid_request.method = "POST"
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
 
+        view = views.ManageProjectRelease(release, pyramid_request)
         result = view.delete_project_release()
+
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_DELETION)
         ]
 
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 (
                     "Project deletion temporarily disabled. "
@@ -3868,7 +3892,7 @@ class TestManageProjectRelease:
             )
         ]
 
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call(
                 "manage.project.release",
                 project_name=release.project.name,
@@ -3876,42 +3900,25 @@ class TestManageProjectRelease:
             )
         ]
 
-    def test_yank_project_release(self, monkeypatch):
-        user = pretend.stub(username=pretend.stub())
-        release = pretend.stub(
-            version="1.2.3",
-            canonical_version="1.2.3",
-            project=pretend.stub(
-                name="foobar",
-                record_event=pretend.call_recorder(lambda *a, **kw: None),
-                users=[user],
-            ),
-            created=datetime.datetime(2017, 2, 5, 17, 18, 18, 462_634),
-            yanked=False,
-            yanked_reason="",
-        )
-        request = pretend.stub(
-            POST={
-                "confirm_yank_version": release.version,
-                "yanked_reason": "Yanky Doodle went to town",
-            },
-            method="POST",
-            db=pretend.stub(add=pretend.call_recorder(lambda a: None)),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            user=user,
-            remote_addr=pretend.stub(),
-        )
-        journal_obj = pretend.stub()
-        journal_cls = pretend.call_recorder(lambda **kw: journal_obj)
+    def test_yank_project_release(self, monkeypatch, db_request):
+        user = UserFactory.create()
+        project = ProjectFactory.create(name="foobar")
+        RoleFactory.create(user=user, project=project)
+        release = ReleaseFactory.create(project=project)
+        project.record_event = pretend.call_recorder(lambda *a, **kw: None)
 
-        get_user_role_in_project = pretend.call_recorder(
-            lambda project, user, req: "Owner"
+        db_request.POST = {
+            "confirm_yank_version": release.version,
+            "yanked_reason": "Yanky Doodle went to town",
+        }
+        db_request.method = "POST"
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
+        db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/the-redirect")
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        monkeypatch.setattr(views, "get_user_role_in_project", get_user_role_in_project)
+        db_request.user = user
 
-        monkeypatch.setattr(views, "JournalEntry", journal_cls)
         send_yanked_project_release_email = pretend.call_recorder(
             lambda req, contrib, **k: None
         )
@@ -3921,8 +3928,7 @@ class TestManageProjectRelease:
             send_yanked_project_release_email,
         )
 
-        view = views.ManageProjectRelease(release, request)
-
+        view = views.ManageProjectRelease(release, db_request)
         result = view.yank_project_release()
 
         assert isinstance(result, HTTPSeeOther)
@@ -3931,66 +3937,62 @@ class TestManageProjectRelease:
         assert release.yanked
         assert release.yanked_reason == "Yanky Doodle went to town"
 
-        assert get_user_role_in_project.calls == [
-            pretend.call(release.project, request.user, request),
-            pretend.call(release.project, request.user, request),
-        ]
-
         assert send_yanked_project_release_email.calls == [
             pretend.call(
-                request,
-                request.user,
+                db_request,
+                db_request.user,
                 release=release,
-                submitter_name=request.user.username,
+                submitter_name=db_request.user.username,
                 submitter_role="Owner",
                 recipient_role="Owner",
             )
         ]
-
-        assert request.db.add.calls == [pretend.call(journal_obj)]
-        assert journal_cls.calls == [
-            pretend.call(
-                name=release.project.name,
-                action="yank release",
-                version=release.version,
-                submitted_by=request.user,
-                submitted_from=request.remote_addr,
-            )
-        ]
-        assert request.session.flash.calls == [
+        entry = (
+            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+        )
+        assert entry.name == release.project.name
+        assert entry.action == "yank release"
+        assert entry.version == release.version
+        assert entry.submitted_by == db_request.user
+        assert entry.submitted_from == db_request.remote_addr
+        assert db_request.session.flash.calls == [
             pretend.call(f"Yanked release {release.version!r}", queue="success")
         ]
-        assert request.route_path.calls == [
+        assert db_request.route_path.calls == [
             pretend.call("manage.project.releases", project_name=release.project.name)
         ]
         assert release.project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.ReleaseYank,
-                ip_address=request.remote_addr,
+                ip_address=db_request.remote_addr,
                 additional={
-                    "submitted_by": request.user.username,
+                    "submitted_by": db_request.user.username,
                     "canonical_version": release.canonical_version,
                     "yanked_reason": "Yanky Doodle went to town",
                 },
             )
         ]
 
-    def test_yank_project_release_no_confirm(self):
+    def test_yank_project_release_no_confirm(self, pyramid_request):
         release = pretend.stub(
             version="1.2.3",
             project=pretend.stub(name="foobar"),
             yanked=False,
             yanked_reason="",
         )
-        request = pretend.stub(
-            POST={"confirm_yank_version": ""},
-            method="POST",
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.POST = {"confirm_yank_version": ""}
+        pyramid_request.method = "POST"
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: False)
         )
-        view = views.ManageProjectRelease(release, request)
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
 
+        view = views.ManageProjectRelease(release, pyramid_request)
         result = view.yank_project_release()
 
         assert isinstance(result, HTTPSeeOther)
@@ -3999,10 +4001,10 @@ class TestManageProjectRelease:
         assert not release.yanked
         assert not release.yanked_reason
 
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Confirm the request", queue="error")
         ]
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call(
                 "manage.project.release",
                 project_name=release.project.name,
@@ -4010,22 +4012,26 @@ class TestManageProjectRelease:
             )
         ]
 
-    def test_yank_project_release_bad_confirm(self):
+    def test_yank_project_release_bad_confirm(self, pyramid_request):
         release = pretend.stub(
             version="1.2.3",
             project=pretend.stub(name="foobar"),
             yanked=False,
             yanked_reason="",
         )
-        request = pretend.stub(
-            POST={"confirm_yank_version": "invalid"},
-            method="POST",
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.POST = {"confirm_yank_version": "invalid"}
+        pyramid_request.method = "POST"
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: False)
         )
-        view = views.ManageProjectRelease(release, request)
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
 
+        view = views.ManageProjectRelease(release, pyramid_request)
         result = view.yank_project_release()
 
         assert isinstance(result, HTTPSeeOther)
@@ -4034,14 +4040,14 @@ class TestManageProjectRelease:
         assert not release.yanked
         assert not release.yanked_reason
 
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 "Could not yank release - "
                 + f"'invalid' is not the same as {release.version!r}",
                 queue="error",
             )
         ]
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call(
                 "manage.project.release",
                 project_name=release.project.name,
@@ -4049,38 +4055,22 @@ class TestManageProjectRelease:
             )
         ]
 
-    def test_unyank_project_release(self, monkeypatch):
-        user = pretend.stub(username=pretend.stub())
-        release = pretend.stub(
-            version="1.2.3",
-            canonical_version="1.2.3",
-            project=pretend.stub(
-                name="foobar",
-                record_event=pretend.call_recorder(lambda *a, **kw: None),
-                users=[user],
-            ),
-            created=datetime.datetime(2017, 2, 5, 17, 18, 18, 462_634),
-            yanked=True,
-        )
-        request = pretend.stub(
-            POST={"confirm_unyank_version": release.version},
-            method="POST",
-            db=pretend.stub(add=pretend.call_recorder(lambda a: None)),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            user=user,
-            remote_addr=pretend.stub(),
-        )
-        journal_obj = pretend.stub()
-        journal_cls = pretend.call_recorder(lambda **kw: journal_obj)
+    def test_unyank_project_release(self, monkeypatch, db_request):
+        user = UserFactory.create()
+        project = ProjectFactory.create(name="foobar")
+        RoleFactory.create(user=user, project=project)
+        release = ReleaseFactory.create(project=project, yanked=True)
+        project.record_event = pretend.call_recorder(lambda *a, **kw: None)
 
-        get_user_role_in_project = pretend.call_recorder(
-            lambda project_name, username, req: "Owner"
+        db_request.POST = {"confirm_unyank_version": release.version}
+        db_request.method = "POST"
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
+        db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/the-redirect")
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        monkeypatch.setattr(views, "get_user_role_in_project", get_user_role_in_project)
+        db_request.user = user
 
-        monkeypatch.setattr(views, "JournalEntry", journal_cls)
         send_unyanked_project_release_email = pretend.call_recorder(
             lambda req, contrib, **k: None
         )
@@ -4090,8 +4080,7 @@ class TestManageProjectRelease:
             send_unyanked_project_release_email,
         )
 
-        view = views.ManageProjectRelease(release, request)
-
+        view = views.ManageProjectRelease(release, db_request)
         result = view.unyank_project_release()
 
         assert isinstance(result, HTTPSeeOther)
@@ -4100,68 +4089,66 @@ class TestManageProjectRelease:
         assert not release.yanked
         assert not release.yanked_reason
 
-        assert get_user_role_in_project.calls == [
-            pretend.call(release.project, request.user, request),
-            pretend.call(release.project, request.user, request),
-        ]
-
         assert send_unyanked_project_release_email.calls == [
             pretend.call(
-                request,
-                request.user,
+                db_request,
+                db_request.user,
                 release=release,
-                submitter_name=request.user.username,
+                submitter_name=db_request.user.username,
                 submitter_role="Owner",
                 recipient_role="Owner",
             )
         ]
 
-        assert request.db.add.calls == [pretend.call(journal_obj)]
-        assert journal_cls.calls == [
-            pretend.call(
-                name=release.project.name,
-                action="unyank release",
-                version=release.version,
-                submitted_by=request.user,
-                submitted_from=request.remote_addr,
-            )
-        ]
-        assert request.session.flash.calls == [
+        entry = (
+            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+        )
+        assert entry.name == release.project.name
+        assert entry.action == "unyank release"
+        assert entry.version == release.version
+        assert entry.submitted_by == db_request.user
+        assert entry.submitted_from == db_request.remote_addr
+
+        assert db_request.session.flash.calls == [
             pretend.call(f"Un-yanked release {release.version!r}", queue="success")
         ]
-        assert request.route_path.calls == [
+        assert db_request.route_path.calls == [
             pretend.call("manage.project.releases", project_name=release.project.name)
         ]
         assert release.project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.ReleaseUnyank,
-                ip_address=request.remote_addr,
+                ip_address=db_request.remote_addr,
                 additional={
-                    "submitted_by": request.user.username,
+                    "submitted_by": db_request.user.username,
                     "canonical_version": release.canonical_version,
                 },
             )
         ]
 
-    def test_unyank_project_release_no_confirm(self):
+    def test_unyank_project_release_no_confirm(self, pyramid_request):
         release = pretend.stub(
             version="1.2.3",
             project=pretend.stub(name="foobar"),
             yanked=True,
             yanked_reason="",
         )
-        request = pretend.stub(
-            POST={
-                "confirm_unyank_version": "",
-                "yanked_reason": "Yanky Doodle went to town",
-            },
-            method="POST",
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.POST = {
+            "confirm_unyank_version": "",
+            "yanked_reason": "Yanky Doodle went to town",
+        }
+        pyramid_request.method = "POST"
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: False)
         )
-        view = views.ManageProjectRelease(release, request)
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
 
+        view = views.ManageProjectRelease(release, pyramid_request)
         result = view.unyank_project_release()
 
         assert isinstance(result, HTTPSeeOther)
@@ -4170,10 +4157,10 @@ class TestManageProjectRelease:
         assert release.yanked
         assert not release.yanked_reason
 
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Confirm the request", queue="error")
         ]
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call(
                 "manage.project.release",
                 project_name=release.project.name,
@@ -4181,22 +4168,29 @@ class TestManageProjectRelease:
             )
         ]
 
-    def test_unyank_project_release_bad_confirm(self):
+    def test_unyank_project_release_bad_confirm(self, pyramid_request):
         release = pretend.stub(
             version="1.2.3",
             project=pretend.stub(name="foobar"),
             yanked=True,
             yanked_reason="Old reason",
         )
-        request = pretend.stub(
-            POST={"confirm_unyank_version": "invalid", "yanked_reason": "New reason"},
-            method="POST",
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.POST = {
+            "confirm_unyank_version": "invalid",
+            "yanked_reason": "New reason",
+        }
+        pyramid_request.method = "POST"
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: False)
         )
-        view = views.ManageProjectRelease(release, request)
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
 
+        view = views.ManageProjectRelease(release, pyramid_request)
         result = view.unyank_project_release()
 
         assert isinstance(result, HTTPSeeOther)
@@ -4205,14 +4199,14 @@ class TestManageProjectRelease:
         assert release.yanked
         assert release.yanked_reason == "Old reason"
 
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 "Could not un-yank release - "
                 + f"'invalid' is not the same as {release.version!r}",
                 queue="error",
             )
         ]
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call(
                 "manage.project.release",
                 project_name=release.project.name,
@@ -4220,40 +4214,22 @@ class TestManageProjectRelease:
             )
         ]
 
-    def test_delete_project_release(self, monkeypatch):
-        user = pretend.stub(username=pretend.stub())
-        release = pretend.stub(
-            version="1.2.3",
-            canonical_version="1.2.3",
-            project=pretend.stub(
-                name="foobar",
-                record_event=pretend.call_recorder(lambda *a, **kw: None),
-                users=[user],
-            ),
-            created=datetime.datetime(2017, 2, 5, 17, 18, 18, 462_634),
-        )
-        request = pretend.stub(
-            POST={"confirm_delete_version": release.version},
-            method="POST",
-            db=pretend.stub(
-                delete=pretend.call_recorder(lambda a: None),
-                add=pretend.call_recorder(lambda a: None),
-            ),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            user=user,
-            remote_addr=pretend.stub(),
-        )
-        journal_obj = pretend.stub()
-        journal_cls = pretend.call_recorder(lambda **kw: journal_obj)
+    def test_delete_project_release(self, monkeypatch, db_request):
+        user = UserFactory.create()
+        project = ProjectFactory.create(name="foobar")
+        RoleFactory.create(user=user, project=project)
+        release = ReleaseFactory.create(project=project, yanked=True)
+        project.record_event = pretend.call_recorder(lambda *a, **kw: None)
 
-        get_user_role_in_project = pretend.call_recorder(
-            lambda project, user, req: "Owner"
+        db_request.POST = {"confirm_delete_version": release.version}
+        db_request.method = "POST"
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda *a: False))
+        db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/the-redirect")
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        monkeypatch.setattr(views, "get_user_role_in_project", get_user_role_in_project)
+        db_request.user = user
 
-        monkeypatch.setattr(views, "JournalEntry", journal_cls)
         send_removed_project_release_email = pretend.call_recorder(
             lambda req, contrib, **k: None
         )
@@ -4263,85 +4239,79 @@ class TestManageProjectRelease:
             send_removed_project_release_email,
         )
 
-        view = views.ManageProjectRelease(release, request)
-
+        view = views.ManageProjectRelease(release, db_request)
         result = view.delete_project_release()
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        assert get_user_role_in_project.calls == [
-            pretend.call(release.project, request.user, request),
-            pretend.call(release.project, request.user, request),
-        ]
-
         assert send_removed_project_release_email.calls == [
             pretend.call(
-                request,
-                request.user,
+                db_request,
+                db_request.user,
                 release=release,
-                submitter_name=request.user.username,
+                submitter_name=db_request.user.username,
                 submitter_role="Owner",
                 recipient_role="Owner",
             )
         ]
 
-        assert request.db.delete.calls == [pretend.call(release)]
-        assert request.db.add.calls == [pretend.call(journal_obj)]
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.DISALLOW_DELETION)
-        ]
-        assert journal_cls.calls == [
-            pretend.call(
-                name=release.project.name,
-                action="remove release",
-                version=release.version,
-                submitted_by=request.user,
-                submitted_from=request.remote_addr,
-            )
-        ]
-        assert request.session.flash.calls == [
+        assert db_request.db.query(Release).all() == []
+        entry = (
+            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+        )
+        assert entry.name == release.project.name
+        assert entry.action == "remove release"
+        assert entry.version == release.version
+        assert entry.submitted_by == db_request.user
+        assert entry.submitted_from == db_request.remote_addr
+
+        assert db_request.session.flash.calls == [
             pretend.call(f"Deleted release {release.version!r}", queue="success")
         ]
-        assert request.route_path.calls == [
+        assert db_request.route_path.calls == [
             pretend.call("manage.project.releases", project_name=release.project.name)
         ]
         assert release.project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.ReleaseRemove,
-                ip_address=request.remote_addr,
+                ip_address=db_request.remote_addr,
                 additional={
-                    "submitted_by": request.user.username,
+                    "submitted_by": db_request.user.username,
                     "canonical_version": release.canonical_version,
                 },
             )
         ]
 
-    def test_delete_project_release_no_confirm(self):
+    def test_delete_project_release_no_confirm(self, pyramid_request):
         release = pretend.stub(version="1.2.3", project=pretend.stub(name="foobar"))
-        request = pretend.stub(
-            POST={"confirm_delete_version": ""},
-            method="POST",
-            db=pretend.stub(delete=pretend.call_recorder(lambda a: None)),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.POST = {"confirm_delete_version": ""}
+        pyramid_request.method = "POST"
+        pyramid_request.db = pretend.stub(delete=pretend.call_recorder(lambda a: None))
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: False)
         )
-        view = views.ManageProjectRelease(release, request)
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
 
+        view = views.ManageProjectRelease(release, pyramid_request)
         result = view.delete_project_release()
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        assert request.db.delete.calls == []
-        assert request.session.flash.calls == [
+        assert pyramid_request.db.delete.calls == []
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Confirm the request", queue="error")
         ]
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_DELETION)
         ]
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call(
                 "manage.project.release",
                 project_name=release.project.name,
@@ -4349,32 +4319,36 @@ class TestManageProjectRelease:
             )
         ]
 
-    def test_delete_project_release_bad_confirm(self):
+    def test_delete_project_release_bad_confirm(self, pyramid_request):
         release = pretend.stub(version="1.2.3", project=pretend.stub(name="foobar"))
-        request = pretend.stub(
-            POST={"confirm_delete_version": "invalid"},
-            method="POST",
-            db=pretend.stub(delete=pretend.call_recorder(lambda a: None)),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.POST = {"confirm_delete_version": "invalid"}
+        pyramid_request.method = "POST"
+        pyramid_request.db = pretend.stub(delete=pretend.call_recorder(lambda a: None))
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: False)
         )
-        view = views.ManageProjectRelease(release, request)
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
 
+        view = views.ManageProjectRelease(release, pyramid_request)
         result = view.delete_project_release()
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        assert request.db.delete.calls == []
-        assert request.session.flash.calls == [
+        assert pyramid_request.db.delete.calls == []
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 "Could not delete release - "
                 + f"'invalid' is not the same as {release.version!r}",
                 queue="error",
             )
         ]
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call(
                 "manage.project.release",
                 project_name=release.project.name,
@@ -4382,26 +4356,30 @@ class TestManageProjectRelease:
             )
         ]
 
-    def test_delete_project_release_file_disallow_deletion(self):
+    def test_delete_project_release_file_disallow_deletion(self, pyramid_request):
         release = pretend.stub(version="1.2.3", project=pretend.stub(name="foobar"))
-        request = pretend.stub(
-            method="POST",
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: True)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.method = "POST"
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: True)
         )
-        view = views.ManageProjectRelease(release, request)
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
 
+        view = views.ManageProjectRelease(release, pyramid_request)
         result = view.delete_project_release_file()
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_DELETION)
         ]
 
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 (
                     "Project deletion temporarily disabled. "
@@ -4410,7 +4388,7 @@ class TestManageProjectRelease:
                 queue="error",
             )
         ]
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call(
                 "manage.project.release",
                 project_name=release.project.name,
@@ -4501,34 +4479,38 @@ class TestManageProjectRelease:
             )
         ]
 
-    def test_delete_project_release_file_no_confirm(self):
+    def test_delete_project_release_file_no_confirm(self, pyramid_request):
         release = pretend.stub(
             version="1.2.3",
             project=pretend.stub(name="foobar", normalized_name="foobar"),
         )
-        request = pretend.stub(
-            POST={"confirm_project_name": ""},
-            method="POST",
-            db=pretend.stub(delete=pretend.call_recorder(lambda a: None)),
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
-            route_path=pretend.call_recorder(lambda *a, **kw: "/the-redirect"),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+        pyramid_request.POST = {"confirm_project_name": ""}
+        pyramid_request.method = "POST"
+        pyramid_request.db = pretend.stub(delete=pretend.call_recorder(lambda a: None))
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda *a: False)
         )
-        view = views.ManageProjectRelease(release, request)
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
 
+        view = views.ManageProjectRelease(release, pyramid_request)
         result = view.delete_project_release_file()
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        assert request.db.delete.calls == []
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.db.delete.calls == []
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_DELETION)
         ]
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Confirm the request", queue="error")
         ]
-        assert request.route_path.calls == [
+        assert pyramid_request.route_path.calls == [
             pretend.call(
                 "manage.project.release",
                 project_name=release.project.name,
@@ -6015,42 +5997,46 @@ class TestManageOIDCPublisherViews:
             pretend.call(request.POST, api_token="fake-api-token")
         ]
 
-    def test_manage_project_oidc_publishers_admin_disabled(self, monkeypatch):
+    def test_manage_project_oidc_publishers_admin_disabled(
+        self, monkeypatch, pyramid_request
+    ):
         project = pretend.stub(oidc_publishers=[])
-        request = pretend.stub(
-            user=pretend.stub(
-                in_oidc_beta=True,
-            ),
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                },
-            ),
-            find_service=lambda *a, **kw: None,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: True)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
+        pyramid_request.user = pretend.stub(
+            in_oidc_beta=True,
         )
+        pyramid_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            },
+        )
+        pyramid_request.find_service = lambda *a, **kw: None
+        pyramid_request.flags = pretend.stub(
+            enabled=pretend.call_recorder(lambda f: True)
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        pyramid_request.POST = pretend.stub()
 
-        view = views.ManageOIDCPublisherViews(project, request)
+        view = views.ManageOIDCPublisherViews(project, pyramid_request)
         github_publisher_form_obj = pretend.stub()
         github_publisher_form_cls = pretend.call_recorder(
             lambda *a, **kw: github_publisher_form_obj
         )
         monkeypatch.setattr(views, "GitHubPublisherForm", github_publisher_form_cls)
 
-        view = views.ManageOIDCPublisherViews(project, request)
+        view = views.ManageOIDCPublisherViews(project, pyramid_request)
         assert view.manage_project_oidc_publishers() == {
             "oidc_enabled": True,
             "project": project,
             "github_publisher_form": github_publisher_form_obj,
         }
 
-        assert request.flags.enabled.calls == [
+        assert pyramid_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call(
                 (
                     "Trusted publishers are temporarily disabled. "
@@ -6060,7 +6046,7 @@ class TestManageOIDCPublisherViews:
             )
         ]
         assert github_publisher_form_cls.calls == [
-            pretend.call(request.POST, api_token="fake-api-token")
+            pretend.call(pyramid_request.POST, api_token="fake-api-token")
         ]
 
     def test_manage_project_oidc_publishers_oidc_not_enabled(self):
@@ -6191,12 +6177,12 @@ class TestManageOIDCPublisherViews:
         assert project.oidc_publishers == [publisher]
 
     def test_add_github_oidc_publisher_created(self, monkeypatch):
-        fakeusers = [pretend.stub(), pretend.stub(), pretend.stub()]
+        fakeuser = pretend.stub()
         project = pretend.stub(
             name="fakeproject",
             oidc_publishers=[],
             record_event=pretend.call_recorder(lambda *a, **kw: None),
-            users=fakeusers,
+            users=[fakeuser],
         )
 
         metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
@@ -6290,28 +6276,25 @@ class TestManageOIDCPublisherViews:
                 project_name="fakeproject",
                 publisher=project.oidc_publishers[0],
             )
-            for fakeuser in fakeusers
         ]
         assert view._hit_ratelimits.calls == [pretend.call()]
         assert view._check_ratelimits.calls == [pretend.call()]
         assert len(project.oidc_publishers) == 1
 
     def test_add_github_oidc_publisher_already_registered_with_project(
-        self, monkeypatch
+        self, monkeypatch, db_request
     ):
-        publisher = pretend.stub(
-            id="fakeid",
-            publisher_name="GitHub",
-            repository_name="fakerepo",
-            owner="fakeowner",
-            owner_id="1234",
-            workflow_filename="fakeworkflow.yml",
+        db_request.user = UserFactory.create()
+        EmailFactory(user=db_request.user, verified=True, primary=True)
+        publisher = GitHubPublisher(
+            repository_name="some-repository",
+            repository_owner="some-owner",
+            repository_owner_id="666",
+            workflow_filename="some-workflow-filename.yml",
             environment="some-environment",
         )
-        # NOTE: Can't set __str__ using pretend.stub()
-        monkeypatch.setattr(publisher.__class__, "__str__", lambda s: "fakespecifier")
-
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
+        db_request.db.add(publisher)
+        db_request.db.flush()  # To get it in the DB
 
         project = pretend.stub(
             name="fakeproject",
@@ -6319,40 +6302,36 @@ class TestManageOIDCPublisherViews:
             record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
 
-        request = pretend.stub(
-            user=pretend.stub(
-                in_oidc_beta=True,
-            ),
-            registry=pretend.stub(
-                settings={
-                    "warehouse.oidc.enabled": True,
-                    "github.token": "fake-api-token",
-                }
-            ),
-            find_service=lambda *a, **kw: metrics,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
-            db=pretend.stub(
-                query=lambda *a: pretend.stub(
-                    filter=lambda *a: pretend.stub(one_or_none=lambda: publisher)
-                ),
-            ),
+        db_request.registry = pretend.stub(
+            settings={
+                "warehouse.oidc.enabled": True,
+                "github.token": "fake-api-token",
+            }
+        )
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda f: False))
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.POST = MultiDict(
+            {
+                "owner": "some-owner",
+                "repository": "some-repository",
+                "workflow_filename": "some-workflow-filename.yml",
+                "environment": "some-environment",
+            }
         )
 
-        github_publisher_form_obj = pretend.stub(
-            validate=pretend.call_recorder(lambda: True),
-            repository=pretend.stub(data=publisher.repository_name),
-            normalized_owner=publisher.owner,
-            workflow_filename=pretend.stub(data=publisher.workflow_filename),
-            normalized_environment=publisher.environment,
+        view = views.ManageOIDCPublisherViews(project, db_request)
+        monkeypatch.setattr(
+            views.ManageOIDCPublisherViews,
+            "github_publisher_form",
+            view.github_publisher_form,
         )
-        github_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: github_publisher_form_obj
+        monkeypatch.setattr(
+            views.GitHubPublisherForm,
+            "_lookup_owner",
+            lambda *a: {"login": "some-owner", "id": "some-owner-id"},
         )
-        monkeypatch.setattr(views, "GitHubPublisherForm", github_publisher_form_cls)
-
-        view = views.ManageOIDCPublisherViews(project, request)
         monkeypatch.setattr(
             view, "_hit_ratelimits", pretend.call_recorder(lambda: None)
         )
@@ -6363,7 +6342,7 @@ class TestManageOIDCPublisherViews:
         assert view.add_github_oidc_publisher() == {
             "oidc_enabled": True,
             "project": project,
-            "github_publisher_form": github_publisher_form_obj,
+            "github_publisher_form": view.github_publisher_form,
         }
         assert view.metrics.increment.calls == [
             pretend.call(
@@ -6371,9 +6350,9 @@ class TestManageOIDCPublisherViews:
             ),
         ]
         assert project.record_event.calls == []
-        assert request.session.flash.calls == [
+        assert db_request.session.flash.calls == [
             pretend.call(
-                "fakespecifier is already registered with fakeproject",
+                f"{str(publisher)} is already registered with fakeproject",
                 queue="error",
             )
         ]
@@ -6521,58 +6500,44 @@ class TestManageOIDCPublisherViews:
         assert view._check_ratelimits.calls == [pretend.call()]
         assert github_publisher_form_obj.validate.calls == [pretend.call()]
 
-    def test_delete_oidc_publisher_registered_to_multiple_projects(self, monkeypatch):
-        publisher = pretend.stub(
-            publisher_name="fakepublisher",
-            id="fakeid",
-            projects=[pretend.stub(), pretend.stub()],
-            publisher_url="some-url",
+    def test_delete_oidc_publisher_registered_to_multiple_projects(
+        self, monkeypatch, db_request
+    ):
+        db_request.user = UserFactory.create()
+        EmailFactory(user=db_request.user, verified=True, primary=True)
+        publisher = GitHubPublisher(
+            repository_name="some-repository",
+            repository_owner="some-owner",
+            repository_owner_id="666",
+            workflow_filename="some-workflow-filename.yml",
+            environment="some-environment",
+        )
+        db_request.db.add(publisher)
+        db_request.db.flush()  # To get it in the DB
+
+        project = ProjectFactory.create(oidc_publishers=[publisher])
+        project.record_event = pretend.call_recorder(lambda *a, **kw: None)
+        RoleFactory.create(user=db_request.user, project=project, role_name="Owner")
+        another_project = ProjectFactory.create(oidc_publishers=[publisher])
+
+        db_request.registry = pretend.stub(settings={"warehouse.oidc.enabled": True})
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda f: False))
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.POST = MultiDict(
+            {
+                "publisher_id": str(publisher.id),
+            }
         )
 
-        # NOTE: Can't set __str__ using pretend.stub()
-        monkeypatch.setattr(publisher.__class__, "__str__", lambda s: "fakespecifier")
-
-        fakeusers = [pretend.stub(), pretend.stub(), pretend.stub()]
-        project = pretend.stub(
-            oidc_publishers=[publisher],
-            name="fakeproject",
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
-            users=fakeusers,
-        )
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        request = pretend.stub(
-            user=pretend.stub(
-                in_oidc_beta=True,
-                username="some-user",
-            ),
-            registry=pretend.stub(settings={"warehouse.oidc.enabled": True}),
-            find_service=lambda *a, **kw: metrics,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
-            db=pretend.stub(
-                query=lambda *a: pretend.stub(get=lambda id: publisher),
-                delete=pretend.call_recorder(lambda o: None),
-            ),
-            remote_addr="0.0.0.0",
-            path="request-path",
-        )
-
-        delete_publisher_form_obj = pretend.stub(
-            validate=pretend.call_recorder(lambda: True),
-            publisher_id=pretend.stub(data="fakeid"),
-        )
-        delete_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: delete_publisher_form_obj
-        )
-        monkeypatch.setattr(views, "DeletePublisherForm", delete_publisher_form_cls)
         monkeypatch.setattr(
             views,
             "send_trusted_publisher_removed_email",
             pretend.call_recorder(lambda *a, **kw: None),
         )
 
-        view = views.ManageOIDCPublisherViews(project, request)
+        view = views.ManageOIDCPublisherViews(project, db_request)
         default_response = {"_": pretend.stub()}
         monkeypatch.setattr(
             views.ManageOIDCPublisherViews, "default_response", default_response
@@ -6586,100 +6551,85 @@ class TestManageOIDCPublisherViews:
                 "warehouse.oidc.delete_publisher.attempt",
             ),
             pretend.call(
-                "warehouse.oidc.delete_publisher.ok", tags=["publisher:fakepublisher"]
+                "warehouse.oidc.delete_publisher.ok",
+                tags=[f"publisher:{publisher.publisher_name}"],
             ),
         ]
 
         assert project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.OIDCPublisherRemoved,
-                ip_address=request.remote_addr,
+                ip_address=db_request.remote_addr,
                 additional={
-                    "publisher": "fakepublisher",
-                    "id": "fakeid",
-                    "specifier": "fakespecifier",
-                    "url": "some-url",
-                    "submitted_by": "some-user",
+                    "publisher": publisher.publisher_name,
+                    "id": str(publisher.id),
+                    "specifier": str(publisher),
+                    "url": publisher.publisher_url,
+                    "submitted_by": db_request.user.username,
                 },
             )
         ]
 
-        assert request.flags.enabled.calls == [
+        assert db_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
-        assert request.session.flash.calls == [
+        assert db_request.session.flash.calls == [
             pretend.call(
-                "Removed trusted publisher for project 'fakeproject'", queue="success"
+                f"Removed trusted publisher for project {project.name!r}",
+                queue="success",
             )
         ]
+
         # The publisher is not actually removed entirely from the DB, since it's
         # registered to other projects that haven't removed it.
-        assert request.db.delete.calls == []
-
-        assert delete_publisher_form_cls.calls == [pretend.call(request.POST)]
-        assert delete_publisher_form_obj.validate.calls == [pretend.call()]
+        assert db_request.db.query(GitHubPublisher).one() == publisher
+        assert another_project.oidc_publishers == [publisher]
 
         assert views.send_trusted_publisher_removed_email.calls == [
             pretend.call(
-                request, fakeuser, project_name="fakeproject", publisher=publisher
+                db_request,
+                db_request.user,
+                project_name=project.name,
+                publisher=publisher,
             )
-            for fakeuser in fakeusers
         ]
 
-    def test_delete_oidc_publisher_entirely(self, monkeypatch):
-        publisher = pretend.stub(
-            publisher_name="fakepublisher",
-            id="fakeid",
-            # NOTE: This is technically out of sync with the state below;
-            # it should be projects=[project], but we make it empty
-            # to trigger the DB deletion case.
-            projects=[],
-            publisher_url="some-url",
+    def test_delete_oidc_publisher_entirely(self, monkeypatch, db_request):
+        db_request.user = UserFactory.create()
+        EmailFactory(user=db_request.user, verified=True, primary=True)
+        publisher = GitHubPublisher(
+            repository_name="some-repository",
+            repository_owner="some-owner",
+            repository_owner_id="666",
+            workflow_filename="some-workflow-filename.yml",
+            environment="some-environment",
         )
-        # NOTE: Can't set __str__ using pretend.stub()
-        monkeypatch.setattr(publisher.__class__, "__str__", lambda s: "fakespecifier")
+        db_request.db.add(publisher)
+        db_request.db.flush()  # To get it in the DB
 
-        fakeusers = [pretend.stub(), pretend.stub(), pretend.stub()]
-        project = pretend.stub(
-            oidc_publishers=[publisher],
-            name="fakeproject",
-            record_event=pretend.call_recorder(lambda *a, **kw: None),
-            users=fakeusers,
+        db_request.user = UserFactory.create()
+        project = ProjectFactory.create(oidc_publishers=[publisher])
+        project.record_event = pretend.call_recorder(lambda *a, **kw: None)
+        RoleFactory.create(user=db_request.user, project=project, role_name="Owner")
+
+        db_request.registry = pretend.stub(settings={"warehouse.oidc.enabled": True})
+        db_request.flags = pretend.stub(enabled=pretend.call_recorder(lambda f: False))
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
-        request = pretend.stub(
-            user=pretend.stub(
-                in_oidc_beta=True,
-                username="some-user",
-            ),
-            registry=pretend.stub(settings={"warehouse.oidc.enabled": True}),
-            find_service=lambda *a, **kw: metrics,
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda f: False)),
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            POST=pretend.stub(),
-            db=pretend.stub(
-                query=lambda *a: pretend.stub(get=lambda id: publisher),
-                delete=pretend.call_recorder(lambda o: None),
-            ),
-            remote_addr="0.0.0.0",
-            path="request-path",
+        db_request.POST = MultiDict(
+            {
+                "publisher_id": str(publisher.id),
+            }
         )
 
-        delete_publisher_form_obj = pretend.stub(
-            validate=pretend.call_recorder(lambda: True),
-            publisher_id=pretend.stub(data="fakeid"),
-        )
-        delete_publisher_form_cls = pretend.call_recorder(
-            lambda *a, **kw: delete_publisher_form_obj
-        )
-        monkeypatch.setattr(views, "DeletePublisherForm", delete_publisher_form_cls)
         monkeypatch.setattr(
             views,
             "send_trusted_publisher_removed_email",
             pretend.call_recorder(lambda *a, **kw: None),
         )
 
-        view = views.ManageOIDCPublisherViews(project, request)
+        view = views.ManageOIDCPublisherViews(project, db_request)
         default_response = {"_": pretend.stub()}
         monkeypatch.setattr(
             views.ManageOIDCPublisherViews, "default_response", default_response
@@ -6693,42 +6643,46 @@ class TestManageOIDCPublisherViews:
                 "warehouse.oidc.delete_publisher.attempt",
             ),
             pretend.call(
-                "warehouse.oidc.delete_publisher.ok", tags=["publisher:fakepublisher"]
+                "warehouse.oidc.delete_publisher.ok",
+                tags=[f"publisher:{publisher.publisher_name}"],
             ),
         ]
 
         assert project.record_event.calls == [
             pretend.call(
-                tag="project:oidc:publisher-removed",
-                ip_address=request.remote_addr,
+                tag=EventTag.Project.OIDCPublisherRemoved,
+                ip_address=db_request.remote_addr,
                 additional={
-                    "publisher": "fakepublisher",
-                    "id": "fakeid",
-                    "specifier": "fakespecifier",
-                    "url": "some-url",
-                    "submitted_by": "some-user",
+                    "publisher": publisher.publisher_name,
+                    "id": str(publisher.id),
+                    "specifier": str(publisher),
+                    "url": publisher.publisher_url,
+                    "submitted_by": db_request.user.username,
                 },
             )
         ]
 
-        assert request.flags.enabled.calls == [
+        assert db_request.flags.enabled.calls == [
             pretend.call(AdminFlagValue.DISALLOW_OIDC)
         ]
-        assert request.session.flash.calls == [
+        assert db_request.session.flash.calls == [
             pretend.call(
-                "Removed trusted publisher for project 'fakeproject'", queue="success"
+                f"Removed trusted publisher for project {project.name!r}",
+                queue="success",
             )
         ]
-        assert request.db.delete.calls == [pretend.call(publisher)]
 
-        assert delete_publisher_form_cls.calls == [pretend.call(request.POST)]
-        assert delete_publisher_form_obj.validate.calls == [pretend.call()]
+        # The publisher is not actually removed entirely from the DB, since it's
+        # registered to other projects that haven't removed it.
+        assert db_request.db.query(GitHubPublisher).all() == []
 
         assert views.send_trusted_publisher_removed_email.calls == [
             pretend.call(
-                request, fakeuser, project_name="fakeproject", publisher=publisher
+                db_request,
+                db_request.user,
+                project_name=project.name,
+                publisher=publisher,
             )
-            for fakeuser in fakeusers
         ]
 
     def test_delete_oidc_publisher_invalid_form(self, monkeypatch):

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1499,6 +1499,7 @@ class ManageAccountPublishingViews:
         )
 
         self.request.db.add(pending_publisher)
+        self.request.db.flush()  # To get the new ID
 
         self.request.user.record_event(
             tag=EventTag.Account.PendingOIDCPublisherAdded,

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1566,6 +1566,13 @@ class ManageAccountPublishingViews:
         # futzes with the form.
         if pending_publisher is None:
             self.request.session.flash(
+                self.request._("Invalid publisher ID"),
+                queue="error",
+            )
+            return self.default_response
+
+        if pending_publisher.added_by != self.request.user:
+            self.request.session.flash(
                 "Invalid publisher ID",
                 queue="error",
             )

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1565,7 +1565,7 @@ class ManageAccountPublishingViews:
         # futzes with the form.
         if pending_publisher is None:
             self.request.session.flash(
-                "Invalid publisher for user",
+                "Invalid publisher ID",
                 queue="error",
             )
             return self.default_response

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1381,7 +1381,7 @@ class ManageAccountPublishingViews:
 
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_OIDC):
             self.request.session.flash(
-                (
+                self.request._(
                     "Trusted publishers are temporarily disabled. "
                     "See https://pypi.org/help#admin-intervention for details."
                 ),
@@ -1404,7 +1404,7 @@ class ManageAccountPublishingViews:
 
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_OIDC):
             self.request.session.flash(
-                (
+                self.request._(
                     "Trusted publishers are temporarily disabled. "
                     "See https://pypi.org/help#admin-intervention for details."
                 ),
@@ -1515,8 +1515,10 @@ class ManageAccountPublishingViews:
         )
 
         self.request.session.flash(
-            "Registered a new publishing publisher to create "
-            f"the project '{pending_publisher.project_name}'.",
+            self.request._(
+                "Registered a new publishing publisher to create "
+                f"the project '{pending_publisher.project_name}'."
+            ),
             queue="success",
         )
 
@@ -1539,7 +1541,7 @@ class ManageAccountPublishingViews:
 
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_OIDC):
             self.request.session.flash(
-                (
+                self.request._(
                     "Trusted publishers are temporarily disabled. "
                     "See https://pypi.org/help#admin-intervention for details."
                 ),
@@ -1553,7 +1555,7 @@ class ManageAccountPublishingViews:
 
         if not form.validate():
             self.request.session.flash(
-                "Invalid publisher ID",
+                self.request._("Invalid publisher ID"),
                 queue="error",
             )
             return self.default_response
@@ -1573,14 +1575,16 @@ class ManageAccountPublishingViews:
 
         if pending_publisher.added_by != self.request.user:
             self.request.session.flash(
-                "Invalid publisher ID",
+                self.request._("Invalid publisher ID"),
                 queue="error",
             )
             return self.default_response
 
         self.request.session.flash(
-            "Removed trusted publisher for project "
-            f"{pending_publisher.project_name!r}",
+            self.request._(
+                "Removed trusted publisher for project "
+                f"{pending_publisher.project_name!r}"
+            ),
             queue="success",
         )
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:455 warehouse/manage/views/__init__.py:803
+#: warehouse/accounts/views.py:455 warehouse/manage/views/__init__.py:805
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -258,6 +258,14 @@ msgstr ""
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
+#: warehouse/accounts/views.py:1384 warehouse/accounts/views.py:1407
+#: warehouse/accounts/views.py:1544 warehouse/manage/views/__init__.py:1211
+#: warehouse/manage/views/__init__.py:1233
+msgid ""
+"Trusted publishers are temporarily disabled. See https://pypi.org/help"
+"#admin-intervention for details."
+msgstr ""
+
 #: warehouse/accounts/views.py:1421
 msgid ""
 "You must have a verified email in order to register a pending trusted "
@@ -268,13 +276,13 @@ msgstr ""
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1450 warehouse/manage/views/__init__.py:1244
+#: warehouse/accounts/views.py:1450 warehouse/manage/views/__init__.py:1252
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1464 warehouse/manage/views/__init__.py:1258
+#: warehouse/accounts/views.py:1464 warehouse/manage/views/__init__.py:1266
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
@@ -282,6 +290,19 @@ msgstr ""
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
+msgstr ""
+
+#: warehouse/accounts/views.py:1518
+msgid "Registered a new publishing publisher to create "
+msgstr ""
+
+#: warehouse/accounts/views.py:1558 warehouse/accounts/views.py:1571
+#: warehouse/accounts/views.py:1578
+msgid "Invalid publisher ID"
+msgstr ""
+
+#: warehouse/accounts/views.py:1584
+msgid "Removed trusted publisher for project "
 msgstr ""
 
 #: warehouse/admin/templates/admin/banners/preview.html:15
@@ -310,7 +331,7 @@ msgstr ""
 msgid "Select project"
 msgstr ""
 
-#: warehouse/manage/forms.py:477 warehouse/oidc/forms.py:174
+#: warehouse/manage/forms.py:477 warehouse/oidc/forms.py:173
 msgid "Specify project name"
 msgstr ""
 
@@ -360,55 +381,106 @@ msgstr ""
 msgid "This team name has already been used. Choose a different team name."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:216
+#: warehouse/manage/views/__init__.py:189
+msgid "Account details updated"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:218
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:751
+#: warehouse/manage/views/__init__.py:753
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:752
+#: warehouse/manage/views/__init__.py:754
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2039
+#: warehouse/manage/views/__init__.py:860
+msgid "Verify your email to create an API token."
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:980
+msgid "Invalid credentials. Try again"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1102
+msgid "2FA requirement cannot be disabled for critical projects"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1477
+#: warehouse/manage/views/__init__.py:1781
+#: warehouse/manage/views/__init__.py:1890
+msgid ""
+"Project deletion temporarily disabled. See https://pypi.org/help#admin-"
+"intervention for details."
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1610
+#: warehouse/manage/views/__init__.py:1696
+#: warehouse/manage/views/__init__.py:1798
+#: warehouse/manage/views/__init__.py:1899
+msgid "Confirm the request"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1622
+msgid "Could not yank release - "
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1708
+msgid "Could not un-yank release - "
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1810
+msgid "Could not delete release - "
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1911
+msgid "Could not find file"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1915
+msgid "Could not delete file - "
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:2066
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2147
+#: warehouse/manage/views/__init__.py:2174
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2215
+#: warehouse/manage/views/__init__.py:2242
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2247
+#: warehouse/manage/views/__init__.py:2274
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2260
+#: warehouse/manage/views/__init__.py:2287
 #: warehouse/manage/views/organizations.py:896
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2326
+#: warehouse/manage/views/__init__.py:2353
 #: warehouse/manage/views/organizations.py:961
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2359
+#: warehouse/manage/views/__init__.py:2386
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2370
+#: warehouse/manage/views/__init__.py:2397
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2403
+#: warehouse/manage/views/__init__.py:2430
 #: warehouse/manage/views/organizations.py:1148
 msgid "Invitation revoked from '${username}'."
 msgstr ""
@@ -484,15 +556,19 @@ msgstr ""
 msgid "Workflow filename must be a filename only, without directories"
 msgstr ""
 
-#: warehouse/oidc/forms.py:177
+#: warehouse/oidc/forms.py:175
 msgid "Invalid project name"
 msgstr ""
 
-#: warehouse/oidc/forms.py:191
+#: warehouse/oidc/forms.py:189
 msgid "This project name is already in use"
 msgstr ""
 
-#: warehouse/oidc/forms.py:204
+#: warehouse/oidc/forms.py:202
+msgid "Specify a publisher ID"
+msgstr ""
+
+#: warehouse/oidc/forms.py:203
 msgid "Publisher must be specified by ID"
 msgstr ""
 

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -185,7 +185,9 @@ class ManageAccountViews:
             self.user_service.update_user(self.request.user.id, **data)
             for email in self.request.user.emails:
                 email.public = email.email == public_email
-            self.request.session.flash("Account details updated", queue="success")
+            self.request.session.flash(
+                self.request._("Account details updated"), queue="success"
+            )
             return HTTPSeeOther(self.request.path)
 
         return {**self.default_response, "save_account_form": form}
@@ -855,7 +857,8 @@ class ProvisionMacaroonViews:
     def create_macaroon(self):
         if not self.request.user.has_primary_verified_email:
             self.request.session.flash(
-                "Verify your email to create an API token.", queue="error"
+                self.request._("Verify your email to create an API token."),
+                queue="error",
             )
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
@@ -969,10 +972,13 @@ class ProvisionMacaroonViews:
                         },
                     )
             self.request.session.flash(
-                f"Deleted API token '{macaroon.description}'.", queue="success"
+                self.request._(f"Deleted API token '{macaroon.description}'."),
+                queue="success",
             )
         else:
-            self.request.session.flash("Invalid credentials. Try again", queue="error")
+            self.request.session.flash(
+                self.request._("Invalid credentials. Try again"), queue="error"
+            )
 
         redirect_to = self.request.referer
         if not is_safe_url(redirect_to, host=self.request.host):
@@ -1093,7 +1099,9 @@ class ManageProjectSettingsViews:
 
         if self.project.pypi_mandates_2fa:
             self.request.session.flash(
-                "2FA requirement cannot be disabled for critical projects",
+                self.request._(
+                    "2FA requirement cannot be disabled for critical projects"
+                ),
                 queue="error",
             )
         elif self.project.owners_require_2fa:
@@ -1104,7 +1112,7 @@ class ManageProjectSettingsViews:
                 additional={"modified_by": self.request.user.username},
             )
             self.request.session.flash(
-                f"2FA requirement disabled for { self.project.name }",
+                self.request._(f"2FA requirement disabled for { self.project.name }"),
                 queue="success",
             )
         else:
@@ -1115,7 +1123,7 @@ class ManageProjectSettingsViews:
                 additional={"modified_by": self.request.user.username},
             )
             self.request.session.flash(
-                f"2FA requirement enabled for { self.project.name }",
+                self.request._(f"2FA requirement enabled for { self.project.name }"),
                 queue="success",
             )
 
@@ -1200,7 +1208,7 @@ class ManageOIDCPublisherViews:
 
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_OIDC):
             self.request.session.flash(
-                (
+                self.request._(
                     "Trusted publishers are temporarily disabled. "
                     "See https://pypi.org/help#admin-intervention for details."
                 ),
@@ -1222,7 +1230,7 @@ class ManageOIDCPublisherViews:
 
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_OIDC):
             self.request.session.flash(
-                (
+                self.request._(
                     "Trusted publishers are temporarily disabled. "
                     "See https://pypi.org/help#admin-intervention for details."
                 ),
@@ -1288,7 +1296,9 @@ class ManageOIDCPublisherViews:
         # publisher can't be registered to the project more than once.
         if publisher in self.project.oidc_publishers:
             self.request.session.flash(
-                f"{publisher} is already registered with {self.project.name}",
+                self.request._(
+                    f"{publisher} is already registered with {self.project.name}"
+                ),
                 queue="error",
             )
             return response
@@ -1390,7 +1400,9 @@ class ManageOIDCPublisherViews:
             )
 
             self.request.session.flash(
-                f"Removed trusted publisher for project {self.project.name!r}",
+                self.request._(
+                    f"Removed trusted publisher for project {self.project.name!r}"
+                ),
                 queue="success",
             )
 
@@ -1462,7 +1474,7 @@ def get_user_role_in_organization_project(project, user, request):
 def delete_project(project, request):
     if request.flags.enabled(AdminFlagValue.DISALLOW_DELETION):
         request.session.flash(
-            (
+            request._(
                 "Project deletion temporarily disabled. "
                 "See https://pypi.org/help#admin-intervention for details."
             ),
@@ -1594,7 +1606,9 @@ class ManageProjectRelease:
         yanked_reason = self.request.POST.get("yanked_reason", "")
 
         if not version:
-            self.request.session.flash("Confirm the request", queue="error")
+            self.request.session.flash(
+                self.request._("Confirm the request"), queue="error"
+            )
             return HTTPSeeOther(
                 self.request.route_path(
                     "manage.project.release",
@@ -1605,8 +1619,10 @@ class ManageProjectRelease:
 
         if version != self.release.version:
             self.request.session.flash(
-                "Could not yank release - "
-                + f"{version!r} is not the same as {self.release.version!r}",
+                self.request._(
+                    "Could not yank release - "
+                    + f"{version!r} is not the same as {self.release.version!r}"
+                ),
                 queue="error",
             )
             return HTTPSeeOther(
@@ -1645,7 +1661,7 @@ class ManageProjectRelease:
         self.release.yanked_reason = yanked_reason
 
         self.request.session.flash(
-            f"Yanked release {self.release.version!r}", queue="success"
+            self.request._(f"Yanked release {self.release.version!r}"), queue="success"
         )
 
         for contributor in self.release.project.users:
@@ -1676,7 +1692,9 @@ class ManageProjectRelease:
     def unyank_project_release(self):
         version = self.request.POST.get("confirm_unyank_version")
         if not version:
-            self.request.session.flash("Confirm the request", queue="error")
+            self.request.session.flash(
+                self.request._("Confirm the request"), queue="error"
+            )
             return HTTPSeeOther(
                 self.request.route_path(
                     "manage.project.release",
@@ -1687,8 +1705,10 @@ class ManageProjectRelease:
 
         if version != self.release.version:
             self.request.session.flash(
-                "Could not un-yank release - "
-                + f"{version!r} is not the same as {self.release.version!r}",
+                self.request._(
+                    "Could not un-yank release - "
+                    + f"{version!r} is not the same as {self.release.version!r}"
+                ),
                 queue="error",
             )
             return HTTPSeeOther(
@@ -1726,7 +1746,8 @@ class ManageProjectRelease:
         self.release.yanked_reason = ""
 
         self.request.session.flash(
-            f"Un-yanked release {self.release.version!r}", queue="success"
+            self.request._(f"Un-yanked release {self.release.version!r}"),
+            queue="success",
         )
 
         for contributor in self.release.project.users:
@@ -1757,7 +1778,7 @@ class ManageProjectRelease:
     def delete_project_release(self):
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_DELETION):
             self.request.session.flash(
-                (
+                self.request._(
                     "Project deletion temporarily disabled. "
                     "See https://pypi.org/help#admin-intervention for details."
                 ),
@@ -1773,7 +1794,9 @@ class ManageProjectRelease:
 
         version = self.request.POST.get("confirm_delete_version")
         if not version:
-            self.request.session.flash("Confirm the request", queue="error")
+            self.request.session.flash(
+                self.request._("Confirm the request"), queue="error"
+            )
             return HTTPSeeOther(
                 self.request.route_path(
                     "manage.project.release",
@@ -1784,8 +1807,10 @@ class ManageProjectRelease:
 
         if version != self.release.version:
             self.request.session.flash(
-                "Could not delete release - "
-                + f"{version!r} is not the same as {self.release.version!r}",
+                self.request._(
+                    "Could not delete release - "
+                    + f"{version!r} is not the same as {self.release.version!r}"
+                ),
                 queue="error",
             )
             return HTTPSeeOther(
@@ -1822,7 +1847,7 @@ class ManageProjectRelease:
         self.request.db.delete(self.release)
 
         self.request.session.flash(
-            f"Deleted release {self.release.version!r}", queue="success"
+            self.request._(f"Deleted release {self.release.version!r}"), queue="success"
         )
 
         for contributor in self.release.project.users:
@@ -1862,7 +1887,7 @@ class ManageProjectRelease:
             )
 
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_DELETION):
-            message = (
+            message = self.request._(
                 "Project deletion temporarily disabled. "
                 "See https://pypi.org/help#admin-intervention for details."
             )
@@ -1871,7 +1896,7 @@ class ManageProjectRelease:
         project_name = self.request.POST.get("confirm_project_name")
 
         if not project_name:
-            return _error("Confirm the request")
+            return _error(self.request._("Confirm the request"))
 
         try:
             release_file = (
@@ -1883,12 +1908,14 @@ class ManageProjectRelease:
                 .one()
             )
         except NoResultFound:
-            return _error("Could not find file")
+            return _error(self.request._("Could not find file"))
 
         if project_name != self.release.project.name:
             return _error(
-                "Could not delete file - " + f"{project_name!r} is not the same as "
-                f"{self.release.project.name!r}"
+                self.request._(
+                    "Could not delete file - " + f"{project_name!r} is not the same as "
+                    f"{self.release.project.name!r}"
+                )
             )
 
         self.request.db.add(

--- a/warehouse/migrations/versions/75ba94852cd1_make_pendingoidcpublisher_added_by_id_.py
+++ b/warehouse/migrations/versions/75ba94852cd1_make_pendingoidcpublisher_added_by_id_.py
@@ -1,0 +1,42 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Make PendingOIDCPublisher.added_by_id non-nullable
+
+Revision ID: 75ba94852cd1
+Revises: f7cd7a943caa
+Create Date: 2023-04-14 18:21:38.683694
+"""
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "75ba94852cd1"
+down_revision = "f7cd7a943caa"
+
+
+def upgrade():
+    op.alter_column(
+        "pending_oidc_publishers",
+        "added_by_id",
+        existing_type=postgresql.UUID(),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "pending_oidc_publishers",
+        "added_by_id",
+        existing_type=postgresql.UUID(),
+        nullable=True,
+    )

--- a/warehouse/oidc/forms.py
+++ b/warehouse/oidc/forms.py
@@ -170,9 +170,7 @@ class PendingGitHubPublisherForm(GitHubPublisherBase):
 
     project_name = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(
-                message=_("Specify project name"),
-            ),
+            wtforms.validators.DataRequired(message=_("Specify project name")),
             wtforms.validators.Regexp(
                 PROJECT_NAME_RE, message=_("Invalid project name")
             ),
@@ -201,6 +199,7 @@ class DeletePublisherForm(forms.Form):
 
     publisher_id = wtforms.StringField(
         validators=[
-            wtforms.validators.UUID(message=_("Publisher must be specified by ID"))
+            wtforms.validators.DataRequired(message=_("Specify a publisher ID")),
+            wtforms.validators.UUID(message=_("Publisher must be specified by ID")),
         ]
     )

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -250,7 +250,7 @@ class PendingOIDCPublisher(OIDCPublisherMixin, db.Model):
 
     project_name = Column(String, nullable=False)
     added_by_id = Column(
-        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
     )
 
     __mapper_args__ = {


### PR DESCRIPTION
This PR started as an attempt to mark many strings used in OIDC-related views as translatable, which also added some strings in non-OIDC views (705f60bee7262e93b1e532ca7153801217f919d0).

This required updating many tests that weren't using `pyramid_request`/`db_request` and would have needed a stub localizer.

While rewriting the tests, I found a few that were doing a bit too much mocking/stubbing, so I refactored these to use our factories as much as possible.

Along the way, I found a few minor bugs in our OIDC implementation:
- `added_by_id` for pending publishers was nullable at the database level (e00e80008d32e13d789e30ec7cf03a64fb798004)
- `publisher_id` was not being validated as required in the `PendingGitHubPublisherForm` (94c6e4a5cc3a8460cd81d1c80dfda2ac10dc981a)
- We had a slightly different error message when the `DeletePublisherForm` form was invalid vs when the publisher ID was wrong, which could lead to this becoming an oracle (6e1b102fb097e669032c65ea837e2edd1b2a9995)
- We weren't flushing the DB after creating a pending publisher, so the ID in the recorded event was `None` (5da818e3a86157f10ea735970a6f73b8ae39ffa3)
- We weren't checking if a request to delete a pending publisher was being made by the user that created that publisher (2b0bbf21b6d389c0af28dd6f3608b211b37a0c3e)

I opted to just include the fixes for these in this PR rather than breaking out each into separate PRs because of the amount of changes I had already made to the tests, and because I'm lazy -- apologies to any reviewers.