### PR TITLE
Counter-StarJacking feature POC - mention about metainformation stealing via .pypi_acknowledged file

### DIFF
--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -620,7 +620,8 @@ class Release(db.Model):
             return "untrusted"
         return "trusted"  # everything is ok
 
-    def get_user_name_and_repo_name(self, urls):
+    @staticmethod
+    def get_user_name_and_repo_name(urls):
         for url in urls:
             parsed = urlparse(url)
             segments = parsed.path.strip("/").split("/")

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -38,7 +38,7 @@
     {% if trusted == "trusted" %}
       <div style='color: darkgreen'>{% trans %}This repository is trusted{% endtrans %}</div>
     {% elif trusted == "irrelevant" %}
-      <div style='color: lightgreen'>{% trans %}The GitHub repository cannot confirm the ownership{% endtrans %}</div>
+      <div style='color: grey'>{% trans %}The GitHub repository cannot confirm the ownership{% endtrans %}</div>
     {% elif trusted == "untrusted" %}
       <div style='color: red'>{% trans %}The GitHub repository confirms that this project probably steals statistic information!{% endtrans %}</div>
     {% endif %}

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -34,6 +34,14 @@
   {% if release.github_repo_info_url and release.github_open_issue_info_url %}
   <div class="hidden github-repo-info" data-controller="github-repo-info">
     {% trans %}GitHub statistics:{% endtrans %}
+    {% set trusted = release.repository_ownership_is_trusted %}
+    {% if trusted == "trusted" %}
+      <div style='color: darkgreen'>{% trans %}This repository is trusted{% endtrans %}</div>
+    {% elif trusted == "irrelevant" %}
+      <div style='color: lightgreen'>{% trans %}The GitHub repository cannot confirm the ownership{% endtrans %}</div>
+    {% elif trusted == "untrusted" %}
+      <div style='color: red'>{% trans %}The GitHub repository confirms that this project probably steals statistic information!{% endtrans %}</div>
+    {% endif %}
     <ul class="vertical-tabs__list">
       <li>
         <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed"


### PR DESCRIPTION
This PR represents a poc of StarJacking protection feature.

[StarJacking on Mitre](https://capec.mitre.org/data/definitions/693.html)

I suggest to use a `.pypi_acknowledged` file to set that GitHub repository is acknowledged that some PyPI packages is connected with it and GitHub repository allows to use star/forks/pr statistics.

`.pypi_acknowledged` is a plain text file, a list of PyPI project names, one per line. It is a simple concept that looks like `requirements.txt` without version binding and links.

[pypi_acknowledged_example](https://github.com/rakovskij-stanislav/pypi_acknowledged_example/tree/main) repository represents this feature on GitHub side and also describes how StarJacking corrupts trust mechanisms in opensource.

For example, `.pypi_acknowledged` has this content:
```
pypi_acknowledged_example
yet_another_acknowledged_package
```

Also we have three projects:
1. `pypi_acknowledged_example`, it sets a proper home page
```toml
[project]
name = "pypi_acknowledged_example"
version = "3.4.1"
description = "This is an example package that represents .pypi_acknowledged feature"
readme = "README.md"
classifiers = [
    "Programming Language :: Python :: 3",
    "License :: OSI Approved :: MIT License",
    "Operating System :: OS Independent",
]

[project.urls]
"Homepage" = "https://github.com/rakovskij-stanislav/pypi_acknowledged_example/tree/main"
```
<img width="856" alt="image" src="https://github.com/pypi/warehouse/assets/25303578/51425341-5a07-4ac9-858f-8ccdb4d8b72b">

---


2. `try_better_next_time`, it abuses statistics of some "popular" project, but the last one is protected by `.pypi_acknowledged`
```toml
[project]
name = "try_better_next_time"
version = "0.0.3"
description = "This is an example package that represents .pypi_acknowledged feature"
readme = "README.md"
classifiers = [
    "Programming Language :: Python :: 3",
    "License :: OSI Approved :: MIT License",
    "Operating System :: OS Independent",
]

[project.urls]
"Homepage" = "https://github.com/rakovskij-stanislav/pypi_acknowledged_example/tree/main"
```
<img width="863" alt="image" src="https://github.com/pypi/warehouse/assets/25303578/c96eaded-bb19-4275-9536-10057035e8de">

---

3. `just_a_package`. It probably links to a proper package, but we just cannot verify it
```
[project]
name = "just_a_package"
version = "0.0.2"
description = "This is an example package that represents .pypi_acknowledged feature"
readme = "README.md"
classifiers = [
    "Programming Language :: Python :: 3",
    "License :: OSI Approved :: MIT License",
    "Operating System :: OS Independent",
]

[project.urls]
"Homepage" = "https://github.com/pypa/sampleproject"
```
<img width="861" alt="image" src="https://github.com/pypi/warehouse/assets/25303578/cb9ae785-33ef-4b8e-a836-a1a5d63872ed">

---

#### Thus, the introduction of this functionality will make the use of reputation statistics more conscious. A lot of packages use `pypa/sampleproject` just because it presents in [a default packaging guide](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata):
<img width="759" alt="image" src="https://github.com/pypi/warehouse/assets/25303578/e2c0d5f5-6d38-4336-923b-a745abf048d2">
