### PR TITLE
Use `InputRequired` with explicit `formdata`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ module = [
     "transaction.*",
     "ua_parser.*",  # https://github.com/ua-parser/uap-python/issues/110
     "venusian.*",
+    "webob.*", # https://github.com/python/typeshed/pull/9874
     "whitenoise.*",
     "wtforms.*", # https://github.com/wtforms/wtforms/issues/618
     "yara.*",

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -17,6 +17,8 @@ import pretend
 import pytest
 import wtforms
 
+from webob.multidict import MultiDict
+
 from warehouse import recaptcha
 from warehouse.accounts import forms
 from warehouse.accounts.interfaces import (
@@ -36,7 +38,9 @@ class TestLoginForm:
         user_service = pretend.stub()
         breach_service = pretend.stub()
         form = forms.LoginForm(
-            request=request, user_service=user_service, breach_service=breach_service
+            request=request,
+            user_service=user_service,
+            breach_service=breach_service,
         )
 
         assert form.request is request
@@ -84,7 +88,7 @@ class TestLoginForm:
         )
         breach_service = pretend.stub()
         form = forms.LoginForm(
-            data={"username": "my_username"},
+            formdata=MultiDict({"username": "my_username"}),
             request=request,
             user_service=user_service,
             breach_service=breach_service,
@@ -110,7 +114,7 @@ class TestLoginForm:
         )
         breach_service = pretend.stub(failure_message="Bad Password!")
         form = forms.LoginForm(
-            data={"username": "my_username"},
+            formdata=MultiDict({"username": "my_username"}),
             request=request,
             user_service=user_service,
             breach_service=breach_service,
@@ -141,7 +145,7 @@ class TestLoginForm:
             check_password=pretend.call_recorder(lambda pw, tags: False)
         )
         form = forms.LoginForm(
-            data={"username": "my_username"},
+            formdata=MultiDict({"username": "my_username"}),
             request=request,
             user_service=user_service,
             breach_service=breach_service,
@@ -183,7 +187,7 @@ class TestLoginForm:
         )
         breach_service = pretend.stub()
         form = forms.LoginForm(
-            data={"username": "my_username"},
+            formdata=MultiDict({"username": "my_username"}),
             request=request,
             user_service=user_service,
             breach_service=breach_service,
@@ -226,7 +230,7 @@ class TestLoginForm:
         )
         breach_service = pretend.stub()
         form = forms.LoginForm(
-            data={"username": "my_username"},
+            formdata=MultiDict({"username": "my_username"}),
             request=request,
             user_service=user_service,
             breach_service=breach_service,
@@ -268,7 +272,7 @@ class TestLoginForm:
         )
 
         form = forms.LoginForm(
-            data={"password": "password"},
+            MultiDict({"password": "password"}),
             request=request,
             user_service=user_service,
             breach_service=breach_service,
@@ -302,7 +306,7 @@ class TestLoginForm:
             check_password=pretend.call_recorder(lambda pw, tags: False)
         )
         form = forms.LoginForm(
-            data={"username": "my_username"},
+            formdata=MultiDict({"username": "my_username"}),
             request=request,
             user_service=user_service,
             breach_service=breach_service,
@@ -335,7 +339,7 @@ class TestLoginForm:
         )
         breach_service = pretend.stub()
         form = forms.LoginForm(
-            data={"username": "my_username"},
+            formdata=MultiDict({"username": "my_username"}),
             request=request,
             user_service=user_service,
             breach_service=breach_service,
@@ -357,7 +361,7 @@ class TestRegistrationForm:
         breach_service = pretend.stub()
 
         form = forms.RegistrationForm(
-            data={},
+            formdata=MultiDict(),
             user_service=user_service,
             recaptcha_service=recaptcha_service,
             breach_service=breach_service,
@@ -368,7 +372,7 @@ class TestRegistrationForm:
 
     def test_password_confirm_required_error(self):
         form = forms.RegistrationForm(
-            data={"password_confirm": ""},
+            formdata=MultiDict({"password_confirm": ""}),
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub())
             ),
@@ -384,7 +388,9 @@ class TestRegistrationForm:
             find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub())
         )
         form = forms.RegistrationForm(
-            data={"new_password": "password", "password_confirm": "mismatch"},
+            formdata=MultiDict(
+                {"new_password": "password", "password_confirm": "mismatch"}
+            ),
             user_service=user_service,
             recaptcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
@@ -401,10 +407,12 @@ class TestRegistrationForm:
             find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub())
         )
         form = forms.RegistrationForm(
-            data={
-                "new_password": "MyStr0ng!shPassword",
-                "password_confirm": "MyStr0ng!shPassword",
-            },
+            formdata=MultiDict(
+                {
+                    "new_password": "MyStr0ng!shPassword",
+                    "password_confirm": "MyStr0ng!shPassword",
+                }
+            ),
             user_service=user_service,
             recaptcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
@@ -416,7 +424,7 @@ class TestRegistrationForm:
 
     def test_email_required_error(self):
         form = forms.RegistrationForm(
-            data={"email": ""},
+            formdata=MultiDict({"email": ""}),
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub())
             ),
@@ -430,7 +438,7 @@ class TestRegistrationForm:
     @pytest.mark.parametrize("email", ["bad", "foo]bar@example.com", "</body></html>"])
     def test_invalid_email_error(self, pyramid_config, email):
         form = forms.RegistrationForm(
-            data={"email": email},
+            formdata=MultiDict({"email": email}),
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: None)
             ),
@@ -445,7 +453,7 @@ class TestRegistrationForm:
 
     def test_exotic_email_success(self):
         form = forms.RegistrationForm(
-            data={"email": "foo@n--tree.net"},
+            formdata=MultiDict({"email": "foo@n--tree.net"}),
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: None)
             ),
@@ -458,7 +466,7 @@ class TestRegistrationForm:
 
     def test_email_exists_error(self, pyramid_config):
         form = forms.RegistrationForm(
-            data={"email": "foo@bar.com"},
+            formdata=MultiDict({"email": "foo@bar.com"}),
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub())
             ),
@@ -475,7 +483,7 @@ class TestRegistrationForm:
 
     def test_prohibited_email_error(self, pyramid_config):
         form = forms.RegistrationForm(
-            data={"email": "foo@bearsarefuzzy.com"},
+            formdata=MultiDict({"email": "foo@bearsarefuzzy.com"}),
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: None)
             ),
