### PR TITLE
chore(dev): use yaml anchors for volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
         DEVEL: "yes"
         IPYTHON: "no"
     image: warehouse:docker-compose
-    volumes:
+    volumes: &base_volumes
       # We specify paths explicitly to only add what we need, and to avoid
       # adding the entire repository.
       # The :z option fixes permission issues with SELinux by setting a
@@ -115,8 +115,7 @@ services:
     command: gunicorn --reload -b 0.0.0.0:8000 --access-logfile - --error-logfile - warehouse.wsgi:application
     env_file: dev/environment
     pull_policy: never
-    volumes_from:
-      - base
+    volumes: *base_volumes
     ports:
       - "${WEB_PORT:-80}:8000"
     depends_on:


### PR DESCRIPTION
`volumes_from` is invalid in Compose v3, so use YAML anchors to share the volume list between services.