### PR TITLE
Python CI speedups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:14.4
+        image: ${{ (matrix.name == 'Tests') && 'postgres:14.4' || '' }}
         ports:
           - 5432:5432
         env:
@@ -71,7 +71,7 @@ jobs:
         # Set health checks to wait until postgres has started
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       stripe:
-        image: stripe/stripe-mock:v0.140.0
+        image: ${{ (matrix.name == 'Tests') && 'stripe/stripe-mock:v0.140.0' || '' }}
         ports:
           - 12111:12111
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,36 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Install platform dependencies
+        run: |
+          sudo apt -y update
+          sudo apt -y install libcurl4-openssl-dev libssl-dev pkg-config libxml2-dev libxslt-dev
+      - uses: actions/setup-python@v4
+        with:
+          python-version-file: '.python-version'
+      - name: pip cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}
+      - name: Cache built Python environment
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+      - name: Install Python dependencies
+        run: |
+          pip install -U setuptools wheel pip
+          pip install -r requirements.txt --no-deps
+          pip install -r requirements/dev.txt
+          pip check
   test:
+    needs: deps
     strategy:
       matrix:
         include:
@@ -54,27 +83,21 @@ jobs:
       - name: Install platform dependencies
         run: |
           sudo apt -y update
-          sudo apt -y install libcurl4-openssl-dev libssl-dev pkg-config
+          sudo apt -y install libcurl4-openssl-dev libssl-dev pkg-config libxml2-dev libxslt-dev
       - uses: actions/setup-python@v4
         with:
           python-version-file: '.python-version'
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements.txt
-            requirements/*.txt
-      - name: Cache common Python cache paths
+      - name: Cache mypy results
+        if: ${{ (matrix.name == 'Lint') }}
         uses: actions/cache@v3
         with:
           path: |
-            .cache
-            .mypy_cache
-            ${{ env.pythonLocation }}
+              .mypy_cache
           key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
-      - name: Install Python dependencies
-        run: |
-          pip install -U pip setuptools wheel
-          pip install -r requirements.txt --no-deps
-          pip install -r requirements/dev.txt
-          pip check
+      - name: Restore built Python environment from deps
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}


### PR DESCRIPTION
does all the deps work once up front, caches the whole environment for downstream tests, only starts the postgres/stripe containers if necessary.

this should also retain a cache of built wheels for our deps thanks to https://github.com/pypa/pip/pull/11897, so incremental changes (dependabot or new dependency addition) shouldn't be too much of a penalty.

"wall clock" time for `Tests` isn't actually impacted *that much*, but all the other individual checks are **much** faster. so we'll fail faster when `Lint`, `Dependencies`, `Licenses` etc fail.

cuts actual compute time used in GHA from ~26m to ~11m in best case 💅🏼 

Compare https://github.com/pypi/warehouse/actions/runs/4946873280/usage with https://github.com/pypi/warehouse/actions/runs/4947718593/usage