### PR TITLE
Fix `find_publisher_by_issuer` environment filter

### DIFF
--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -823,6 +823,7 @@ class TestNullOIDCPublisherService:
             repository_owner="foo",
             repository_owner_id="123",
             workflow_filename="example.yml",
+            environment=None,
         )
 
         claims = {
@@ -862,6 +863,7 @@ class TestNullOIDCPublisherService:
             repository_owner="foo",
             repository_owner_id="123",
             workflow_filename="example.yml",
+            environment=None,
         )
 
         claims = {

--- a/tests/unit/oidc/test_utils.py
+++ b/tests/unit/oidc/test_utils.py
@@ -43,8 +43,7 @@ def test_find_publisher_by_issuer_github(db_request, environment, expected_id):
         repository_name="bar",
         repository_owner_id="1234",
         workflow_filename="ci.yml",
-        environment=None,
-        # No environment
+        environment=None,  # No environment
     )
     GitHubPublisherFactory(
         id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -73,5 +72,3 @@ def test_find_publisher_by_issuer_github(db_request, environment, expected_id):
     )
 
 
-# def test_find_publisher_by_issuer_with_environment_finds_match(db_request)
-# def test_find_publisher_by_issuer_with_environment_finds_wildcard(db_request)

--- a/tests/unit/oidc/test_utils.py
+++ b/tests/unit/oidc/test_utils.py
@@ -70,5 +70,3 @@ def test_find_publisher_by_issuer_github(db_request, environment, expected_id):
         ).id
         == expected_id
     )
-
-

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -250,6 +250,7 @@ def test_mint_token_from_oidc_pending_publisher_ok(
         repository_owner="foo",
         repository_owner_id="123",
         workflow_filename="example.yml",
+        environment=None,
     )
 
     db_request.registry.settings = {"warehouse.oidc.enabled": True}
@@ -306,6 +307,7 @@ def test_mint_token_from_pending_trusted_publisher_invalidates_others(
         repository_owner="foo",
         repository_owner_id="123",
         workflow_filename="example.yml",
+        environment=None,
     )
 
     # Create some other pending publishers for the same nonexistent project,


### PR DESCRIPTION
Previously, we weren't adequately filtering on `environment` in `find_publisher_by_issuer`, which resulted in this function raising a `MultipleResultsFound` exception if more than one publisher was configured that matched the claimset.

Instead, the behavior should be as follows:
* If no `environment` claim is present
  * If there's a publisher that doesn't restrict on `environment`, return it
  * or return `None`
* If an `environment` claim is present
  * If there's a publisher that restricts on this `environment`, return it
  * If there's a publisher that doesn't restrict on `environment`, return it
  * or return `None`

Fixes https://python-software-foundation.sentry.io/issues/4150013748/.