### PR TITLE
chore: remove calls to JournalEntry.submitted_from

### DIFF
--- a/tests/unit/admin/views/test_journals.py
+++ b/tests/unit/admin/views/test_journals.py
@@ -119,27 +119,3 @@ class TestProjectList:
             "journals": [journals[0]],
             "query": f"version:{journals[0].version}",
         }
-
-    def test_query_term_ip(self, db_request):
-        ipv4 = "10.6.6.6"
-        ipv6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
-        journals0 = sorted(
-            [JournalEntryFactory.create(submitted_from=ipv4) for _ in range(10)],
-            key=lambda j: (j.submitted_date, j.id),
-            reverse=True,
-        )
-        journals1 = sorted(
-            [JournalEntryFactory.create(submitted_from=ipv6) for _ in range(10)],
-            key=lambda j: (j.submitted_date, j.id),
-            reverse=True,
-        )
-
-        db_request.GET["q"] = f"ip:{ipv4}"
-        result = views.journals_list(db_request)
-
-        assert result == {"journals": journals0, "query": f"ip:{ipv4}"}
-
-        db_request.GET["q"] = f"ip:{ipv6}"
-        result = views.journals_list(db_request)
-
-        assert result == {"journals": journals1, "query": f"ip:{ipv6}"}

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -1472,16 +1472,12 @@ class TestFileUpload:
             .order_by("submitted_date", "id")
             .all()
         )
-        assert [
-            (j.name, j.version, j.action, j.submitted_by, j.submitted_from)
-            for j in journals
-        ] == [
+        assert [(j.name, j.version, j.action, j.submitted_by) for j in journals] == [
             (
                 release.project.name,
                 release.version,
                 f"add source file {filename}",
                 user,
-                db_request.remote_addr,
             )
         ]
 
@@ -2118,26 +2114,11 @@ class TestFileUpload:
             .order_by("submitted_date", "id")
             .all()
         )
