### PR TITLE
Extend timeout for pending_oidc_publishers alter

### DIFF
--- a/warehouse/migrations/versions/75ba94852cd1_make_pendingoidcpublisher_added_by_id_.py
+++ b/warehouse/migrations/versions/75ba94852cd1_make_pendingoidcpublisher_added_by_id_.py
@@ -25,6 +25,8 @@ down_revision = "f7cd7a943caa"
 
 
 def upgrade():
+    conn = op.get_bind()
+    conn.execute("SET statement_timeout = 120000")
     op.alter_column(
         "pending_oidc_publishers",
         "added_by_id",

--- a/warehouse/migrations/versions/75ba94852cd1_make_pendingoidcpublisher_added_by_id_.py
+++ b/warehouse/migrations/versions/75ba94852cd1_make_pendingoidcpublisher_added_by_id_.py
@@ -27,6 +27,7 @@ down_revision = "f7cd7a943caa"
 def upgrade():
     conn = op.get_bind()
     conn.execute("SET statement_timeout = 120000")
+    conn.execute("SET lock_timeout = 120000")
     op.alter_column(
         "pending_oidc_publishers",
         "added_by_id",


### PR DESCRIPTION
Extends the timeout of the migration in #13429.