@@ -492,7 +500,7 @@ class TestRegistrationForm:
 
     def test_recaptcha_disabled(self):
         form = forms.RegistrationForm(
-            data={"g_recpatcha_response": ""},
+            formdata=MultiDict({"g_recpatcha_response": ""}),
             user_service=pretend.stub(),
             recaptcha_service=pretend.stub(
                 enabled=False,
@@ -507,7 +515,7 @@ class TestRegistrationForm:
 
     def test_recaptcha_required_error(self):
         form = forms.RegistrationForm(
-            data={"g_recaptcha_response": ""},
+            formdata=MultiDict({"g_recaptcha_response": ""}),
             user_service=pretend.stub(),
             recaptcha_service=pretend.stub(
                 enabled=True,
@@ -520,7 +528,7 @@ class TestRegistrationForm:
 
     def test_recaptcha_error(self):
         form = forms.RegistrationForm(
-            data={"g_recaptcha_response": "asd"},
+            formdata=MultiDict({"g_recaptcha_response": "asd"}),
             user_service=pretend.stub(),
             recaptcha_service=pretend.stub(
                 verify_response=pretend.raiser(recaptcha.RecaptchaError),
@@ -533,7 +541,7 @@ class TestRegistrationForm:
 
     def test_username_exists(self, pyramid_config):
         form = forms.RegistrationForm(
-            data={"username": "foo"},
+            formdata=MultiDict({"username": "foo"}),
             user_service=pretend.stub(
                 find_userid=pretend.call_recorder(lambda name: 1),
                 username_is_prohibited=lambda a: False,
@@ -553,7 +561,7 @@ class TestRegistrationForm:
 
     def test_username_prohibted(self, pyramid_config):
         form = forms.RegistrationForm(
-            data={"username": "foo"},
+            formdata=MultiDict({"username": "foo"}),
             user_service=pretend.stub(
                 username_is_prohibited=lambda a: True,
             ),
@@ -573,7 +581,7 @@ class TestRegistrationForm:
     @pytest.mark.parametrize("username", ["_foo", "bar_", "foo^bar"])
     def test_username_is_valid(self, username, pyramid_config):
         form = forms.RegistrationForm(
-            data={"username": username},
+            formdata=MultiDict({"username": username}),
             user_service=pretend.stub(
                 find_userid=pretend.call_recorder(lambda _: None),
                 username_is_prohibited=lambda a: False,
@@ -601,7 +609,7 @@ class TestRegistrationForm:
         )
         for pwd, valid in cases:
             form = forms.RegistrationForm(
-                data={"new_password": pwd, "password_confirm": pwd},
+                formdata=MultiDict({"new_password": pwd, "password_confirm": pwd}),
                 user_service=pretend.stub(),
                 recaptcha_service=pretend.stub(
                     enabled=False,
@@ -614,7 +622,7 @@ class TestRegistrationForm:
 
     def test_password_breached(self):
         form = forms.RegistrationForm(
-            data={"new_password": "password"},
+            formdata=MultiDict({"new_password": "password"}),
             user_service=pretend.stub(
                 find_userid=pretend.call_recorder(lambda _: None)
             ),
@@ -638,7 +646,7 @@ class TestRegistrationForm:
 
     def test_name_too_long(self, pyramid_config):
         form = forms.RegistrationForm(
-            data={"full_name": "hello " * 50},
+            formdata=MultiDict({"full_name": "hello " * 50}),
             user_service=pretend.stub(
                 find_userid=pretend.call_recorder(lambda _: None)
             ),
@@ -703,7 +711,7 @@ class TestRequestPasswordResetForm:
 class TestResetPasswordForm:
     def test_password_confirm_required_error(self):
         form = forms.ResetPasswordForm(
-            data={"password_confirm": ""},
+            formdata=MultiDict({"password_confirm": ""}),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -712,13 +720,15 @@ class TestResetPasswordForm:
 
     def test_passwords_mismatch_error(self, pyramid_config):
         form = forms.ResetPasswordForm(
-            data={
-                "new_password": "password",
-                "password_confirm": "mismatch",
-                "username": "username",
-                "full_name": "full_name",
-                "email": "email",
-            },
+            formdata=MultiDict(
+                {
+                    "new_password": "password",
+                    "password_confirm": "mismatch",
+                    "username": "username",
+                    "full_name": "full_name",
+                    "email": "email",
+                }
+            ),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -734,13 +744,15 @@ class TestResetPasswordForm:
     )
     def test_password_strength(self, password, expected):
         form = forms.ResetPasswordForm(
-            data={
-                "new_password": password,
-                "password_confirm": password,
-                "username": "username",
-                "full_name": "full_name",
-                "email": "email",
-            },
+            formdata=MultiDict(
+                {
+                    "new_password": password,
+                    "password_confirm": password,
+                    "username": "username",
+                    "full_name": "full_name",
+                    "email": "email",
+                }
+            ),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -748,13 +760,15 @@ class TestResetPasswordForm:
 
     def test_passwords_match_success(self):
         form = forms.ResetPasswordForm(
-            data={
-                "new_password": "MyStr0ng!shPassword",
-                "password_confirm": "MyStr0ng!shPassword",
-                "username": "username",
-                "full_name": "full_name",
-                "email": "email",
-            },
+            formdata=MultiDict(
+                {
+                    "new_password": "MyStr0ng!shPassword",
+                    "password_confirm": "MyStr0ng!shPassword",
+                    "username": "username",
+                    "full_name": "full_name",
+                    "email": "email",
+                }
+            ),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -762,13 +776,15 @@ class TestResetPasswordForm:
 
     def test_password_breached(self):
         form = forms.ResetPasswordForm(
-            data={
-                "new_password": "MyStr0ng!shPassword",
-                "password_confirm": "MyStr0ng!shPassword",
-                "username": "username",
-                "full_name": "full_name",
-                "email": "email",
-            },
+            formdata=MultiDict(
+                {
+                    "new_password": "MyStr0ng!shPassword",
+                    "password_confirm": "MyStr0ng!shPassword",
+                    "username": "username",
+                    "full_name": "full_name",
+                    "email": "email",
+                }
+            ),
             user_service=pretend.stub(
                 find_userid=pretend.call_recorder(lambda _: None)
             ),
@@ -803,8 +819,8 @@ class TestTOTPAuthenticationForm:
         request = pretend.stub(remote_addr="1.2.3.4")
 
         form = forms.TOTPAuthenticationForm(
+            formdata=MultiDict({"totp_value": ""}),
             request=request,
-            data={"totp_value": ""},
             user_id=pretend.stub(),
             user_service=pretend.stub(get_user=get_user),
         )
@@ -813,7 +829,7 @@ class TestTOTPAuthenticationForm:
 
         form = forms.TOTPAuthenticationForm(
             request=request,
-            data={"totp_value": "not_a_real_value"},
+            formdata=MultiDict({"totp_value": "not_a_real_value"}),
             user_id=pretend.stub(),
             user_service=pretend.stub(
                 check_totp_value=lambda *a: True, get_user=get_user
@@ -824,7 +840,7 @@ class TestTOTPAuthenticationForm:
 
         form = forms.TOTPAuthenticationForm(
             request=request,
-            data={"totp_value": "1 2 3 4 5 6 7"},
+            formdata=MultiDict({"totp_value": "1 2 3 4 5 6 7"}),
             user_id=pretend.stub(),
             user_service=pretend.stub(
                 check_totp_value=lambda *a: True, get_user=get_user
@@ -838,8 +854,8 @@ class TestTOTPAuthenticationForm:
             get_user=get_user,
         )
         form = forms.TOTPAuthenticationForm(
+            formdata=MultiDict({"totp_value": "123456"}),
             request=request,
-            data={"totp_value": "123456"},
             user_id=1,
             user_service=user_service,
         )
@@ -855,8 +871,8 @@ class TestTOTPAuthenticationForm:
         ]
 
         form = forms.TOTPAuthenticationForm(
+            formdata=MultiDict({"totp_value": "123456"}),
             request=request,
-            data={"totp_value": "123456"},
             user_id=pretend.stub(),
             user_service=pretend.stub(
                 check_totp_value=lambda *a: True, get_user=get_user
@@ -866,7 +882,7 @@ class TestTOTPAuthenticationForm:
 
         form = forms.TOTPAuthenticationForm(
             request=request,
-            data={"totp_value": " 1 2 3 4  5 6 "},
+            formdata=MultiDict({"totp_value": " 1 2 3 4  5 6 "}),
             user_id=pretend.stub(),
             user_service=pretend.stub(
                 check_totp_value=lambda *a: True, get_user=get_user
@@ -876,7 +892,7 @@ class TestTOTPAuthenticationForm:
 
         form = forms.TOTPAuthenticationForm(
             request=request,
-            data={"totp_value": "123 456"},
+            formdata=MultiDict({"totp_value": "123 456"}),
             user_id=pretend.stub(),
             user_service=pretend.stub(
                 check_totp_value=lambda *a: True, get_user=get_user
@@ -1006,8 +1022,8 @@ class TestRecoveryCodeForm:
     def test_missing_value(self):
         request = pretend.stub()
         form = forms.RecoveryCodeAuthenticationForm(
+            formdata=MultiDict({"recovery_code_value": ""}),
             request=request,
-            data={"recovery_code_value": ""},
             user_id=pretend.stub(),
             user_service=pretend.stub(),
         )
@@ -1038,8 +1054,8 @@ class TestRecoveryCodeForm:
             get_user=pretend.call_recorder(lambda userid: user),
         )
         form = forms.RecoveryCodeAuthenticationForm(
+            formdata=MultiDict({"recovery_code_value": "deadbeef00001111"}),
             request=request,
-            data={"recovery_code_value": "deadbeef00001111"},
             user_id=1,
             user_service=user_service,
         )
@@ -1059,8 +1075,8 @@ class TestRecoveryCodeForm:
         request = pretend.stub(remote_addr="1.2.3.4")
         user = pretend.stub(id=pretend.stub(), username="foobar")
         form = forms.RecoveryCodeAuthenticationForm(
+            formdata=MultiDict({"recovery_code_value": "deadbeef00001111"}),
             request=request,
-            data={"recovery_code_value": "deadbeef00001111"},
             user_id=pretend.stub(),
             user_service=pretend.stub(
                 check_recovery_code=pretend.call_recorder(lambda *a, **kw: True),
@@ -1095,7 +1111,7 @@ class TestRecoveryCodeForm:
         user = pretend.stub(id=pretend.stub(), username="foobar")
         form = forms.RecoveryCodeAuthenticationForm(
             request=request,
-            data={"recovery_code_value": input_string},
+            formdata=MultiDict({"recovery_code_value": input_string}),
             user_id=pretend.stub(),
             user_service=pretend.stub(
                 check_recovery_code=pretend.call_recorder(lambda *a, **kw: True),

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -1899,7 +1899,7 @@ class TestResetPassword:
         assert result["form"] is form_inst
         assert form_class.calls == [
             pretend.call(
-                token=db_request.params["token"],
+                db_request.POST,
                 username=user.username,
                 full_name=user.name,
                 email=user.email,
@@ -1964,7 +1964,7 @@ class TestResetPassword:
         assert form_obj.validate.calls == [pretend.call()]
         assert form_class.calls == [
             pretend.call(
-                token=db_request.params["token"],
+                db_request.POST,
                 username=user.username,
                 full_name=user.name,
                 email=user.email,

--- a/tests/unit/admin/views/test_banners.py
+++ b/tests/unit/admin/views/test_banners.py
@@ -217,15 +217,9 @@ class TestPreviewBanner:
 
 
 class TestBannerForm:
-    def test_required_fields(self, banner_data):
-        form = views.BannerForm(formdata=MultiDict())
-
-        assert form.validate() is False
-        assert set(form.errors) == set(banner_data)
-
-    def test_valid_data(self, banner_data):
+    def test_validate(self, banner_data):
         form = views.BannerForm(formdata=MultiDict(banner_data))
-        assert form.validate() is True
+        assert form.validate(), str(form.errors)
         data = form.data
         defaults = {
             "fa_icon": Banner.DEFAULT_FA_ICON,
@@ -236,3 +230,9 @@ class TestBannerForm:
         # Mash the `end` into a date object to match the form's coerced result.
         banner_data["end"] = datetime.date.fromisoformat(banner_data["end"])
         assert data == {**banner_data, **defaults}
+
+    def test_required_fields(self, banner_data):
+        form = views.BannerForm(formdata=MultiDict())
+
+        assert form.validate() is False
+        assert set(form.errors) == set(banner_data)

--- a/tests/unit/admin/views/test_banners.py
+++ b/tests/unit/admin/views/test_banners.py
@@ -218,13 +218,13 @@ class TestPreviewBanner:
 
 class TestBannerForm:
     def test_required_fields(self, banner_data):
-        form = views.BannerForm(data={})
+        form = views.BannerForm(formdata=MultiDict())
 
         assert form.validate() is False
         assert set(form.errors) == set(banner_data)
 
     def test_valid_data(self, banner_data):
-        form = views.BannerForm(data=banner_data)
+        form = views.BannerForm(formdata=MultiDict(banner_data))
         assert form.validate() is True
         data = form.data
         defaults = {
@@ -232,4 +232,7 @@ class TestBannerForm:
             "active": False,
             "link_label": Banner.DEFAULT_BTN_LABEL,
         }
+
+        # Mash the `end` into a date object to match the form's coerced result.
+        banner_data["end"] = datetime.date.fromisoformat(banner_data["end"])
         assert data == {**banner_data, **defaults}

--- a/tests/unit/admin/views/test_sponsors.py
+++ b/tests/unit/admin/views/test_sponsors.py
@@ -260,29 +260,29 @@ class TestSponsorForm(TestCase):
             assert field in form.errors
 
     def test_valid_data(self):
-        form = views.SponsorForm(data=self.data)
+        form = views.SponsorForm(formdata=MultiDict(self.data))
         assert form.validate() is True
 
     def test_white_logo_is_required_for_footer_display(self):
         self.data["footer"] = True
 
         # don't validate without logo
-        form = views.SponsorForm(data=self.data)
+        form = views.SponsorForm(formdata=MultiDict(self.data))
         assert form.validate() is False
         assert "white_logo" in form.errors
 
         self.data["white_logo_url"] = "http://domain.com/white-logo.jpg"
-        form = views.SponsorForm(data=self.data)
+        form = views.SponsorForm(formdata=MultiDict(self.data))
         assert form.validate() is True
 
     def test_white_logo_is_required_for_infra_display(self):
         self.data["infra_sponsor"] = True
 
         # don't validate without logo
-        form = views.SponsorForm(data=self.data)
+        form = views.SponsorForm(formdata=MultiDict(self.data))
         assert form.validate() is False
         assert "white_logo" in form.errors
 
         self.data["white_logo_url"] = "http://domain.com/white-logo.jpg"
-        form = views.SponsorForm(data=self.data)
+        form = views.SponsorForm(formdata=MultiDict(self.data))
         assert form.validate() is True

--- a/tests/unit/admin/views/test_sponsors.py
+++ b/tests/unit/admin/views/test_sponsors.py
@@ -48,6 +48,16 @@ WHITE_LOGO_FILE.file = io.BytesIO(
 WHITE_LOGO_FILE.type = "image/png"
 
 
+class TestSponsorForm:
+    def test_validate(self):
+        form = views.SponsorForm(MultiDict({
+            'name': "foo",
+            'link_url': "https://foo.bar",
+
+        }))
+        assert form.validate(), str(form.errors)
+
+
 class TestSponsorList:
     def test_list_all_sponsors(self, db_request):
         SponsorFactory.create_batch(5)

--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -103,6 +103,18 @@ class TestUserList:
         assert result == {"users": users, "query": "foobar:what"}
 
 
+class TestEmailForm:
+    def test_validate(self):
+        form = views.EmailForm(formdata=MultiDict({'email': "foo@bar.net"}))
+        assert form.validate(), str(form.errors)
+
+
+class TestUserForm:
+    def test_validate(self):
+        form = views.UserForm()
+        assert form.validate(), str(form.erros)
+
+
 class TestUserDetail:
     def test_gets_user(self, db_request):
         email = EmailFactory.create(primary=True)

--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -105,7 +105,7 @@ class TestUserList:
 
 class TestEmailForm:
     def test_validate(self):
-        form = views.EmailForm(formdata=MultiDict({'email': "foo@bar.net"}))
+        form = views.EmailForm(formdata=MultiDict({"email": "foo@bar.net"}))
         assert form.validate(), str(form.errors)
 
 

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -922,58 +922,6 @@ class TestCreateOrganizationRoleForm:
         assert form.validate(), str(form.errors)
 
 
-class TestCreateOrganizationForm:
-    """
-    Covers SaveOrganizationNameForm, SaveOrganizationForm
-    """
-
-    def test_validate(self):
-        organization_service = pretend.stub(find_organizationid=lambda org: None)
-        form = forms.CreateOrganizationForm(
-            formdata=MultiDict(
-                {
-                    "name": "foo",
-                    "display_name": "Foo Company",
-                    "link_url": "https://foo.com",
-                    "description": "Organization for foos",
-                    "orgtype": "Company",
-                }
-            ),
-            organization_service=organization_service,
-        )
-
-        assert form.organization_service is organization_service
-        assert form.validate(), str(form.errors)
-
-    def test_validate_name_with_no_organization(self):
-        organization_service = pretend.stub(
-            find_organizationid=pretend.call_recorder(lambda name: None)
-        )
-        form = forms.CreateOrganizationForm(organization_service=organization_service)
-        field = pretend.stub(data="my_organization_name")
-        forms._ = lambda string: string
-
-        form.validate_name(field)
-
-        assert organization_service.find_organizationid.calls == [
-            pretend.call("my_organization_name")
-        ]
-
-    def test_validate_name_with_organization(self):
-        organization_service = pretend.stub(
-            find_organizationid=pretend.call_recorder(lambda name: 1)
-        )
-        form = forms.CreateOrganizationForm(organization_service=organization_service)
-        field = pretend.stub(data="my_organization_name")
-
-        with pytest.raises(wtforms.validators.ValidationError):
-            form.validate_name(field)
-
-        assert organization_service.find_organizationid.calls == [
-            pretend.call("my_organization_name")
-        ]
-
-
 class TestCreateTeamRoleForm:
     @pytest.mark.parametrize(
         ("username", "user_choices", "errors"),

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -1023,5 +1023,6 @@ class TestCreateTeamForm:
         assert form.team_id is team_id
         assert form.organization_service is organization_service
         assert not form.validate() if errors else form.validate(), str(form.errors)
-        # NOTE(jleightcap): testing with Regexp validators returns raw objects.
+        # NOTE(jleightcap): testing with Regexp validators returns raw LazyString
+        # objects in the error dict's values. Just assert on keys.
         assert list(form.errors.keys()) == errors

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -57,7 +57,7 @@ class TestCreateRoleForm:
         [
             ("", "Select role"),
             ("invalid", "Not a valid choice."),
-            (None, "Not a valid choice."),
+            (None, "Select role"),
         ],
     )
     def test_validate_role_name_fails(self, value, expected):
@@ -81,7 +81,7 @@ class TestAddEmailForm:
     def test_email_exists_error(self, pyramid_config):
         user_id = pretend.stub()
         form = forms.AddEmailForm(
-            data={"email": "foo@bar.com"},
+            formdata=MultiDict({"email": "foo@bar.com"}),
             user_id=user_id,
             user_service=pretend.stub(find_userid_by_email=lambda _: user_id),
         )
@@ -95,7 +95,7 @@ class TestAddEmailForm:
 
     def test_email_exists_other_account_error(self, pyramid_config):
         form = forms.AddEmailForm(
-            data={"email": "foo@bar.com"},
+            formdata=MultiDict({"email": "foo@bar.com"}),
             user_id=pretend.stub(),
             user_service=pretend.stub(find_userid_by_email=lambda _: pretend.stub()),
         )
@@ -109,7 +109,7 @@ class TestAddEmailForm:
 
     def test_prohibited_email_error(self, pyramid_config):
         form = forms.AddEmailForm(
-            data={"email": "foo@bearsarefuzzy.com"},
+            formdata=MultiDict({"email": "foo@bearsarefuzzy.com"}),
             user_service=pretend.stub(find_userid_by_email=lambda _: None),
             user_id=pretend.stub(),
         )
@@ -148,7 +148,7 @@ class TestProvisionTOTPForm:
         monkeypatch.setattr(otp, "verify_totp", verify_totp)
 
         form = forms.ProvisionTOTPForm(
-            data={"totp_value": "123456"}, totp_secret=pretend.stub()
+            formdata=MultiDict({"totp_value": "123456"}), totp_secret=pretend.stub()
         )
         assert not form.validate()
         assert form.totp_value.errors.pop() == "Invalid TOTP code. Try again?"
@@ -158,7 +158,7 @@ class TestProvisionTOTPForm:
         monkeypatch.setattr(otp, "verify_totp", verify_totp)
 
         form = forms.ProvisionTOTPForm(
-            data={"totp_value": "123456"}, totp_secret=pretend.stub()
+            formdata=MultiDict({"totp_value": "123456"}), totp_secret=pretend.stub()
         )
         assert form.validate()
 
@@ -182,10 +182,9 @@ class TestDeleteTOTPForm:
             ),
         )
         form = forms.DeleteTOTPForm(
-            username="username",
+            formdata=MultiDict({"username": "username", "password": "password"}),
             request=request,
             user_service=user_service,
-            password="password",
         )
 
         assert form.validate()
@@ -218,7 +217,7 @@ class TestProvisionWebAuthnForm:
         )
 
         form = forms.ProvisionWebAuthnForm(
-            data={"credential": "invalid json", "label": "fake label"},
+            formdata=MultiDict({"credential": "invalid json", "label": "fake label"}),
             user_service=user_service,
             user_id=pretend.stub(),
             challenge=pretend.stub(),
@@ -239,7 +238,7 @@ class TestProvisionWebAuthnForm:
             get_webauthn_by_label=pretend.call_recorder(lambda *a: None),
         )
         form = forms.ProvisionWebAuthnForm(
-            data={"credential": "{}", "label": "fake label"},
+            formdata=MultiDict({"credential": "{}", "label": "fake label"}),
             user_service=user_service,
             user_id=pretend.stub(),
             challenge=pretend.stub(),
@@ -255,7 +254,7 @@ class TestProvisionWebAuthnForm:
             verify_webauthn_credential=lambda *a, **kw: pretend.stub()
         )
         form = forms.ProvisionWebAuthnForm(
-            data={"credential": "{}"},
+            formdata=MultiDict({"credential": "{}"}),
             user_service=user_service,
             user_id=pretend.stub(),
             challenge=pretend.stub(),
@@ -272,7 +271,7 @@ class TestProvisionWebAuthnForm:
             get_webauthn_by_label=pretend.call_recorder(lambda *a: pretend.stub()),
         )
         form = forms.ProvisionWebAuthnForm(
-            data={"credential": "{}", "label": "fake label"},
+            formdata=MultiDict({"credential": "{}", "label": "fake label"}),
             user_service=user_service,
             user_id=pretend.stub(),
             challenge=pretend.stub(),
@@ -290,7 +289,7 @@ class TestProvisionWebAuthnForm:
             get_webauthn_by_label=pretend.call_recorder(lambda *a: None),
         )
         form = forms.ProvisionWebAuthnForm(
-            data={"credential": "{}", "label": "fake label"},
+            formdata=MultiDict({"credential": "{}", "label": "fake label"}),
             user_service=user_service,
             user_id=pretend.stub(),
             challenge=pretend.stub(),
@@ -323,7 +322,7 @@ class TestDeleteWebAuthnForm:
             get_webauthn_by_label=pretend.call_recorder(lambda *a: None)
         )
         form = forms.DeleteWebAuthnForm(
-            data={"label": "fake label"},
+            formdata=MultiDict({"label": "fake label"}),
             user_service=user_service,
             user_id=pretend.stub(),
         )
@@ -337,7 +336,7 @@ class TestDeleteWebAuthnForm:
             get_webauthn_by_label=pretend.call_recorder(lambda *a: fake_webauthn)
         )
         form = forms.DeleteWebAuthnForm(
-            data={"label": "fake label"},
+            formdata=MultiDict({"label": "fake label"}),
             user_service=user_service,
             user_id=pretend.stub(),
         )
@@ -363,7 +362,7 @@ class TestCreateMacaroonForm:
 
     def test_validate_description_missing(self):
         form = forms.CreateMacaroonForm(
-            data={"token_scope": "scope:user"},
+            formdata=MultiDict({"token_scope": "scope:user"}),
             user_id=pretend.stub(),
             macaroon_service=pretend.stub(),
             project_names=pretend.stub(),
@@ -374,7 +373,7 @@ class TestCreateMacaroonForm:
 
     def test_validate_description_in_use(self):
         form = forms.CreateMacaroonForm(
-            data={"description": "dummy", "token_scope": "scope:user"},
+            formdata=MultiDict({"description": "dummy", "token_scope": "scope:user"}),
             user_id=pretend.stub(),
             macaroon_service=pretend.stub(
                 get_macaroon_by_description=lambda *a: pretend.stub()
@@ -387,7 +386,7 @@ class TestCreateMacaroonForm:
 
     def test_validate_token_scope_missing(self):
         form = forms.CreateMacaroonForm(
-            data={"description": "dummy"},
+            formdata=MultiDict({"description": "dummy"}),
             user_id=pretend.stub(),
             macaroon_service=pretend.stub(get_macaroon_by_description=lambda *a: None),
             project_names=pretend.stub(),
@@ -398,7 +397,9 @@ class TestCreateMacaroonForm:
 
     def test_validate_token_scope_unspecified(self):
         form = forms.CreateMacaroonForm(
-            data={"description": "dummy", "token_scope": "scope:unspecified"},
+            formdata=MultiDict(
+                {"description": "dummy", "token_scope": "scope:unspecified"}
+            ),
             user_id=pretend.stub(),
             macaroon_service=pretend.stub(get_macaroon_by_description=lambda *a: None),
             project_names=pretend.stub(),
@@ -412,7 +413,7 @@ class TestCreateMacaroonForm:
     )
     def test_validate_token_scope_invalid_format(self, scope):
         form = forms.CreateMacaroonForm(
-            data={"description": "dummy", "token_scope": scope},
+            formdata=MultiDict({"description": "dummy", "token_scope": scope}),
             user_id=pretend.stub(),
             macaroon_service=pretend.stub(get_macaroon_by_description=lambda *a: None),
             project_names=pretend.stub(),
@@ -423,7 +424,9 @@ class TestCreateMacaroonForm:
 
     def test_validate_token_scope_invalid_project(self):
         form = forms.CreateMacaroonForm(
-            data={"description": "dummy", "token_scope": "scope:project:foo"},
+            formdata=MultiDict(
+                {"description": "dummy", "token_scope": "scope:project:foo"}
+            ),
             user_id=pretend.stub(),
             macaroon_service=pretend.stub(get_macaroon_by_description=lambda *a: None),
             project_names=["bar"],
@@ -434,7 +437,7 @@ class TestCreateMacaroonForm:
 
     def test_validate_token_scope_valid_user(self):
         form = forms.CreateMacaroonForm(
-            data={"description": "dummy", "token_scope": "scope:user"},
+            formdata=MultiDict({"description": "dummy", "token_scope": "scope:user"}),
             user_id=pretend.stub(),
             macaroon_service=pretend.stub(get_macaroon_by_description=lambda *a: None),
             project_names=pretend.stub(),
@@ -444,7 +447,9 @@ class TestCreateMacaroonForm:
 
     def test_validate_token_scope_valid_project(self):
         form = forms.CreateMacaroonForm(
-            data={"description": "dummy", "token_scope": "scope:project:foo"},
+            formdata=MultiDict(
+                {"description": "dummy", "token_scope": "scope:project:foo"}
+            ),
             user_id=pretend.stub(),
             macaroon_service=pretend.stub(get_macaroon_by_description=lambda *a: None),
             project_names=["foo"],
@@ -478,7 +483,7 @@ class TestDeleteMacaroonForm:
             remote_addr="1.2.3.4", banned=pretend.stub(by_ip=lambda ip_address: False)
         )
         form = forms.DeleteMacaroonForm(
-            data={"macaroon_id": pretend.stub(), "password": "password"},
+            formdata=MultiDict({"macaroon_id": pretend.stub(), "password": "password"}),
             request=request,
             macaroon_service=macaroon_service,
             user_service=user_service,
@@ -499,10 +504,15 @@ class TestDeleteMacaroonForm:
             remote_addr="1.2.3.4", banned=pretend.stub(by_ip=lambda ip_address: False)
         )
         form = forms.DeleteMacaroonForm(
-            data={"macaroon_id": pretend.stub(), "password": "password"},
+            formdata=MultiDict(
+                {
+                    "macaroon_id": pretend.stub(),
+                    "username": "username",
+                    "password": "password",
+                }
+            ),
             request=request,
             macaroon_service=macaroon_service,
-            username="username",
             user_service=user_service,
         )
 

--- a/tests/unit/manage/views/test_organizations.py
+++ b/tests/unit/manage/views/test_organizations.py
@@ -116,7 +116,7 @@ class TestManageOrganizations:
             user=pretend.stub(),
         )
 
-        default_response = {"default": "response"}
+        default_response = MultiDict({"default": "response"})
         monkeypatch.setattr(
             org_views.ManageOrganizationsViews,
             "default_response",
@@ -508,11 +508,15 @@ class TestManageOrganizationSettings:
         }
         assert save_organization_cls.calls == [
             pretend.call(
-                name=organization.name,
-                display_name=organization.display_name,
-                link_url=organization.link_url,
-                description=organization.description,
-                orgtype=organization.orgtype,
+                MultiDict(
+                    {
+                        "name": organization.name,
+                        "display_name": organization.display_name,
+                        "link_url": organization.link_url,
+                        "description": organization.description,
+                        "orgtype": organization.orgtype,
+                    }
+                )
             ),
         ]
 

--- a/tests/unit/oidc/test_forms.py
+++ b/tests/unit/oidc/test_forms.py
@@ -21,13 +21,26 @@ from warehouse.oidc import forms
 
 
 class TestPendingGitHubPublisherForm:
-    def test_creation(self):
-        project_factory = pretend.stub()
+    def test_validate(self, monkeypatch):
+        project_factory = []
+        data = MultiDict(
+            {
+                "owner": "some-owner",
+                "repository": "some-repo",
+                "workflow_filename": "some-workflow.yml",
+                "project_name": "some-project",
+            }
+        )
         form = forms.PendingGitHubPublisherForm(
-            api_token="fake-token", project_factory=project_factory
+            MultiDict(data), api_token=pretend.stub(), project_factory=project_factory
         )
 
+        # We're testing only the basic validation here.
+        owner_info = {"login": "fake-username", "id": "1234"}
+        monkeypatch.setattr(form, "_lookup_owner", lambda o: owner_info)
+
         assert form._project_factory == project_factory
+        assert form.validate()
 
     def test_validate_project_name_already_in_use(self):
         project_factory = ["some-project"]
@@ -38,25 +51,6 @@ class TestPendingGitHubPublisherForm:
         field = pretend.stub(data="some-project")
         with pytest.raises(wtforms.validators.ValidationError):
             form.validate_project_name(field)
-
-    def test_validate(self, monkeypatch):
-        data = MultiDict(
-            {
-                "owner": "some-owner",
-                "repository": "some-repo",
-                "workflow_filename": "some-workflow.yml",
-                "project_name": "some-project",
-            }
-        )
-        form = forms.PendingGitHubPublisherForm(
-            MultiDict(data), api_token=pretend.stub(), project_factory=[]
-        )
-
-        # We're testing only the basic validation here.
-        owner_info = {"login": "fake-username", "id": "1234"}
-        monkeypatch.setattr(form, "_lookup_owner", lambda o: owner_info)
-
-        assert form.validate()
 
 
 class TestGitHubPublisherForm:
@@ -70,11 +64,23 @@ class TestGitHubPublisherForm:
             ("fake-token", {"Authorization": "token fake-token"}),
         ],
     )
-    def test_creation(self, token, headers):
-        form = forms.GitHubPublisherForm(api_token=token)
+    def test_validate(self, token, headers, monkeypatch):
+        data = MultiDict(
+            {
+                "owner": "some-owner",
+                "repository": "some-repo",
+                "workflow_filename": "some-workflow.yml",
+            }
+        )
+        form = forms.GitHubPublisherForm(MultiDict(data), api_token=token)
+
+        # We're testing only the basic validation here.
+        owner_info = {"login": "fake-username", "id": "1234"}
+        monkeypatch.setattr(form, "_lookup_owner", lambda o: owner_info)
 
         assert form._api_token == token
         assert form._headers_auth() == headers
+        assert form.validate(), str(form.errors)
 
     def test_lookup_owner_404(self, monkeypatch):
         response = pretend.stub(
@@ -271,22 +277,6 @@ class TestGitHubPublisherForm:
         monkeypatch.setattr(form, "_lookup_owner", lambda o: owner_info)
 
         assert not form.validate()
-
-    def test_validate(self, monkeypatch):
-        data = MultiDict(
-            {
-                "owner": "some-owner",
-                "repository": "some-repo",
-                "workflow_filename": "some-workflow.yml",
-            }
-        )
-        form = forms.GitHubPublisherForm(MultiDict(data), api_token=pretend.stub())
-
-        # We're testing only the basic validation here.
-        owner_info = {"login": "fake-username", "id": "1234"}
-        monkeypatch.setattr(form, "_lookup_owner", lambda o: owner_info)
-
-        assert form.validate()
 
     def test_validate_owner(self, monkeypatch):
         form = forms.GitHubPublisherForm(api_token=pretend.stub())

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -13,9 +13,16 @@
 import pretend
 import pytest
 
+from webob.multidict import MultiDict
 from wtforms.validators import StopValidation, ValidationError
 
-from warehouse.forms import DBForm, Form, PasswordStrengthValidator, URIValidator
+from warehouse.forms import (
+    DBForm,
+    Form,
+    PasswordStrengthValidator,
+    SetLocaleForm,
+    URIValidator,
+)
 
 
 class TestURIValidator:
@@ -201,3 +208,9 @@ class TestDBForm:
         db = pretend.stub()
         form = DBForm(db=db)
         assert form.db is db
+
+
+class TestSetLocaleForm:
+    def test_validate(self):
+        form = SetLocaleForm(MultiDict({"locale_id": "es"}))
+        assert form.validate(), str(form.errors)

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -48,7 +48,7 @@ INVALID_PASSWORD_MESSAGE = _("The password is invalid. Try again.")
 
 
 class UsernameMixin:
-    username = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
+    username = wtforms.StringField(validators=[wtforms.validators.InputRequired()])
 
     def validate_username(self, field):
         userid = self.user_service.find_userid(field.data)
@@ -62,7 +62,7 @@ class UsernameMixin:
 class TOTPValueMixin:
     totp_value = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.Regexp(
                 rf"^ *([0-9] *){{{TOTP_LENGTH}}}$",
                 message=_(
@@ -75,13 +75,13 @@ class TOTPValueMixin:
 
 
 class WebAuthnCredentialMixin:
-    credential = wtforms.StringField(wtforms.validators.DataRequired())
+    credential = wtforms.StringField(wtforms.validators.InputRequired())
 
 
 class RecoveryCodeValueMixin:
     recovery_code_value = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.Regexp(
                 rf"^ *([0-9a-f] *){{{2*RECOVERY_CODE_BYTES}}}$",
                 message=_(
@@ -96,7 +96,7 @@ class RecoveryCodeValueMixin:
 class NewUsernameMixin:
     username = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.Length(
                 max=50, message=_("Choose a username with 50 characters or less.")
             ),
@@ -131,7 +131,7 @@ class NewUsernameMixin:
 class PasswordMixin:
     password = wtforms.PasswordField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.Length(
                 max=MAX_PASSWORD_SIZE,
                 message=_("Password too long."),
@@ -180,7 +180,7 @@ class PasswordMixin:
 class NewPasswordMixin:
     new_password = wtforms.PasswordField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.Length(
                 max=MAX_PASSWORD_SIZE,
                 message=_("Password too long."),
@@ -193,7 +193,7 @@ class NewPasswordMixin:
 
     password_confirm = wtforms.PasswordField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.Length(
                 max=MAX_PASSWORD_SIZE,
                 message=_("Password too long."),
@@ -208,8 +208,8 @@ class NewPasswordMixin:
     # PasswordStrengthValidator of the new_password field, to ensure that the
     # newly set password doesn't contain any of them
     full_name = wtforms.StringField()  # May be empty
-    username = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
-    email = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
+    username = wtforms.StringField(validators=[wtforms.validators.InputRequired()])
+    email = wtforms.StringField(validators=[wtforms.validators.InputRequired()])
 
     def __init__(self, *args, breach_service, **kwargs):
         super().__init__(*args, **kwargs)
@@ -227,7 +227,7 @@ class NewPasswordMixin:
 class NewEmailMixin:
     email = wtforms.fields.EmailField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.Regexp(
                 r".+@.+\..+", message=_("The email address isn't valid. Try again.")
             ),
@@ -423,13 +423,13 @@ class ReAuthenticateForm(PasswordMixin, forms.Form):
     __params__ = ["username", "password", "next_route", "next_route_matchdict"]
 
     username = wtforms.fields.HiddenField(
-        validators=[wtforms.validators.DataRequired()]
+        validators=[wtforms.validators.InputRequired()]
     )
     next_route = wtforms.fields.HiddenField(
-        validators=[wtforms.validators.DataRequired()]
+        validators=[wtforms.validators.InputRequired()]
     )
     next_route_matchdict = wtforms.fields.HiddenField(
-        validators=[wtforms.validators.DataRequired()]
+        validators=[wtforms.validators.InputRequired()]
     )
 
     def __init__(self, *args, user_service, **kwargs):
@@ -472,7 +472,7 @@ class RecoveryCodeAuthenticationForm(
 
 class RequestPasswordResetForm(forms.Form):
     username_or_email = wtforms.StringField(
-        validators=[wtforms.validators.DataRequired()]
+        validators=[wtforms.validators.InputRequired()]
     )
 
     def __init__(self, *args, user_service, **kwargs):

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -207,9 +207,11 @@ class NewPasswordMixin:
     # These fields are here to provide the various user-defined fields to the
     # PasswordStrengthValidator of the new_password field, to ensure that the
     # newly set password doesn't contain any of them
+    # NOTE: These intentionally use `DataRequired` instead of `InputRequired`,
+    # since they may not be form inputs (i.e., they may be precomputed).
     full_name = wtforms.StringField()  # May be empty
-    username = wtforms.StringField(validators=[wtforms.validators.InputRequired()])
-    email = wtforms.StringField(validators=[wtforms.validators.InputRequired()])
+    username = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
+    email = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
 
     def __init__(self, *args, breach_service, **kwargs):
         super().__init__(*args, **kwargs)

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -772,7 +772,7 @@ def reset_password(request, _form_class=ResetPasswordForm):
         )
 
     form = _form_class(
-        **request.params,
+        request.POST,
         username=user.username,
         full_name=user.name,
         email=user.email,

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -32,6 +32,7 @@ from pyramid.security import forget, remember
 from pyramid.view import view_config, view_defaults
 from sqlalchemy.exc import NoResultFound
 from webauthn.helpers import bytes_to_base64url
+from webob.multidict import MultiDict
 
 from warehouse.accounts import REDIRECT_FIELD_NAME
 from warehouse.accounts.forms import (
@@ -603,10 +604,12 @@ def register(request, _form_class=RegistrationForm):
 
     # the form contains an auto-generated field from recaptcha with
     # hyphens in it. make it play nice with wtforms.
-    post_body = {key.replace("-", "_"): value for key, value in request.POST.items()}
+    post_body = MultiDict(
+        {key.replace("-", "_"): value for key, value in request.POST.items()}
+    )
 
     form = _form_class(
-        data=post_body,
+        formdata=post_body,
         user_service=user_service,
         recaptcha_service=recaptcha_service,
         breach_service=breach_service,

--- a/warehouse/admin/views/banners.py
+++ b/warehouse/admin/views/banners.py
@@ -148,18 +148,18 @@ class BannerForm(Form):
     name = wtforms.fields.StringField(
         validators=[
             wtforms.validators.Length(max=100),
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
         ],
     )
     text = wtforms.fields.StringField(
         validators=[
             wtforms.validators.Length(max=280),
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
         ],
     )
     link_url = wtforms.fields.StringField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             URIValidator(),
         ]
     )
@@ -179,4 +179,4 @@ class BannerForm(Form):
     active = wtforms.fields.BooleanField(
         validators=[wtforms.validators.Optional()], default=False
     )
-    end = wtforms.fields.DateField(validators=[wtforms.validators.DataRequired()])
+    end = wtforms.fields.DateField(validators=[wtforms.validators.InputRequired()])

--- a/warehouse/admin/views/sponsors.py
+++ b/warehouse/admin/views/sponsors.py
@@ -30,7 +30,7 @@ class SponsorForm(Form):
     name = wtforms.fields.StringField(
         validators=[
             wtforms.validators.Length(max=100),
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
         ],
     )
     service = wtforms.fields.StringField(
@@ -39,7 +39,7 @@ class SponsorForm(Form):
 
     link_url = wtforms.fields.StringField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             URIValidator(),
         ]
     )

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -74,7 +74,7 @@ def user_list(request):
 
 
 class EmailForm(forms.Form):
-    email = wtforms.fields.EmailField(validators=[wtforms.validators.DataRequired()])
+    email = wtforms.fields.EmailField(validators=[wtforms.validators.InputRequired()])
     primary = wtforms.fields.BooleanField()
     verified = wtforms.fields.BooleanField()
     public = wtforms.fields.BooleanField()

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -422,7 +422,7 @@ class MetadataForm(forms.Form):
     metadata_version = wtforms.StringField(
         description="Metadata-Version",
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.AnyOf(
                 # Note: This isn't really Metadata 2.0, however bdist_wheel
                 #       claims it is producing a Metadata 2.0 metadata when in
@@ -437,7 +437,7 @@ class MetadataForm(forms.Form):
     name = wtforms.StringField(
         description="Name",
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.Regexp(
                 PROJECT_NAME_RE,
                 re.IGNORECASE,
@@ -451,7 +451,7 @@ class MetadataForm(forms.Form):
     version = wtforms.StringField(
         description="Version",
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.Regexp(
                 r"^(?!\s).*(?<!\s)$",
                 message="Can't have leading or trailing whitespace.",
@@ -527,7 +527,7 @@ class MetadataForm(forms.Form):
     pyversion = wtforms.StringField(validators=[wtforms.validators.Optional()])
     filetype = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(),
+            wtforms.validators.InputRequired(),
             wtforms.validators.AnyOf(
                 ["bdist_egg", "bdist_wheel", "sdist"], message="Use a known file type."
             ),

--- a/warehouse/forms.py
+++ b/warehouse/forms.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 from wtforms import Form as BaseForm, StringField
-from wtforms.validators import DataRequired, StopValidation, ValidationError
+from wtforms.validators import InputRequired, StopValidation, ValidationError
 from zxcvbn import zxcvbn
 
 from warehouse.i18n import KNOWN_LOCALES
@@ -124,7 +124,7 @@ class DBForm(Form):
 class SetLocaleForm(Form):
     __params__ = ["locale_id"]
 
-    locale_id = StringField(validators=[DataRequired(message="Missing locale ID")])
+    locale_id = StringField(validators=[InputRequired(message="Missing locale ID")])
 
     def validate_locale_id(self, field):
         if field.data not in KNOWN_LOCALES.keys():

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1,10 +1,10 @@
-#: warehouse/views.py:140
+#: warehouse/views.py:141
 msgid ""
 "Two-factor authentication must be enabled on your account to perform this"
 " action."
 msgstr ""
 
-#: warehouse/views.py:265
+#: warehouse/views.py:266
 msgid "Locale updated"
 msgstr ""
 
@@ -56,260 +56,260 @@ msgstr ""
 msgid "Your passwords don't match. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:232 warehouse/accounts/forms.py:243
+#: warehouse/accounts/forms.py:234 warehouse/accounts/forms.py:245
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:251
+#: warehouse/accounts/forms.py:253
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:262
+#: warehouse/accounts/forms.py:264
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:269
+#: warehouse/accounts/forms.py:271
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:290 warehouse/manage/forms.py:139
+#: warehouse/accounts/forms.py:292 warehouse/manage/forms.py:139
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:380
+#: warehouse/accounts/forms.py:382
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:397
+#: warehouse/accounts/forms.py:399
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:459
+#: warehouse/accounts/forms.py:461
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:469
+#: warehouse/accounts/forms.py:471
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:488
+#: warehouse/accounts/forms.py:490
 msgid "No user found with that username or email"
 msgstr ""
 
-#: warehouse/accounts/views.py:102
+#: warehouse/accounts/views.py:103
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for {}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:119
+#: warehouse/accounts/views.py:120
 msgid ""
 "Too many emails have been added to this account without verifying them. "
 "Check your inbox and follow the verification links. (IP: ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:131
+#: warehouse/accounts/views.py:132
 msgid ""
 "Too many password resets have been requested for this account without "
 "completing them. Check your inbox and follow the verification links. (IP:"
 " ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:306 warehouse/accounts/views.py:370
-#: warehouse/accounts/views.py:372 warehouse/accounts/views.py:399
-#: warehouse/accounts/views.py:401 warehouse/accounts/views.py:467
+#: warehouse/accounts/views.py:307 warehouse/accounts/views.py:371
+#: warehouse/accounts/views.py:373 warehouse/accounts/views.py:400
+#: warehouse/accounts/views.py:402 warehouse/accounts/views.py:468
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:364
+#: warehouse/accounts/views.py:365
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:443
+#: warehouse/accounts/views.py:444
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:499 warehouse/manage/views/__init__.py:816
+#: warehouse/accounts/views.py:500 warehouse/manage/views/__init__.py:822
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:591
+#: warehouse/accounts/views.py:592
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:723
+#: warehouse/accounts/views.py:726
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:725
+#: warehouse/accounts/views.py:728
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:727 warehouse/accounts/views.py:830
-#: warehouse/accounts/views.py:930 warehouse/accounts/views.py:1103
+#: warehouse/accounts/views.py:730 warehouse/accounts/views.py:833
+#: warehouse/accounts/views.py:933 warehouse/accounts/views.py:1106
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:731
+#: warehouse/accounts/views.py:734
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:736
+#: warehouse/accounts/views.py:739
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:747
+#: warehouse/accounts/views.py:750
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:765
+#: warehouse/accounts/views.py:768
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:798
+#: warehouse/accounts/views.py:801
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:826
+#: warehouse/accounts/views.py:829
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:828
+#: warehouse/accounts/views.py:831
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:834
+#: warehouse/accounts/views.py:837
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:843
+#: warehouse/accounts/views.py:846
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:846
+#: warehouse/accounts/views.py:849
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:864
+#: warehouse/accounts/views.py:867
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:868
+#: warehouse/accounts/views.py:871
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:873
+#: warehouse/accounts/views.py:876
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:926
+#: warehouse/accounts/views.py:929
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:928
+#: warehouse/accounts/views.py:931
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:934
+#: warehouse/accounts/views.py:937
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:938
+#: warehouse/accounts/views.py:941
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:947
+#: warehouse/accounts/views.py:950
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1000
+#: warehouse/accounts/views.py:1003
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1065
+#: warehouse/accounts/views.py:1068
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1099
+#: warehouse/accounts/views.py:1102
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1101
+#: warehouse/accounts/views.py:1104
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1107
+#: warehouse/accounts/views.py:1110
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1111
+#: warehouse/accounts/views.py:1114
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1126
+#: warehouse/accounts/views.py:1129
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1159
+#: warehouse/accounts/views.py:1162
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1227
+#: warehouse/accounts/views.py:1230
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1451 warehouse/accounts/views.py:1471
-#: warehouse/accounts/views.py:1606 warehouse/manage/views/__init__.py:1225
-#: warehouse/manage/views/__init__.py:1244
+#: warehouse/accounts/views.py:1454 warehouse/accounts/views.py:1474
+#: warehouse/accounts/views.py:1609 warehouse/manage/views/__init__.py:1235
+#: warehouse/manage/views/__init__.py:1254
 msgid ""
 "Trusted publishers are temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1485
+#: warehouse/accounts/views.py:1488
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1498
+#: warehouse/accounts/views.py:1501
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1514 warehouse/manage/views/__init__.py:1263
+#: warehouse/accounts/views.py:1517 warehouse/manage/views/__init__.py:1273
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1528 warehouse/manage/views/__init__.py:1277
+#: warehouse/accounts/views.py:1531 warehouse/manage/views/__init__.py:1287
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1547
+#: warehouse/accounts/views.py:1550
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1583
+#: warehouse/accounts/views.py:1586
 msgid "Registered a new publishing publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1620 warehouse/accounts/views.py:1633
-#: warehouse/accounts/views.py:1640
+#: warehouse/accounts/views.py:1623 warehouse/accounts/views.py:1636
+#: warehouse/accounts/views.py:1643
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1646
+#: warehouse/accounts/views.py:1649
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -399,130 +399,130 @@ msgstr ""
 msgid "This team name has already been used. Choose a different team name."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:189
+#: warehouse/manage/views/__init__.py:190
 msgid "Account details updated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:219
+#: warehouse/manage/views/__init__.py:220
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:762
+#: warehouse/manage/views/__init__.py:768
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:763
+#: warehouse/manage/views/__init__.py:769
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:871
+#: warehouse/manage/views/__init__.py:877
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:995
+#: warehouse/manage/views/__init__.py:1005
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1117
+#: warehouse/manage/views/__init__.py:1127
 msgid "2FA requirement cannot be disabled for critical projects"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1487
-#: warehouse/manage/views/__init__.py:1791
-#: warehouse/manage/views/__init__.py:1900
+#: warehouse/manage/views/__init__.py:1497
+#: warehouse/manage/views/__init__.py:1801
+#: warehouse/manage/views/__init__.py:1910
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1620
-#: warehouse/manage/views/__init__.py:1706
-#: warehouse/manage/views/__init__.py:1808
-#: warehouse/manage/views/__init__.py:1909
+#: warehouse/manage/views/__init__.py:1630
+#: warehouse/manage/views/__init__.py:1716
+#: warehouse/manage/views/__init__.py:1818
+#: warehouse/manage/views/__init__.py:1919
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1632
+#: warehouse/manage/views/__init__.py:1642
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1718
+#: warehouse/manage/views/__init__.py:1728
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1820
+#: warehouse/manage/views/__init__.py:1830
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1921
+#: warehouse/manage/views/__init__.py:1931
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1925
+#: warehouse/manage/views/__init__.py:1935
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2076
+#: warehouse/manage/views/__init__.py:2086
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2186
+#: warehouse/manage/views/__init__.py:2196
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2255
+#: warehouse/manage/views/__init__.py:2265
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2287
+#: warehouse/manage/views/__init__.py:2297
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2300
-#: warehouse/manage/views/organizations.py:886
+#: warehouse/manage/views/__init__.py:2310
+#: warehouse/manage/views/organizations.py:891
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2367
-#: warehouse/manage/views/organizations.py:953
+#: warehouse/manage/views/__init__.py:2377
+#: warehouse/manage/views/organizations.py:958
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2400
+#: warehouse/manage/views/__init__.py:2410
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2411
+#: warehouse/manage/views/__init__.py:2421
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2445
-#: warehouse/manage/views/organizations.py:1142
+#: warehouse/manage/views/__init__.py:2455
+#: warehouse/manage/views/organizations.py:1147
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:862
+#: warehouse/manage/views/organizations.py:867
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:873
+#: warehouse/manage/views/organizations.py:878
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1036
-#: warehouse/manage/views/organizations.py:1078
+#: warehouse/manage/views/organizations.py:1041
+#: warehouse/manage/views/organizations.py:1083
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1046
+#: warehouse/manage/views/organizations.py:1051
 msgid "Organization invitation could not be re-sent."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1093
+#: warehouse/manage/views/organizations.py:1098
 msgid "Expired invitation for '${username}' deleted."
 msgstr ""
 

--- a/warehouse/manage/forms.py
+++ b/warehouse/manage/forms.py
@@ -40,7 +40,7 @@ class RoleNameMixin:
     role_name = wtforms.SelectField(
         "Select role",
         choices=[("", "Select role"), ("Maintainer", "Maintainer"), ("Owner", "Owner")],
-        validators=[wtforms.validators.DataRequired(message="Select role")],
+        validators=[wtforms.validators.InputRequired(message="Select role")],
     )
 
 
@@ -49,13 +49,13 @@ class TeamProjectRoleNameMixin:
         "Select permissions",
         choices=[("", "Select role"), ("Maintainer", "Maintainer"), ("Owner", "Owner")],
         coerce=lambda string: TeamProjectRoleType(string) if string else None,
-        validators=[wtforms.validators.DataRequired(message="Select role")],
+        validators=[wtforms.validators.InputRequired(message="Select role")],
     )
 
 
 class UsernameMixin:
     username = wtforms.StringField(
-        validators=[wtforms.validators.DataRequired(message="Specify username")]
+        validators=[wtforms.validators.InputRequired(message="Specify username")]
     )
 
     def validate_username(self, field):
@@ -212,7 +212,7 @@ class DeleteWebAuthnForm(forms.Form):
 
     label = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(message="Specify a device name"),
+            wtforms.validators.InputRequired(message="Specify a device name"),
             wtforms.validators.Length(
                 max=64, message=("Label must be 64 characters or less")
             ),
@@ -238,7 +238,7 @@ class ProvisionWebAuthnForm(WebAuthnCredentialMixin, forms.Form):
 
     label = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(message="Specify a label"),
+            wtforms.validators.InputRequired(message="Specify a label"),
             wtforms.validators.Length(
                 max=64, message=("Label must be 64 characters or less")
             ),
@@ -293,7 +293,7 @@ class CreateMacaroonForm(forms.Form):
 
     description = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(message="Specify a token name"),
+            wtforms.validators.InputRequired(message="Specify a token name"),
             wtforms.validators.Length(
                 max=100, message="Description must be 100 characters or less"
             ),
@@ -301,7 +301,7 @@ class CreateMacaroonForm(forms.Form):
     )
 
     token_scope = wtforms.StringField(
-        validators=[wtforms.validators.DataRequired(message="Specify the token scope")]
+        validators=[wtforms.validators.InputRequired(message="Specify the token scope")]
     )
 
     def validate_description(self, field):
@@ -347,7 +347,7 @@ class DeleteMacaroonForm(UsernameMixin, PasswordMixin, forms.Form):
     __params__ = ["confirm_password", "macaroon_id"]
 
     macaroon_id = wtforms.StringField(
-        validators=[wtforms.validators.DataRequired(message="Identifier required")]
+        validators=[wtforms.validators.InputRequired(message="Identifier required")]
     )
 
     def __init__(self, *args, macaroon_service, user_service, **kwargs):
@@ -381,14 +381,14 @@ class OrganizationRoleNameMixin:
             ("Billing Manager", "Billing Manager"),
         ],
         coerce=lambda string: OrganizationRoleType(string) if string else None,
-        validators=[wtforms.validators.DataRequired(message="Select role")],
+        validators=[wtforms.validators.InputRequired(message="Select role")],
     )
 
 
 class OrganizationNameMixin:
     name = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(
+            wtforms.validators.InputRequired(
                 message="Specify organization account name"
             ),
             wtforms.validators.Length(
@@ -504,7 +504,7 @@ class TransferOrganizationProjectForm(forms.Form):
         "Select organization",
         choices=[("", "Select organization")],
         validators=[
-            wtforms.validators.DataRequired(message="Select organization"),
+            wtforms.validators.InputRequired(message="Select organization"),
         ],
     )
 
@@ -558,7 +558,7 @@ class SaveOrganizationForm(forms.Form):
 
     display_name = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(message="Specify your organization name"),
+            wtforms.validators.InputRequired(message="Specify your organization name"),
             wtforms.validators.Length(
                 max=100,
                 message=_(
@@ -570,7 +570,7 @@ class SaveOrganizationForm(forms.Form):
     )
     link_url = wtforms.URLField(
         validators=[
-            wtforms.validators.DataRequired(message="Specify your organization URL"),
+            wtforms.validators.InputRequired(message="Specify your organization URL"),
             wtforms.validators.Length(
                 max=400,
                 message=_(
@@ -586,7 +586,7 @@ class SaveOrganizationForm(forms.Form):
     )
     description = wtforms.TextAreaField(
         validators=[
-            wtforms.validators.DataRequired(
+            wtforms.validators.InputRequired(
                 message="Specify your organization description"
             ),
             wtforms.validators.Length(
@@ -602,7 +602,7 @@ class SaveOrganizationForm(forms.Form):
         choices=[("Company", "Company"), ("Community", "Community")],
         coerce=OrganizationType,
         validators=[
-            wtforms.validators.DataRequired(message="Select organization type"),
+            wtforms.validators.InputRequired(message="Select organization type"),
         ],
     )
 
@@ -653,7 +653,7 @@ class SaveTeamForm(forms.Form):
 
     name = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(message="Specify team name"),
+            wtforms.validators.InputRequired(message="Specify team name"),
             wtforms.validators.Length(
                 max=50,
                 message=_("Choose a team name with 50 characters or less."),

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -585,9 +585,13 @@ class ProvisionTOTPViews:
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
         form = DeleteTOTPForm(
+            formdata=MultiDict(
+                {
+                    "password": self.request.POST["confirm_password"],
+                    "username": self.request.user.username,
+                }
+            ),
             request=self.request,
-            password=self.request.POST["confirm_password"],
-            username=self.request.user.username,
             user_service=self.user_service,
         )
 

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -20,6 +20,7 @@ from pyramid.httpexceptions import (
 )
 from pyramid.view import view_config, view_defaults
 from sqlalchemy import orm
+from webob.multidict import MultiDict
 
 from warehouse.accounts.interfaces import ITokenService, IUserService, TokenExpired
 from warehouse.accounts.models import User
@@ -273,11 +274,15 @@ class ManageOrganizationSettingsViews:
         return {
             "organization": self.organization,
             "save_organization_form": SaveOrganizationForm(
-                name=self.organization.name,
-                display_name=self.organization.display_name,
-                link_url=self.organization.link_url,
-                description=self.organization.description,
-                orgtype=self.organization.orgtype,
+                MultiDict(
+                    {
+                        "name": self.organization.name,
+                        "display_name": self.organization.display_name,
+                        "link_url": self.organization.link_url,
+                        "description": self.organization.description,
+                        "orgtype": self.organization.orgtype,
+                    }
+                )
             ),
             "save_organization_name_form": SaveOrganizationNameForm(
                 organization_service=self.organization_service,

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -13,6 +13,7 @@ from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound, HTTPSeeOther
 from pyramid.view import view_config, view_defaults
 from sqlalchemy.exc import NoResultFound
+from webob.multidict import MultiDict
 
 from warehouse.accounts import IUserService
 from warehouse.email import (
@@ -77,7 +78,11 @@ class ManageTeamSettingsViews:
         return {
             "team": self.team,
             "save_team_form": SaveTeamForm(
-                name=self.team.name,
+                formdata=MultiDict(
+                    {
+                        "name": self.team.name,
+                    }
+                ),
                 organization_service=self.organization_service,
                 organization_id=self.team.organization_id,
                 team_id=self.team.id,

--- a/warehouse/oidc/forms.py
+++ b/warehouse/oidc/forms.py
@@ -29,7 +29,7 @@ class GitHubPublisherBase(forms.Form):
 
     owner = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(
+            wtforms.validators.InputRequired(
                 message=_("Specify GitHub repository owner (username or organization)"),
             ),
         ]
@@ -37,7 +37,7 @@ class GitHubPublisherBase(forms.Form):
 
     repository = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(message=_("Specify repository name")),
+            wtforms.validators.InputRequired(message=_("Specify repository name")),
             wtforms.validators.Regexp(
                 _VALID_GITHUB_REPO, message=_("Invalid repository name")
             ),
@@ -46,7 +46,7 @@ class GitHubPublisherBase(forms.Form):
 
     workflow_filename = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(message=_("Specify workflow filename"))
+            wtforms.validators.InputRequired(message=_("Specify workflow filename"))
         ]
     )
 
@@ -170,7 +170,7 @@ class PendingGitHubPublisherForm(GitHubPublisherBase):
 
     project_name = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(message=_("Specify project name")),
+            wtforms.validators.InputRequired(message=_("Specify project name")),
             wtforms.validators.Regexp(
                 PROJECT_NAME_RE, message=_("Invalid project name")
             ),
@@ -199,7 +199,7 @@ class DeletePublisherForm(forms.Form):
 
     publisher_id = wtforms.StringField(
         validators=[
-            wtforms.validators.DataRequired(message=_("Specify a publisher ID")),
+            wtforms.validators.InputRequired(message=_("Specify a publisher ID")),
             wtforms.validators.UUID(message=_("Publisher must be specified by ID")),
         ]
     )

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -40,6 +40,7 @@ from pyramid.view import (
 from sqlalchemy import func
 from sqlalchemy.sql import exists, expression
 from trove_classifiers import deprecated_classifiers, sorted_classifiers
+from webob.multidict import MultiDict
 
 from warehouse.accounts import REDIRECT_FIELD_NAME
 from warehouse.accounts.models import User
@@ -246,7 +247,7 @@ def index(request):
 )
 def locale(request):
     try:
-        form = SetLocaleForm(locale_id=request.GET.getone("locale_id"))
+        form = SetLocaleForm(MultiDict({"locale_id": request.GET.getone("locale_id")}))
     except KeyError:
         raise HTTPBadRequest("Invalid amount of locale_id parameters provided")
 


### PR DESCRIPTION
# Prefer `InputRequired` over `DataRequired`

See [wtforms note](https://wtforms.readthedocs.io/en/2.3.x/validators/?highlight=inputrequired#wtforms.validators.DataRequired):

> Unless a very specific reason exists, we recommend using the [InputRequired](https://wtforms.readthedocs.io/en/2.3.x/validators/?highlight=inputrequired#wtforms.validators.InputRequired) instead.

This PR removes instances of `DataRequired`, and populates previously implicit data into `formdata`.

# Testing Changes

- All Form types now have an associated `test_validate` that gives an example of a valid construction and validation.

# Functional Refactors

All constructions of form objects outside of the definitions in `forms.py`:

## [warehouse/forklift/legacy.py](https://github.com/pypi/warehouse/blob/main/warehouse/forklift/legacy.py)

- No changes.

## [warehouse/manage/views/__init__.py](https://github.com/pypi/warehouse/blob/main/warehouse/manage/views/__init__.py)

- Wraps `**self.request.POST` into `MultiDict`.
- Moves the required fields in `DeleteMacaroon` field into the `formdata` `MultiDict`.

## warehouse/manage/__init__.py

- Constructions by `request`, no change.

## warehouse/manage/views/organizations.py

- [`default_response`](https://github.com/pypi/warehouse/blob/main/warehouse/manage/views/organizations.py#L180-L182) -- this is partially initialized, later with a [`reponse` object](https://github.com/pypi/warehouse/blob/main/warehouse/manage/views/organizations.py#L199-L202). This is a general pattern, I'm not sure why?
- Most forms constructed by `request`, no change.

## warehouse/manage/views/teams.py

- One fix with the `SaveTeamForm`.

## warehouse/accounts/views.py

- Two instances of a `**request.` first arg being wrapped in a `MultiDict`.
- What's with `request.params` instead of `request.POST` on `reset_password`?
- These break tests. TODO

## warehouse/views.py

- Fix `SetLocaleForm` construction.

## [warehouse/manage/views/__init__.py](https://github.com/pypi/warehouse/pull/13828/files#diff-5199d088db7ae9b8202edd6b5774f43898b9405a5afd4c9db5280dbfd1e175f0)

- Wrap `**self.request.POST` in `MultiDict`.

## warehouse/admin/views/users.py

- How does a `UserForm` take a raw `user` object as the second arg?

## warehouse/admin/views/sponsors.py

- Same as above with `SponsorForm` and `sponsor` object.

## warehouse/admin/views/banners.py

- No changes.