-        assert [
-            (j.name, j.version, j.action, j.submitted_by, j.submitted_from)
-            for j in journals
-        ] == [
-            ("example", None, "create", user, db_request.remote_addr),
-            (
-                "example",
-                None,
-                f"add Owner {user.username}",
-                user,
-                db_request.remote_addr,
-            ),
-            ("example", "1.0", "new release", user, db_request.remote_addr),
-            (
-                "example",
-                "1.0",
-                "add source file example-1.0.tar.gz",
-                user,
-                db_request.remote_addr,
-            ),
+        assert [(j.name, j.version, j.action, j.submitted_by) for j in journals] == [
+            ("example", None, "create", user),
+            ("example", None, f"add Owner {user.username}", user),
+            ("example", "1.0", "new release", user),
+            ("example", "1.0", "add source file example-1.0.tar.gz", user),
         ]
 
     def test_upload_fails_with_previously_used_filename(
@@ -2768,16 +2749,12 @@ class TestFileUpload:
             .order_by("submitted_date", "id")
             .all()
         )
-        assert [
-            (j.name, j.version, j.action, j.submitted_by, j.submitted_from)
-            for j in journals
-        ] == [
+        assert [(j.name, j.version, j.action, j.submitted_by) for j in journals] == [
             (
                 release.project.name,
                 release.version,
                 f"add cp34 file {filename}",
                 user,
-                db_request.remote_addr,
             )
         ]
 
@@ -2902,16 +2879,12 @@ class TestFileUpload:
             .order_by("submitted_date", "id")
             .all()
         )
-        assert [
-            (j.name, j.version, j.action, j.submitted_by, j.submitted_from)
-            for j in journals
-        ] == [
+        assert [(j.name, j.version, j.action, j.submitted_by) for j in journals] == [
             (
                 release.project.name,
                 release.version,
                 f"add cp34 file {filename}",
                 user,
-                db_request.remote_addr,
             )
         ]
 
@@ -3167,23 +3140,18 @@ class TestFileUpload:
             .order_by("submitted_date", "id")
             .all()
         )
-        assert [
-            (j.name, j.version, j.action, j.submitted_by, j.submitted_from)
-            for j in journals
-        ] == [
+        assert [(j.name, j.version, j.action, j.submitted_by) for j in journals] == [
             (
                 release.project.name,
                 release.version,
                 "new release",
                 user,
-                db_request.remote_addr,
             ),
             (
                 release.project.name,
                 release.version,
                 f"add source file {filename}",
                 user,
-                db_request.remote_addr,
             ),
         ]
 
@@ -3464,26 +3432,11 @@ class TestFileUpload:
             .order_by("submitted_date", "id")
             .all()
         )
-        assert [
-            (j.name, j.version, j.action, j.submitted_by, j.submitted_from)
-            for j in journals
-        ] == [
-            ("example", None, "create", user, db_request.remote_addr),
-            (
-                "example",
-                None,
-                f"add Owner {user.username}",
-                user,
-                db_request.remote_addr,
-            ),
-            ("example", "1.0", "new release", user, db_request.remote_addr),
-            (
-                "example",
-                "1.0",
-                "add source file example-1.0.tar.gz",
-                user,
-                db_request.remote_addr,
-            ),
+        assert [(j.name, j.version, j.action, j.submitted_by) for j in journals] == [
+            ("example", None, "create", user),
+            ("example", None, f"add Owner {user.username}", user),
+            ("example", "1.0", "new release", user),
+            ("example", "1.0", "add source file example-1.0.tar.gz", user),
         ]
 
     def test_upload_succeeds_with_signature(

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -3975,7 +3975,6 @@ class TestManageProjectRelease:
         assert entry.action == "yank release"
         assert entry.version == release.version
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
         assert db_request.session.flash.calls == [
             pretend.call(f"Yanked release {release.version!r}", queue="success")
         ]
@@ -4129,7 +4128,6 @@ class TestManageProjectRelease:
         assert entry.action == "unyank release"
         assert entry.version == release.version
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
 
         assert db_request.session.flash.calls == [
             pretend.call(f"Un-yanked release {release.version!r}", queue="success")
@@ -4287,7 +4285,6 @@ class TestManageProjectRelease:
         assert entry.action == "remove release"
         assert entry.version == release.version
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
 
         assert db_request.session.flash.calls == [
             pretend.call(f"Deleted release {release.version!r}", queue="success")
@@ -4474,7 +4471,6 @@ class TestManageProjectRelease:
                 version=release.version,
                 action=f"remove file {release_file.filename}",
                 submitted_by=user,
-                submitted_from=db_request.remote_addr,
             )
             .one()
         )
@@ -5460,7 +5456,6 @@ class TestChangeProjectRole:
         assert entry.name == project.name
         assert entry.action == "change Owner testuser to Maintainer"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
 
     def test_change_role_invalid_role_name(self, pyramid_request):
         project = pretend.stub(name="foobar")
@@ -5578,7 +5573,6 @@ class TestDeleteProjectRole:
         assert entry.name == project.name
         assert entry.action == "remove Owner testuser"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
 
     def test_delete_missing_role(self, db_request):
         project = ProjectFactory.create(name="foobar")
@@ -5674,7 +5668,6 @@ class TestDeleteProjectRole:
         assert entry.name == project.name
         assert entry.action == "remove Owner testuser"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
 
     def test_delete_non_owner_role(self, db_request):
         project = ProjectFactory.create(name="foobar")

--- a/tests/unit/manage/views/test_teams.py
+++ b/tests/unit/manage/views/test_teams.py
@@ -838,7 +838,6 @@ class TestChangeTeamProjectRole:
         assert entry.name == organization_project.name
         assert entry.action == f"change Owner {organization_team.name} to Maintainer"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
 
     def test_change_role_invalid_role_name(self, pyramid_request, organization_project):
         pyramid_request.method = "POST"
@@ -1023,7 +1022,6 @@ class TestDeleteTeamProjectRole:
         assert entry.name == organization_project.name
         assert entry.action == f"remove Owner {organization_team.name}"
         assert entry.submitted_by == db_request.user
-        assert entry.submitted_from == db_request.remote_addr
 
     def test_delete_missing_role(self, db_request, organization_project):
         missing_role_id = str(uuid.uuid4())

--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -140,7 +140,6 @@ def test_remove_project(db_request, flash):
     )
     assert journal_entry.action == "remove project"
     assert journal_entry.submitted_by == db_request.user
-    assert journal_entry.submitted_from == db_request.remote_addr
 
 
 @pytest.mark.parametrize("flash", [True, False])
@@ -164,7 +163,6 @@ def test_destroy_docs(db_request, flash):
     )
     assert journal_entry.action == "docdestroy"
     assert journal_entry.submitted_by == db_request.user
-    assert journal_entry.submitted_from == db_request.remote_addr
 
     assert not (
         db_request.db.query(Project)

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1127,7 +1127,6 @@ def verify_project_role(request):
             name=project.name,
             action=f"accepted {desired_role} {user.username}",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
         )
     )
     project.record_event(

--- a/warehouse/admin/templates/admin/journals/list.html
+++ b/warehouse/admin/templates/admin/journals/list.html
@@ -26,7 +26,7 @@
   <div class="card-body">
     <form>
       <div class="input-group input-group-lg">
-        <input name="q" type="text" class="form-control input-lg" placeholder="Search: supported terms are user: project: version: ip:"{% if query %} value="{{ query }}"{% endif %}>
+        <input name="q" type="text" class="form-control input-lg" placeholder="Search: supported terms are user: project: version:"{% if query %} value="{{ query }}"{% endif %}>
         <div class="input-group-btn input-group-append">
           <button type="submit" class="btn btn-default"><i class="fa fa-search"></i></button>
         </div>
@@ -44,7 +44,6 @@
         <th>Version</th>
         <th>Date</th>
         <th>Submitted By</th>
-        <th>Submitted From</th>
         <th>Action</th>
       </tr>
       </thead>
@@ -55,13 +54,6 @@
         <td>{{ journal.version }}</td>
         <td>{{ journal.submitted_date }}</td>
         <td><a href="{{ request.route_path('admin.user.detail', username=journal.submitted_by.username) }}">{{ journal.submitted_by.username }}</a></td>
-        <td>
-          {% if journal.submitted_from %}
-          <a href="{{ request.route_path('admin.journals.list', _query={'q': 'ip:' + journal.submitted_from}) }}">
-            {{ journal.submitted_from }}
-          </a>
-          {% endif %}
-        </td>
         <td>{{ journal.action }}</td>
       </tr>
       {% endfor %}

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -280,7 +280,6 @@
             <th>version</th>
             <th>date</th>
             <th>submitted_by</th>
-            <th>submitted_from</th>
             <th>action</th>
           </tr>
         </thead>
@@ -291,7 +290,6 @@
             <td>{{ entry.version }}</td>
             <td>{{ entry.submitted_date }}</td>
             <td><a href="{{ request.route_path('admin.user.detail', username=entry.submitted_by.username) }}">{{ entry.submitted_by.username }}</a></td>
-            <td>{{ entry.submitted_from }}</td>
             <td>{{ entry.action }}</td>
           </tr>
           {% endfor %}

--- a/warehouse/admin/templates/admin/projects/journals_list.html
+++ b/warehouse/admin/templates/admin/projects/journals_list.html
@@ -46,7 +46,6 @@
         <th>Version</th>
         <th>Date</th>
         <th>Submitted By</th>
-        <th>Submitted From</th>
         <th>Action</th>
       </tr>
       </thead>
@@ -58,7 +57,6 @@
         <td>{{ journal.version }}</td>
         <td>{{ journal.submitted_date }}</td>
         <td><a href="{{ request.route_path('admin.user.detail', username=journal.submitted_by.username) }}">{{ journal.submitted_by.username }}</a></td>
-        <td>{{ journal.submitted_from }}</td>
         <td>{{ journal.action }}</td>
       </tr>
       {% endfor %}

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -103,7 +103,7 @@
         <tr>
           <td>{{ journal.action }}</td>
           <td>{{ journal.submitted_date|format_datetime() }}</td>
-          <td>{{ journal.submitted_by.username }} from {{ journal.submitted_from }}</td>
+          <td>{{ journal.submitted_by.username }}</td>
         </tr>
         {% endfor %}
         </tbody>

--- a/warehouse/admin/views/journals.py
+++ b/warehouse/admin/views/journals.py
@@ -55,8 +55,6 @@ def journals_list(request):
                     filters.append(JournalEntry.version.ilike(value))
                 if field.lower() == "user":
                     filters.append(JournalEntry._submitted_by.like(value))
-                if field.lower() == "ip":
-                    filters.append(JournalEntry.submitted_from.ilike(value))
             else:
                 filters.append(JournalEntry.name.ilike(term))
 

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -404,7 +404,6 @@ def add_role(project, request):
             name=project.name,
             action=f"add {role_name} {user.username}",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
         )
     )
 
