### PR TITLE
fix: use correct URL link

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -5507,6 +5507,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:194
+#: warehouse/templates/manage/project/releases.html:140
 #, python-format
 msgid ""
 "Consider <a href=\"%(yank_href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -5570,15 +5571,6 @@ msgstr ""
 
 #: warehouse/templates/manage/project/releases.html:119
 msgid "Un-yank release"
-msgstr ""
-
-#: warehouse/templates/manage/project/releases.html:140
-#, python-format
-msgid ""
-"Consider <a href=\"%(yank_href)s\" title=\"%(title)s\" target=\"_blank\" "
-"rel=\"noopener\">yanking</a> this release, making a new release or a <a "
-"href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
-"rel=\"noopener\">post release</a> instead."
 msgstr ""
 
 #: warehouse/templates/manage/project/releases.html:151

--- a/warehouse/templates/manage/project/releases.html
+++ b/warehouse/templates/manage/project/releases.html
@@ -137,7 +137,7 @@
           {% set custom_warning_text %}
           <p>{% trans %}You will not be able to re-upload a new distribution of the same type with the same version number.{% endtrans %}</p>
           <p>{% trans %}Deletion will break any downstream projects relying on a pinned version of this package. It is intended as a last resort to address legal issues or remove harmful releases.{% endtrans %}</p>
-          <p>{% trans yank_href=request.help_url(_anchor='yanked'), post_href='https://www.python.org/dev/peps/pep-0440/#post-releases', title=gettext('External link') %}Consider <a href="{{ yank_href }}" title="{{ title }}" target="_blank" rel="noopener">yanking</a> this release, making a new release or a <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">post release</a> instead.{% endtrans %}</p>
+          <p>{% trans yank_href=request.help_url(_anchor='yanked'), post_href='https://www.python.org/dev/peps/pep-0440/#post-releases', title=gettext('External link') %}Consider <a href="{{ yank_href }}" title="{{ title }}" target="_blank" rel="noopener">yanking</a> this release, making a new release or a <a href="{{ post_href }}" title="{{ title }}" target="_blank" rel="noopener">post release</a> instead.{% endtrans %}</p>
           {% endset %}
           {{ confirm_modal(title, gettext('Version'), 'delete_version', release.version, slug, custom_warning_text=custom_warning_text, action=action) }}
         {% endif %}


### PR DESCRIPTION
Current behavior links back to the release page, which is incorrect.