### PR TITLE
chore(dev): provide a `runmigrations` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,13 @@ initdb: .state/docker-build-base
 	docker compose run --rm web psql -h db -d postgres -U postgres -c "CREATE DATABASE warehouse ENCODING 'UTF8'"
 	docker compose run --rm web bash -c "xz -d -f -k dev/$(DB).sql.xz --stdout | psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f -"
 	docker compose run --rm web psql -h db -d warehouse -U postgres -c "UPDATE users SET name='Ee Durbin' WHERE username='ewdurbin'"
-	docker compose run --rm web python -m warehouse db upgrade head
+	$(MAKE) runmigrations
 	docker compose run --rm web python -m warehouse sponsors populate-db
 	docker compose run --rm web python -m warehouse classifiers sync
 	$(MAKE) reindex
+
+runmigrations: .state/docker-build-base
+	docker compose run --rm web python -m warehouse db upgrade head
 
 reindex: .state/docker-build-base
 	docker compose run --rm web python -m warehouse search reindex
@@ -128,4 +131,4 @@ purge: stop clean
 stop:
 	docker compose stop
 
-.PHONY: default build serve initdb shell dbshell tests dev-docs user-docs deps clean purge debug stop compile-pot
+.PHONY: default build serve initdb shell dbshell tests dev-docs user-docs deps clean purge debug stop compile-pot runmigrations

--- a/docs/dev/development/database-migrations.rst
+++ b/docs/dev/development/database-migrations.rst
@@ -14,7 +14,7 @@ above:
 
 Then migrate and test your migration::
 
-    $ docker compose run web python -m warehouse db upgrade head
+    $ make runmigrations
 
 Migrations are automatically run as part of the deployment process, but prior
 to the old version of Warehouse from being shut down. This means that each


### PR DESCRIPTION
When updating code from upstream, provide a simple facility to get the new migrations applied, rather than having to fully reinit the database.