@@ -455,7 +454,6 @@ def delete_role(project, request):
             name=project.name,
             action=f"remove {role.role_name} {role.user.username}",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
         )
     )
 

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -207,7 +207,6 @@ def _nuke_user(user, request):
                 name=project.name,
                 action="remove project",
                 submitted_by=request.user,
-                submitted_from=request.remote_addr,
             )
         )
     projects.delete(synchronize_session=False)
@@ -239,7 +238,6 @@ def _nuke_user(user, request):
             name=f"user:{user.username}",
             action="nuke user",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
         )
     )
 

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1164,7 +1164,6 @@ def file_upload(request):
                 version=release.version,
                 action="new release",
                 submitted_by=request.user if request.user else None,
-                submitted_from=request.remote_addr,
             )
         )
 
@@ -1437,7 +1436,6 @@ def file_upload(request):
                     python_version=file_.python_version, filename=file_.filename
                 ),
                 submitted_by=request.user if request.user else None,
-                submitted_from=request.remote_addr,
             )
         )
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -262,54 +262,54 @@ msgstr ""
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1184
+#: warehouse/accounts/views.py:1183
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1402 warehouse/accounts/views.py:1422
-#: warehouse/accounts/views.py:1557 warehouse/manage/views/__init__.py:1225
+#: warehouse/accounts/views.py:1401 warehouse/accounts/views.py:1421
+#: warehouse/accounts/views.py:1556 warehouse/manage/views/__init__.py:1225
 #: warehouse/manage/views/__init__.py:1244
 msgid ""
 "Trusted publishers are temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1436
