### PR TITLE
Guard against potentially missing org creation event

### DIFF
--- a/warehouse/admin/templates/admin/organizations/detail.html
+++ b/warehouse/admin/templates/admin/organizations/detail.html
@@ -80,6 +80,7 @@
               Click <b>Approve</b> to change the decision.
             </p>
             {% endif %}
+            {% if user %}
             <div class="modal fade" id="approveModal" tabindex="-1" role="dialog">
               <form method="POST" action="{{ request.route_path('admin.organization.approve', organization_id=organization.id) }}">
                 <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
@@ -172,6 +173,7 @@
                 </div>
               </form>
             </div>
+            {% endif %}
           </div>
         </div>
       </div>
@@ -195,9 +197,11 @@
                 {% elif organization.is_approved == False %}
                 Declined by <a href="{{ request.route_url('admin.user.detail', username=admin.username) }}">{{ admin.username }}</a><br>
                 {{ organization.date_approved|format_date() }}
-                {% else %}
+                {% elif user %}
                 Pending request by <a href="{{ request.route_url('admin.user.detail', username=user.username) }}">{{ user.username }}</a><br>
                 {{ organization.created|format_date() }}
+                {% else %}
+                Unknown
                 {% endif %}
               </div>
             </div>
@@ -206,8 +210,12 @@
                 Requesting User
               </label>
               <div class="col-sm-7">
+                {% if user %}
                 <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a><br>
                 <a href="mailto:{{ user.email }}">{{ user.email }}</a>
+                {% else %}
+                <i>n/a</i>
+                {% endif %}
               </div>
             </div>
             <div class="form-group">

--- a/warehouse/admin/views/organizations.py
+++ b/warehouse/admin/views/organizations.py
@@ -156,7 +156,11 @@ def organization_detail(request):
         .order_by(Organization.Event.time.desc())
         .first()
     )
-    user = user_service.get_user(create_event.additional["created_by_user_id"])
+    user = (
+        user_service.get_user(create_event.additional["created_by_user_id"])
+        if create_event
+        else None
+    )
 
     if organization.is_approved is True:
         approve_event = (


### PR DESCRIPTION
This happens when an admin creates the org via other means than a user-submitted request. Fixes https://python-software-foundation.sentry.io/issues/4112484144/