### PR TITLE
refactor: store hashed remote address on journals

### DIFF
--- a/tests/unit/cli/test_hashing.py
+++ b/tests/unit/cli/test_hashing.py
@@ -1,0 +1,116 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import hashlib
+
+import pretend
+
+from warehouse import db
+from warehouse.cli import hashing
+
+from ...common.db.packaging import JournalEntry, JournalEntryFactory
+
+
+def remote_addr_salty_hash(remote_addr, salt):
+    return hashlib.sha256(f"{remote_addr}{salt}".encode()).hexdigest()
+
+
+class TestHashingJournalEntry:
+    def test_no_records_to_hash(self, cli, db_request, monkeypatch):
+        engine = pretend.stub()
+        config = pretend.stub(registry={"sqlalchemy.engine": engine})
+        session_cls = pretend.call_recorder(lambda bind: db_request.db)
+        monkeypatch.setattr(db, "Session", session_cls)
+
+        assert db_request.db.query(JournalEntry).count() == 0
+
+        args = ["--salt", "test"]
+
+        result = cli.invoke(hashing.journal_entry, args, obj=config)
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "No rows to hash. Done!"
+
+    def tests_hashes_records(self, cli, db_request, remote_addr, monkeypatch):
+        engine = pretend.stub()
+        config = pretend.stub(registry={"sqlalchemy.engine": engine})
+        session_cls = pretend.call_recorder(lambda bind: db_request.db)
+        monkeypatch.setattr(db, "Session", session_cls)
+
+        # create some JournalEntry records with unhashed ip addresses
+        JournalEntryFactory.create_batch(3, submitted_from=remote_addr)
+        assert db_request.db.query(JournalEntry).count() == 3
+
+        salt = "NaCl"
+        salted_hash = remote_addr_salty_hash(remote_addr, salt)
+
+        args = [
+            "--salt",
+            salt,
+            "--batch-size",
+            "2",
+        ]
+
+        result = cli.invoke(hashing.journal_entry, args, obj=config)
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "Hashing 2 rows...\nHashed 2 rows"
+        # check that two of the ip addresses have been hashed
+        assert (
+            db_request.db.query(JournalEntry)
+            .filter_by(submitted_from=remote_addr)
+            .one()
+        )
+        assert (
+            db_request.db.query(JournalEntry)
+            .filter_by(submitted_from=salted_hash)
+            .count()
+            == 2
+        )
+
+    def test_continue_until_done(self, cli, db_request, remote_addr, monkeypatch):
+        engine = pretend.stub()
+        config = pretend.stub(registry={"sqlalchemy.engine": engine})
+        session_cls = pretend.call_recorder(lambda bind: db_request.db)
+        monkeypatch.setattr(db, "Session", session_cls)
+
+        # create some JournalEntry records with unhashed ip addresses
+        JournalEntryFactory.create_batch(3, submitted_from=remote_addr)
+
+        salt = "NaCl"
+        salted_hash = remote_addr_salty_hash(remote_addr, salt)
+
+        args = [
+            "--salt",
+            salt,
+            "--batch-size",
+            "1",
+            "--sleep-time",
+            "0",
+            "--continue-until-done",
+        ]
+
+        result = cli.invoke(hashing.journal_entry, args, obj=config)
+
+        assert result.exit_code == 0
+        # check that all the ip addresses have been hashed
+        assert (
+            db_request.db.query(JournalEntry)
+            .filter_by(submitted_from=salted_hash)
+            .count()
+            == 3
+        )
+        assert (
+            db_request.db.query(JournalEntry)
+            .filter_by(submitted_from=remote_addr)
+            .count()
+            == 0
+        )

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -1481,7 +1481,7 @@ class TestFileUpload:
                 release.version,
                 f"add source file {filename}",
                 user,
-                db_request.remote_addr,
+                db_request.remote_addr_hashed,
             )
         ]
 
@@ -2122,21 +2122,27 @@ class TestFileUpload:
             (j.name, j.version, j.action, j.submitted_by, j.submitted_from)
             for j in journals
         ] == [
-            ("example", None, "create", user, db_request.remote_addr),
+            ("example", None, "create", user, db_request.ip_address.hashed_ip_address),
             (
                 "example",
                 None,
                 f"add Owner {user.username}",
                 user,
-                db_request.remote_addr,
+                db_request.ip_address.hashed_ip_address,
             ),
-            ("example", "1.0", "new release", user, db_request.remote_addr),
+            (
+                "example",
+                "1.0",
+                "new release",
+                user,
+                db_request.ip_address.hashed_ip_address,
+            ),
             (
                 "example",
                 "1.0",
                 "add source file example-1.0.tar.gz",
                 user,
-                db_request.remote_addr,
+                db_request.ip_address.hashed_ip_address,
             ),
         ]
 
