### PR TITLE
refactor: remove joinedload of User

### DIFF
--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -202,7 +202,6 @@ class DatabaseMacaroonService:
         try:
             dm = (
                 self.db.query(Macaroon)
-                .options(joinedload("user"))
                 .filter(Macaroon.description == description)
                 .filter(Macaroon.user_id == user_id)
                 .one()

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -16,7 +16,6 @@ import uuid
 import pymacaroons
 
 from pymacaroons.exceptions import MacaroonDeserializationException
-from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import joinedload
 from zope.interface import implementer
 
@@ -199,15 +198,12 @@ class DatabaseMacaroonService:
 
         Returns None if the user doesn't have a macaroon with this description.
         """
-        try:
-            dm = (
-                self.db.query(Macaroon)
-                .filter(Macaroon.description == description)
-                .filter(Macaroon.user_id == user_id)
-                .one()
-            )
-        except NoResultFound:
-            return None
+        dm = (
+            self.db.query(Macaroon)
+            .filter(Macaroon.description == description)
+            .filter(Macaroon.user_id == user_id)
+            .one_or_none()
+        )
 
         return dm
 


### PR DESCRIPTION
In refactoring the string-based loaders to class-based attributes, I
found that we do nothing with the resulting user data from `joinedload("user")`,
we're only looking for existence of a user-linked macaroon based on `user_id`.

Simplified query response.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>