### PR TITLE
Bugfix to match docs to behavior on necessary upload checksum field(s)

### DIFF
--- a/docs/dev/api-reference/legacy.rst
+++ b/docs/dev/api-reference/legacy.rst
@@ -129,8 +129,10 @@ POST request with the following fields:
 - ``protocol_version`` set to ``1``
 - ``content`` with the file to be uploaded and the proper filename
   (i.e. ``my_foo_bar-4.2-cp36-cp36m-manylinux1_x86_64.whl``)
-- ``md5_digest`` set to the md5 hash of the uploaded file in urlsafe base64
+- One of the following hash digests:
+    - ``md5_digest`` set to the md5 hash of the uploaded file in urlsafe base64
   with no padding
+    - ``sha256_digest`` set to the SHA2-256 hash in hexadecimal
 - ``filetype`` set to the type of the artifact, i.e. ``bdist_wheel``
   or ``sdist``
 - When used with ``bdist_wheel`` for ``filetype``, ``pyversion`` must be set to


### PR DESCRIPTION
Currently the documentation mentions that only md5_digest is supported for the legacy upload API but according to [the validator](https://github.com/pypi/warehouse/blob/main/warehouse/forklift/legacy.py#L614) it accepts the valid SHA256 digest as a possible digest for uploaded objects.

There may be a follow-up PR that could include the new blake2b_256 checksum as a supported type given it is also a validated field, but that has enough other changes that this correction is different enough in scope to warrant separating