### PR TITLE
feat: add remote_addr_hashed to Request

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,15 @@ def remote_addr():
 
 
 @pytest.fixture
+def remote_addr_hashed():
+    """
+    Static output of `hashlib.sha256(remote_addr.encode("utf8")).hexdigest()`
+    Created statically to prevent needing to calculate it every run.
+    """
+    return "6694f83c9f476da31f5df6bcc520034e7e57d421d247b9d34f49edbfc84a764c"
+
+
+@pytest.fixture
 def jinja():
     dir_name = os.path.join(os.path.dirname(warehouse.__file__))
 
@@ -163,11 +172,12 @@ def pyramid_services(
 
 
 @pytest.fixture
-def pyramid_request(pyramid_services, jinja, remote_addr):
+def pyramid_request(pyramid_services, jinja, remote_addr, remote_addr_hashed):
     pyramid.testing.setUp()
     dummy_request = pyramid.testing.DummyRequest()
     dummy_request.find_service = pyramid_services.find_service
     dummy_request.remote_addr = remote_addr
+    dummy_request.remote_addr_hashed = remote_addr_hashed
     dummy_request.authentication_method = pretend.stub()
     dummy_request._unauthenticated_userid = None
     dummy_request.oidc_publisher = None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -368,6 +368,7 @@ def test_configure(monkeypatch, settings, environment):
             pretend.call(".banners"),
             pretend.call(".admin"),
             pretend.call(".forklift"),
+            pretend.call(".utils.wsgi"),
             pretend.call(".sentry"),
             pretend.call(".csp"),
             pretend.call(".referrer_policy"),

--- a/tests/unit/utils/test_wsgi.py
+++ b/tests/unit/utils/test_wsgi.py
@@ -41,6 +41,7 @@ class TestProxyFixer:
             "HTTP_WAREHOUSE_TOKEN": "1234",
             "HTTP_WAREHOUSE_PROTO": "http",
             "HTTP_WAREHOUSE_IP": "1.2.3.4",
+            "HTTP_WAREHOUSE_HASHED_IP": "hashbrowns",
             "HTTP_WAREHOUSE_HOST": "example.com",
         }
         start_response = pretend.stub()
@@ -52,6 +53,7 @@ class TestProxyFixer:
             pretend.call(
                 {
                     "REMOTE_ADDR": "1.2.3.4",
+                    "REMOTE_ADDR_HASHED": "hashbrowns",
                     "HTTP_HOST": "example.com",
                     "wsgi.url_scheme": "http",
                 },
@@ -162,3 +164,17 @@ class TestVhmRootRemover:
 
         assert resp is response
         assert app.calls == [pretend.call({"HTTP_X_FOOBAR": "wat"}, start_response)]
+
+
+def test_remote_addr_hashed(remote_addr_hashed):
+    environ = {"REMOTE_ADDR_HASHED": remote_addr_hashed}
+    request = pretend.stub(environ=environ)
+
+    assert wsgi._remote_addr_hashed(request) == remote_addr_hashed
+
+
+def test_remote_addr_hashed_missing():
+    environ = {}
+    request = pretend.stub(environ=environ)
+
+    assert wsgi._remote_addr_hashed(request) == ""

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -668,6 +668,9 @@ def configure(settings=None):
     # Protect against cache poisoning via the X-Vhm-Root headers.
     config.add_wsgi_middleware(VhmRootRemover)
 
+    # Add our extensions to Request
+    config.include(".utils.wsgi")
+
     # We want Sentry to be the last things we add here so that it's the outer
     # most WSGI middleware.
     config.include(".sentry")

--- a/warehouse/utils/wsgi.py
+++ b/warehouse/utils/wsgi.py
@@ -9,8 +9,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import hmac
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyramid.request import Request
 
 
 def _forwarded_value(values, num_proxies):
@@ -33,6 +39,7 @@ class ProxyFixer:
             # Compute our values from the environment.
             proto = environ.get("HTTP_WAREHOUSE_PROTO", "")
             remote_addr = environ.get("HTTP_WAREHOUSE_IP", "")
+            remote_addr_hashed = environ.get("HTTP_WAREHOUSE_HASHED_IP", "")
             host = environ.get("HTTP_WAREHOUSE_HOST", "")
         # If we're not getting headers from a trusted third party via the
         # specialized Warehouse-* headers, then we'll fall back to looking at
@@ -43,11 +50,14 @@ class ProxyFixer:
             remote_addr = _forwarded_value(
                 environ.get("HTTP_X_FORWARDED_FOR", ""), self.num_proxies
             )
+            remote_addr_hashed = ""
             host = environ.get("HTTP_X_FORWARDED_HOST", "")
 
         # Put the new header values into our environment.
         if remote_addr:
             environ["REMOTE_ADDR"] = remote_addr
+        if remote_addr_hashed:
+            environ["REMOTE_ADDR_HASHED"] = remote_addr_hashed
         if host:
             environ["HTTP_HOST"] = host
         if proto:
@@ -62,6 +72,7 @@ class ProxyFixer:
             "HTTP_WAREHOUSE_TOKEN",
             "HTTP_WAREHOUSE_PROTO",
             "HTTP_WAREHOUSE_IP",
+            "HTTP_WAREHOUSE_HASHED_IP",
             "HTTP_WAREHOUSE_HOST",
         }:
             if header in environ:
@@ -81,3 +92,15 @@ class VhmRootRemover:
             del environ["HTTP_X_VHM_ROOT"]
 
         return self.app(environ, start_response)
+
+
+def _remote_addr_hashed(request: Request) -> str:
+    """Return the hashed remote address from the environment."""
+    return request.environ.get("REMOTE_ADDR_HASHED", "")
+
+
+def includeme(config):
+    # Add property to Request to get the hashed IP address
+    config.add_request_method(
+        _remote_addr_hashed, name="remote_addr_hashed", property=True, reify=True
+    )


### PR DESCRIPTION
As a precursor to implementing further IP Geo functionality, add a property to the `request` object as it flows through our system