### PR TITLE
Use `packaging_legacy` for `parse_version` filter

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -16,6 +16,7 @@ import urllib.parse
 from functools import partial
 
 import packaging.version
+import packaging_legacy.version
 import pretend
 import pytest
 
@@ -203,7 +204,11 @@ def test_format_package_type(inp, expected):
 
 
 @pytest.mark.parametrize(
-    ("inp", "expected"), [("1.0", packaging.version.Version("1.0"))]
+    ("inp", "expected"),
+    [
+        ("1.0", packaging.version.Version("1.0")),
+        ("dog", packaging_legacy.version.LegacyVersion("dog")),
+    ],
 )
 def test_parse_version(inp, expected):
     assert filters.parse_version(inp) == expected

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -25,7 +25,7 @@ import html5lib
 import html5lib.serializer
 import html5lib.treewalkers
 import jinja2
-import packaging.version
+import packaging_legacy.version
 import pytz
 
 from natsort import natsorted
@@ -157,7 +157,7 @@ def contains_valid_uris(items):
 
 
 def parse_version(version_str):
-    return packaging.version.parse(version_str)
+    return packaging_legacy.version.parse(version_str)
 
 
 def localize_datetime(timestamp):


### PR DESCRIPTION
Missed in #13500.