### PR TITLE
move all record_event instances to send a request

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -341,9 +341,9 @@ def user_service(db_session, metrics, remote_addr):
 
 
 @pytest.fixture
-def project_service(db_session, remote_addr, metrics, ratelimiters=None):
+def project_service(db_session, metrics, ratelimiters=None):
     return packaging_services.ProjectService(
-        db_session, remote_addr, metrics, ratelimiters=ratelimiters
+        db_session, metrics, ratelimiters=ratelimiters
     )
 
 

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -269,7 +269,7 @@ class TestLogin:
             ),
             is_disabled=pretend.call_recorder(lambda user_id: (False, None)),
             disable_password=pretend.call_recorder(
-                lambda user_id, reason=None, request=None: None
+                lambda user_id, request, reason=None: None
             ),
         )
         breach_service = pretend.stub(
@@ -304,8 +304,8 @@ class TestLogin:
         assert service.disable_password.calls == [
             pretend.call(
                 2,
+                pyramid_request,
                 reason=DisableReason.CompromisedPassword,
-                request=pyramid_request,
             )
         ]
         assert send_email.calls == [pretend.call(pyramid_request, user)]

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -105,6 +105,7 @@ class TestLogin:
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
                 ip_address="1.2.3.4",
+                request=pyramid_request,
                 additional={"reason": "invalid_password", "auth_method": "basic"},
             )
         ]
@@ -245,6 +246,7 @@ class TestLogin:
         assert user.record_event.calls == [
             pretend.call(
                 ip_address="1.2.3.4",
+                request=pyramid_request,
                 tag=EventTag.Account.LoginSuccess,
                 additional={"auth_method": "basic"},
             )
@@ -267,7 +269,7 @@ class TestLogin:
             ),
             is_disabled=pretend.call_recorder(lambda user_id: (False, None)),
             disable_password=pretend.call_recorder(
-                lambda user_id, reason=None, ip_address="127.0.0.1": None
+                lambda user_id, reason=None, request=None: None
             ),
         )
         breach_service = pretend.stub(
@@ -301,7 +303,9 @@ class TestLogin:
         ]
         assert service.disable_password.calls == [
             pretend.call(
-                2, reason=DisableReason.CompromisedPassword, ip_address="1.2.3.4"
+                2,
+                reason=DisableReason.CompromisedPassword,
+                request=pyramid_request,
             )
         ]
         assert send_email.calls == [pretend.call(pyramid_request, user)]

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -259,7 +259,7 @@ class TestLoginForm:
             get_user=lambda _: user,
             check_password=lambda userid, pw, tags=None: True,
             disable_password=pretend.call_recorder(
-                lambda user_id, reason=None, request=None: None
+                lambda user_id, request, reason=None: None
             ),
             is_disabled=lambda userid: (False, None),
         )
@@ -278,8 +278,8 @@ class TestLoginForm:
         assert user_service.disable_password.calls == [
             pretend.call(
                 1,
+                request,
                 reason=DisableReason.CompromisedPassword,
-                request=request,
             )
         ]
         assert send_email.calls == [pretend.call(request, user)]

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -203,6 +203,7 @@ class TestLoginForm:
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"reason": "invalid_password"},
             )
         ]
@@ -258,7 +259,7 @@ class TestLoginForm:
             get_user=lambda _: user,
             check_password=lambda userid, pw, tags=None: True,
             disable_password=pretend.call_recorder(
-                lambda user_id, reason=None, ip_address="127.0.0.1": None
+                lambda user_id, reason=None, request=None: None
             ),
             is_disabled=lambda userid: (False, None),
         )
@@ -276,7 +277,9 @@ class TestLoginForm:
         assert form.password.errors.pop() == "Bad Password!"
         assert user_service.disable_password.calls == [
             pretend.call(
-                1, reason=DisableReason.CompromisedPassword, ip_address="1.2.3.4"
+                1,
+                reason=DisableReason.CompromisedPassword,
+                request=request,
             )
         ]
         assert send_email.calls == [pretend.call(request, user)]
@@ -846,6 +849,7 @@ class TestTOTPAuthenticationForm:
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"reason": "invalid_totp"},
             )
         ]
@@ -944,6 +948,7 @@ class TestWebAuthnAuthenticationForm:
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"reason": "invalid_webauthn"},
             )
         ]
@@ -1045,6 +1050,7 @@ class TestRecoveryCodeForm:
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"reason": expected_reason},
             )
         ]

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -49,6 +49,7 @@ from warehouse.metrics import IMetricsService, NullMetrics
 from warehouse.rate_limiting.interfaces import IRateLimiter
 
 from ...common.db.accounts import EmailFactory, UserFactory
+from ...common.db.ip_addresses import IpAddressFactory
 
 
 class TestDatabaseUserService:
@@ -440,6 +441,10 @@ class TestDatabaseUserService:
         ],
     )
     def test_disable_password(self, user_service, reason, expected):
+        request = pretend.stub(
+            remote_addr="127.0.0.1",
+            ip_address=IpAddressFactory.create(ip_address="127.0.0.1"),
+        )
         user = UserFactory.create()
         user.record_event = pretend.call_recorder(lambda *a, **kw: None)
 
@@ -448,13 +453,14 @@ class TestDatabaseUserService:
         assert user.password != "!"
 
         # Now we'll actually test our disable function.
-        user_service.disable_password(user.id, reason=reason)
+        user_service.disable_password(user.id, reason=reason, request=request)
         assert user.password == "!"
 
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PasswordDisabled,
                 ip_address="127.0.0.1",
+                request=request,
                 additional={"reason": expected},
             )
         ]
@@ -464,10 +470,14 @@ class TestDatabaseUserService:
         [(True, None), (True, DisableReason.CompromisedPassword), (False, None)],
     )
     def test_is_disabled(self, user_service, disabled, reason):
+        request = pretend.stub(
+            remote_addr="127.0.0.1",
+            ip_address=IpAddressFactory.create(ip_address="127.0.0.1"),
+        )
         user = UserFactory.create()
         user_service.update_user(user.id, password="foo")
         if disabled:
-            user_service.disable_password(user.id, reason=reason)
+            user_service.disable_password(user.id, reason=reason, request=request)
         assert user_service.is_disabled(user.id) == (disabled, reason)
 
     def test_is_disabled_user_frozen(self, user_service):
@@ -475,8 +485,14 @@ class TestDatabaseUserService:
         assert user_service.is_disabled(user.id) == (True, DisableReason.AccountFrozen)
 
     def test_updating_password_undisables(self, user_service):
+        request = pretend.stub(
+            remote_addr="127.0.0.1",
+            ip_address=IpAddressFactory.create(ip_address="127.0.0.1"),
+        )
         user = UserFactory.create()
-        user_service.disable_password(user.id, reason=DisableReason.CompromisedPassword)
+        user_service.disable_password(
+            user.id, reason=DisableReason.CompromisedPassword, request=request
+        )
         assert user_service.is_disabled(user.id) == (
             True,
             DisableReason.CompromisedPassword,

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -443,7 +443,7 @@ class TestDatabaseUserService:
     def test_disable_password(self, user_service, reason, expected):
         request = pretend.stub(
             remote_addr="127.0.0.1",
-            ip_address=IpAddressFactory.create(ip_address="127.0.0.1"),
+            ip_address=IpAddressFactory.create(),
         )
         user = UserFactory.create()
         user.record_event = pretend.call_recorder(lambda *a, **kw: None)
@@ -472,7 +472,7 @@ class TestDatabaseUserService:
     def test_is_disabled(self, user_service, disabled, reason):
         request = pretend.stub(
             remote_addr="127.0.0.1",
-            ip_address=IpAddressFactory.create(ip_address="127.0.0.1"),
+            ip_address=IpAddressFactory.create(),
         )
         user = UserFactory.create()
         user_service.update_user(user.id, password="foo")
@@ -487,7 +487,7 @@ class TestDatabaseUserService:
     def test_updating_password_undisables(self, user_service):
         request = pretend.stub(
             remote_addr="127.0.0.1",
-            ip_address=IpAddressFactory.create(ip_address="127.0.0.1"),
+            ip_address=IpAddressFactory.create(),
         )
         user = UserFactory.create()
         user_service.disable_password(

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -288,6 +288,7 @@ class TestLogin:
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
                 additional={"two_factor_method": None, "two_factor_label": None},
             )
         ]
