### PR TITLE
feat(admin): display hashed value if possible

### DIFF
--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -320,6 +320,7 @@
           <th scope="col">Event</th>
           <th scope="col">Time</th>
           <th scope="col">IP address</th>
+          <th scope="col">Hashed IP address</th>
           <th scope="col">Additional information</th>
         </tr>
       </thead>
@@ -328,7 +329,8 @@
         <tr>
           <td>{{ event.tag }}</td>
           <td>{{ event.time }}</td>
-          <td>{{ event.ip_address.hashed_ip_address if event.ip_address.hashed_ip_address else event.ip_address }}</td>
+          <td>{{ event.ip_address }}</td>
+          <td>{{ event.ip_address.hashed_ip_address }}</td>
           <td>{{ event.additional }}</td>
         </tr>
         {% endfor %}

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -328,7 +328,7 @@
         <tr>
           <td>{{ event.tag }}</td>
           <td>{{ event.time }}</td>
-          <td>{{ event.ip_address }}</td>
+          <td>{{ event.ip_address.hashed_ip_address if event.ip_address.hashed_ip_address else event.ip_address }}</td>
           <td>{{ event.additional }}</td>
         </tr>
         {% endfor %}

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -457,6 +457,7 @@
                 <th scope="col">Event</th>
                 <th scope="col">Time</th>
                 <th scope="col">IP address</th>
+                <th scope="col">Hashed IP address</th>
                 <th scope="col">Additional information</th>
               </tr>
             </thead>
@@ -465,7 +466,8 @@
               <tr>
                 <td>{{ event.tag }}</td>
                 <td>{{ event.time }}</td>
-                <td>{{ event.ip_address.hashed_ip_address if event.ip_address.hashed_ip_address else event.ip_address }}</td>
+                <td>{{ event.ip_address }}</td>
+                <td>{{ event.ip_address.hashed_ip_address }}</td>
                 <td>{{ event.additional }}</td>
               </tr>
               {% endfor %}

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -465,7 +465,7 @@
               <tr>
                 <td>{{ event.tag }}</td>
                 <td>{{ event.time }}</td>
-                <td>{{ event.ip_address }}</td>
+                <td>{{ event.ip_address.hashed_ip_address if event.ip_address.hashed_ip_address else event.ip_address }}</td>
                 <td>{{ event.additional }}</td>
               </tr>
               {% endfor %}


### PR DESCRIPTION
As a way to ease into using new values off the `IpAddress` model.

In Admin project and user activity, display the hashed value if possible.