### PR TITLE
Fix yet another missing `legacyversion`

### DIFF
--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -21,7 +21,7 @@ def test_build_search():
     release = pretend.stub(
         name="Foobar",
         normalized_name="foobar",
-        all_versions=["5.0.dev0", "4.0", "3.0", "2.0", "1.0"],
+        all_versions=["5.0.dev0", "4.0", "3.0", "2.0", "1.0", "dog"],
         latest_version="4.0",
         summary="This is my summary",
         description="This is my description",

--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -40,7 +40,7 @@ def test_build_search():
 
     assert obj.meta.id == "foobar"
     assert obj["name"] == "Foobar"
-    assert obj["version"] == ["5.0.dev0", "4.0", "3.0", "2.0", "1.0"]
+    assert obj["version"] == ["5.0.dev0", "4.0", "3.0", "2.0", "1.0", "dog"]
     assert obj["latest_version"] == "4.0"
     assert obj["summary"] == "This is my summary"
     assert obj["description"] == "This is my description"

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import packaging.version
+import packaging_legacy.version
 
 from elasticsearch_dsl import Date, Document, Keyword, Text, analyzer
 
@@ -55,7 +55,9 @@ class Project(Document):
         obj["name"] = release.name
         obj["normalized_name"] = release.normalized_name
         obj["version"] = sorted(
-            release.all_versions, key=lambda r: packaging.version.parse(r), reverse=True
+            release.all_versions,
+            key=lambda r: packaging_legacy.version.parse(r),
+            reverse=True,
         )
         obj["latest_version"] = release.latest_version
         obj["summary"] = release.summary


### PR DESCRIPTION
Fixes https://python-software-foundation.sentry.io/issues/4124046214/
Fixes https://python-software-foundation.sentry.io/issues/4124045140/