### PR TITLE
fix: update source sans font to latest

### DIFF
--- a/warehouse/static/sass/settings/_fonts.scss
+++ b/warehouse/static/sass/settings/_fonts.scss
@@ -14,7 +14,7 @@
 
 // SETTINGS - FONTS
 
-$base-font-family: "Source Sans Pro", "Helvetica", arial, sans-serif;
+$base-font-family: "Source Sans 3", "Helvetica", arial, sans-serif;
 $code-font: "Source Code Pro", monospace;
 
 

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -94,7 +94,7 @@
 
     <link rel="stylesheet" href="{{ request.static_path('warehouse:static/dist/css/warehouse-{}.css'.format(request.locale.text_direction)) }}">
     <link rel="stylesheet" href="{{ request.static_path('warehouse:static/dist/css/fontawesome.css') }}">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,600,600italic,700,700italic%7CSource+Code+Pro:500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+3:400,400italic,600,600italic,700,700italic%7CSource+Code+Pro:500">
     <noscript>
       <link rel="stylesheet" href="{{ request.static_path('warehouse:static/dist/css/noscript.css') }}">
     </noscript>


### PR DESCRIPTION
The 3.x series of Source Sans was released in 2020, and contains the desired italicized glyphs.
It was added to Google Fonts in 2021 in google/fonts#3856

The author dropped "Pro" from the name, and replaced with "3".

See: https://blog.adobe.com/en/publish/2020/11/30/whats-new-in-source-sans-3

Fixes #8634