### PR TITLE
[oidc] Normalize GitHub `environment` claim

### DIFF
--- a/tests/unit/oidc/test_utils.py
+++ b/tests/unit/oidc/test_utils.py
@@ -34,6 +34,7 @@ def test_find_publisher_by_issuer_bad_issuer_url():
         (None, uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")),
         ("some_other_environment", uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")),
         ("some_environment", uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")),
+        ("sOmE_eNvIrOnMeNt", uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")),
     ],
 )
 def test_find_publisher_by_issuer_github(db_request, environment, expected_id):

--- a/warehouse/oidc/utils.py
+++ b/warehouse/oidc/utils.py
@@ -57,7 +57,7 @@ def find_publisher_by_issuer(session, issuer_url, signed_claims, *, pending=Fals
                     repository_name=repository_name,
                     repository_owner=repository_owner,
                     repository_owner_id=signed_claims["repository_owner_id"],
-                    environment=environment,
+                    environment=environment.lower(),
                 )
                 .filter(
                     literal(workflow_ref).like(


### PR DESCRIPTION
Missed in #13566.

From https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment:

> Environment names are not case sensitive.