@@ -351,6 +352,7 @@ class TestLogin:
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
                 additional={"two_factor_method": None, "two_factor_label": None},
             )
         ]
@@ -714,6 +716,7 @@ class TestTwoFactor:
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
                 additional={"two_factor_method": "totp", "two_factor_label": "totp"},
             )
         ]
@@ -1157,6 +1160,7 @@ class TestRecoveryCode:
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
                 additional={
                     "two_factor_method": "recovery-code",
                     "two_factor_label": None,
@@ -1165,6 +1169,7 @@ class TestRecoveryCode:
             pretend.call(
                 tag=EventTag.Account.RecoveryCodesUsed,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
             ),
         ]
         assert pyramid_request.session.flash.calls == [
@@ -1411,11 +1416,13 @@ class TestRegister:
             pretend.call(
                 tag=EventTag.Account.AccountCreate,
                 ip_address=db_request.remote_addr,
+                request=db_request,
                 additional={"email": "foo@bar.com"},
             ),
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
                 ip_address=db_request.remote_addr,
+                request=db_request,
                 additional={"two_factor_method": None, "two_factor_label": None},
             ),
         ]
@@ -1524,6 +1531,7 @@ class TestRequestPasswordReset:
             pretend.call(
                 tag=EventTag.Account.PasswordResetRequest,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
             )
         ]
 
@@ -1588,6 +1596,7 @@ class TestRequestPasswordReset:
             pretend.call(
                 tag=EventTag.Account.PasswordResetRequest,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
             )
         ]
         assert user_service.ratelimiters["password.reset"].test.calls == [
@@ -1663,6 +1672,7 @@ class TestRequestPasswordReset:
             pretend.call(
                 tag=EventTag.Account.PasswordResetRequest,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
             )
         ]
         assert user_service.ratelimiters["password.reset"].test.calls == [
@@ -1762,6 +1772,7 @@ class TestRequestPasswordReset:
             pretend.call(
                 tag=EventTag.Account.PasswordResetAttempt,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
             )
         ]
 
@@ -3569,6 +3580,7 @@ class TestManageAccountPublishingViews:
             pretend.call(
                 tag=EventTag.Account.PendingOIDCPublisherAdded,
                 ip_address="1.2.3.4",
+                request=db_request,
                 additional={
                     "project": "some-project-name",
                     "publisher": pending_publisher.publisher_name,
@@ -3802,6 +3814,7 @@ class TestManageAccountPublishingViews:
             pretend.call(
                 tag=EventTag.Account.PendingOIDCPublisherRemoved,
                 ip_address="1.2.3.4",
+                request=db_request,
                 additional={
                     "project": "some-project-name",
                     "publisher": "GitHub",

--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -406,7 +406,7 @@ class TestUserResetPassword:
         service = pretend.stub(
             find_userid=pretend.call_recorder(lambda username: user.username),
             disable_password=pretend.call_recorder(
-                lambda userid, reason, request=None: None
+                lambda userid, request, reason: None
             ),
         )
         db_request.find_service = pretend.call_recorder(lambda iface, context: service)
@@ -421,9 +421,7 @@ class TestUserResetPassword:
         ]
         assert send_email.calls == [pretend.call(db_request, user)]
         assert service.disable_password.calls == [
-            pretend.call(
-                user.id, reason=DisableReason.CompromisedPassword, request=db_request
-            )
+            pretend.call(user.id, db_request, reason=DisableReason.CompromisedPassword)
         ]
         assert db_request.route_path.calls == [
             pretend.call("admin.user.detail", username=user.username)

--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -405,7 +405,9 @@ class TestUserResetPassword:
         db_request.user = UserFactory.create()
         service = pretend.stub(
             find_userid=pretend.call_recorder(lambda username: user.username),
-            disable_password=pretend.call_recorder(lambda userid, reason: None),
+            disable_password=pretend.call_recorder(
+                lambda userid, reason, request=None: None
+            ),
         )
         db_request.find_service = pretend.call_recorder(lambda iface, context: service)
 
@@ -419,7 +421,9 @@ class TestUserResetPassword:
         ]
         assert send_email.calls == [pretend.call(db_request, user)]
         assert service.disable_password.calls == [
-            pretend.call(user.id, reason=DisableReason.CompromisedPassword)
+            pretend.call(
+                user.id, reason=DisableReason.CompromisedPassword, request=db_request
+            )
         ]
         assert db_request.route_path.calls == [
             pretend.call("admin.user.detail", username=user.username)

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -308,10 +308,11 @@ class TestSendEmail:
             def __init__(self):
                 self.events = []
 
-            def record_event(self, tag, ip_address, additional):
+            def record_event(self, tag, ip_address, request=None, additional=None):
                 self.events.append(
                     {
                         "ip_address": ip_address,
+                        "request": request,
                         "tag": tag,
                         "additional": additional,
                     }
@@ -382,6 +383,7 @@ class TestSendEmail:
             assert user_service.user.events == [
                 {
                     "tag": "account:email:sent",
+                    "request": request,
                     "ip_address": request.remote_addr,
                     "additional": {
                         "from_": "noreply@example.com",

--- a/tests/unit/integration/github/test_utils.py
+++ b/tests/unit/integration/github/test_utils.py
@@ -610,6 +610,7 @@ def test_analyze_disclosure(monkeypatch):
         pretend.call(
             tag=EventTag.Account.APITokenRemovedLeak,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "macaroon_id": "12",
                 "public_url": "http://example.com",

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -307,6 +307,7 @@ class TestManageAccount:
             pretend.call(
                 tag=EventTag.Account.EmailAdd,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
                 additional={"email": email_address},
             )
         ]
@@ -381,6 +382,7 @@ class TestManageAccount:
             pretend.call(
                 tag=EventTag.Account.EmailRemove,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"email": email.email},
             )
         ]
@@ -473,6 +475,7 @@ class TestManageAccount:
             pretend.call(
                 tag=EventTag.Account.EmailPrimaryChange,
                 ip_address=db_request.remote_addr,
+                request=db_request,
                 additional={"old_primary": "old", "new_primary": "new"},
             )
         ]
@@ -508,6 +511,7 @@ class TestManageAccount:
             pretend.call(
                 tag=EventTag.Account.EmailPrimaryChange,
                 ip_address=db_request.remote_addr,
+                request=db_request,
                 additional={"old_primary": None, "new_primary": new_primary.email},
             )
         ]
@@ -575,6 +579,7 @@ class TestManageAccount:
             pretend.call(
                 tag=EventTag.Account.EmailReverify,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"email": email.email},
             )
         ]
@@ -737,7 +742,9 @@ class TestManageAccount:
         ]
         assert request.user.record_event.calls == [
             pretend.call(
-                tag=EventTag.Account.PasswordChange, ip_address=request.remote_addr
+                tag=EventTag.Account.PasswordChange,
+                ip_address=request.remote_addr,
+                request=request,
             )
         ]
 
@@ -1143,6 +1150,7 @@ class TestProvisionTOTP:
             pretend.call(
                 tag=EventTag.Account.TwoFactorMethodAdded,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"method": "totp"},
             )
         ]
