### PR TITLE
fix: remove invalid unicode characters from xml

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -267,3 +267,20 @@ def test_format_author_email(meta_email, expected_name, expected_email):
     author_name, author_email = filters.format_author_email(meta_email)
     assert author_name == expected_name
     assert author_email == expected_email
+
+
+@pytest.mark.parametrize(
+    ("inp", "expected"),
+    [
+        ("foo", "foo"),  # no change
+        (" foo  bar ", " foo  bar "),  # U+001B : <control> ESCAPE [ESC]
+        ("foo \x1b bar", "foo  bar"),  # U+001B : <control> ESCAPE [ESC]
+        ("foo \x00 bar", "foo  bar"),  # U+0000 : <control> NULL
+        ("foo 🐍 bar", "foo 🐍 bar"),  # U+1F40D : SNAKE [snake] (emoji) [Python]
+    ],
+)
+def test_remove_invalid_xml_unicode(inp, expected):
+    """
+    Test that invalid XML unicode characters are removed.
+    """
+    assert filters.remove_invalid_xml_unicode(inp) == expected

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -458,6 +458,9 @@ def configure(settings=None):
     filters.setdefault("is_recent", "warehouse.filters:is_recent")
     filters.setdefault("canonicalize_name", "packaging.utils:canonicalize_name")
     filters.setdefault("format_author_email", "warehouse.filters:format_author_email")
+    filters.setdefault(
+        "remove_invalid_xml_unicode", "warehouse.filters:remove_invalid_xml_unicode"
+    )
 
     # We also want to register some global functions for Jinja
     jglobals = config.get_settings().setdefault("jinja2.globals", {})

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -188,5 +188,15 @@ def format_author_email(metadata_email: str) -> tuple[str, str]:
     return author_emails[0][0], author_emails[0][1]
 
 
+def remove_invalid_xml_unicode(value: str) -> str:
+    """
+    Remove invalid unicode characters from a string.
+    Useful for XML Templates.
+
+    Ref: https://www.w3.org/TR/REC-xml/#NT-Char
+    """
+    return "".join(c for c in value if ord(c) >= 32)
+
+
 def includeme(config):
     config.add_request_method(_camo_url, name="camo_url")

--- a/warehouse/templates/rss/packages.xml
+++ b/warehouse/templates/rss/packages.xml
@@ -7,7 +7,7 @@
       <title>{{ project.name }} added to PyPI</title>
       <link>{{ request.route_url('packaging.project', name=project.normalized_name) }}</link>
       <guid>{{ request.route_url('packaging.project', name=project.normalized_name) }}</guid>
-      <description>{{ project.releases[0].summary }}</description>
+      <description>{{ project.releases[0].summary | remove_invalid_xml_unicode }}</description>
       {% if author %}<author>{{ author }}</author>{% endif %}
       <pubDate>{{ project.created|format_rfc822_datetime() }}</pubDate>
     </item>

--- a/warehouse/templates/rss/project_releases.xml
+++ b/warehouse/templates/rss/project_releases.xml
@@ -7,7 +7,7 @@
     <item>
       <title>{{ release.version }}</title>
       <link>{{ request.route_url('packaging.release', name=release.project.normalized_name, version=release.version) }}</link>
-      <description>{{ release.summary }}</description>
+      <description>{{ release.summary | remove_invalid_xml_unicode }}</description>
       {% if author %}<author>{{ author }}</author>{% endif %}
       <pubDate>{{ release.created|format_rfc822_datetime() }}</pubDate>
     </item>

--- a/warehouse/templates/rss/updates.xml
+++ b/warehouse/templates/rss/updates.xml
@@ -6,7 +6,7 @@
     <item>
       <title>{{ release.project.name }} {{ release.version }}</title>
       <link>{{ request.route_url('packaging.release', name=release.project.normalized_name, version=release.version) }}</link>
-      <description>{{ release.summary }}</description>
+      <description>{{ release.summary | remove_invalid_xml_unicode }}</description>
       {% if author %}<author>{{ author }}</author>{% endif %}
       <pubDate>{{ release.created|format_rfc822_datetime() }}</pubDate>
     </item>


### PR DESCRIPTION
Certain control characters are invalid in XML, so we should strip them out before adding them to an XML template.

Currently only targeting the `description` tag, as that's what was identified in the reported issue.

Fixes #13471