@@ -2777,7 +2783,7 @@ class TestFileUpload:
                 release.version,
                 f"add cp34 file {filename}",
                 user,
-                db_request.remote_addr,
+                db_request.remote_addr_hashed,
             )
         ]
 
@@ -2911,7 +2917,7 @@ class TestFileUpload:
                 release.version,
                 f"add cp34 file {filename}",
                 user,
-                db_request.remote_addr,
+                db_request.remote_addr_hashed,
             )
         ]
 
@@ -3176,14 +3182,14 @@ class TestFileUpload:
                 release.version,
                 "new release",
                 user,
-                db_request.remote_addr,
+                db_request.remote_addr_hashed,
             ),
             (
                 release.project.name,
                 release.version,
                 f"add source file {filename}",
                 user,
-                db_request.remote_addr,
+                db_request.remote_addr_hashed,
             ),
         ]
 
@@ -3468,21 +3474,27 @@ class TestFileUpload:
             (j.name, j.version, j.action, j.submitted_by, j.submitted_from)
             for j in journals
         ] == [
-            ("example", None, "create", user, db_request.remote_addr),
+            ("example", None, "create", user, db_request.ip_address.hashed_ip_address),
             (
                 "example",
                 None,
                 f"add Owner {user.username}",
                 user,
-                db_request.remote_addr,
+                db_request.ip_address.hashed_ip_address,
             ),
-            ("example", "1.0", "new release", user, db_request.remote_addr),
+            (
+                "example",
+                "1.0",
+                "new release",
+                user,
+                db_request.ip_address.hashed_ip_address,
+            ),
             (
                 "example",
                 "1.0",
                 "add source file example-1.0.tar.gz",
                 user,
-                db_request.remote_addr,
+                db_request.ip_address.hashed_ip_address,
             ),
         ]
 

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -3975,7 +3975,7 @@ class TestManageProjectRelease:
         assert entry.action == "yank release"
         assert entry.version == release.version
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
+        assert entry.submitted_from == db_request.ip_address.hashed_ip_address
         assert db_request.session.flash.calls == [
             pretend.call(f"Yanked release {release.version!r}", queue="success")
         ]
@@ -4129,7 +4129,7 @@ class TestManageProjectRelease:
         assert entry.action == "unyank release"
         assert entry.version == release.version
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
+        assert entry.submitted_from == db_request.ip_address.hashed_ip_address
 
         assert db_request.session.flash.calls == [
             pretend.call(f"Un-yanked release {release.version!r}", queue="success")
@@ -4287,7 +4287,7 @@ class TestManageProjectRelease:
         assert entry.action == "remove release"
         assert entry.version == release.version
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
+        assert entry.submitted_from == db_request.ip_address.hashed_ip_address
 
         assert db_request.session.flash.calls == [
             pretend.call(f"Deleted release {release.version!r}", queue="success")
@@ -4474,7 +4474,7 @@ class TestManageProjectRelease:
                 version=release.version,
                 action=f"remove file {release_file.filename}",
                 submitted_by=user,
-                submitted_from=db_request.remote_addr,
+                submitted_from=db_request.ip_address.hashed_ip_address,
             )
             .one()
         )
@@ -5460,7 +5460,7 @@ class TestChangeProjectRole:
         assert entry.name == project.name
         assert entry.action == "change Owner testuser to Maintainer"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
+        assert entry.submitted_from == db_request.ip_address.hashed_ip_address
 
     def test_change_role_invalid_role_name(self, pyramid_request):
         project = pretend.stub(name="foobar")
@@ -5578,7 +5578,7 @@ class TestDeleteProjectRole:
         assert entry.name == project.name
         assert entry.action == "remove Owner testuser"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
+        assert entry.submitted_from == db_request.ip_address.hashed_ip_address
 
     def test_delete_missing_role(self, db_request):
         project = ProjectFactory.create(name="foobar")
@@ -5674,7 +5674,7 @@ class TestDeleteProjectRole:
         assert entry.name == project.name
         assert entry.action == "remove Owner testuser"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
