### PR TITLE
refactor(admin): replace usage of clipboard.js

### DIFF
--- a/warehouse/admin/static/js/warehouse.js
+++ b/warehouse/admin/static/js/warehouse.js
@@ -18,12 +18,6 @@ import "admin-lte/node_modules/bootstrap";
 // Import AdminLTE JS
 import "admin-lte/build/js/AdminLTE";
 
-// We'll use docReady as a modern replacement for $(document).ready() which
-// does not require all of jQuery to use. This will let us use it without
-// having to load all of jQuery, which will make things faster.
-import docReady from "warehouse/utils/doc-ready";
-
-import Clipboard from "clipboard";
 
 document.querySelectorAll("a[data-form-submit]").forEach(function (element) {
   element.addEventListener("click", function(event) {
@@ -89,37 +83,20 @@ document.querySelectorAll(".btn-group[data-input][data-state]").forEach(function
   });
 });
 
-// Copy handler for copy tooltips, e.g.
-//   - the pip command on package detail page
-//   - the copy hash on package detail page
-//   - the copy hash on release maintainers page
+// Copy handler for copying text, e.g.
+//   - prohibited project names confirmation page
 //
-// Copied from https://github.com/pypi/warehouse/blob/3ebae1ffe8f9f258f80eb8bf048f0e1fcc2df2b4/warehouse/static/js/warehouse/index.js#LL76-L107C4
-docReady(() => {
-  let setCopiedTooltip = (e) => {
-    e.trigger.setAttribute("data-tooltip-label", "Copied");
-    e.trigger.setAttribute("role", "alert");
-    e.clearSelection();
-  };
+document.querySelectorAll(".copy-text").forEach(function (element) {
+  function copy(text, target) {
+    setTimeout(function () {
+      $("#copied_tip").remove();
+    }, 1000);
+    $(target).append("<div class='tip' id='copied_tip'>Copied!</div>");
+    navigator.clipboard.writeText(text);
+  }
 
-  new Clipboard(".copy-tooltip").on("success", setCopiedTooltip);
-
-  let setOriginalLabel = (element) => {
-    element.setAttribute("data-tooltip-label", "Copy to clipboard");
-    element.removeAttribute("role");
-    element.blur();
-  };
-
-  let tooltippedElems = Array.from(document.querySelectorAll(".copy-tooltip"));
-
-  tooltippedElems.forEach((element) => {
-    element.addEventListener("focusout",
-      setOriginalLabel.bind(undefined, element),
-      false
-    );
-    element.addEventListener("mouseout",
-      setOriginalLabel.bind(undefined, element),
-      false
-    );
+  element.addEventListener("click", function(event) {
+    event.preventDefault();
+    copy(element.dataset.copyText, element);
   });
 });

--- a/warehouse/admin/templates/admin/prohibited_project_names/confirm.html
+++ b/warehouse/admin/templates/admin/prohibited_project_names/confirm.html
@@ -62,7 +62,7 @@
         <p>
           Are you sure you want to prohibit
           <code id="project-name">{{ prohibited_project_names.project }}</code>
-          <button type="button" class="copy-tooltip copy-tooltip-s" data-clipboard-target="#project-name" data-tooltip-label="Copy to clipboard">
+          <button type="button" class="copy-text" data-copy-text="{{ prohibited_project_names.project }}">
             <i class="fa fa-copy" aria-hidden="true"></i>
           </button>
           ?


### PR DESCRIPTION
The Admin interface already uses Bootstrap 4 and jQuery, so we don't need our own `docReady` function.

Replace use of the third-party Clipboard package, which will be removed in a future changeset once confirmed fully unused.

Update comment on where code is used in admin interface.