+#: warehouse/accounts/views.py:1435
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1449
+#: warehouse/accounts/views.py:1448
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1465 warehouse/manage/views/__init__.py:1263
+#: warehouse/accounts/views.py:1464 warehouse/manage/views/__init__.py:1263
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1479 warehouse/manage/views/__init__.py:1277
+#: warehouse/accounts/views.py:1478 warehouse/manage/views/__init__.py:1277
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1498
+#: warehouse/accounts/views.py:1497
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1534
+#: warehouse/accounts/views.py:1533
 msgid "Registered a new publishing publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1571 warehouse/accounts/views.py:1584
-#: warehouse/accounts/views.py:1591
+#: warehouse/accounts/views.py:1570 warehouse/accounts/views.py:1583
+#: warehouse/accounts/views.py:1590
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1597
+#: warehouse/accounts/views.py:1596
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -418,17 +418,17 @@ msgid "2FA requirement cannot be disabled for critical projects"
 msgstr ""
 
 #: warehouse/manage/views/__init__.py:1487
-#: warehouse/manage/views/__init__.py:1793
-#: warehouse/manage/views/__init__.py:1903
+#: warehouse/manage/views/__init__.py:1791
+#: warehouse/manage/views/__init__.py:1900
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
 #: warehouse/manage/views/__init__.py:1620
-#: warehouse/manage/views/__init__.py:1707
-#: warehouse/manage/views/__init__.py:1810
-#: warehouse/manage/views/__init__.py:1912
+#: warehouse/manage/views/__init__.py:1706
+#: warehouse/manage/views/__init__.py:1808
+#: warehouse/manage/views/__init__.py:1909
 msgid "Confirm the request"
 msgstr ""
 
@@ -436,83 +436,83 @@ msgstr ""
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1719
+#: warehouse/manage/views/__init__.py:1718
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1822
+#: warehouse/manage/views/__init__.py:1820
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1924
+#: warehouse/manage/views/__init__.py:1921
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1928
+#: warehouse/manage/views/__init__.py:1925
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2080
+#: warehouse/manage/views/__init__.py:2076
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2191
+#: warehouse/manage/views/__init__.py:2186
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2261
+#: warehouse/manage/views/__init__.py:2255
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2293
+#: warehouse/manage/views/__init__.py:2287
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2306
-#: warehouse/manage/views/organizations.py:896
+#: warehouse/manage/views/__init__.py:2300
+#: warehouse/manage/views/organizations.py:895
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2374
-#: warehouse/manage/views/organizations.py:963
+#: warehouse/manage/views/__init__.py:2367
+#: warehouse/manage/views/organizations.py:962
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2407
+#: warehouse/manage/views/__init__.py:2400
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2418
+#: warehouse/manage/views/__init__.py:2411
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2453
-#: warehouse/manage/views/organizations.py:1152
+#: warehouse/manage/views/__init__.py:2445
+#: warehouse/manage/views/organizations.py:1151
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:872
+#: warehouse/manage/views/organizations.py:871
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:883
+#: warehouse/manage/views/organizations.py:882
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1046
-#: warehouse/manage/views/organizations.py:1088
+#: warehouse/manage/views/organizations.py:1045
+#: warehouse/manage/views/organizations.py:1087
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1056
+#: warehouse/manage/views/organizations.py:1055
 msgid "Organization invitation could not be re-sent."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1103