+        assert entry.submitted_from == db_request.ip_address.hashed_ip_address
 
     def test_delete_non_owner_role(self, db_request):
         project = ProjectFactory.create(name="foobar")

--- a/tests/unit/manage/views/test_teams.py
+++ b/tests/unit/manage/views/test_teams.py
@@ -838,7 +838,7 @@ class TestChangeTeamProjectRole:
         assert entry.name == organization_project.name
         assert entry.action == f"change Owner {organization_team.name} to Maintainer"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
+        assert entry.submitted_from == db_request.ip_address.hashed_ip_address
 
     def test_change_role_invalid_role_name(self, pyramid_request, organization_project):
         pyramid_request.method = "POST"
@@ -1023,7 +1023,7 @@ class TestDeleteTeamProjectRole:
         assert entry.name == organization_project.name
         assert entry.action == f"remove Owner {organization_team.name}"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
+        assert entry.submitted_from == db_request.ip_address.hashed_ip_address
 
     def test_delete_missing_role(self, db_request, organization_project):
         missing_role_id = str(uuid.uuid4())

--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -140,7 +140,7 @@ def test_remove_project(db_request, flash):
     )
     assert journal_entry.action == "remove project"
     assert journal_entry.submitted_by == db_request.user
-    assert journal_entry.submitted_from == db_request.remote_addr
+    assert journal_entry.submitted_from == db_request.ip_address.hashed_ip_address
 
 
 @pytest.mark.parametrize("flash", [True, False])
@@ -164,7 +164,7 @@ def test_destroy_docs(db_request, flash):
     )
     assert journal_entry.action == "docdestroy"
     assert journal_entry.submitted_by == db_request.user
-    assert journal_entry.submitted_from == db_request.remote_addr
+    assert journal_entry.submitted_from == db_request.ip_address.hashed_ip_address
 
     assert not (
         db_request.db.query(Project)

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1127,7 +1127,7 @@ def verify_project_role(request):
             name=project.name,
             action=f"accepted {desired_role} {user.username}",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
+            submitted_from=request.ip_address.hashed_ip_address,
         )
     )
     project.record_event(

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -404,7 +404,7 @@ def add_role(project, request):
             name=project.name,
             action=f"add {role_name} {user.username}",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
+            submitted_from=request.ip_address.hashed_ip_address,
         )
     )
 
@@ -455,7 +455,7 @@ def delete_role(project, request):
             name=project.name,
             action=f"remove {role.role_name} {role.user.username}",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
+            submitted_from=request.ip_address.hashed_ip_address,
         )
     )
 

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -207,7 +207,7 @@ def _nuke_user(user, request):
                 name=project.name,
                 action="remove project",
                 submitted_by=request.user,
-                submitted_from=request.remote_addr,
+                submitted_from=request.ip_address.hashed_ip_address,
             )
         )
     projects.delete(synchronize_session=False)
@@ -239,7 +239,7 @@ def _nuke_user(user, request):
             name=f"user:{user.username}",
             action="nuke user",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
+            submitted_from=request.ip_address.hashed_ip_address,
         )
     )
 

