### PR TITLE
Add unchecked 'enterprise' OIDC claim for GitHub

### DIFF
--- a/tests/unit/oidc/test_models.py
+++ b/tests/unit/oidc/test_models.py
@@ -74,6 +74,7 @@ class TestGitHubPublisher:
             "workflow_ref",
             "runner_environment",
             "environment_node_id",
+            "enterprise",
         }
 
     def test_github_publisher_computed_properties(self):

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -312,6 +312,7 @@ class GitHubPublisherMixin:
         "workflow_ref",
         "runner_environment",
         "environment_node_id",
+        "enterprise",
     }
 
     @property


### PR DESCRIPTION
Fixes warning at https://python-software-foundation.sentry.io/issues/4078138178/.