@@ -1300,6 +1308,7 @@ class TestProvisionTOTP:
             pretend.call(
                 tag=EventTag.Account.TwoFactorMethodRemoved,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"method": "totp"},
             )
         ]
@@ -1516,6 +1525,7 @@ class TestProvisionWebAuthn:
             pretend.call(
                 tag=EventTag.Account.TwoFactorMethodAdded,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "method": "webauthn",
                     "label": provision_webauthn_obj.label.data,
@@ -1608,6 +1618,7 @@ class TestProvisionWebAuthn:
             pretend.call(
                 tag=EventTag.Account.TwoFactorMethodRemoved,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "method": "webauthn",
                     "label": delete_webauthn_obj.label.data,
@@ -1698,6 +1709,7 @@ class TestProvisionRecoveryCodes:
             pretend.call(
                 tag=EventTag.Account.RecoveryCodesGenerated,
                 ip_address=request.remote_addr,
+                request=request,
             )
         ]
 
@@ -1771,6 +1783,7 @@ class TestProvisionRecoveryCodes:
             pretend.call(
                 tag=EventTag.Account.RecoveryCodesRegenerated,
                 ip_address=request.remote_addr,
+                request=request,
             )
         ]
 
@@ -2070,6 +2083,7 @@ class TestProvisionMacaroonViews:
             pretend.call(
                 tag=EventTag.Account.APITokenAdded,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "description": create_macaroon_obj.description.data,
                     "caveats": [
@@ -2165,6 +2179,7 @@ class TestProvisionMacaroonViews:
             pretend.call(
                 tag=EventTag.Account.APITokenAdded,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "description": create_macaroon_obj.description.data,
                     "caveats": [
@@ -2181,6 +2196,7 @@ class TestProvisionMacaroonViews:
             pretend.call(
                 tag=EventTag.Project.APITokenAdded,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "description": create_macaroon_obj.description.data,
                     "user": request.user.username,
@@ -2189,6 +2205,7 @@ class TestProvisionMacaroonViews:
             pretend.call(
                 tag=EventTag.Project.APITokenAdded,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "description": create_macaroon_obj.description.data,
                     "user": request.user.username,
@@ -2321,6 +2338,7 @@ class TestProvisionMacaroonViews:
             pretend.call(
                 tag=EventTag.Account.APITokenRemoved,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
                 additional={"macaroon_id": delete_macaroon_obj.macaroon_id.data},
             )
         ]
@@ -2388,6 +2406,7 @@ class TestProvisionMacaroonViews:
         assert pyramid_request.user.record_event.calls == [
             pretend.call(
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
                 tag=EventTag.Account.APITokenRemoved,
                 additional={"macaroon_id": delete_macaroon_obj.macaroon_id.data},
             )
@@ -2396,6 +2415,7 @@ class TestProvisionMacaroonViews:
             pretend.call(
                 tag=EventTag.Project.APITokenRemoved,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
                 additional={
                     "description": "fake macaroon",
                     "user": pyramid_request.user.username,
@@ -2404,6 +2424,7 @@ class TestProvisionMacaroonViews:
             pretend.call(
                 tag=EventTag.Project.APITokenRemoved,
                 ip_address=pyramid_request.remote_addr,
+                request=pyramid_request,
                 additional={
                     "description": "fake macaroon",
                     "user": pyramid_request.user.username,
@@ -3965,6 +3986,7 @@ class TestManageProjectRelease:
             pretend.call(
                 tag=EventTag.Project.ReleaseYank,
                 ip_address=db_request.remote_addr,
+                request=db_request,
                 additional={
                     "submitted_by": db_request.user.username,
                     "canonical_version": release.canonical_version,
@@ -4119,6 +4141,7 @@ class TestManageProjectRelease:
             pretend.call(
                 tag=EventTag.Project.ReleaseUnyank,
                 ip_address=db_request.remote_addr,
+                request=db_request,
                 additional={
                     "submitted_by": db_request.user.username,
                     "canonical_version": release.canonical_version,
@@ -4276,6 +4299,7 @@ class TestManageProjectRelease:
             pretend.call(
                 tag=EventTag.Project.ReleaseRemove,
                 ip_address=db_request.remote_addr,
+                request=db_request,
                 additional={
                     "submitted_by": db_request.user.username,
                     "canonical_version": release.canonical_version,
@@ -6135,6 +6159,7 @@ class TestManageOIDCPublisherViews:
             pretend.call(
                 tag=EventTag.Project.OIDCPublisherAdded,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "publisher": "GitHub",
                     "id": "fakeid",
@@ -6231,6 +6256,7 @@ class TestManageOIDCPublisherViews:
             pretend.call(
                 tag=EventTag.Project.OIDCPublisherAdded,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "publisher": "GitHub",
                     "id": "fakeid",
@@ -6521,6 +6547,7 @@ class TestManageOIDCPublisherViews:
             pretend.call(
                 tag=EventTag.Project.OIDCPublisherRemoved,
                 ip_address=db_request.remote_addr,
+                request=db_request,
                 additional={
                     "publisher": publisher.publisher_name,
                     "id": str(publisher.id),
@@ -6612,6 +6639,7 @@ class TestManageOIDCPublisherViews:
             pretend.call(
                 tag=EventTag.Project.OIDCPublisherRemoved,
                 ip_address=db_request.remote_addr,
+                request=db_request,
                 additional={
                     "publisher": publisher.publisher_name,
                     "id": str(publisher.id),

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -466,6 +466,7 @@ def test_mint_token_from_oidc_no_pending_publisher_ok(
         pretend.call(
             tag=EventTag.Project.ShortLivedAPITokenAdded,
             ip_address="0.0.0.0",
+            request=request,
             additional={
                 "expires": 900,
                 "publisher_name": "fakepublishername",

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -981,13 +981,10 @@ class TestGenericLocalBlobStorage:
 
 def test_project_service_factory():
     db = pretend.stub()
-    remote_addr = pretend.stub()
     request = pretend.stub(
         db=db,
-        remote_addr=remote_addr,
         find_service=lambda iface, name=None, context=None: None,
     )
 
     service = project_service_factory(pretend.stub(), request)
     assert service.db == db
-    assert service.remote_addr == remote_addr

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -349,8 +349,8 @@ class LoginForm(PasswordMixin, UsernameMixin, forms.Form):
                 send_password_compromised_email_hibp(self.request, user)
                 self.user_service.disable_password(
                     user.id,
+                    self.request,
                     reason=DisableReason.CompromisedPassword,
-                    request=self.request,
                 )
                 raise wtforms.validators.ValidationError(
                     markupsafe.Markup(self.breach_service.failure_message)

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -160,6 +160,7 @@ class PasswordMixin:
                     user.record_event(
                         tag=f"account:{self.action}:failure",
                         ip_address=self.request.remote_addr,
+                        request=self.request,
                         additional={"reason": "invalid_password"},
                     )
                     raise wtforms.validators.ValidationError(INVALID_PASSWORD_MESSAGE)
@@ -349,7 +350,7 @@ class LoginForm(PasswordMixin, UsernameMixin, forms.Form):
                 self.user_service.disable_password(
                     user.id,
                     reason=DisableReason.CompromisedPassword,
-                    ip_address=self.request.remote_addr,
+                    request=self.request,
                 )
                 raise wtforms.validators.ValidationError(
                     markupsafe.Markup(self.breach_service.failure_message)
@@ -373,6 +374,7 @@ class TOTPAuthenticationForm(TOTPValueMixin, _TwoFactorAuthenticationForm):
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"reason": "invalid_totp"},
             )
             raise wtforms.validators.ValidationError(_("Invalid TOTP code."))
@@ -409,6 +411,7 @@ class WebAuthnAuthenticationForm(WebAuthnCredentialMixin, _TwoFactorAuthenticati
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"reason": "invalid_webauthn"},
             )
             raise wtforms.validators.ValidationError(str(e))
@@ -450,6 +453,7 @@ class RecoveryCodeAuthenticationForm(
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"reason": "invalid_recovery_code"},
             )
             raise wtforms.validators.ValidationError(_("Invalid recovery code."))
@@ -458,6 +462,7 @@ class RecoveryCodeAuthenticationForm(
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"reason": "burned_recovery_code"},
             )
             raise wtforms.validators.ValidationError(

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -116,7 +116,7 @@ class IUserService(Interface):
         Updates the user object
         """
 
-    def disable_password(user_id, reason=None):
+    def disable_password(user_id, request, reason=None):
         """
         Disables the given user's password, preventing further login until the user
         resets their password. If a reason was given, this will be persisted and reset

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -86,8 +86,8 @@ def _basic_auth_check(username, password, request):
                 send_password_compromised_email_hibp(request, user)
                 login_service.disable_password(
                     user.id,
+                    request,
                     reason=DisableReason.CompromisedPassword,
-                    request=request,
                 )
                 raise _format_exc_status(
                     BasicAuthBreachedPassword(), breach_service.failure_message_plain

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -87,7 +87,7 @@ def _basic_auth_check(username, password, request):
                 login_service.disable_password(
                     user.id,
                     reason=DisableReason.CompromisedPassword,
-                    ip_address=request.remote_addr,
+                    request=request,
                 )
                 raise _format_exc_status(
                     BasicAuthBreachedPassword(), breach_service.failure_message_plain
@@ -97,6 +97,7 @@ def _basic_auth_check(username, password, request):
             user.record_event(
                 tag=EventTag.Account.LoginSuccess,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"auth_method": "basic"},
             )
             return True
@@ -104,6 +105,7 @@ def _basic_auth_check(username, password, request):
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={"reason": "invalid_password", "auth_method": "basic"},
             )
             raise _format_exc_status(

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -300,7 +300,7 @@ class DatabaseUserService:
 
         return user
 
-    def disable_password(self, user_id, reason=None, request=None):
+    def disable_password(self, user_id, request, reason=None):
         user = self.get_user(user_id)
         user.password = self.hasher.disable()
         user.disabled_for = reason

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -300,13 +300,14 @@ class DatabaseUserService:
 
         return user
 
-    def disable_password(self, user_id, reason=None, ip_address="127.0.0.1"):
+    def disable_password(self, user_id, reason=None, request=None):
         user = self.get_user(user_id)
         user.password = self.hasher.disable()
         user.disabled_for = reason
         user.record_event(
             tag=EventTag.Account.PasswordDisabled,
-            ip_address=ip_address,
+            ip_address=request.remote_addr,
+            request=request,
             additional={"reason": reason.value if reason else None},
         )
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -452,7 +452,9 @@ def recovery_code(request, _form_class=RecoveryCodeAuthenticationForm):
 
             user = user_service.get_user(userid)
             user.record_event(
-                tag=EventTag.Account.RecoveryCodesUsed, ip_address=request.remote_addr
+                tag=EventTag.Account.RecoveryCodesUsed,
+                ip_address=request.remote_addr,
+                request=request,
             )
 
             request.session.flash(
@@ -575,6 +577,7 @@ def register(request, _form_class=RegistrationForm):
         user.record_event(
             tag=EventTag.Account.AccountCreate,
             ip_address=request.remote_addr,
+            request=request,
             additional={"email": form.email.data},
         )
 
@@ -622,6 +625,7 @@ def request_password_reset(request, _form_class=RequestPasswordResetForm):
             user.record_event(
                 tag=EventTag.Account.PasswordResetRequest,
                 ip_address=request.remote_addr,
+                request=request,
             )
             user_service.ratelimiters["password.reset"].hit(user.id)
 
@@ -632,6 +636,7 @@ def request_password_reset(request, _form_class=RequestPasswordResetForm):
             user.record_event(
                 tag=EventTag.Account.PasswordResetAttempt,
                 ip_address=request.remote_addr,
+                request=request,
             )
             request.session.flash(
                 request._(
@@ -735,7 +740,9 @@ def reset_password(request, _form_class=ResetPasswordForm):
         # Update password.
         user_service.update_user(user.id, password=form.new_password.data)
         user.record_event(
-            tag=EventTag.Account.PasswordReset, ip_address=request.remote_addr
+            tag=EventTag.Account.PasswordReset,
+            ip_address=request.remote_addr,
+            request=request,
         )
         password_reset_limiter.clear(user.id)
 
@@ -800,6 +807,7 @@ def verify_email(request):
     email.user.record_event(
         tag=EventTag.Account.EmailVerified,
         ip_address=request.remote_addr,
+        request=request,
         additional={"email": email.email, "primary": email.primary},
     )
 
@@ -908,6 +916,7 @@ def verify_organization_role(request):
         organization.record_event(
             tag=EventTag.Organization.OrganizationRoleDeclineInvite,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by_user_id": str(submitter_user.id),
                 "role_name": desired_role,
@@ -917,6 +926,7 @@ def verify_organization_role(request):
         user.record_event(
             tag=EventTag.Account.OrganizationRoleDeclineInvite,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by_user_id": str(submitter_user.id),
                 "organization_name": organization.name,
@@ -961,6 +971,7 @@ def verify_organization_role(request):
     organization.record_event(
         tag=EventTag.Organization.OrganizationRoleAdd,
         ip_address=request.remote_addr,
+        request=request,
         additional={
             "submitted_by_user_id": str(submitter_user.id),
             "role_name": desired_role,
@@ -970,6 +981,7 @@ def verify_organization_role(request):
     user.record_event(
         tag=EventTag.Account.OrganizationRoleAdd,
         ip_address=request.remote_addr,
+        request=request,
         additional={
             "submitted_by_user_id": str(submitter_user.id),
             "organization_name": organization.name,
@@ -1082,6 +1094,7 @@ def verify_project_role(request):
         project.record_event(
             tag=EventTag.Project.RoleDeclineInvite,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by": submitter_user.username,
                 "role_name": desired_role,
@@ -1091,6 +1104,7 @@ def verify_project_role(request):
         user.record_event(
             tag=EventTag.Account.RoleDeclineInvite,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by": submitter_user.username,
                 "project_name": project.name,
@@ -1119,6 +1133,7 @@ def verify_project_role(request):
     project.record_event(
         tag=EventTag.Project.RoleAdd,
         ip_address=request.remote_addr,
+        request=request,
         additional={
             "submitted_by": request.user.username,
             "role_name": desired_role,
@@ -1128,6 +1143,7 @@ def verify_project_role(request):
     user.record_event(
         tag=EventTag.Account.RoleAdd,
         ip_address=request.remote_addr,
+        request=request,
         additional={
             "submitted_by": request.user.username,
             "project_name": project.name,
@@ -1223,6 +1239,7 @@ def _login_user(request, userid, two_factor_method=None, two_factor_label=None):
     user.record_event(
         tag=EventTag.Account.LoginSuccess,
         ip_address=request.remote_addr,
+        request=request,
         additional={
             "two_factor_method": two_factor_method,
             "two_factor_label": two_factor_label,
@@ -1502,6 +1519,7 @@ class ManageAccountPublishingViews:
         self.request.user.record_event(
             tag=EventTag.Account.PendingOIDCPublisherAdded,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "project": pending_publisher.project_name,
                 "publisher": pending_publisher.publisher_name,
@@ -1591,6 +1609,7 @@ class ManageAccountPublishingViews:
         self.request.user.record_event(
             tag=EventTag.Account.PendingOIDCPublisherRemoved,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "project": pending_publisher.project_name,
                 "publisher": pending_publisher.publisher_name,

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -289,7 +289,9 @@ def user_reset_password(user, request):
 
     login_service = request.find_service(IUserService, context=None)
     send_password_compromised_email(request, user)
-    login_service.disable_password(user.id, reason=DisableReason.CompromisedPassword)
+    login_service.disable_password(
+        user.id, reason=DisableReason.CompromisedPassword, request=request
+    )
 
     request.session.flash(f"Reset password for {user.username!r}", queue="success")
     return HTTPSeeOther(request.route_path("admin.user.detail", username=user.username))

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -290,7 +290,7 @@ def user_reset_password(user, request):
     login_service = request.find_service(IUserService, context=None)
     send_password_compromised_email(request, user)
     login_service.disable_password(
-        user.id, reason=DisableReason.CompromisedPassword, request=request
+        user.id, request, reason=DisableReason.CompromisedPassword
     )
 
     request.session.flash(f"Reset password for {user.username!r}", queue="success")

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -69,6 +69,7 @@ def send_email(task, request, recipient, msg, success_event):
         sender.send(recipient, msg)
         user_service = request.find_service(IUserService, context=None)
         user = user_service.get_user(success_event.pop("user_id"))
+        success_event["request"] = request
         if user is not None:  # We send account deletion confirmation emails
             user.record_event(**success_event)
     except (BadHeaders, EncodingError, InvalidMessage) as exc:

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -130,28 +130,19 @@ class HasEvents:
         """Records an Event record on the associated model."""
         session = orm.object_session(self)
 
-        if request is not None:
-            # Get-or-create a new IpAddress object
-            ip_address_obj = request.ip_address
-            # Add `request.ip_address.geoip_info` data to `Event.additional`
-            if ip_address_obj.geoip_info is not None:
-                additional = additional or {}
-                additional["geoip_info"] = ip_address_obj.geoip_info
+        # Get-or-create a new IpAddress object
+        ip_address_obj = request.ip_address
+        # Add `request.ip_address.geoip_info` data to `Event.additional`
+        if ip_address_obj.geoip_info is not None:
+            additional = additional or {}
+            additional["geoip_info"] = ip_address_obj.geoip_info
 
-            event = self.Event(
-                source=self,
-                tag=tag,
-                ip_address_obj=ip_address_obj,
-                additional=additional,
-            )
-        else:
-            # Our hope is to eventually remove this once `Request` is not None
-            event = self.Event(
-                source=self,
-                tag=tag,
-                ip_address=ip_address,
-                additional=additional,
-            )
+        event = self.Event(
+            source=self,
+            tag=tag,
+            ip_address_obj=ip_address_obj,
+            additional=additional,
+        )
 
         session.add(event)
 

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -124,9 +124,7 @@ class HasEvents:
             back_populates="source",
         )
 
-    def record_event(
-        self, *, tag, ip_address, request: Request, additional=None
-    ):
+    def record_event(self, *, tag, ip_address, request: Request, additional=None):
         """Records an Event record on the associated model."""
         session = orm.object_session(self)
 

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -125,7 +125,7 @@ class HasEvents:
         )
 
     def record_event(
-        self, *, tag, ip_address, request: Request = None, additional=None
+        self, *, tag, ip_address, request: Request, additional=None
     ):
         """Records an Event record on the associated model."""
         session = orm.object_session(self)

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -970,7 +970,9 @@ def file_upload(request):
 
         project_service = request.find_service(IProjectService)
         try:
-            project = project_service.create_project(form.name.data, request.user)
+            project = project_service.create_project(
+                form.name.data, request.user, request
+            )
         except RateLimiterException:
             msg = "Too many new projects created"
             raise _exc_with_message(HTTPTooManyRequests, msg)
@@ -1169,6 +1171,7 @@ def file_upload(request):
         project.record_event(
             tag=EventTag.Project.ReleaseAdd,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by": request.user.username
                 if request.user
@@ -1409,6 +1412,7 @@ def file_upload(request):
         file_.record_event(
             tag=EventTag.File.FileAdd,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "filename": file_.filename,
                 "submitted_by": request.user.username

--- a/warehouse/integrations/github/utils.py
+++ b/warehouse/integrations/github/utils.py
@@ -245,6 +245,7 @@ def _analyze_disclosure(request, disclosure_record, origin):
     database_macaroon.user.record_event(
         tag=EventTag.Account.APITokenRemovedLeak,
         ip_address=request.remote_addr,
+        request=request,
         additional={
             "macaroon_id": str(database_macaroon.id),
             "public_url": disclosure.public_url,

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -41,62 +41,62 @@ msgid ""
 "different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:137 warehouse/accounts/forms.py:185
-#: warehouse/accounts/forms.py:198
+#: warehouse/accounts/forms.py:137 warehouse/accounts/forms.py:186
+#: warehouse/accounts/forms.py:199
 msgid "Password too long."
 msgstr ""
 
-#: warehouse/accounts/forms.py:173
+#: warehouse/accounts/forms.py:174
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for ${time}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/forms.py:201
+#: warehouse/accounts/forms.py:202
 msgid "Your passwords don't match. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:231 warehouse/accounts/forms.py:242
+#: warehouse/accounts/forms.py:232 warehouse/accounts/forms.py:243
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:250
+#: warehouse/accounts/forms.py:251
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:261
+#: warehouse/accounts/forms.py:262
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:268
+#: warehouse/accounts/forms.py:269
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:289 warehouse/manage/forms.py:139
+#: warehouse/accounts/forms.py:290 warehouse/manage/forms.py:139
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:378
+#: warehouse/accounts/forms.py:380
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:395
+#: warehouse/accounts/forms.py:397
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:455
+#: warehouse/accounts/forms.py:459
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:464
+#: warehouse/accounts/forms.py:469
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:483
+#: warehouse/accounts/forms.py:488
 msgid "No user found with that username or email"
 msgstr ""
 
@@ -133,183 +133,183 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:459 warehouse/manage/views/__init__.py:805
+#: warehouse/accounts/views.py:461 warehouse/manage/views/__init__.py:816
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:545
+#: warehouse/accounts/views.py:547
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:674
+#: warehouse/accounts/views.py:679
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:676
+#: warehouse/accounts/views.py:681
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:678 warehouse/accounts/views.py:779
-#: warehouse/accounts/views.py:878 warehouse/accounts/views.py:1047
+#: warehouse/accounts/views.py:683 warehouse/accounts/views.py:786
+#: warehouse/accounts/views.py:886 warehouse/accounts/views.py:1059
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:682
+#: warehouse/accounts/views.py:687
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:687
+#: warehouse/accounts/views.py:692
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:698
+#: warehouse/accounts/views.py:703
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:716
+#: warehouse/accounts/views.py:721
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:747
+#: warehouse/accounts/views.py:754
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:775
+#: warehouse/accounts/views.py:782
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:777
+#: warehouse/accounts/views.py:784
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:783
+#: warehouse/accounts/views.py:790
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:792
+#: warehouse/accounts/views.py:799
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:795
+#: warehouse/accounts/views.py:802
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:812
+#: warehouse/accounts/views.py:820
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:816
+#: warehouse/accounts/views.py:824
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:821
+#: warehouse/accounts/views.py:829
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:874
+#: warehouse/accounts/views.py:882
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:876
+#: warehouse/accounts/views.py:884
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:882
+#: warehouse/accounts/views.py:890
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:886
+#: warehouse/accounts/views.py:894
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:895
+#: warehouse/accounts/views.py:903
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:946
+#: warehouse/accounts/views.py:956
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1009
+#: warehouse/accounts/views.py:1021
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1043
+#: warehouse/accounts/views.py:1055
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1045
+#: warehouse/accounts/views.py:1057
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1051
+#: warehouse/accounts/views.py:1063
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1055
+#: warehouse/accounts/views.py:1067
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1070
+#: warehouse/accounts/views.py:1082
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1101
+#: warehouse/accounts/views.py:1115
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1168
+#: warehouse/accounts/views.py:1184
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1385 warehouse/accounts/views.py:1405
-#: warehouse/accounts/views.py:1539 warehouse/manage/views/__init__.py:1208
-#: warehouse/manage/views/__init__.py:1227
+#: warehouse/accounts/views.py:1402 warehouse/accounts/views.py:1422
+#: warehouse/accounts/views.py:1557 warehouse/manage/views/__init__.py:1225
+#: warehouse/manage/views/__init__.py:1244
 msgid ""
 "Trusted publishers are temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1419
+#: warehouse/accounts/views.py:1436
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1432
+#: warehouse/accounts/views.py:1449
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1448 warehouse/manage/views/__init__.py:1246
+#: warehouse/accounts/views.py:1465 warehouse/manage/views/__init__.py:1263
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1462 warehouse/manage/views/__init__.py:1260
+#: warehouse/accounts/views.py:1479 warehouse/manage/views/__init__.py:1277
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1481
+#: warehouse/accounts/views.py:1498
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1516
+#: warehouse/accounts/views.py:1534
 msgid "Registered a new publishing publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1553 warehouse/accounts/views.py:1566
-#: warehouse/accounts/views.py:1573
+#: warehouse/accounts/views.py:1571 warehouse/accounts/views.py:1584
+#: warehouse/accounts/views.py:1591
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1579
+#: warehouse/accounts/views.py:1597
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -393,126 +393,126 @@ msgstr ""
 msgid "Account details updated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:218
+#: warehouse/manage/views/__init__.py:219
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:753
+#: warehouse/manage/views/__init__.py:762
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:754
+#: warehouse/manage/views/__init__.py:763
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:860
+#: warehouse/manage/views/__init__.py:871
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:980
+#: warehouse/manage/views/__init__.py:995
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1102
+#: warehouse/manage/views/__init__.py:1117
 msgid "2FA requirement cannot be disabled for critical projects"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1468
-#: warehouse/manage/views/__init__.py:1772
-#: warehouse/manage/views/__init__.py:1881
+#: warehouse/manage/views/__init__.py:1487
+#: warehouse/manage/views/__init__.py:1793
+#: warehouse/manage/views/__init__.py:1903
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1601
-#: warehouse/manage/views/__init__.py:1687
-#: warehouse/manage/views/__init__.py:1789
-#: warehouse/manage/views/__init__.py:1890
+#: warehouse/manage/views/__init__.py:1620
+#: warehouse/manage/views/__init__.py:1707
+#: warehouse/manage/views/__init__.py:1810
+#: warehouse/manage/views/__init__.py:1912
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1613
+#: warehouse/manage/views/__init__.py:1632
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1699
+#: warehouse/manage/views/__init__.py:1719
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1801
+#: warehouse/manage/views/__init__.py:1822
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1902
+#: warehouse/manage/views/__init__.py:1924
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1906
+#: warehouse/manage/views/__init__.py:1928
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2057
+#: warehouse/manage/views/__init__.py:2080
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2165
+#: warehouse/manage/views/__init__.py:2191
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2233
+#: warehouse/manage/views/__init__.py:2261
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2265
+#: warehouse/manage/views/__init__.py:2293
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2278
-#: warehouse/manage/views/organizations.py:895
+#: warehouse/manage/views/__init__.py:2306
+#: warehouse/manage/views/organizations.py:896
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2344
-#: warehouse/manage/views/organizations.py:962
+#: warehouse/manage/views/__init__.py:2374
+#: warehouse/manage/views/organizations.py:963
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2377
+#: warehouse/manage/views/__init__.py:2407
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2388
+#: warehouse/manage/views/__init__.py:2418
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2421
-#: warehouse/manage/views/organizations.py:1151
+#: warehouse/manage/views/__init__.py:2453
+#: warehouse/manage/views/organizations.py:1152
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:871
+#: warehouse/manage/views/organizations.py:872
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:882
+#: warehouse/manage/views/organizations.py:883
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1045
-#: warehouse/manage/views/organizations.py:1087
+#: warehouse/manage/views/organizations.py:1046
+#: warehouse/manage/views/organizations.py:1088
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1055
+#: warehouse/manage/views/organizations.py:1056
 msgid "Organization invitation could not be re-sent."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1102
+#: warehouse/manage/views/organizations.py:1103
 msgid "Expired invitation for '${username}' deleted."
 msgstr ""
 

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -209,6 +209,7 @@ class ManageAccountViews:
             self.request.user.record_event(
                 tag=EventTag.Account.EmailAdd,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"email": email.email},
             )
 
@@ -252,6 +253,7 @@ class ManageAccountViews:
             self.request.user.record_event(
                 tag=EventTag.Account.EmailRemove,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"email": email.email},
             )
             self.request.session.flash(
@@ -288,6 +290,7 @@ class ManageAccountViews:
         self.request.user.record_event(
             tag=EventTag.Account.EmailPrimaryChange,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "old_primary": previous_primary_email.email
                 if previous_primary_email
@@ -334,6 +337,7 @@ class ManageAccountViews:
                 email.user.record_event(
                     tag=EventTag.Account.EmailReverify,
                     ip_address=self.request.remote_addr,
+                    request=self.request,
                     additional={"email": email.email},
                 )
 
@@ -372,6 +376,7 @@ class ManageAccountViews:
             self.request.user.record_event(
                 tag=EventTag.Account.PasswordChange,
                 ip_address=self.request.remote_addr,
+                request=self.request,
             )
             send_password_change_email(self.request, self.request.user)
             self.request.db.flush()  # ensure password_date is available
@@ -550,6 +555,7 @@ class ProvisionTOTPViews:
             self.request.user.record_event(
                 tag=EventTag.Account.TwoFactorMethodAdded,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"method": "totp"},
             )
             self.request.session.flash(
@@ -588,6 +594,7 @@ class ProvisionTOTPViews:
             self.request.user.record_event(
                 tag=EventTag.Account.TwoFactorMethodRemoved,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"method": "totp"},
             )
             self.request.session.flash(
@@ -675,6 +682,7 @@ class ProvisionWebAuthnViews:
             self.request.user.record_event(
                 tag=EventTag.Account.TwoFactorMethodAdded,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"method": "webauthn", "label": form.label.data},
             )
             self.request.session.flash(
@@ -715,6 +723,7 @@ class ProvisionWebAuthnViews:
             self.request.user.record_event(
                 tag=EventTag.Account.TwoFactorMethodRemoved,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"method": "webauthn", "label": form.label.data},
             )
             self.request.session.flash("Security device removed", queue="success")
@@ -761,6 +770,7 @@ class ProvisionRecoveryCodesViews:
         self.request.user.record_event(
             tag=EventTag.Account.RecoveryCodesGenerated,
             ip_address=self.request.remote_addr,
+            request=self.request,
         )
 
         return {"recovery_codes": recovery_codes}
@@ -777,6 +787,7 @@ class ProvisionRecoveryCodesViews:
         self.request.user.record_event(
             tag=EventTag.Account.RecoveryCodesRegenerated,
             ip_address=self.request.remote_addr,
+            request=self.request,
         )
 
         return {"recovery_codes": recovery_codes}
@@ -902,6 +913,7 @@ class ProvisionMacaroonViews:
             self.request.user.record_event(
                 tag=EventTag.Account.APITokenAdded,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={
                     "description": form.description.data,
                     "caveats": recorded_caveats,
@@ -921,6 +933,7 @@ class ProvisionMacaroonViews:
                     project.record_event(
                         tag=EventTag.Project.APITokenAdded,
                         ip_address=self.request.remote_addr,
+                        request=self.request,
                         additional={
                             "description": form.description.data,
                             "user": self.request.user.username,
@@ -953,6 +966,7 @@ class ProvisionMacaroonViews:
             self.request.user.record_event(
                 tag=EventTag.Account.APITokenRemoved,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"macaroon_id": form.macaroon_id.data},
             )
             if "projects" in macaroon.permissions_caveat:
@@ -966,6 +980,7 @@ class ProvisionMacaroonViews:
                     project.record_event(
                         tag=EventTag.Project.APITokenRemoved,
                         ip_address=self.request.remote_addr,
+                        request=self.request,
                         additional={
                             "description": macaroon.description,
                             "user": self.request.user.username,
@@ -1109,6 +1124,7 @@ class ManageProjectSettingsViews:
             self.project.record_event(
                 tag=EventTag.Project.OwnersRequire2FADisabled,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"modified_by": self.request.user.username},
             )
             self.request.session.flash(
@@ -1120,6 +1136,7 @@ class ManageProjectSettingsViews:
             self.project.record_event(
                 tag=EventTag.Project.OwnersRequire2FAEnabled,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={"modified_by": self.request.user.username},
             )
             self.request.session.flash(
@@ -1310,6 +1327,7 @@ class ManageOIDCPublisherViews:
         self.project.record_event(
             tag=EventTag.Project.OIDCPublisherAdded,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "publisher": publisher.publisher_name,
                 "id": str(publisher.id),
@@ -1381,6 +1399,7 @@ class ManageOIDCPublisherViews:
             self.project.record_event(
                 tag=EventTag.Project.OIDCPublisherRemoved,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={
                     "publisher": publisher.publisher_name,
                     "id": str(publisher.id),
@@ -1641,6 +1660,7 @@ class ManageProjectRelease:
         self.release.project.record_event(
             tag=EventTag.Project.ReleaseYank,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "submitted_by": self.request.user.username,
                 "canonical_version": self.release.canonical_version,
@@ -1727,6 +1747,7 @@ class ManageProjectRelease:
         self.release.project.record_event(
             tag=EventTag.Project.ReleaseUnyank,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "submitted_by": self.request.user.username,
                 "canonical_version": self.release.canonical_version,
@@ -1829,6 +1850,7 @@ class ManageProjectRelease:
         self.release.project.record_event(
             tag=EventTag.Project.ReleaseRemove,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "submitted_by": self.request.user.username,
                 "canonical_version": self.release.canonical_version,
@@ -1922,6 +1944,7 @@ class ManageProjectRelease:
         release_file.record_event(
             tag=EventTag.File.FileRemove,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "submitted_by": self.request.user.username,
                 "canonical_version": self.release.canonical_version,
@@ -2082,6 +2105,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         project.record_event(
             tag=EventTag.Project.TeamProjectRoleAdd,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
                 "role_name": role_name.value,
@@ -2091,6 +2115,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         team.organization.record_event(
             tag=EventTag.Organization.TeamProjectRoleAdd,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
                 "project_name": project.name,
@@ -2101,6 +2126,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         team.record_event(
             tag=EventTag.Team.TeamProjectRoleAdd,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
                 "project_name": project.name,
@@ -2193,6 +2219,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         project.record_event(
             tag=EventTag.Project.RoleAdd,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by": request.user.username,
                 "role_name": role_name,
@@ -2202,6 +2229,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         user.record_event(
             tag=EventTag.Account.RoleAdd,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "submitted_by": request.user.username,
                 "project_name": project.name,
@@ -2325,6 +2353,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
             project.record_event(
                 tag=EventTag.Project.RoleInvite,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "submitted_by": request.user.username,
                     "role_name": role_name,
@@ -2334,6 +2363,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
             user.record_event(
                 tag=EventTag.Account.RoleInvite,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "submitted_by": request.user.username,
                     "project_name": project.name,
@@ -2402,6 +2432,7 @@ def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm)
     project.record_event(
         tag=EventTag.Project.RoleRevokeInvite,
         ip_address=request.remote_addr,
+        request=request,
         additional={
             "submitted_by": request.user.username,
             "role_name": role_name,
@@ -2411,6 +2442,7 @@ def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm)
     user.record_event(
         tag=EventTag.Account.RoleRevokeInvite,
         ip_address=request.remote_addr,
+        request=request,
         additional={
             "submitted_by": request.user.username,
             "project_name": project.name,
@@ -2468,6 +2500,7 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
                 project.record_event(
                     tag=EventTag.Project.RoleChange,
                     ip_address=request.remote_addr,
+                    request=request,
                     additional={
                         "submitted_by": request.user.username,
                         "role_name": form.role_name.data,
@@ -2477,6 +2510,7 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
                 role.user.record_event(
                     tag=EventTag.Account.RoleChange,
                     ip_address=request.remote_addr,
+                    request=request,
                     additional={
                         "submitted_by": request.user.username,
                         "project_name": project.name,
@@ -2552,6 +2586,7 @@ def delete_project_role(project, request):
             project.record_event(
                 tag=EventTag.Project.RoleRemove,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "submitted_by": request.user.username,
                     "role_name": role.role_name,

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -797,6 +797,7 @@ class ManageOrganizationProjectsViews:
             project = project_service.create_project(
                 form.new_project_name.data,
                 self.request.user,
+                request=self.request,
                 creator_is_owner=False,
                 ratelimited=False,
             )

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -104,6 +104,7 @@ class ManageTeamSettingsViews:
             self.team.organization.record_event(
                 tag=EventTag.Organization.TeamRename,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={
                     "team_name": self.team.name,
                     "previous_team_name": previous_team_name,
@@ -113,6 +114,7 @@ class ManageTeamSettingsViews:
             self.team.record_event(
                 tag=EventTag.Team.TeamRename,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={
                     "previous_team_name": previous_team_name,
                     "renamed_by_user_id": str(self.request.user.id),
@@ -142,6 +144,7 @@ class ManageTeamSettingsViews:
         organization.record_event(
             tag=EventTag.Organization.TeamDelete,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "deleted_by_user_id": str(self.request.user.id),
                 "team_name": team_name,
@@ -150,6 +153,7 @@ class ManageTeamSettingsViews:
         self.team.record_event(
             tag=EventTag.Team.TeamDelete,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "deleted_by_user_id": str(self.request.user.id),
             },
@@ -296,6 +300,7 @@ class ManageTeamRolesViews:
         self.team.organization.record_event(
             tag=EventTag.Organization.TeamRoleAdd,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "submitted_by_user_id": str(self.request.user.id),
                 "team_name": self.team.name,
@@ -306,6 +311,7 @@ class ManageTeamRolesViews:
         self.team.record_event(
             tag=EventTag.Team.TeamRoleAdd,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "submitted_by_user_id": str(self.request.user.id),
                 "role_name": role_name.value,
@@ -315,6 +321,7 @@ class ManageTeamRolesViews:
         role.user.record_event(
             tag=EventTag.Account.TeamRoleAdd,
             ip_address=self.request.remote_addr,
+            request=self.request,
             additional={
                 "submitted_by_user_id": str(self.request.user.id),
                 "organization_name": self.team.organization.name,
@@ -381,6 +388,7 @@ class ManageTeamRolesViews:
             self.team.organization.record_event(
                 tag=EventTag.Organization.TeamRoleRemove,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={
                     "submitted_by_user_id": str(self.request.user.id),
                     "team_name": self.team.name,
@@ -391,6 +399,7 @@ class ManageTeamRolesViews:
             self.team.record_event(
                 tag=EventTag.Team.TeamRoleRemove,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={
                     "submitted_by_user_id": str(self.request.user.id),
                     "role_name": role.role_name.value,
@@ -400,6 +409,7 @@ class ManageTeamRolesViews:
             role.user.record_event(
                 tag=EventTag.Account.TeamRoleRemove,
                 ip_address=self.request.remote_addr,
+                request=self.request,
                 additional={
                     "submitted_by_user_id": str(self.request.user.id),
                     "organization_name": self.team.organization.name,
@@ -538,6 +548,7 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
                 project.record_event(
                     tag=EventTag.Project.TeamProjectRoleChange,
                     ip_address=request.remote_addr,
+                    request=request,
                     additional={
                         "submitted_by_user_id": str(request.user.id),
                         "role_name": role.role_name.value,
@@ -547,6 +558,7 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
                 role.team.organization.record_event(
                     tag=EventTag.Organization.TeamProjectRoleChange,
                     ip_address=request.remote_addr,
+                    request=request,
                     additional={
                         "submitted_by_user_id": str(request.user.id),
                         "project_name": role.project.name,
@@ -557,6 +569,7 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
                 role.team.record_event(
                     tag=EventTag.Team.TeamProjectRoleChange,
                     ip_address=request.remote_addr,
+                    request=request,
                     additional={
                         "submitted_by_user_id": str(request.user.id),
                         "project_name": role.project.name,
@@ -641,6 +654,7 @@ def delete_team_project_role(project, request):
             project.record_event(
                 tag=EventTag.Project.TeamProjectRoleRemove,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
                     "role_name": role_name.value,
@@ -650,6 +664,7 @@ def delete_team_project_role(project, request):
             team.organization.record_event(
                 tag=EventTag.Organization.TeamProjectRoleRemove,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
                     "project_name": project.name,
@@ -660,6 +675,7 @@ def delete_team_project_role(project, request):
             team.record_event(
                 tag=EventTag.Team.TeamProjectRoleRemove,
                 ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
                     "project_name": project.name,

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -133,6 +133,7 @@ def mint_token_from_oidc(request):
         new_project = project_service.create_project(
             pending_publisher.project_name,
             pending_publisher.added_by,
+            request,
             ratelimited=False,
         )
         oidc_service.reify_pending_publisher(pending_publisher, new_project)
@@ -204,6 +205,7 @@ def mint_token_from_oidc(request):
         project.record_event(
             tag=EventTag.Project.ShortLivedAPITokenAdded,
             ip_address=request.remote_addr,
+            request=request,
             additional={
                 "expires": expires_at,
                 "publisher_name": publisher.publisher_name,

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -74,7 +74,7 @@ class IDocsStorage(Interface):
 
 
 class IProjectService(Interface):
-    def create_project(name, creator, *, creator_is_owner=True):
+    def create_project(name, creator, request, *, creator_is_owner=True):
         """
         Creates a new project, recording a user as its creator.
 

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -369,20 +369,18 @@ class GCSSimpleStorage(GenericGCSBlobStorage):
 
 @implementer(IProjectService)
 class ProjectService:
-    def __init__(self, session, remote_addr, metrics=None, ratelimiters=None) -> None:
+    def __init__(self, session, metrics=None, ratelimiters=None) -> None:
         if ratelimiters is None:
             ratelimiters = {}
 
         self.db = session
-        self.remote_addr = remote_addr
         self.ratelimiters = collections.defaultdict(DummyRateLimiter, ratelimiters)
         self._metrics = metrics
 
-    def _check_ratelimits(self, creator):
+    def _check_ratelimits(self, request, creator):
         # First we want to check if a single IP is exceeding our rate limiter.
-        print(self.ratelimiters)
-        if self.remote_addr is not None:
-            if not self.ratelimiters["project.create.ip"].test(self.remote_addr):
+        if request.remote_addr is not None:
+            if not self.ratelimiters["project.create.ip"].test(request.remote_addr):
                 logger.warning("IP failed project create threshold reached.")
                 self._metrics.increment(
                     "warehouse.project.create.ratelimited",
@@ -390,7 +388,7 @@ class ProjectService:
                 )
                 raise TooManyProjectsCreated(
                     resets_in=self.ratelimiters["project.create.ip"].resets_in(
-                        self.remote_addr
+                        request.remote_addr
                     )
                 )
 
@@ -402,17 +400,19 @@ class ProjectService:
             )
             raise TooManyProjectsCreated(
                 resets_in=self.ratelimiters["project.create.user"].resets_in(
-                    self.remote_addr
+                    request.remote_addr
                 )
             )
 
-    def _hit_ratelimits(self, creator):
+    def _hit_ratelimits(self, request, creator):
         self.ratelimiters["project.create.user"].hit(creator.id)
-        self.ratelimiters["project.create.ip"].hit(self.remote_addr)
+        self.ratelimiters["project.create.ip"].hit(request.remote_addr)
 
-    def create_project(self, name, creator, *, creator_is_owner=True, ratelimited=True):
+    def create_project(
+        self, name, creator, request, *, creator_is_owner=True, ratelimited=True
+    ):
         if ratelimited:
-            self._check_ratelimits(creator)
+            self._check_ratelimits(request, creator)
 
         project = Project(name=name)
         self.db.add(project)
@@ -425,12 +425,13 @@ class ProjectService:
                 name=project.name,
                 action="create",
                 submitted_by=creator,
-                submitted_from=self.remote_addr,
+                submitted_from=request.remote_addr,
             )
         )
         project.record_event(
             tag=EventTag.Project.ProjectCreate,
-            ip_address=self.remote_addr,
+            ip_address=request.remote_addr,
+            request=request,
             additional={"created_by": creator.username},
         )
 
@@ -445,12 +446,13 @@ class ProjectService:
                     name=project.name,
                     action=f"add Owner {creator.username}",
                     submitted_by=creator,
-                    submitted_from=self.remote_addr,
+                    submitted_from=request.remote_addr,
                 )
             )
             project.record_event(
                 tag=EventTag.Project.RoleAdd,
-                ip_address=self.remote_addr,
+                ip_address=request.remote_addr,
+                request=request,
                 additional={
                     "submitted_by": creator.username,
                     "role_name": "Owner",
@@ -459,7 +461,7 @@ class ProjectService:
             )
 
         if ratelimited:
-            self._hit_ratelimits(creator)
+            self._hit_ratelimits(request, creator)
         return project
 
 
@@ -473,6 +475,4 @@ def project_service_factory(context, request):
             IRateLimiter, name="project.create.ip", context=None
         ),
     }
-    return ProjectService(
-        request.db, request.remote_addr, metrics=metrics, ratelimiters=ratelimiters
-    )
+    return ProjectService(request.db, metrics=metrics, ratelimiters=ratelimiters)


### PR DESCRIPTION
One more step towards #8158, updates all `record_event` calls to use a `request`.