### PR TITLE
Filter maintainer's email when presenting project data

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -268,10 +268,10 @@ def test_is_recent_none():
         ('"Foo Bar" <foo@bar.com>', "Foo Bar", "foo@bar.com"),
     ],
 )
-def test_format_author_email(meta_email, expected_name, expected_email):
-    author_name, author_email = filters.format_author_email(meta_email)
-    assert author_name == expected_name
-    assert author_email == expected_email
+def test_format_email(meta_email, expected_name, expected_email):
+    name, email = filters.format_email(meta_email)
+    assert name == expected_name
+    assert email == expected_email
 
 
 @pytest.mark.parametrize(

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -470,7 +470,7 @@ def configure(settings=None):
     filters.setdefault("ctime", "warehouse.filters:ctime")
     filters.setdefault("is_recent", "warehouse.filters:is_recent")
     filters.setdefault("canonicalize_name", "packaging.utils:canonicalize_name")
-    filters.setdefault("format_author_email", "warehouse.filters:format_author_email")
+    filters.setdefault("format_email", "warehouse.filters:format_email")
     filters.setdefault(
         "remove_invalid_xml_unicode", "warehouse.filters:remove_invalid_xml_unicode"
     )

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -174,18 +174,18 @@ def is_recent(timestamp):
     return False
 
 
-def format_author_email(metadata_email: str) -> tuple[str, str]:
+def format_email(metadata_email: str) -> tuple[str, str]:
     """
     Return the name and email address from a metadata RFC-822 string.
     Use Jinja's `first` and `last` to access each part in a template.
     TODO: Support more than one email address, per RFC-822.
     """
-    author_emails = []
-    for author_name, author_email in getaddresses([metadata_email]):
-        if "@" not in author_email:
-            return author_name, ""
-        author_emails.append((author_name, author_email))
-    return author_emails[0][0], author_emails[0][1]
+    emails = []
+    for name, email in getaddresses([metadata_email]):
+        if "@" not in email:
+            return name, ""
+        emails.append((name, email))
+    return emails[0][0], emails[0][1]
 
 
 def remove_invalid_xml_unicode(value: str | None) -> str | None:

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -89,7 +89,7 @@
     <p><strong>{% trans %}Author:{% endtrans %}</strong> {{ release.author }}</p>
   {% endif %}
   {% if release.maintainer_email %}
-    <p><strong>{% trans %}Maintainer:{% endtrans %}</strong> <a href="mailto:{{ release.maintainer_email }}">{{ release.maintainer or release.maintainer_email }}</a></p>
+    <p><strong>{% trans %}Maintainer:{% endtrans %}</strong> <a href="mailto:{{ release.maintainer_email|format_email|last }}">{{ release.maintainer or release.maintainer_email|format_email|first }}</a></p>
   {% elif release.maintainer %}
     <p><strong>{% trans %}Maintainer:{% endtrans %}</strong> {{ release.maintainer }}</p>
   {% endif %}

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -84,7 +84,7 @@
   <p><strong>{% trans %}License:{% endtrans %}</strong> {{ license }}</p>
   {% endif %}
   {% if release.author_email %}
-    <p><strong>{% trans %}Author:{% endtrans %}</strong> <a href="mailto:{{ release.author_email|format_author_email|last }}">{{ release.author or release.author_email|format_author_email|first }}</a></p>
+    <p><strong>{% trans %}Author:{% endtrans %}</strong> <a href="mailto:{{ release.author_email|format_email|last }}">{{ release.author or release.author_email|format_email|first }}</a></p>
   {% elif release.author %}
     <p><strong>{% trans %}Author:{% endtrans %}</strong> {{ release.author }}</p>
   {% endif %}


### PR DESCRIPTION
When preparing to present the `maintainer_email` metadata for a project, format this content in the same way as `author_email`. This is to prevent rendering a maintainer's Email inside the mailto's link text. For [example](https://pypi.org/project/sphinxcontrib-confluencebuilder/):

![image](https://github.com/pypi/warehouse/assets/1834509/d9bd95ad-3544-4606-9e40-da6923d334ad)
