### PR TITLE
refactor: SQLAlchemy deprecations

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -1468,7 +1468,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-            .options(joinedload("submitted_by"))
+            .options(joinedload(JournalEntry.submitted_by))
             .order_by("submitted_date", "id")
             .all()
         )
@@ -2110,7 +2110,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-            .options(joinedload("submitted_by"))
+            .options(joinedload(JournalEntry.submitted_by))
             .order_by("submitted_date", "id")
             .all()
         )
@@ -2745,7 +2745,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-            .options(joinedload("submitted_by"))
+            .options(joinedload(JournalEntry.submitted_by))
             .order_by("submitted_date", "id")
             .all()
         )
@@ -2875,7 +2875,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-            .options(joinedload("submitted_by"))
+            .options(joinedload(JournalEntry.submitted_by))
             .order_by("submitted_date", "id")
             .all()
         )
@@ -3136,7 +3136,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-            .options(joinedload("submitted_by"))
+            .options(joinedload(JournalEntry.submitted_by))
             .order_by("submitted_date", "id")
             .all()
         )
@@ -3428,7 +3428,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-            .options(joinedload("submitted_by"))
+            .options(joinedload(JournalEntry.submitted_by))
             .order_by("submitted_date", "id")
             .all()
         )

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -821,7 +821,7 @@ class TestManageAccount:
 
         journal = (
             db_request.db.query(JournalEntry)
-            .options(joinedload("submitted_by"))
+            .options(joinedload(JournalEntry.submitted_by))
             .filter_by(id=jid)
             .one()
         )
@@ -3969,7 +3969,9 @@ class TestManageProjectRelease:
             )
         ]
         entry = (
-            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+            db_request.db.query(JournalEntry)
+            .options(joinedload(JournalEntry.submitted_by))
+            .one()
         )
         assert entry.name == release.project.name
         assert entry.action == "yank release"
@@ -4122,7 +4124,9 @@ class TestManageProjectRelease:
         ]
 
         entry = (
-            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+            db_request.db.query(JournalEntry)
+            .options(joinedload(JournalEntry.submitted_by))
+            .one()
         )
         assert entry.name == release.project.name
         assert entry.action == "unyank release"
@@ -4279,7 +4283,9 @@ class TestManageProjectRelease:
 
         assert db_request.db.query(Release).all() == []
         entry = (
-            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+            db_request.db.query(JournalEntry)
+            .options(joinedload(JournalEntry.submitted_by))
+            .one()
         )
         assert entry.name == release.project.name
         assert entry.action == "remove release"
@@ -5450,7 +5456,9 @@ class TestChangeProjectRole:
         assert result.headers["Location"] == "/the-redirect"
 
         entry = (
-            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+            db_request.db.query(JournalEntry)
+            .options(joinedload(JournalEntry.submitted_by))
+            .one()
         )
 
         assert entry.name == project.name
@@ -5567,7 +5575,9 @@ class TestDeleteProjectRole:
         assert result.headers["Location"] == "/the-redirect"
 
         entry = (
-            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+            db_request.db.query(JournalEntry)
+            .options(joinedload(JournalEntry.submitted_by))
+            .one()
         )
 
         assert entry.name == project.name
@@ -5662,7 +5672,9 @@ class TestDeleteProjectRole:
         assert result.headers["Location"] == "/the-redirect"
 
         entry = (
-            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+            db_request.db.query(JournalEntry)
+            .options(joinedload(JournalEntry.submitted_by))
+            .one()
         )
 
         assert entry.name == project.name

--- a/tests/unit/manage/views/test_teams.py
+++ b/tests/unit/manage/views/test_teams.py
@@ -832,7 +832,9 @@ class TestChangeTeamProjectRole:
         assert result.headers["Location"] == "/the-redirect"
 
         entry = (
-            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+            db_request.db.query(JournalEntry)
+            .options(joinedload(JournalEntry.submitted_by))
+            .one()
         )
 
         assert entry.name == organization_project.name
@@ -1016,7 +1018,9 @@ class TestDeleteTeamProjectRole:
         assert result.headers["Location"] == "/the-redirect"
 
         entry = (
-            db_request.db.query(JournalEntry).options(joinedload("submitted_by")).one()
+            db_request.db.query(JournalEntry)
+            .options(joinedload(JournalEntry.submitted_by))
+            .one()
         )
 
         assert entry.name == organization_project.name

--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -134,7 +134,7 @@ def test_remove_project(db_request, flash):
 
     journal_entry = (
         db_request.db.query(JournalEntry)
-        .options(joinedload("submitted_by"))
+        .options(joinedload(JournalEntry.submitted_by))
         .filter(JournalEntry.name == "foo")
         .one()
     )