--- a/warehouse/cli/hashing.py
+++ b/warehouse/cli/hashing.py
@@ -1,0 +1,135 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import hashlib
+import time
+
+import click
+
+from warehouse.cli import warehouse
+
+
+@warehouse.group()
+def hashing():
+    """
+    Run Hashing operations for Warehouse data
+    """
+
+
+@hashing.command()
+@click.option(
+    "-s",
+    "--salt",
+    prompt=True,
+    hide_input=True,
+    help="Pass value instead of prompting for salt",
+)
+@click.option(
+    "-b",
+    "--batch-size",
+    default=10_000,
+    show_default=True,
+    help="Number of rows to hash at a time",
+)
+@click.option(
+    "-st",
+    "--sleep-time",
+    default=1,
+    show_default=True,
+    help="Number of seconds to sleep between batches",
+)
+@click.option(
+    "--continue-until-done",
+    is_flag=True,
+    default=False,
+    help="Continue hashing until all rows are hashed",
+)
+@click.pass_obj
+def journal_entry(
+    config,
+    salt: str,
+    batch_size: int,
+    sleep_time: int,
+    continue_until_done: bool,
+):
+    """
+    Hash `journals.submitted_from` column with salt
+    """
+    # Imported here because we don't want to trigger an import from anything
+    # but warehouse.cli at the module scope.
+    from warehouse.db import Session
+
+    # This lives in the outer function so we only create a single session per
+    # invocation of the CLI command.
+    session = Session(bind=config.registry["sqlalchemy.engine"])
+
+    _hash_journal_entries_submitted_from(
+        session, salt, batch_size, sleep_time, continue_until_done
+    )
+
+
+def _hash_journal_entries_submitted_from(
+    session,
+    salt: str,
+    batch_size: int,
+    sleep_time: int,
+    continue_until_done: bool,
+) -> None:
+    """
+    Perform hashing of the `journals.submitted_from` column
+
+    Broken out from the CLI command so that it can be called recursively.
+    """
+    from sqlalchemy import func, select
+
+    from warehouse.packaging.models import JournalEntry
+
+    # Get rows a batch at a time, only if the row hasn't already been hashed
+    # (i.e. the value is shorter than 64 characters)
+    unhashed_rows = session.scalars(
+        select(JournalEntry)
+        .where(func.length(JournalEntry.submitted_from) < 63)
+        .order_by(JournalEntry.submitted_date)
+        .limit(batch_size)
+    ).all()
+
+    # If there are no rows to hash, we're done
+    if not unhashed_rows:
+        click.echo("No rows to hash. Done!")
+        return
+
+    how_many = len(unhashed_rows)
+
+    # Hash the value rows
+    click.echo(f"Hashing {how_many} rows...")
+    for row in unhashed_rows:
+        row.submitted_from = hashlib.sha256(
+            (row.submitted_from + salt).encode("utf8")
+        ).hexdigest()
+
+    # Update the rows
+    session.add_all(unhashed_rows)
+    session.commit()
+
+    # If there are more rows to hash, recurse until done
+    if continue_until_done and how_many == batch_size:
+        click.echo(f"Hashed {batch_size} rows. Sleeping for {sleep_time} second(s)...")
+        time.sleep(sleep_time)
+        _hash_journal_entries_submitted_from(
+            session,
+            salt,
+            batch_size,
+            sleep_time,
+            continue_until_done,
+        )
+    else:
+        click.echo(f"Hashed {how_many} rows")
+    return

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1164,7 +1164,7 @@ def file_upload(request):
                 version=release.version,
                 action="new release",
                 submitted_by=request.user if request.user else None,
-                submitted_from=request.remote_addr,
+                submitted_from=request.ip_address.hashed_ip_address,
             )
         )
 
@@ -1437,7 +1437,7 @@ def file_upload(request):
                     python_version=file_.python_version, filename=file_.filename
                 ),
                 submitted_by=request.user if request.user else None,
-                submitted_from=request.remote_addr,
+                submitted_from=request.ip_address.hashed_ip_address,
             )
         )
 

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -1653,7 +1653,7 @@ class ManageProjectRelease:
                 action="yank release",
                 version=self.release.version,
                 submitted_by=self.request.user,
-                submitted_from=self.request.remote_addr,
+                submitted_from=self.request.ip_address.hashed_ip_address,
             )
         )
 
@@ -1740,7 +1740,7 @@ class ManageProjectRelease:
                 action="unyank release",
                 version=self.release.version,
                 submitted_by=self.request.user,
-                submitted_from=self.request.remote_addr,
+                submitted_from=self.request.ip_address.hashed_ip_address,
             )
         )
 
@@ -1843,7 +1843,7 @@ class ManageProjectRelease:
                 action="remove release",
                 version=self.release.version,
                 submitted_by=self.request.user,
-                submitted_from=self.request.remote_addr,
+                submitted_from=self.request.ip_address.hashed_ip_address,
             )
         )
 
@@ -1937,7 +1937,7 @@ class ManageProjectRelease:
                 action=f"remove file {release_file.filename}",
                 version=self.release.version,
                 submitted_by=self.request.user,
-                submitted_from=self.request.remote_addr,
+                submitted_from=self.request.ip_address.hashed_ip_address,
             )
         )
 
@@ -2097,7 +2097,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                 name=project.name,
                 action=f"add {role_name.value} {team_name}",
                 submitted_by=request.user,
-                submitted_from=request.remote_addr,
+                submitted_from=request.ip_address.hashed_ip_address,
             )
         )
 
@@ -2211,7 +2211,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                 name=project.name,
                 action=f"add {role_name} {user.username}",
                 submitted_by=request.user,
