### PR TITLE
2FA basic auth notification email

### DIFF
--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -34,11 +34,7 @@ from warehouse.accounts.services import (
     TokenServiceFactory,
     database_login_factory,
 )
-from warehouse.errors import (
-    BasicAuthBreachedPassword,
-    BasicAuthFailedPassword,
-    BasicAuthTwoFactorEnabled,
-)
+from warehouse.errors import BasicAuthBreachedPassword, BasicAuthFailedPassword
 from warehouse.events.tags import EventTag
 from warehouse.oidc.models import OIDCPublisher
 from warehouse.rate_limiting import IRateLimiter, RateLimit
@@ -80,7 +76,6 @@ class TestLogin:
                 lambda userid, password, tags=None: False
             ),
             is_disabled=pretend.call_recorder(lambda user_id: (False, None)),
-            has_two_factor=pretend.call_recorder(lambda uid: False),
         )
         pyramid_services.register_service(service, IUserService, None)
         pyramid_services.register_service(
@@ -217,7 +212,6 @@ class TestLogin:
             ),
             update_user=pretend.call_recorder(lambda userid, last_login: None),
             is_disabled=pretend.call_recorder(lambda user_id: (False, None)),
-            has_two_factor=pretend.call_recorder(lambda uid: False),
         )
         breach_service = pretend.stub(
             check_password=pretend.call_recorder(lambda pw, tags=None: False)
@@ -238,7 +232,6 @@ class TestLogin:
         assert service.find_userid.calls == [pretend.call("myuser")]
         assert service.get_user.calls == [pretend.call(2)]
         assert service.is_disabled.calls == [pretend.call(2)]
-        assert service.has_two_factor.calls == [pretend.call(2)]
         assert service.check_password.calls == [
             pretend.call(
                 2,
@@ -259,52 +252,6 @@ class TestLogin:
             )
         ]
 
-    def test_via_basic_auth_2fa_enforced(
-        self, monkeypatch, pyramid_request, pyramid_services
-    ):
-        send_email = pretend.call_recorder(lambda *a, **kw: None)
-
-        user = pretend.stub(id=2, username="multiFactor")
-        service = pretend.stub(
-            get_user=pretend.call_recorder(lambda user_id: user),
-            find_userid=pretend.call_recorder(lambda username: 2),
-            check_password=pretend.call_recorder(
-                lambda userid, password, tags=None: True
-            ),
-            is_disabled=pretend.call_recorder(lambda user_id: (False, None)),
-            disable_password=pretend.call_recorder(
-                lambda user_id, request, reason=None: None
-            ),
-            has_two_factor=pretend.call_recorder(lambda uid: True),
-        )
-        breach_service = pretend.stub(
-            check_password=pretend.call_recorder(lambda pw, tags=None: False),
-        )
-
-        pyramid_services.register_service(service, IUserService, None)
-        pyramid_services.register_service(
-            breach_service, IPasswordBreachedService, None
-        )
-
-        pyramid_request.matched_route = pretend.stub(name="forklift.legacy.file_upload")
-
-        with pytest.raises(BasicAuthTwoFactorEnabled) as excinfo:
-            _basic_auth_check("multiFactor", "mypass", pyramid_request)
-
-        assert excinfo.value.status == (
-            "401 User multiFactor has two factor auth enabled, "
-            "an API Token or Trusted Publisher must be used "
-            "to upload in place of password."
-        )
-        assert service.find_userid.calls == [pretend.call("multiFactor")]
-        assert service.get_user.calls == [pretend.call(2)]
-        assert service.is_disabled.calls == [pretend.call(2)]
-        assert service.has_two_factor.calls == [pretend.call(2)]
-        assert service.check_password.calls == []
-        assert breach_service.check_password.calls == []
-        assert service.disable_password.calls == []
-        assert send_email.calls == []
-
     def test_via_basic_auth_compromised(
         self, monkeypatch, pyramid_request, pyramid_services
     ):
@@ -324,7 +271,6 @@ class TestLogin:
             disable_password=pretend.call_recorder(
                 lambda user_id, request, reason=None: None
             ),
-            has_two_factor=pretend.call_recorder(lambda uid: False),
         )
         breach_service = pretend.stub(
             check_password=pretend.call_recorder(lambda pw, tags=None: True),

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -29,7 +29,6 @@ from warehouse.errors import (
     BasicAuthAccountFrozen,
     BasicAuthBreachedPassword,
     BasicAuthFailedPassword,
-    BasicAuthTwoFactorEnabled,
     WarehouseDenied,
 )
 from warehouse.events.tags import EventTag
@@ -76,15 +75,6 @@ def _basic_auth_check(username, password, request):
                 raise _format_exc_status(BasicAuthAccountFrozen(), "Account is frozen.")
             else:
                 raise _format_exc_status(HTTPUnauthorized(), "Account is disabled.")
-        elif login_service.has_two_factor(user.id):
-            raise _format_exc_status(
-                BasicAuthTwoFactorEnabled(),
-                (
-                    f"User {user.username} has two factor auth enabled, "
-                    "an API Token or Trusted Publisher must be used to upload "
-                    "in place of password."
-                ),
-            )
         elif login_service.check_password(
             user.id,
             password,

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1744,17 +1744,17 @@ msgstr ""
 #, python-format
 msgid ""
 "During your recent upload or upload attempt of %(project_name)s to "
-"%(site)s, we noticed you used basic authentication (username &amp; "
-"password). However, your account has two-factor authentication (2FA) "
-"enabled."
+"%(site)s, we noticed you attempted to use basic authentication (username "
+"&amp; password). However, your account has two-factor authentication "
+"(2FA) enabled."
 msgstr ""
 
 #: warehouse/templates/email/basic-auth-with-2fa/body.html:22
 #, python-format
 msgid ""
-"In the near future, %(site)s will begin prohibiting uploads using basic "
-"authentication for accounts with two-factor authentication enabled. "
-"Instead, we will require API tokens to be used."
+"%(site)s now prohibits uploads using basic authentication for accounts "
+"with two-factor authentication enabled. Instead, we require API tokens or"
+" Trusted Publishers to be used instead."
 msgstr ""
 
 #: warehouse/templates/email/basic-auth-with-2fa/body.html:25
@@ -1767,10 +1767,15 @@ msgstr ""
 #: warehouse/templates/email/basic-auth-with-2fa/body.html:27
 #, python-format
 msgid ""
-"First, generate an API token for your account or project at "
-"%(new_token_url)s. Then, use this token when publishing instead of your "
+"If using API tokens, generate an API token for your account or project at"
+" %(new_token_url)s. Then, use this token when publishing instead of your "
 "username and password. See %(token_help_url)s for help using API tokens "
 "to publish."
+msgstr ""
+
+#: warehouse/templates/email/basic-auth-with-2fa/body.html:30
+#, python-format
+msgid "If using Trusted Publishers (preferred), see %(tp_url)s to get started."
 msgstr ""
 
 #: warehouse/templates/email/canceled-as-invited-organization-member/body.html:19

--- a/warehouse/templates/email/basic-auth-with-2fa/body.html
+++ b/warehouse/templates/email/basic-auth-with-2fa/body.html
@@ -16,14 +16,17 @@
 {% block content %}
 <h3>{% trans %}What?{% endtrans %}</h3>
 <p>
-  {% trans site=request.registry.settings["site.name"] %}During your recent upload or upload attempt of {{ project_name }} to {{ site }}, we noticed you used basic authentication (username &amp; password). However, your account has two-factor authentication (2FA) enabled.{% endtrans %}
+  {% trans site=request.registry.settings["site.name"] %}During your recent upload or upload attempt of {{ project_name }} to {{ site }}, we noticed you attempted to use basic authentication (username &amp; password). However, your account has two-factor authentication (2FA) enabled.{% endtrans %}
 </p>
 <p>
-  {% trans site=request.registry.settings["site.name"] %}In the near future, {{ site }} will begin prohibiting uploads using basic authentication for accounts with two-factor authentication enabled. Instead, we will require API tokens to be used.{% endtrans %}
+  {% trans site=request.registry.settings["site.name"] %}{{ site }} now prohibits uploads using basic authentication for accounts with two-factor authentication enabled. Instead, we require API tokens or Trusted Publishers to be used instead.{% endtrans %}
 </p>
 
 <h3>{% trans %}What should I do?{% endtrans %}</h3>
 <p>
-  {% trans new_token_url=request.route_url('manage.account.token', _host=request.registry.settings.get('warehouse.domain')), token_help_url=request.help_url(_anchor='apitoken') %}First, generate an API token for your account or project at {{ new_token_url }}. Then, use this token when publishing instead of your username and password. See {{ token_help_url }} for help using API tokens to publish.{% endtrans %}
+  {% trans new_token_url=request.route_url('manage.account.token', _host=request.registry.settings.get('warehouse.domain')), token_help_url=request.help_url(_anchor='apitoken') %}If using API tokens, generate an API token for your account or project at {{ new_token_url }}. Then, use this token when publishing instead of your username and password. See {{ token_help_url }} for help using API tokens to publish.{% endtrans %}
+</p>
+<p>
+{% trans tp_url="https://docs.pypi.org/trusted-publishers/" %}If using Trusted Publishers (preferred), see {{ tp_url }} to get started.{% endtrans %}
 </p>
 {% endblock %}

--- a/warehouse/templates/email/basic-auth-with-2fa/body.txt
+++ b/warehouse/templates/email/basic-auth-with-2fa/body.txt
@@ -16,12 +16,14 @@
 {% block content %}
 # {% trans %}What?{% endtrans %}
 
-{% trans site=request.registry.settings["site.name"] %}During your recent upload or upload attempt of {{ project_name }} to {{ site }}, we noticed you used basic authentication (username & password). However, your account has two-factor authentication (2FA) enabled.{% endtrans %}
+{% trans site=request.registry.settings["site.name"] %}During your recent upload or upload attempt of {{ project_name }} to {{ site }}, we noticed you attempted to use basic authentication (username & password). However, your account has two-factor authentication (2FA) enabled.{% endtrans %}
 
-{% trans site=request.registry.settings["site.name"] %}In the near future, {{ site }} will begin prohibiting uploads using basic authentication for accounts with two-factor authentication enabled. Instead, we will require API tokens to be used.{% endtrans %}
+{% trans site=request.registry.settings["site.name"] %}{{ site }} now prohibits uploads using basic authentication for accounts with two-factor authentication enabled. Instead, we require API tokens or Trusted Publishers to be used instead.{% endtrans %}
 
 # {% trans %}What should I do?{% endtrans %}
 
-{% trans new_token_url=request.route_url('manage.account.token', _host=request.registry.settings.get('warehouse.domain')), token_help_url=request.help_url(_anchor='apitoken') %}First, generate an API token for your account or project at {{ new_token_url }}. Then, use this token when publishing instead of your username and password. See {{ token_help_url }} for help using API tokens to publish.{% endtrans %}
+{% trans new_token_url=request.route_url('manage.account.token', _host=request.registry.settings.get('warehouse.domain')), token_help_url=request.help_url(_anchor='apitoken') %}If using API tokens, generate an API token for your account or project at {{ new_token_url }}. Then, use this token when publishing instead of your username and password. See {{ token_help_url }} for help using API tokens to publish.{% endtrans %}
+
+{% trans tp_url="https://docs.pypi.org/trusted-publishers/" %}If using Trusted Publishers (preferred), see {{ tp_url }} to get started.{% endtrans %}
 
 {% endblock %}

--- a/warehouse/templates/email/basic-auth-with-2fa/subject.txt
+++ b/warehouse/templates/email/basic-auth-with-2fa/subject.txt
@@ -14,4 +14,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}{% trans site=request.registry.settings["site.name"] %}Migrate to API tokens for uploading to {{ site }}{% endtrans %}{% endblock %}
+{% block subject %}{% trans site=request.registry.settings["site.name"] %}Migrate authentication for uploading to {{ site }}{% endtrans %}{% endblock %}


### PR DESCRIPTION
This updates #13830 so that the 2FA notification email on upload to still sends, with updated content.