### PR TITLE
Fix `remove_invalid_xml_unicode` to handle `None`

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -277,6 +277,7 @@ def test_format_author_email(meta_email, expected_name, expected_email):
         ("foo \x1b bar", "foo  bar"),  # U+001B : <control> ESCAPE [ESC]
         ("foo \x00 bar", "foo  bar"),  # U+0000 : <control> NULL
         ("foo 🐍 bar", "foo 🐍 bar"),  # U+1F40D : SNAKE [snake] (emoji) [Python]
+        (None, None),  # no change
     ],
 )
 def test_remove_invalid_xml_unicode(inp, expected):

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -188,14 +188,14 @@ def format_author_email(metadata_email: str) -> tuple[str, str]:
     return author_emails[0][0], author_emails[0][1]
 
 
-def remove_invalid_xml_unicode(value: str) -> str:
+def remove_invalid_xml_unicode(value: str | None) -> str | None:
     """
     Remove invalid unicode characters from a string.
     Useful for XML Templates.
 
     Ref: https://www.w3.org/TR/REC-xml/#NT-Char
     """
-    return "".join(c for c in value if ord(c) >= 32)
+    return "".join(c for c in value if ord(c) >= 32) if value else value
 
 
 def includeme(config):


### PR DESCRIPTION
Missed in #13474.

Fixes https://python-software-foundation.sentry.io/issues/4115796799/.