### PR TITLE
implement a generic "Observation" model mixin

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -572,6 +572,10 @@ msgstr ""
 msgid "Publisher must be specified by ID"
 msgstr ""
 
+#: warehouse/packaging/views.py:207
+msgid "Issue report submitted."
+msgstr ""
+
 #: warehouse/subscriptions/models.py:42
 #: warehouse/templates/manage/project/history.html:218
 msgid "Active"
@@ -653,8 +657,8 @@ msgstr ""
 #: warehouse/templates/manage/project/release.html:194
 #: warehouse/templates/manage/project/releases.html:140
 #: warehouse/templates/manage/project/releases.html:179
-#: warehouse/templates/packaging/detail.html:364
-#: warehouse/templates/packaging/detail.html:383
+#: warehouse/templates/packaging/detail.html:366
+#: warehouse/templates/packaging/detail.html:385
 #: warehouse/templates/pages/classifiers.html:25
 #: warehouse/templates/pages/help.html:20
 #: warehouse/templates/pages/help.html:218
@@ -1164,6 +1168,7 @@ msgstr ""
 #: warehouse/templates/manage/account.html:23
 #: warehouse/templates/manage/account/token.html:22
 #: warehouse/templates/manage/account/totp-provision.html:22
+#: warehouse/templates/packaging/report-project-issue.html:17
 #: warehouse/templates/re-auth.html:17
 msgid "Error processing form"
 msgstr ""
@@ -1243,6 +1248,8 @@ msgstr ""
 #: warehouse/templates/manage/project/roles.html:350
 #: warehouse/templates/manage/team/roles.html:106
 #: warehouse/templates/manage/team/settings.html:35
+#: warehouse/templates/packaging/report-project-issue.html:39
+#: warehouse/templates/packaging/report-project-issue.html:58
 #: warehouse/templates/re-auth.html:51
 msgid "(required)"
 msgstr ""
@@ -1555,6 +1562,7 @@ msgstr ""
 
 #: warehouse/templates/accounts/reset-password.html:18
 #: warehouse/templates/accounts/reset-password.html:24
+#: warehouse/templates/packaging/report-project-issue.html:18
 #: warehouse/templates/pages/sitemap.html:34
 msgid "Reset your password"
 msgstr ""
@@ -2772,6 +2780,10 @@ msgstr ""
 #: warehouse/templates/pages/classifiers.html:21
 #: warehouse/templates/pages/sitemap.html:39
 msgid "Classifiers"
+msgstr ""
+
+#: warehouse/templates/includes/packaging/report-issue-button.html:16
+msgid "Report issue"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:33
@@ -6138,78 +6150,78 @@ msgid "Navigation"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:220
-#: warehouse/templates/packaging/detail.html:252
+#: warehouse/templates/packaging/detail.html:254
 #, python-format
 msgid "Navigation for %(project)s"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:223
-#: warehouse/templates/packaging/detail.html:255
+#: warehouse/templates/packaging/detail.html:257
 msgid "Project description. Focus will be moved to the description."
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:225
-#: warehouse/templates/packaging/detail.html:257
-#: warehouse/templates/packaging/detail.html:285
+#: warehouse/templates/packaging/detail.html:259
+#: warehouse/templates/packaging/detail.html:287
 msgid "Project description"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:229
-#: warehouse/templates/packaging/detail.html:267
+#: warehouse/templates/packaging/detail.html:269
 msgid "Release history. Focus will be moved to the history panel."
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:231
-#: warehouse/templates/packaging/detail.html:269
-#: warehouse/templates/packaging/detail.html:307
+#: warehouse/templates/packaging/detail.html:271
+#: warehouse/templates/packaging/detail.html:309
 msgid "Release history"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:236
-#: warehouse/templates/packaging/detail.html:274
+#: warehouse/templates/packaging/detail.html:276
 msgid "Download files. Focus will be moved to the project files."
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:238
-#: warehouse/templates/packaging/detail.html:276
-#: warehouse/templates/packaging/detail.html:363
+#: warehouse/templates/packaging/detail.html:278
+#: warehouse/templates/packaging/detail.html:365
 msgid "Download files"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:261
+#: warehouse/templates/packaging/detail.html:263
 msgid "Project details. Focus will be moved to the project details."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:263
-#: warehouse/templates/packaging/detail.html:299
+#: warehouse/templates/packaging/detail.html:265
+#: warehouse/templates/packaging/detail.html:301
 msgid "Project details"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:292
+#: warehouse/templates/packaging/detail.html:294
 msgid "The author of this package has not provided a project description"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:309
+#: warehouse/templates/packaging/detail.html:311
 msgid "Release notifications"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:310
+#: warehouse/templates/packaging/detail.html:312
 msgid "RSS feed"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:322
