### PR TITLE
chore: replace local development broker with redis

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -6,7 +6,7 @@ WAREHOUSE_TOKEN=insecuretoken
 
 AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=foo
-BROKER_URL=sqs://localstack:4566/?region=us-east-1&queue_name_prefix=warehouse-dev
+BROKER_URL=redis://redis:6379/1
 
 DATABASE_URL=postgresql://postgres@db/warehouse
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,17 +46,6 @@ services:
   redis:
     image: redis:4.0
 
-  localstack:
-    image: localstack/localstack:1.4
-    environment:
-      SERVICES: "sqs"
-      HOSTNAME: "localstack"
-      HOSTNAME_EXTERNAL: "localstack"
-      DEFAULT_REGION: "us-east-2"
-      LS_LOG: "error"
-    ports:
-      - "4566:4566"
-
   elasticsearch:
     image: elasticsearch:7.10.1
     environment:
@@ -156,6 +145,19 @@ services:
       FILES_BACKEND: "warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files:9001/packages/{path}"
       ARCHIVE_FILES_BACKEND: "warehouse.packaging.services.LocalArchiveFileStorage path=/var/opt/warehouse/packages-archive/ url=http://files:9001/packages-archive/{path}"
       SIMPLE_BACKEND: "warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://files:9001/simple/{path}"
+
+  flower:
+    image: warehouse:docker-compose
+    pull_policy: never
+    command: celery -A warehouse flower
+    ports:
+      - "5555:5555"
+    env_file: dev/environment
+    environment:
+      CELERY_BROKER_URL: redis://redis:6379/1
+      CELERY_RESULT_BACKEND: redis://redis:6379/1
+    depends_on:
+      - redis
 
   static:
     build:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,4 @@ asyncudp>=0.7
 hupper>=1.9
 pip-tools>=1.0
 pyramid_debugtoolbar>=2.5
+flower


### PR DESCRIPTION
As a means to test and demonstrate that using Redis as a broker is an easy replacement for SQS.

Add flower at `http://localhost:5555` to play around with and observe behaviors.

Doesn't touch main runtime dependencies until we decide to retire SQS behaviors, and even then, not much changes other than minor tweaks to the depgraph - we still need all the packages we install anyhow.

Drops the largeish ~2GB localstack docker image

Relates to #13702