### PR TITLE
allow gpg_signature to be a tuple/FieldStorage

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -894,7 +894,7 @@ def file_upload(request):
     # FieldStorage. The 'content' field _should_ be a FieldStorage, however.
     # ref: https://github.com/pypi/warehouse/issues/2185
     # ref: https://github.com/pypi/warehouse/issues/2491
-    for field in set(request.POST) - {"content"}:
+    for field in set(request.POST) - {"content", "gpg_signature"}:
         values = request.POST.getall(field)
         if any(isinstance(value, FieldStorage) for value in values):
             raise _exc_with_message(HTTPBadRequest, f"{field}: Should not be a tuple.")


### PR DESCRIPTION
Even though we're ignoring the `gpg_signature`, we still need to continue to allow `gpg_signature` to be a `FieldStorage`, since that's what clients will typically upload it as. Otherwise uploading with a signature is an error rather than a warning.