+#: warehouse/manage/views/organizations.py:1102
 msgid "Expired invitation for '${username}' deleted."
 msgstr ""
 

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -1653,7 +1653,6 @@ class ManageProjectRelease:
                 action="yank release",
                 version=self.release.version,
                 submitted_by=self.request.user,
-                submitted_from=self.request.remote_addr,
             )
         )
 
@@ -1740,7 +1739,6 @@ class ManageProjectRelease:
                 action="unyank release",
                 version=self.release.version,
                 submitted_by=self.request.user,
-                submitted_from=self.request.remote_addr,
             )
         )
 
@@ -1843,7 +1841,6 @@ class ManageProjectRelease:
                 action="remove release",
                 version=self.release.version,
                 submitted_by=self.request.user,
-                submitted_from=self.request.remote_addr,
             )
         )
 
@@ -1937,7 +1934,6 @@ class ManageProjectRelease:
                 action=f"remove file {release_file.filename}",
                 version=self.release.version,
                 submitted_by=self.request.user,
-                submitted_from=self.request.remote_addr,
             )
         )
 
@@ -2097,7 +2093,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                 name=project.name,
                 action=f"add {role_name.value} {team_name}",
                 submitted_by=request.user,
-                submitted_from=request.remote_addr,
             )
         )
 
@@ -2211,7 +2206,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                 name=project.name,
                 action=f"add {role_name} {user.username}",
                 submitted_by=request.user,
-                submitted_from=request.remote_addr,
             )
         )
 
@@ -2338,7 +2332,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                     name=project.name,
                     action=f"invite {role_name} {username}",
                     submitted_by=request.user,
-                    submitted_from=request.remote_addr,
                 )
             )
             send_project_role_verification_email(
@@ -2426,7 +2419,6 @@ def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm)
             name=project.name,
             action=f"revoke_invite {role_name} {user.username}",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
         )
     )
     project.record_event(
@@ -2493,7 +2485,6 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
                             role.role_name, role.user.username, form.role_name.data
                         ),
                         submitted_by=request.user,
-                        submitted_from=request.remote_addr,
                     )
                 )
                 role.role_name = form.role_name.data
@@ -2580,7 +2571,6 @@ def delete_project_role(project, request):
                     name=project.name,
                     action=f"remove {role.role_name} {role.user.username}",
                     submitted_by=request.user,
-                    submitted_from=request.remote_addr,
                 )
             )
             project.record_event(

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -759,7 +759,6 @@ class ManageOrganizationProjectsViews:
                         name=project.name,
                         action=f"remove {role.role_name} {role.user.username}",
                         submitted_by=self.request.user,
-                        submitted_from=self.request.remote_addr,
                     )
                 )
                 project.record_event(
@@ -1552,7 +1551,6 @@ def transfer_organization_project(project, request):
                 name=project.name,
                 action=f"remove {role.role_name} {role.user.username}",
                 submitted_by=request.user,
-                submitted_from=request.remote_addr,
             )
         )
         project.record_event(

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -537,7 +537,6 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
                             form.team_project_role_name.data.value,
                         ),
                         submitted_by=request.user,
-                        submitted_from=request.remote_addr,
                     )
                 )
 
@@ -646,7 +645,6 @@ def delete_team_project_role(project, request):
                     name=project.name,
                     action=f"remove {role_name.value} {team.name}",
                     submitted_by=request.user,
-                    submitted_from=request.remote_addr,
                 )
             )
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -752,7 +752,6 @@ class JournalEntry(db.ModelBase):
         nullable=True,
     )
     submitted_by = orm.relationship(User, lazy="raise_on_sql")
-    submitted_from = Column(Text)
 
 
 class ProhibitedProjectName(db.Model):

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -425,7 +425,6 @@ class ProjectService:
                 name=project.name,
                 action="create",
                 submitted_by=creator,
-                submitted_from=request.remote_addr,
             )
         )
         project.record_event(
@@ -446,7 +445,6 @@ class ProjectService:
                     name=project.name,
                     action=f"add Owner {creator.username}",
                     submitted_by=creator,
-                    submitted_from=request.remote_addr,
                 )
             )
             project.record_event(

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -192,7 +192,6 @@ def remove_project(project, request, flash=True):
             name=project.name,
             action="remove project",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
         )
     )
 
@@ -209,7 +208,6 @@ def destroy_docs(project, request, flash=True):
             name=project.name,
             action="docdestroy",
             submitted_by=request.user,
-            submitted_from=request.remote_addr,
         )
     )
 


### PR DESCRIPTION
We don't really need this data, so stop storing it.

Related to #8158

A separate PR will provide a migration to drop the column.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>