### PR TITLE
Enable translations for `mint_token_from_oidc` endpoint

### DIFF
--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -70,7 +70,7 @@ def oidc_audience(request):
     require_methods=["POST"],
     renderer="json",
     require_csrf=False,
-    has_translations=False,
+    has_translations=True,
 )
 def mint_token_from_oidc(request):
     def _invalid(errors):


### PR DESCRIPTION
Fixes https://python-software-foundation.sentry.io/issues/4194994394/.