### PR TITLE
Increase timeout on long-running migration

### DIFF
--- a/warehouse/migrations/versions/4490777c984f_migrate_existing_data_for_release_is_.py
+++ b/warehouse/migrations/versions/4490777c984f_migrate_existing_data_for_release_is_.py
@@ -35,7 +35,7 @@ def _get_num_rows(conn):
 
 def upgrade():
     conn = op.get_bind()
-    conn.execute("SET statement_timeout = 60000")
+    conn.execute("SET statement_timeout = 120000")
     total_rows = _get_num_rows(conn)
     max_loops = total_rows / 100000 * 2
     loops = 0


### PR DESCRIPTION
This long-running migration fails to execute successfully when setting up a development instance of `warehouse` on a resource constricted development environment, such as GitHub Codespaces.  

Doubling the timeout resolves the issue. 