### PR TITLE
test: emit test durations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-addopts = "--disable-socket --allow-hosts='localhost,::1,stripe'"
+addopts = "--disable-socket --allow-hosts='localhost,::1,stripe' --durations=20"
 norecursedirs = ['build', 'dist', 'node_modules', '*.egg-info', '.state requirements']
 markers = [
     'unit: Quick running unit tests which test small units of functionality.',


### PR DESCRIPTION
As a way to identify any particularly slow test cases. Refs: https://docs.pytest.org/en/7.3.x/how-to/usage.html#profiling-test-execution-duration