### PR TITLE
Make _check_claim_binary and _check_claim_invariant not private

### DIFF
--- a/tests/unit/oidc/models/test_core.py
+++ b/tests/unit/oidc/models/test_core.py
@@ -16,23 +16,23 @@ from warehouse.oidc.models import _core
 
 
 def test_check_claim_binary():
-    wrapped = _core._check_claim_binary(str.__eq__)
+    wrapped = _core.check_claim_binary(str.__eq__)
 
     assert wrapped("foo", "bar", pretend.stub()) is False
     assert wrapped("foo", "foo", pretend.stub()) is True
 
 
 def test_check_claim_invariant():
-    wrapped = _core._check_claim_invariant(True)
+    wrapped = _core.check_claim_invariant(True)
     assert wrapped(True, True, pretend.stub()) is True
     assert wrapped(False, True, pretend.stub()) is False
 
-    wrapped = _core._check_claim_invariant(False)
+    wrapped = _core.check_claim_invariant(False)
     assert wrapped(False, False, pretend.stub()) is True
     assert wrapped(True, False, pretend.stub()) is False
 
     identity = object()
-    wrapped = _core._check_claim_invariant(identity)
+    wrapped = _core.check_claim_invariant(identity)
     assert wrapped(object(), object(), pretend.stub()) is False
     assert wrapped(identity, object(), pretend.stub()) is False
     assert wrapped(object(), identity, pretend.stub()) is False

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -16,7 +16,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from warehouse.oidc.models._core import (
     OIDCPublisher,
     PendingOIDCPublisher,
-    _check_claim_binary,
+    check_claim_binary,
 )
 
 
@@ -91,9 +91,9 @@ class GitHubPublisherMixin:
 
     __required_verifiable_claims__ = {
         "sub": _check_sub,
-        "repository": _check_claim_binary(str.__eq__),
-        "repository_owner": _check_claim_binary(str.__eq__),
-        "repository_owner_id": _check_claim_binary(str.__eq__),
+        "repository": check_claim_binary(str.__eq__),
+        "repository_owner": check_claim_binary(str.__eq__),
+        "repository_owner_id": check_claim_binary(str.__eq__),
         "job_workflow_ref": _check_job_workflow_ref,
     }
 

--- a/warehouse/oidc/models/google.py
+++ b/warehouse/oidc/models/google.py
@@ -17,8 +17,8 @@ from sqlalchemy.dialects.postgresql import UUID
 from warehouse.oidc.models._core import (
     OIDCPublisher,
     PendingOIDCPublisher,
-    _check_claim_binary,
-    _check_claim_invariant,
+    check_claim_binary,
+    check_claim_invariant,
 )
 
 
@@ -46,8 +46,8 @@ class GooglePublisherMixin:
     sub = Column(String, nullable=True)
 
     __required_verifiable_claims__ = {
-        "email": _check_claim_binary(str.__eq__),
-        "email_verified": _check_claim_invariant(True),
+        "email": check_claim_binary(str.__eq__),
+        "email_verified": check_claim_invariant(True),
     }
 
     __optional_verifiable_claims__ = {"sub": _check_sub}


### PR DESCRIPTION
Small change request with the end goal of removing as much red ink from my editor as possible.

The `_blah` to `blah` change removes a `"_blah" is not accessed Pylance` error from where it's defined in **warehouse/oidc/models/_core.py**.

It also removes the following error when it's imported in another file: `"_blah" is private and used outside of the module in which it is declared  Pylance`.  Since it appears that `_check_claim_binary` and `_check_claim_invariant` are expected to be used outside the module/file where they are defined, this change makes sense to me.

I acknowledge that there are at least two other possibilities:
1. I change my Pylance config to not report this Pylance `reportPrivateUsage` error
2. There is another way to structure the code so that **warehouse/oidc/models/github.py** and **warehouse/oidc/models/google.py** don't get this error when importing code from **_core.py**.
    1. I'm not 100% sure what that stucture would be. 

I've included a few type declarations as well as I'm getting a lot of `Type of "blah" is partially unknown Pylance` errors.

This PR is a pre-lude to more work I have on the go for adding ActiveState as an OIDC provider. 