+#: warehouse/templates/packaging/detail.html:324
 msgid "This version"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:342
+#: warehouse/templates/packaging/detail.html:344
 msgid "pre-release"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:347
+#: warehouse/templates/packaging/detail.html:349
 msgid "yanked"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:364
+#: warehouse/templates/packaging/detail.html:366
 #, python-format
 msgid ""
 "Download the file for your platform. If you're not sure which to choose, "
@@ -6217,28 +6229,45 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">installing packages</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:366
+#: warehouse/templates/packaging/detail.html:368
 msgid "Source Distribution"
 msgid_plural "Source Distributions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/packaging/detail.html:382
+#: warehouse/templates/packaging/detail.html:384
 msgid "No source distribution files available for this release."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:383
+#: warehouse/templates/packaging/detail.html:385
 #, python-format
 msgid ""
 "See tutorial on <a href=\"%(href)s\" title=\"%(title)s\" "
 "target=\"_blank\" rel=\"noopener\">generating distribution archives</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:390
+#: warehouse/templates/packaging/detail.html:392
 msgid "Built Distribution"
 msgid_plural "Built Distributions"
 msgstr[0] ""
 msgstr[1] ""
+
+#: warehouse/templates/packaging/report-project-issue.html:24
+#, python-format
+msgid "Report an issue with <code>%(project_name)s</code> project"
+msgstr ""
+
+#: warehouse/templates/packaging/report-project-issue.html:37
+msgid "What's the issue?"
+msgstr ""
+
+#: warehouse/templates/packaging/report-project-issue.html:56
+msgid "Description"
+msgstr ""
+
+#: warehouse/templates/packaging/report-project-issue.html:73
+msgid "Submit issue report"
+msgstr ""
 
 #: warehouse/templates/pages/classifiers.html:22
 msgid ""

