### PR TITLE
Fingerprint `capture_message` calls for OIDC warnings

### DIFF
--- a/tests/unit/oidc/test_models.py
+++ b/tests/unit/oidc/test_models.py
@@ -103,7 +103,15 @@ class TestGitHubPublisher:
             workflow_filename="fakeworkflow.yml",
         )
 
-        sentry_sdk = pretend.stub(capture_message=pretend.call_recorder(lambda s: None))
+        scope = pretend.stub()
+        sentry_sdk = pretend.stub(
+            capture_message=pretend.call_recorder(lambda s: None),
+            push_scope=pretend.call_recorder(
+                lambda: pretend.stub(
+                    __enter__=lambda *a: scope, __exit__=lambda *a: None
+                )
+            ),
+        )
         monkeypatch.setattr(models, "sentry_sdk", sentry_sdk)
 
         # We don't care if these actually verify, only that they're present.
@@ -112,12 +120,15 @@ class TestGitHubPublisher:
             for claim_name in models.GitHubPublisher.all_known_claims()
         }
         signed_claims["fake-claim"] = "fake"
+        signed_claims["another-fake-claim"] = "also-fake"
         assert not publisher.verify_claims(signed_claims=signed_claims)
         assert sentry_sdk.capture_message.calls == [
             pretend.call(
-                "JWT for GitHubPublisher has unaccounted claims: {'fake-claim'}"
+                "JWT for GitHubPublisher has unaccounted claims: "
+                "['another-fake-claim', 'fake-claim']"
             )
         ]
+        assert scope.fingerprint == ["another-fake-claim", "fake-claim"]
 
     def test_github_publisher_missing_claims(self, monkeypatch):
         publisher = models.GitHubPublisher(
@@ -127,7 +138,15 @@ class TestGitHubPublisher:
             workflow_filename="fakeworkflow.yml",
         )
 
-        sentry_sdk = pretend.stub(capture_message=pretend.call_recorder(lambda s: None))
+        scope = pretend.stub()
+        sentry_sdk = pretend.stub(
+            capture_message=pretend.call_recorder(lambda s: None),
+            push_scope=pretend.call_recorder(
+                lambda: pretend.stub(
+                    __enter__=lambda *a: scope, __exit__=lambda *a: None
+                )
+            ),
+        )
         monkeypatch.setattr(models, "sentry_sdk", sentry_sdk)
 
         signed_claims = {
@@ -142,6 +161,7 @@ class TestGitHubPublisher:
         assert sentry_sdk.capture_message.calls == [
             pretend.call("JWT for GitHubPublisher is missing claim: sub")
         ]
+        assert scope.fingerprint == ["sub"]
 
     def test_github_publisher_missing_optional_claims(self, monkeypatch):
         publisher = models.GitHubPublisher(


### PR DESCRIPTION
As is, Sentry won't consider each of these to be separate issues, but we want to treat them as such.