### PR TITLE
[orgs] Disable billing activation

### DIFF
--- a/tests/unit/manage/views/test_organizations.py
+++ b/tests/unit/manage/views/test_organizations.py
@@ -331,6 +331,7 @@ class TestManageOrganizations:
             organization_access=True,
             remote_addr="0.0.0.0",
             route_path=lambda *a, **kw: "manage-subscription-url",
+            path="request-path",
         )
 
         create_organization_obj = pretend.stub(
@@ -427,7 +428,7 @@ class TestManageOrganizations:
             ),
         ]
         assert isinstance(result, HTTPSeeOther)
-        assert result.headers["Location"] == "manage-subscription-url"
+        assert result.headers["Location"] == "request-path"
 
     def test_create_organization_validation_fails(self, monkeypatch):
         admins = []

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -253,14 +253,6 @@ class ManageOrganizationsViews:
         else:
             return {"create_organization_form": form}
 
-        if form.orgtype.data == OrganizationType.Company:
-            return HTTPSeeOther(
-                self.request.route_path(
-                    "manage.organization.activate_subscription",
-                    organization_name=organization.normalized_name,
-                )
-            )
-
         return HTTPSeeOther(self.request.path)
 
 

--- a/warehouse/templates/manage/organizations.html
+++ b/warehouse/templates/manage/organizations.html
@@ -72,14 +72,15 @@
             {% if organization.is_approved and organization.is_active %}
             <a href="{{ request.route_path('organizations.profile', organization=organization.name) }}">{{ organization.name }}</a>
             {% else %}{{ organization.name }}{% endif %}
-            {% if organization.orgtype == OrganizationType.Company and not organization.active_subscription %}
+
+            {% if organization.is_approved == None %}
+            <span class="badge badge--neutral" title="{% trans %}You will receive an email when the organization has been approved{% endtrans %}">{% trans %}Request Submitted{% endtrans %}</span>
+            {% elif organization.orgtype == OrganizationType.Company and not organization.active_subscription %}
               {% if organization.name in (organizations_owned + organizations_billing) %}
               <a class="badge badge--danger" href="{{ request.route_path('manage.organization.activate_subscription', organization_name=organization.normalized_name) }}">{% trans %}Billing Inactive{% endtrans %}</a>
               {% else %}
               <span class="badge badge--danger" title="{% trans %}This organization's billing can be activated by an organization owner or billing manager{% endtrans %}">{% trans %}Billing Inactive{% endtrans %}</span>
               {% endif %}
-            {% elif organization.is_approved == None %}
-            <span class="badge badge--neutral" title="{% trans %}You will receive an email when the organization has been approved{% endtrans %}">{% trans %}Request Submitted{% endtrans %}</span>
             {% elif organization.is_active == False %}
             <span class="badge badge--danger" title="{% trans %}This organization is not active{% endtrans %}">{% trans %}Inactive{% endtrans %}</span>
             {% elif organization.name in organizations_managed %}

--- a/warehouse/templates/manage/organizations.html
+++ b/warehouse/templates/manage/organizations.html
@@ -104,7 +104,7 @@
           {% elif organization.orgtype == OrganizationType.Company and not organization.active_subscription %}
             {% if organization.name in (organizations_owned + organizations_billing) %}
             {# Show "Activate Billing" button for owners and billing managers #}
-            <a class="button button--primary" href="{{ request.route_path('manage.organization.activate_subscription', organization_name=organization.normalized_name) }}" title="{% trans %}Activate billing for this organization{% endtrans %}">
+            <a class="button button--primary {{"button--disabled" if organization.is_approved == None else ""}}" href="{{ request.route_path('manage.organization.activate_subscription', organization_name=organization.normalized_name) }}" title="{% trans %}Activate billing for this organization{% endtrans %}">
               {% trans %}Activate Billing{% endtrans %}
             </a>
             {% else %}


### PR DESCRIPTION
This disables the redirect to billing activation for org signups for corps, since we aren't ready to do that yet. It also disables related buttons to make it clear that we don't want the user to activate billing.