@@ -157,7 +157,7 @@ def test_destroy_docs(db_request, flash):
 
     journal_entry = (
         db_request.db.query(JournalEntry)
-        .options(joinedload("submitted_by"))
+        .options(joinedload(JournalEntry.submitted_by))
         .filter(JournalEntry.name == "foo")
         .one()
     )

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -108,7 +108,6 @@ class User(SitemapMixin, HasEvents, db.Model):
 
     macaroons = orm.relationship(
         "Macaroon",
-        backref="user",
         cascade="all, delete-orphan",
         lazy=True,
         order_by="Macaroon.created.desc()",

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -141,7 +141,7 @@ class User(SitemapMixin, HasEvents, db.Model):
     @email.expression  # type: ignore
     def email(self):
         return (
-            select([Email.email])
+            select(Email.email)
             .where((Email.user_id == self.id) & (Email.primary.is_(True)))
             .scalar_subquery()
         )

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -117,7 +117,7 @@ def project_detail(project, request):
         entry
         for entry in (
             request.db.query(JournalEntry)
-            .options(joinedload("submitted_by"))
+            .options(joinedload(JournalEntry.submitted_by))
             .filter(JournalEntry.name == project.name)
             .order_by(JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
             .limit(30)
@@ -198,7 +198,7 @@ def releases_list(project, request):
 def release_detail(release, request):
     journals = (
         request.db.query(JournalEntry)
-        .options(joinedload("submitted_by"))
+        .options(joinedload(JournalEntry.submitted_by))
         .filter(JournalEntry.name == release.project.name)
         .filter(JournalEntry.version == release.version)
         .order_by(JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
@@ -230,7 +230,7 @@ def journals_list(project, request):
 
     journals_query = (
         request.db.query(JournalEntry)
-        .options(joinedload("submitted_by"))
+        .options(joinedload(JournalEntry.submitted_by))
         .filter(JournalEntry.name == project.name)
         .order_by(JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
     )

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -216,7 +216,7 @@ def _nuke_user(user, request):
 
     journals = (
         request.db.query(JournalEntry)
-        .options(joinedload("submitted_by"))
+        .options(joinedload(JournalEntry.submitted_by))
         .filter(JournalEntry.submitted_by == user)
         .all()
     )

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -48,7 +48,10 @@ def _json_data(request, project, release, *, all_releases):
         request.db.query(Release, File)
         .options(
             Load(Release).load_only(
-                "version", "requires_python", "yanked", "yanked_reason"
+                Release.version,
+                Release.requires_python,
+                Release.yanked,
+                Release.yanked_reason,
             )
         )
         .outerjoin(File)

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -259,7 +259,8 @@ def package_hosting_mode(request, package_name: str):
 def user_packages(request, username: str):
     roles = (
         request.db.query(Role)
-        .join(User, Project)
+        .join(User)
+        .join(Project)
         .filter(User.username == username)
         .order_by(Role.role_name.desc(), Project.name)
         .all()
@@ -385,7 +386,8 @@ def package_urls(request, package_name, version):
 def release_urls(request, package_name: str, version: str):
     files = (
         request.db.query(File)
-        .join(Release, Project)
+        .join(Release)
+        .join(Project)
         .filter(
             (Project.normalized_name == func.normalize_pep426_name(package_name))
             & (Release.version == version)
@@ -422,7 +424,8 @@ def release_urls(request, package_name: str, version: str):
 def package_roles(request, package_name: str):
     roles = (
         request.db.query(Role)
-        .join(User, Project)
+        .join(User)
+        .join(Project)
         .filter(Project.normalized_name == func.normalize_pep426_name(package_name))
         .order_by(Role.role_name.desc(), User.username)
         .all()

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -492,7 +492,7 @@ def browse(request, classifiers: list[str]):
     )
 
     release_classifiers_q = (
-        select([release_classifiers])
+        select(release_classifiers)
         .where(release_classifiers.c.trove_id == classifiers_q.c.id)
         .alias("rc")
     )

--- a/warehouse/macaroons/models.py
+++ b/warehouse/macaroons/models.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
     LargeBinary,
     String,
     UniqueConstraint,
+    orm,
     sql,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -76,3 +77,8 @@ class Macaroon(db.Model):
     # prefer to just always use urandom. Thus we'll do this ourselves here
     # in our application.
     key = Column(LargeBinary, nullable=False, default=_generate_key)
+
+    # Intentionally not using a back references here, since we express
+    # relationships in terms of the "other" side of the relationship.
+    user = orm.relationship("User", lazy=True, viewonly=True)
+    oidc_publisher = orm.relationship("OIDCPublisher", lazy=True, viewonly=True)

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -58,7 +58,9 @@ class DatabaseMacaroonService:
             return None
 
         return self.db.get(
-            Macaroon, macaroon_id, (joinedload("user"), joinedload("oidc_publisher"))
+            Macaroon,
+            macaroon_id,
+            (joinedload(Macaroon.user), joinedload(Macaroon.oidc_publisher)),
         )
 
     def _deserialize_raw_macaroon(self, raw_macaroon):

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -425,7 +425,7 @@ class ManageAccountViews:
 
         journals = (
             self.request.db.query(JournalEntry)
-            .options(joinedload("submitted_by"))
+            .options(joinedload(JournalEntry.submitted_by))
             .filter(JournalEntry.submitted_by == self.request.user)
             .all()
         )
@@ -1553,7 +1553,7 @@ def manage_project_releases(project, request):
     # release version and the package types
     filecounts = (
         request.db.query(Release.version, File.packagetype, func.count(File.id))
-        .options(Load(Release).load_only("version"))
+        .options(Load(Release).load_only(Release.version))
         .outerjoin(File)
         .group_by(Release.id)
         .group_by(File.packagetype)

--- a/warehouse/migrations/versions/1fdf5dc6bbf3_data_migration_for_canonical_version_.py
+++ b/warehouse/migrations/versions/1fdf5dc6bbf3_data_migration_for_canonical_version_.py
@@ -35,7 +35,7 @@ releases = sa.Table(
 
 def upgrade():
     connection = op.get_bind()
-    version_query = sa.select([releases.c.version]).distinct()
+    version_query = sa.select(releases.c.version).distinct()
 
     for release in connection.execute(version_query):
         connection.execute(

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -192,9 +192,7 @@ class OIDCPublisher(OIDCPublisherMixin, db.Model):
         secondary=OIDCPublisherProjectAssociation.__table__,  # type: ignore
         backref="oidc_publishers",
     )
-    macaroons = orm.relationship(
-        Macaroon, backref="oidc_publisher", cascade="all, delete-orphan", lazy=True
-    )
+    macaroons = orm.relationship(Macaroon, cascade="all, delete-orphan", lazy=True)
 
     __mapper_args__ = {
         "polymorphic_identity": "oidc_publishers",

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -316,7 +316,7 @@ class Organization(HasEvents, db.Model):
         query = session.query(OrganizationRole).filter(
             OrganizationRole.organization == self
         )
-        query = query.options(orm.lazyload("organization"))
+        query = query.options(orm.lazyload(OrganizationRole.organization))
         query = query.join(User).order_by(User.id.asc())
         for role in sorted(
             query.all(),

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -264,8 +264,8 @@ class Project(SitemapMixin, TwoFactorRequireable, HasEvents, db.Model):
 
         # Get all of the users for this project.
         query = session.query(Role).filter(Role.project == self)
-        query = query.options(orm.lazyload("project"))
-        query = query.options(orm.lazyload("user"))
+        query = query.options(orm.lazyload(Role.project))
+        query = query.options(orm.lazyload(Role.user))
         permissions = {
             (role.user_id, "Administer" if role.role_name == "Owner" else "Upload")
             for role in query.all()
@@ -273,8 +273,8 @@ class Project(SitemapMixin, TwoFactorRequireable, HasEvents, db.Model):
 
         # Add all of the team members for this project.
         query = session.query(TeamProjectRole).filter(TeamProjectRole.project == self)
-        query = query.options(orm.lazyload("project"))
-        query = query.options(orm.lazyload("team"))
+        query = query.options(orm.lazyload(TeamProjectRole.project))
+        query = query.options(orm.lazyload(TeamProjectRole.team))
         for role in query.all():
             permissions |= {
                 (user.id, "Administer" if role.role_name.value == "Owner" else "Upload")
@@ -287,8 +287,8 @@ class Project(SitemapMixin, TwoFactorRequireable, HasEvents, db.Model):
                 OrganizationRole.organization == self.organization,
                 OrganizationRole.role_name == OrganizationRoleType.Owner,
             )
-            query = query.options(orm.lazyload("organization"))
-            query = query.options(orm.lazyload("user"))
+            query = query.options(orm.lazyload(OrganizationRole.organization))
+            query = query.options(orm.lazyload(OrganizationRole.user))
             permissions |= {(role.user_id, "Administer") for role in query.all()}
 
         for user_id, permission_name in sorted(permissions, key=lambda x: (x[1], x[0])):

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -317,7 +317,7 @@ def search(request):
         request.db.query(Classifier)
         .with_entities(Classifier.classifier)
         .filter(
-            exists([release_classifiers.c.trove_id]).where(
+            exists(release_classifiers.c.trove_id).where(
                 release_classifiers.c.trove_id == Classifier.id
             ),
             Classifier.classifier.notin_(deprecated_classifiers.keys()),


### PR DESCRIPTION
Resolves:

```
RemovedIn20Warning: The legacy calling style of select() is deprecated
and will be removed in SQLAlchemy 2.0.
Please use the new calling style described at select().
```

and

```
RemovedIn20Warning: Using strings to indicate column or relationship
paths in loader options is deprecated and will be removed in
SQLAlchemy 2.0.  Please use the class-bound attribute directly.
```