-                submitted_from=request.remote_addr,
+                submitted_from=request.ip_address.hashed_ip_address,
             )
         )
 
@@ -2338,7 +2338,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                     name=project.name,
                     action=f"invite {role_name} {username}",
                     submitted_by=request.user,
-                    submitted_from=request.remote_addr,
+                    submitted_from=request.ip_address.hashed_ip_address,
                 )
             )
             send_project_role_verification_email(
@@ -2426,7 +2426,7 @@ def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm)
             name=project.name,
             action=f"revoke_invite {role_name} {user.username}",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
+            submitted_from=request.ip_address.hashed_ip_address,
         )
     )
     project.record_event(
@@ -2493,7 +2493,7 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
                             role.role_name, role.user.username, form.role_name.data
                         ),
                         submitted_by=request.user,
-                        submitted_from=request.remote_addr,
+                        submitted_from=request.ip_address.hashed_ip_address,
                     )
                 )
                 role.role_name = form.role_name.data
@@ -2580,7 +2580,7 @@ def delete_project_role(project, request):
                     name=project.name,
                     action=f"remove {role.role_name} {role.user.username}",
                     submitted_by=request.user,
-                    submitted_from=request.remote_addr,
+                    submitted_from=request.ip_address.hashed_ip_address,
                 )
             )
             project.record_event(

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -759,7 +759,7 @@ class ManageOrganizationProjectsViews:
                         name=project.name,
                         action=f"remove {role.role_name} {role.user.username}",
                         submitted_by=self.request.user,
-                        submitted_from=self.request.remote_addr,
+                        submitted_from=self.request.ip_address.hashed_ip_address,
                     )
                 )
                 project.record_event(
@@ -1552,7 +1552,7 @@ def transfer_organization_project(project, request):
                 name=project.name,
                 action=f"remove {role.role_name} {role.user.username}",
                 submitted_by=request.user,
-                submitted_from=request.remote_addr,
+                submitted_from=request.ip_address.hashed_ip_address,
             )
         )
         project.record_event(

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -537,7 +537,7 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
                             form.team_project_role_name.data.value,
                         ),
                         submitted_by=request.user,
-                        submitted_from=request.remote_addr,
+                        submitted_from=request.ip_address.hashed_ip_address,
                     )
                 )
 
@@ -646,7 +646,7 @@ def delete_team_project_role(project, request):
                     name=project.name,
                     action=f"remove {role_name.value} {team.name}",
                     submitted_by=request.user,
-                    submitted_from=request.remote_addr,
+                    submitted_from=request.ip_address.hashed_ip_address,
                 )
             )
 

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -425,7 +425,7 @@ class ProjectService:
                 name=project.name,
                 action="create",
                 submitted_by=creator,
-                submitted_from=request.remote_addr,
+                submitted_from=request.ip_address.hashed_ip_address,
             )
         )
         project.record_event(
@@ -446,7 +446,7 @@ class ProjectService:
                     name=project.name,
                     action=f"add Owner {creator.username}",
                     submitted_by=creator,
-                    submitted_from=request.remote_addr,
+                    submitted_from=request.ip_address.hashed_ip_address,
                 )
             )
             project.record_event(

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -192,7 +192,7 @@ def remove_project(project, request, flash=True):
             name=project.name,
             action="remove project",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
+            submitted_from=request.ip_address.hashed_ip_address,
         )
     )
 
@@ -209,7 +209,7 @@ def destroy_docs(project, request, flash=True):
             name=project.name,
             action="docdestroy",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
+            submitted_from=request.ip_address.hashed_ip_address,
         )
     )
 


### PR DESCRIPTION
Another step towards #8158 .

Starts storing only hashed IP addresses in `JournalEntry.submitted_from` text column from merge-time forward for any new Journals.

Provides a CLI command:

```shellsession
$ python -m warehouse hashing journal-entry -h
Usage: python -m warehouse hashing journal-entry [OPTIONS]

  Hash `journals.submitted_from` column with salt

Options:
  -s, --salt TEXT            Pass value instead of prompting for salt
  -b, --batch-size INTEGER   Number of rows to hash at a time  [default:
                             10000]
  -st, --sleep-time INTEGER  Number of seconds to sleep between batches
                             [default: 1]
  --continue-until-done      Continue hashing until all rows are hashed
  -h, --help                 Show this message and exit.
```

