### PR TITLE
Add full content on blog RSS

### DIFF
--- a/docs/mkdocs-blog.yml
+++ b/docs/mkdocs-blog.yml
@@ -48,7 +48,6 @@ plugins:
         default_timezone: "UTC"
         default_time: "06:09"
       enabled: true
-      feed_ttl: 1440
       image: https://blog.pypi.org/assets/logo.png
       length: 20
       pretty_print: true

--- a/docs/mkdocs-blog.yml
+++ b/docs/mkdocs-blog.yml
@@ -50,7 +50,6 @@ plugins:
       enabled: true
       image: https://blog.pypi.org/assets/logo.png
       length: 20
-      pretty_print: true
       match_path: "posts/.*"
 extra:
   homepage: https://pypi.org

--- a/docs/mkdocs-blog.yml
+++ b/docs/mkdocs-blog.yml
@@ -38,8 +38,7 @@ plugins:
       time_format: '%Y-%m-%d' # The format used to display the time
       meta_time_format: '%Y-%m-%d %H:%M' # The format used to parse the time from meta
   - rss:
-      abstract_chars_count: 160
-      abstract_delimiter: <!-- more -->
+      abstract_chars_count: -1
       categories:
         - tags
       date_from_meta:


### PR DESCRIPTION
I make an experiment on changing the configurations of RSS feed generation to include the whole content of the posts (#13812). Apparently the `pretty_print: true` was the responsible for weird RSS.

It looks like the results are fine with my newsreader (NetNewsWire):

![Screenshot 2023-05-31 at 6 47 16 AM](https://github.com/pypi/warehouse/assets/160418/feea847c-88c6-4c05-b1d6-0b5562227471)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
    <channel>
        <title>The Python Package Index</title>
        <description>The official blog of the Python Package Index</description>
        <link>http://0.0.0.0:7000/</link>
        <atom:link href="http://0.0.0.0:7000/feed_rss_created.xml" rel="self"
            type="application/rss+xml" />
        <docs>https://github.com/pypi/warehouse</docs>
        <language>en-None</language>
        <pubDate>Wed, 31 May 2023 09:38:11 -0000</pubDate>
        <lastBuildDate>Wed, 31 May 2023 09:38:11 -0000</lastBuildDate>
        <ttl>1440</ttl>
        <generator>MkDocs RSS plugin - v1.7.0</generator>
        <image>
            <url>https://blog.pypi.org/assets/logo.png</url>
            <title>The Python Package Index</title>
            <link>http://0.0.0.0:7000/</link>
        </image>
        <item>
            <title>Reducing Stored IP Data in PyPI</title>
            <author>Mike Fiedler</author>
            <category>security</category>
            <category>transparency</category>
            <description>&lt;div class=&#34;blogging-tags-grid&#34;&gt; &lt;a
                href=&#34;http://0.0.0.0:7000/tags#security&#34;
                class=&#34;blogging-tag&#34;&gt;&lt;code&gt;#security&lt;/code&gt;&lt;/a&gt; &lt;a
                href=&#34;http://0.0.0.0:7000/tags#transparency&#34;

... [cut] ...

               for reading!&lt;/p&gt;&lt;hr&gt;&lt;p&gt;&lt;em&gt;Mike Fiedler is a PyPI
                administratorand maintainer of the Python Package Index since
                2022.&lt;/em&gt;&lt;/p&gt;</description>
            <link>http://0.0.0.0:7000/posts/2023-05-26-reducing-stored-ip-data/</link>
            <pubDate>Fri, 26 May 2023 15:00:00 +0000</pubDate>
            <source url="http://0.0.0.0:7000/feed_rss_created.xml">The Python Package Index</source>
            <guid isPermaLink="true">http://0.0.0.0:7000/posts/2023-05-26-reducing-stored-ip-data/</guid>
        </item>
        <item>
            <title>Securing PyPI accounts via Two-Factor Authentication</title>
            <author>Donald Stufft</author>
            <category>2fa</category>
            <category>security</category>
            <description>&lt;div class=&#34;blogging-tags-grid&#34;&gt; &lt;a
                href=&#34;http://0.0.0.0:7000/tags#security&#34;
                class=&#34;blogging-tag&#34;&gt;&lt;code&gt;#security&lt;/code&gt;&lt;/a&gt; &lt;a
                href=&#34;http://0.0.0.0:7000/tags#2fa&#34;

... [cut] ...

                denying them access to their account.[^3]: For end users it forces them to purchase
                some kind of hardware token &lt;em&gt;OR&lt;/em&gt; to use some sort of TOTP
                application. In both cases it forces them to keep track of something else besides
                their password and changes the login flow from what they are used to. For PyPI it
                increases the chance that someone may get locked out of their account, requiring
                intervention by administrators.[^4]: Not for nothing, but PyPI is also an Open
                Source project, run largely by volunteers, and cleaning up after a compromise on
                PyPI is something that affects those volunteers significantly.&lt;/p&gt;</description>
            <link>http://0.0.0.0:7000/posts/2023-05-25-securing-pypi-with-2fa/</link>
            <pubDate>Thu, 25 May 2023 00:00:00 +0000</pubDate>
            <source url="http://0.0.0.0:7000/feed_rss_created.xml">The Python Package Index</source>
            <guid isPermaLink="true">http://0.0.0.0:7000/posts/2023-05-25-securing-pypi-with-2fa/</guid>
        </item>
        <item>
            <title>PyPI was subpoenaed</title>
            <author>Ee Durbin</author>
            <category>compliance</category>
            <category>transparency</category>
            <description>&lt;div class=&#34;blogging-tags-grid&#34;&gt; &lt;a
                href=&#34;http://0.0.0.0:7000/tags#transparency&#34;
                class=&#34;blogging-tag&#34;&gt;&lt;code&gt;#transparency&lt;/code&gt;&lt;/a&gt;
                &lt;a href=&#34;http://0.0.0.0:7000/tags#compliance&#34;
                class=&#34;blogging-tag&#34;&gt;&lt;code&gt;#compliance&lt;/code&gt;&lt;/a&gt;

... [cut] ...

                QUESTION}&#39;;&lt;/code&gt;&lt;/p&gt;&lt;hr&gt;&lt;p&gt;&lt;em&gt;Ee Durbin is the
                Director of Infrastructure atthe Python Software Foundation.They have been
                contributing to keeping PyPI online, available, andsecure since
                2013.&lt;/em&gt;&lt;/p&gt;</description>
            <link>http://0.0.0.0:7000/posts/2023-05-24-pypi-was-subpoenaed/</link>
            <pubDate>Wed, 24 May 2023 13:12:00 +0000</pubDate>
            <source url="http://0.0.0.0:7000/feed_rss_created.xml">The Python Package Index</source>
            <guid isPermaLink="true">http://0.0.0.0:7000/posts/2023-05-24-pypi-was-subpoenaed/</guid>
        </item>
        <item>
            <title>Removing PGP from PyPI</title>
            <author>Donald Stufft</author>
            <category>security</category>
            <description>&lt;div class=&#34;blogging-tags-grid&#34;&gt; &lt;a
                href=&#34;http://0.0.0.0:7000/tags#security&#34;
                class=&#34;blogging-tag&#34;&gt;&lt;code&gt;#security&lt;/code&gt;&lt;/a&gt;
                &lt;/div&gt;&lt;style&gt; .md-typeset .blogging-tags-grid { display: flex;

... [cut] ...

                was present but had since expired.[^3]: We use meaningfully verified to mean that
                the signature was valid and the key that made it was not expired and had binding
                identify information that could tell us if this key was the correct key.&lt;/p&gt;</description>
            <link>http://0.0.0.0:7000/posts/2023-05-23-removing-pgp/</link>
            <pubDate>Tue, 23 May 2023 00:00:00 +0000</pubDate>
            <source url="http://0.0.0.0:7000/feed_rss_created.xml">The Python Package Index</source>
            <guid isPermaLink="true">http://0.0.0.0:7000/posts/2023-05-23-removing-pgp/</guid>
        </item>
    </channel>
</rss>
```