--- a/warehouse/migrations/versions/ffa5f25104f9_add_observations.py
+++ b/warehouse/migrations/versions/ffa5f25104f9_add_observations.py
@@ -1,0 +1,129 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add observations
+
+Revision ID: ffa5f25104f9
+Revises: fd0479fed881
+Create Date: 2023-05-05 21:06:49.627547
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "ffa5f25104f9"
+down_revision = "fd0479fed881"
+
+
+def upgrade():
+    op.create_table(
+        "project_observations",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column(
+            "time", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("additional", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("subject_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["subject_id"],
+            ["projects.id"],
+            ondelete="CASCADE",
+            initially="DEFERRED",
+            deferrable=True,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_project_observations_subject_id",
+        "project_observations",
+        ["subject_id"],
+        unique=False,
+    )
+    op.create_table(
+        "release_observations",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column(
+            "time", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("additional", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("subject_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["subject_id"],
+            ["releases.id"],
+            ondelete="CASCADE",
+            initially="DEFERRED",
+            deferrable=True,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_release_observations_subject_id",
+        "release_observations",
+        ["subject_id"],
+        unique=False,
+    )
+    op.create_table(
+        "file_observations",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column(
+            "time", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("additional", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("subject_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["subject_id"],
+            ["release_files.id"],
+            ondelete="CASCADE",
+            initially="DEFERRED",
+            deferrable=True,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_file_observations_subject_id",
+        "file_observations",
+        ["subject_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index("ix_file_observations_subject_id", table_name="file_observations")
+    op.drop_table("file_observations")
+    op.drop_index(
+        "ix_release_observations_subject_id", table_name="release_observations"
+    )
+    op.drop_table("release_observations")
+    op.drop_index(
+        "ix_project_observations_subject_id", table_name="project_observations"
+    )
+    op.drop_table("project_observations")

--- a/warehouse/observations/__init__.py
+++ b/warehouse/observations/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/warehouse/observations/kinds.py
+++ b/warehouse/observations/kinds.py
@@ -1,0 +1,56 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import enum
+
+
+class ObservationKindEnum(str, enum.Enum):
+    source: str
+    subject: str
+    short_desc: str
+
+    description: str
+
+    # Name = ("source:subject:description", "Friendly description")
+    def __new__(cls, value: str, description: str):
+        values = value.split(":")
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        obj.source = values[0]
+        obj.subject = values[1]
+        obj.short_desc = values[2]
+
+        obj.description = description
+
+        return obj
+
+
+class ObservationKind:
+    class Account(ObservationKindEnum):
+        IsMalicious = ("pypi_user_report:account:is_malicious", "It is malicious")
+        IsSpam = ("pypi_user_report:account:is_spam", "It is spam")
+        SomethingElse = ("pypi_user_report:account:something_else", "Something else")
+
+    class Project(ObservationKindEnum):
+        IsMalicious = ("pypi_user_report:project:is_malicious", "It is malicious")
+        IsSpam = ("pypi_user_report:project:is_spam", "It is spam")
+        SomethingElse = ("pypi_user_report:project:something_else", "Something else")
+
+    class Release(ObservationKindEnum):
+        IsMalicious = ("pypi_user_report:release:is_malicious", "It is malicious")
+        IsSpam = ("pypi_user_report:release:is_spam", "It is spam")
+        SomethingElse = ("pypi_user_report:release:something_else", "Something else")
+
+    class File(ObservationKindEnum):
+        IsMalicious = ("pypi_user_report:file:is_malicious", "It is malicious")
+        IsSpam = ("pypi_user_report:file:is_spam", "It is spam")
+        SomethingElse = ("pypi_user_report:file:something_else", "Something else")

--- a/warehouse/observations/models.py
+++ b/warehouse/observations/models.py
@@ -1,0 +1,96 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, String, orm, sql
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.declarative import AbstractConcreteBase
+from sqlalchemy.orm import declared_attr
+
+from warehouse import db
+
+
+class Observation(AbstractConcreteBase):
+    kind = Column(String, nullable=False)
+    time = Column(DateTime, nullable=False, server_default=sql.func.now())
+    additional = Column(JSONB, nullable=True)
+
+    @declared_attr
+    def __tablename__(cls):  # noqa: N805
+        return "_".join(
+            [cls.__name__.removesuffix("Observation").lower(), "observations"]
+        )
+
+    @declared_attr
+    def __table_args__(cls):  # noqa: N805
+        return (Index(f"ix_{ cls.__tablename__ }_subject_id", "subject_id"),)
+
+    @declared_attr
+    def __mapper_args__(cls):  # noqa: N805
+        return (
+            {"polymorphic_identity": cls.__name__, "concrete": True}
+            if cls.__name__ != "Observation"
+            else {}
+        )
+
+    @declared_attr
+    def subject_id(cls):  # noqa: N805
+        return Column(
+            UUID(as_uuid=True),
+            ForeignKey(
+                "%s.id" % cls._parent_class.__tablename__,
+                deferrable=True,
+                initially="DEFERRED",
+                ondelete="CASCADE",
+            ),
+            nullable=False,
+        )
+
+    @declared_attr
+    def subject(cls):  # noqa: N805
+        return orm.relationship(cls._parent_class, back_populates="observations")
+
+    def __init_subclass__(cls, /, parent_class, **kwargs):
+        cls._parent_class = parent_class
+        return cls
+
+
+class HasObservations:
+    def __init_subclass__(cls, /, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.Observation = type(
+            f"{cls.__name__}Observation",
+            (Observation, db.Model),
+            dict(),
+            parent_class=cls,
+        )
+        return cls
+
+    @declared_attr
+    def observations(cls):  # noqa: N805
+        return orm.relationship(
+            cls.Observation,
+            cascade="all, delete-orphan",
+            passive_deletes=True,
+            lazy="dynamic",
+            back_populates="subject",
+        )
+
+    def record_observation(self, *, kind, additional=None):
+        session = orm.object_session(self)
+        observation = self.Observation(
+            subject=self,
+            kind=kind,
+            additional=additional,
+        )
+        session.add(observation)
+
+        return observation

--- a/warehouse/packaging/forms.py
+++ b/warehouse/packaging/forms.py
@@ -1,0 +1,32 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import wtforms
+
+from warehouse.forms import Form
+from warehouse.observations.kinds import ObservationKind
+
+
+class ReportProjectIssueForm(Form):
+    issue_kind = wtforms.fields.SelectField(
+        "What is the issue?",
+        [wtforms.validators.InputRequired()],
+        choices=[(kind._value_, kind.description) for kind in ObservationKind.Project],
+    )
+    issue_description = wtforms.fields.TextAreaField(
+        "Describe the issue, providing as much detail as you are able.",
+        [wtforms.validators.InputRequired(), wtforms.validators.Length(max=200)],
+    )
+
+    def __init__(self, *args, subject, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.subject = subject

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -53,6 +53,7 @@ from warehouse.accounts.models import User
 from warehouse.classifiers.models import Classifier
 from warehouse.events.models import HasEvents
 from warehouse.integrations.vulnerabilities.models import VulnerabilityRecord
+from warehouse.observations.models import HasObservations
 from warehouse.organizations.models import (
     Organization,
     OrganizationProject,
@@ -158,7 +159,7 @@ class TwoFactorRequireable:
         return self.owners_require_2fa | self.pypi_mandates_2fa
 
 
-class Project(SitemapMixin, TwoFactorRequireable, HasEvents, db.Model):
+class Project(SitemapMixin, TwoFactorRequireable, HasEvents, HasObservations, db.Model):
     __tablename__ = "projects"
     __table_args__ = (
         CheckConstraint(
@@ -415,7 +416,7 @@ class ReleaseURL(db.Model):
     url = Column(Text, nullable=False)
 
 
-class Release(db.Model):
+class Release(HasObservations, db.Model):
     __tablename__ = "releases"
 
     @declared_attr
@@ -618,7 +619,7 @@ class Release(db.Model):
         )
 
 
-class File(HasEvents, db.Model):
+class File(HasObservations, HasEvents, db.Model):
     __tablename__ = "release_files"
 
     @declared_attr

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -94,6 +94,13 @@ def includeme(config):
         domain=warehouse,
     )
     config.add_route(
+        "includes.report-issue-button",
+        "/_includes/report-issue-button/{project_name}",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{project_name}",
+        domain=warehouse,
+    )
+    config.add_route(
         "includes.profile-actions",
         "/_includes/profile-actions/{username}",
         factory="warehouse.accounts.models:UserFactory",
@@ -479,6 +486,15 @@ def includeme(config):
         "/manage/project/{project_name}/history/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{project_name}",
+        domain=warehouse,
+    )
+
+    # Report Packaging Issues
+    config.add_route(
+        "packaging.project.report_issue",
+        "/project/{name}/report_issue/",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{name}/",
         domain=warehouse,
     )
 

--- a/warehouse/templates/includes/packaging/report-issue-button.html
+++ b/warehouse/templates/includes/packaging/report-issue-button.html
@@ -1,0 +1,18 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% if request.user %}
+  <a href="{{ request.route_path('packaging.project.report_issue', name=project.name) }}" class="button button--small button--secondary package-description__report-issue-button">{% trans %}Report issue{% endtrans %}</a>
+  <hr>
+{% endif %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -243,6 +243,8 @@
           </nav>
         </div>
         {% include "warehouse:templates/includes/packaging/project-data.html" %}
+        {% csi request.route_path("includes.report-issue-button", project_name=project.normalized_name) %}
+        {% endcsi %}
         {% set include_sponsor_logos = project.organization.orgtype != OrganizationType.Company %}
         {% include "warehouse:templates/includes/sidebar-sponsor-logo.html" %}
 

--- a/warehouse/templates/packaging/report-project-issue.html
+++ b/warehouse/templates/packaging/report-project-issue.html
@@ -1,0 +1,77 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "base.html" %}
+
+{% block title %}
+  {% if form.errors %}{% trans %}Error processing form{% endtrans %} –{% endif %}
+  {% trans %}Reset your password{% endtrans %}
+{% endblock %}
+
+{% block content %}
+  <div class="horizontal-section">
+    <div class="site-container">
+      <h1 class="page-title">{% trans project_name=form.subject.name %}Report an issue with <code>{{ project_name }}</code> project{% endtrans %}</h1>
+      <form method="POST" action="{{ request.current_route_path() }}">
+        <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+        {% if form.errors.__all__ %}
+          <ul class="errors">
+            {% for error in form.errors.__all__ %}
+            <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+
+        <div class="form-group">
+          <label for="issue_kind" class="form-group__label">
+            {% trans %}What's the issue?{% endtrans %}
+            {% if form.issue_kind.flags.required %}
+            <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
+            {% endif %}
+          </label>
+          {{ form.issue_kind(class_="form-group__field", **{"aria-describedby":"issue_kind-errors"}) }}
+          <div id="issue_kind-errors">
+            {% if form.issue_kind.errors %}
+            <ul class="form-errors" role="alert">
+              {% for error in form.issue_kind.errors %}
+              <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+            {% endif %}
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="issue_description" class="form-group__label">
+            {% trans %}Description{% endtrans %}
+            {% if form.issue_description.flags.required %}
+            <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
+            {% endif %}
+          </label>
+          {{ form.issue_description(class_="form-group__field", **{"aria-describedby":"issue_description-errors"}) }}
+          <div id="issue_description-errors">
+            {% if form.issue_description.errors %}
+            <ul class="form-errors" role="alert">
+              {% for error in form.issue_description.errors %}
+              <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+            {% endif %}
+          </div>
+        </div>
+
+        <input type="submit" value="{% trans %}Submit issue report{% endtrans %}" class="button button--primary" data-password-match-target="submit" tabindex="3">
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Idea is to add a generic way to attach information to objects in the database.

Usecases:
  - Internal annotations to PyPI
  - User reported information via Web UI
  - Third-Party declarations about Projects/Releases/Files
    - Malware reports
    - Metadata/file validity

demo with "report project issue":
  - Logged in users see "Report Issue" button in project sidebar
  - Issues are reported/stored in db on submission

Further extensions could be done to accept these Observations via API.