### PR TITLE
Refactor Authorization

### DIFF
--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -406,10 +406,6 @@ def test_includeme(monkeypatch):
     macaroon_policy_cls = pretend.call_recorder(lambda: macaroon_policy_obj)
     monkeypatch.setattr(accounts, "MacaroonSecurityPolicy", macaroon_policy_cls)
 
-    twofactor_policy_obj = pretend.stub()
-    twofactor_policy_cls = pretend.call_recorder(lambda: twofactor_policy_obj)
-    monkeypatch.setattr(accounts, "TwoFactorSecurityPolicy", twofactor_policy_cls)
-
     config = pretend.stub(
         registry=pretend.stub(
             settings={
@@ -476,7 +472,6 @@ def test_includeme(monkeypatch):
                 session_policy_obj,
                 basic_policy_obj,
                 macaroon_policy_obj,
-                twofactor_policy_obj,
             ]
         )
     ]

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -390,14 +390,8 @@ class TestUnauthenticatedUserid:
 
 
 def test_includeme(monkeypatch):
-    authz_obj = pretend.stub()
-    authz_cls = pretend.call_recorder(lambda *a, **kw: authz_obj)
-    monkeypatch.setattr(accounts, "ACLAuthorizationPolicy", authz_cls)
-    monkeypatch.setattr(accounts, "MacaroonAuthorizationPolicy", authz_cls)
-    monkeypatch.setattr(accounts, "TwoFactorAuthorizationPolicy", authz_cls)
-
     multi_policy_obj = pretend.stub()
-    multi_policy_cls = pretend.call_recorder(lambda ps, authz: multi_policy_obj)
+    multi_policy_cls = pretend.call_recorder(lambda ps: multi_policy_obj)
     monkeypatch.setattr(accounts, "MultiSecurityPolicy", multi_policy_cls)
 
     session_policy_obj = pretend.stub()
@@ -411,6 +405,10 @@ def test_includeme(monkeypatch):
     macaroon_policy_obj = pretend.stub()
     macaroon_policy_cls = pretend.call_recorder(lambda: macaroon_policy_obj)
     monkeypatch.setattr(accounts, "MacaroonSecurityPolicy", macaroon_policy_cls)
+
+    twofactor_policy_obj = pretend.stub()
+    twofactor_policy_cls = pretend.call_recorder(lambda: twofactor_policy_obj)
+    monkeypatch.setattr(accounts, "TwoFactorSecurityPolicy", twofactor_policy_cls)
 
     config = pretend.stub(
         registry=pretend.stub(
@@ -474,6 +472,11 @@ def test_includeme(monkeypatch):
     assert config.set_security_policy.calls == [pretend.call(multi_policy_obj)]
     assert multi_policy_cls.calls == [
         pretend.call(
-            [session_policy_obj, basic_policy_obj, macaroon_policy_obj], authz_obj
+            [
+                session_policy_obj,
+                basic_policy_obj,
+                macaroon_policy_obj,
+                twofactor_policy_obj,
+            ]
         )
     ]

--- a/tests/unit/accounts/test_models.py
+++ b/tests/unit/accounts/test_models.py
@@ -210,7 +210,6 @@ class TestUser:
     )
     def test_principals(
         self,
-        # db_session,
         is_superuser,
         is_moderator,
         is_psf_staff,

--- a/tests/unit/accounts/test_models.py
+++ b/tests/unit/accounts/test_models.py
@@ -175,50 +175,36 @@ class TestUser:
             "expected",
         ),
         [
-            (False, False, False, ["group:with_admin_dashboard_access"]),
+            (False, False, False, []),
             (
                 True,
                 False,
                 False,
-                [
-                    "group:admins",
-                    "group:moderators",
-                    "group:psf_staff",
-                    "group:with_admin_dashboard_access",
-                ],
+                ["group:admins", "group:moderators", "group:psf_staff"],
             ),
             (
                 False,
                 True,
                 False,
-                ["group:moderators", "group:with_admin_dashboard_access"],
+                ["group:moderators"],
             ),
             (
                 True,
                 True,
                 False,
-                [
-                    "group:admins",
-                    "group:moderators",
-                    "group:psf_staff",
-                    "group:with_admin_dashboard_access",
-                ],
+                ["group:admins", "group:moderators", "group:psf_staff"],
             ),
             (
                 False,
                 False,
                 True,
-                ["group:psf_staff", "group:with_admin_dashboard_access"],
+                ["group:psf_staff"],
             ),
             (
                 False,
                 True,
                 True,
-                [
-                    "group:moderators",
-                    "group:psf_staff",
-                    "group:with_admin_dashboard_access",
-                ],
+                ["group:moderators", "group:psf_staff"],
             ),
         ],
     )

--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -517,7 +517,7 @@ class TestTwoFactorSecurityPolicy:
     def test_noops(self):
         policy = security_policy.TwoFactorSecurityPolicy()
 
-        assert policy.identity(pretend.stub()) == None
+        assert policy.identity(pretend.stub()) is None
         assert policy.forget(pretend.stub()) == []
         assert policy.remember(pretend.stub(), pretend.stub()) == []
 

--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -16,15 +16,11 @@ import pytest
 
 from pyramid.authorization import Allow
 from pyramid.interfaces import ISecurityPolicy
-from pyramid.security import Allowed
 from zope.interface.verify import verifyClass
 
 from warehouse.accounts import security_policy
 from warehouse.accounts.interfaces import IUserService
-from warehouse.errors import WarehouseDenied
 from warehouse.utils.security_policy import AuthenticationMethod
-
-from ...common.db.packaging import ProjectFactory
 
 
 class TestBasicAuthSecurityPolicy:

--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -16,7 +16,7 @@ import pytest
 
 from pyramid.authorization import Allow
 from pyramid.interfaces import ISecurityPolicy
-from pyramid.security import Allowed, Denied
+from pyramid.security import Denied
 from zope.interface.verify import verifyClass
 
 from warehouse.macaroons import security_policy

--- a/tests/unit/oidc/test_utils.py
+++ b/tests/unit/oidc/test_utils.py
@@ -15,8 +15,11 @@ import uuid
 import pretend
 import pytest
 
+from pyramid.authorization import Authenticated
+
 from tests.common.db.oidc import GitHubPublisherFactory
 from warehouse.oidc import utils
+from warehouse.utils.security_policy import principals_for
 
 
 def test_find_publisher_by_issuer_bad_issuer_url():
@@ -71,3 +74,12 @@ def test_find_publisher_by_issuer_github(db_request, environment, expected_id):
         ).id
         == expected_id
     )
+
+
+def test_OIDContext_principals():
+    assert principals_for(
+        utils.OIDCContext(publisher=pretend.stub(id=17), claims=None)
+    ) == [
+        Authenticated,
+        "oidc:17",
+    ]

--- a/tests/unit/oidc/test_utils.py
+++ b/tests/unit/oidc/test_utils.py
@@ -76,7 +76,7 @@ def test_find_publisher_by_issuer_github(db_request, environment, expected_id):
     )
 
 
-def test_OIDContext_principals():
+def test_oidc_context_principals():
     assert principals_for(
         utils.OIDCContext(publisher=pretend.stub(id=17), claims=None)
     ) == [

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -470,13 +470,8 @@ def test_configure(monkeypatch, settings, environment):
 def test_root_factory_access_control_list():
     acl = config.RootFactory.__acl__
 
-    assert len(acl) == 5
+    assert len(acl) == 4
     assert acl[0] == (Allow, "group:admins", "admin")
     assert acl[1] == (Allow, "group:moderators", "moderator")
     assert acl[2] == (Allow, "group:psf_staff", "psf_staff")
-    assert acl[3] == (
-        Allow,
-        "group:with_admin_dashboard_access",
-        "admin_dashboard_access",
-    )
-    assert acl[4] == (Allow, Authenticated, "manage:user")
+    assert acl[3] == (Allow, Authenticated, "manage:user")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -470,8 +470,12 @@ def test_configure(monkeypatch, settings, environment):
 def test_root_factory_access_control_list():
     acl = config.RootFactory.__acl__
 
-    assert len(acl) == 4
-    assert acl[0] == (Allow, "group:admins", "admin")
-    assert acl[1] == (Allow, "group:moderators", "moderator")
-    assert acl[2] == (Allow, "group:psf_staff", "psf_staff")
-    assert acl[3] == (Allow, Authenticated, "manage:user")
+    assert acl == [
+        (Allow, "group:admins", "admin"),
+        (Allow, "group:admins", "admin_dashboard_access"),
+        (Allow, "group:moderators", "moderator"),
+        (Allow, "group:moderators", "admin_dashboard_access"),
+        (Allow, "group:psf_staff", "psf_staff"),
+        (Allow, "group:psf_staff", "admin_dashboard_access"),
+        (Allow, Authenticated, "manage:user"),
+    ]

--- a/tests/unit/utils/test_security_policy.py
+++ b/tests/unit/utils/test_security_policy.py
@@ -11,18 +11,11 @@
 # limitations under the License.
 
 import pretend
-import pytest
 
-from pyramid.authorization import Authenticated
-from pyramid.security import Allowed, Denied
-from zope.interface.verify import verifyClass
 from pyramid.interfaces import ISecurityPolicy
+from zope.interface.verify import verifyClass
 
-from warehouse.oidc.utils import OIDCContext
 from warehouse.utils import security_policy
-
-from ...common.db.accounts import UserFactory
-from ...common.db.oidc import GitHubPublisherFactory
 
 
 def test_principals_for():

--- a/tests/unit/utils/test_security_policy.py
+++ b/tests/unit/utils/test_security_policy.py
@@ -96,16 +96,13 @@ def test_principals_for_authenticated_user(
 class TestMultiSecurityPolicy:
     def test_initializes(self):
         subpolicies = pretend.stub()
-        authz = pretend.stub()
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
 
         assert policy._policies is subpolicies
-        assert policy._authz is authz
 
     def test_identity_none(self):
         subpolicies = [pretend.stub(identity=pretend.call_recorder(lambda r: None))]
-        authz = pretend.stub()
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
 
         request = pretend.stub()
         assert policy.identity(request) is None
@@ -120,8 +117,7 @@ class TestMultiSecurityPolicy:
             pretend.stub(identity=pretend.call_recorder(lambda r: identity1)),
             pretend.stub(identity=pretend.call_recorder(lambda r: identity2)),
         ]
-        authz = pretend.stub()
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
 
         request = pretend.stub()
         assert policy.identity(request) is identity1
@@ -132,8 +128,7 @@ class TestMultiSecurityPolicy:
     def test_authenticated_userid_no_identity(self):
         request = pretend.stub()
         subpolicies = [pretend.stub(identity=pretend.call_recorder(lambda r: None))]
-        authz = pretend.stub()
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
 
         assert policy.authenticated_userid(request) is None
         assert subpolicies[0].identity.calls == [pretend.call(request)]
@@ -142,8 +137,7 @@ class TestMultiSecurityPolicy:
         request = pretend.stub()
         nonuser = pretend.stub(id="not-a-user-instance")
         subpolicies = [pretend.stub(identity=pretend.call_recorder(lambda r: nonuser))]
-        authz = pretend.stub()
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
 
         assert policy.authenticated_userid(request) is None
         assert subpolicies[0].identity.calls == [pretend.call(request)]
@@ -152,8 +146,7 @@ class TestMultiSecurityPolicy:
         request = pretend.stub()
         user = UserFactory.create()
         subpolicies = [pretend.stub(identity=pretend.call_recorder(lambda r: user))]
-        authz = pretend.stub()
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
 
         assert policy.authenticated_userid(request) == str(user.id)
         assert subpolicies[0].identity.calls == [pretend.call(request)]
@@ -163,8 +156,7 @@ class TestMultiSecurityPolicy:
         subpolicies = [
             pretend.stub(forget=pretend.call_recorder(lambda r, **kw: [header]))
         ]
-        authz = pretend.stub()
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
 
         request = pretend.stub()
         assert policy.forget(request, foo=None) == [header]
@@ -175,8 +167,7 @@ class TestMultiSecurityPolicy:
         subpolicies = [
             pretend.stub(remember=pretend.call_recorder(lambda r, uid, **kw: [header]))
         ]
-        authz = pretend.stub()
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
 
         request = pretend.stub()
         userid = pretend.stub()
@@ -186,10 +177,11 @@ class TestMultiSecurityPolicy:
         ]
 
     def test_permits_user(self, db_request, monkeypatch):
-        subpolicies = pretend.stub()
         status = pretend.stub()
-        authz = pretend.stub(permits=pretend.call_recorder(lambda *a: status))
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+
+        policy = security_policy.MultiSecurityPolicy([])
+        acl = pretend.stub(permits=pretend.call_recorder(lambda *a: status))
+        monkeypatch.setattr(policy, "_acl", acl)
 
         principals_for_authenticated_user = pretend.call_recorder(
             lambda *a: ["some:principal"]
@@ -205,7 +197,7 @@ class TestMultiSecurityPolicy:
         context = pretend.stub()
         permission = pretend.stub()
         assert policy.permits(request, context, permission) is status
-        assert authz.permits.calls == [
+        assert acl.permits.calls == [
             pretend.call(
                 context,
                 [Authenticated, f"user:{user.id}", "some:principal"],
@@ -213,18 +205,35 @@ class TestMultiSecurityPolicy:
             )
         ]
 
-    def test_permits_oidc_publisher(self, db_request):
-        subpolicies = pretend.stub()
+    def test_permits_subpolicy_denied(self, db_request):
+        def permits_raises(request, context, permission):
+            raise NotImplementedError
+
+        denied = Denied("Because")
+        subpolicies = [
+            pretend.stub(permits=permits_raises),
+            pretend.stub(permits=lambda r, c, p: True),
+            pretend.stub(permits=lambda r, c, p: denied),
+        ]
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
+        user = UserFactory.create()
+        request = pretend.stub(identity=user)
+        context = pretend.stub()
+        permission = pretend.stub()
+        assert policy.permits(request, context, permission) is denied
+
+    def test_permits_oidc_publisher(self, db_request, monkeypatch):
         status = pretend.stub()
-        authz = pretend.stub(permits=pretend.call_recorder(lambda *a: status))
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy([])
+        acl = pretend.stub(permits=pretend.call_recorder(lambda *a: status))
+        monkeypatch.setattr(policy, "_acl", acl)
 
         publisher = GitHubPublisherFactory.create()
         request = pretend.stub(identity=OIDCContext(publisher, None))
         context = pretend.stub()
         permission = pretend.stub()
         assert policy.permits(request, context, permission) is status
-        assert authz.permits.calls == [
+        assert acl.permits.calls == [
             pretend.call(
                 context,
                 [Authenticated, f"oidc:{publisher.id}"],
@@ -232,10 +241,10 @@ class TestMultiSecurityPolicy:
             )
         ]
 
-    def test_permits_nonuser_denied(self):
-        subpolicies = pretend.stub()
-        authz = pretend.stub(permits=pretend.call_recorder(lambda *a: pretend.stub()))
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+    def test_permits_nonuser_denied(self, monkeypatch):
+        policy = security_policy.MultiSecurityPolicy([])
+        acl = pretend.stub(permits=pretend.call_recorder(lambda *a: pretend.stub()))
+        monkeypatch.setattr(policy, "_acl", acl)
 
         # Anything that doesn't pass an isinstance check for User
         fakeuser = pretend.stub()
@@ -243,24 +252,25 @@ class TestMultiSecurityPolicy:
         context = pretend.stub()
         permission = pretend.stub()
         assert policy.permits(request, context, permission) == Denied("unimplemented")
-        assert authz.permits.calls == []
+        assert acl.permits.calls == []
 
-    def test_permits_no_identity(self):
-        subpolicies = pretend.stub()
+    def test_permits_no_identity(self, monkeypatch):
         status = pretend.stub()
-        authz = pretend.stub(permits=pretend.call_recorder(lambda *a: status))
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy([])
+        acl = pretend.stub(permits=pretend.call_recorder(lambda *a: status))
+        monkeypatch.setattr(policy, "_acl", acl)
 
         request = pretend.stub(identity=None)
         context = pretend.stub()
         permission = pretend.stub()
         assert policy.permits(request, context, permission) is status
-        assert authz.permits.calls == [pretend.call(context, [], permission)]
+        assert acl.permits.calls == [pretend.call(context, [], permission)]
 
-    def test_cant_use_unauthenticated_userid(self):
+    def test_cant_use_unauthenticated_userid(self, monkeypatch):
         subpolicies = pretend.stub()
-        authz = pretend.stub(permits=pretend.call_recorder(lambda *a: pretend.stub()))
-        policy = security_policy.MultiSecurityPolicy(subpolicies, authz)
+        policy = security_policy.MultiSecurityPolicy(subpolicies)
+        acl = pretend.stub(permits=pretend.call_recorder(lambda *a: pretend.stub()))
+        monkeypatch.setattr(policy, "_acl", acl)
 
         with pytest.raises(NotImplementedError):
             policy.unauthenticated_userid(pretend.stub())

--- a/tests/unit/utils/test_security_policy.py
+++ b/tests/unit/utils/test_security_policy.py
@@ -14,7 +14,7 @@ import pretend
 import pytest
 
 from pyramid.authorization import Authenticated
-from pyramid.security import Denied
+from pyramid.security import Allowed, Denied
 
 from warehouse.oidc.utils import OIDCContext
 from warehouse.utils import security_policy
@@ -205,22 +205,68 @@ class TestMultiSecurityPolicy:
             )
         ]
 
-    def test_permits_subpolicy_denied(self, db_request):
-        def permits_raises(request, context, permission):
+    class SubPolicyHelpers:
+        @staticmethod
+        def subpolicy(fn):
+            return pretend.stub(permits=fn)
+
+        @subpolicy
+        @staticmethod
+        def raises(a, b, c):
             raise NotImplementedError
 
-        denied = Denied("Because")
-        subpolicies = [
-            pretend.stub(permits=permits_raises),
-            pretend.stub(permits=lambda r, c, p: True),
-            pretend.stub(permits=lambda r, c, p: denied),
-        ]
-        policy = security_policy.MultiSecurityPolicy(subpolicies)
+        @subpolicy
+        @staticmethod
+        def passes(a, b, c):
+            return Allowed("subpolicy")
+
+        @subpolicy
+        @staticmethod
+        def denies(a, b, c):
+            return Denied("subpolicy")
+
+    @pytest.mark.parametrize(
+        ("policies", "expected"),
+        [
+            ([], None),
+            ([SubPolicyHelpers.raises], None),
+            ([SubPolicyHelpers.denies], Denied("subpolicy")),
+            ([SubPolicyHelpers.passes], None),
+            (
+                [
+                    SubPolicyHelpers.raises,
+                    SubPolicyHelpers.passes,
+                    SubPolicyHelpers.passes,
+                ],
+                None,
+            ),
+            ([SubPolicyHelpers.passes, SubPolicyHelpers.denies], Denied("subpolicy")),
+            (
+                [
+                    SubPolicyHelpers.raises,
+                    SubPolicyHelpers.passes,
+                    SubPolicyHelpers.denies,
+                ],
+                Denied("subpolicy"),
+            ),
+        ],
+    )
+    def test_permits_subpolicies(self, db_request, monkeypatch, policies, expected):
+        status = pretend.stub(s="")
+        policy = security_policy.MultiSecurityPolicy(policies)
+        acl = pretend.stub(permits=pretend.call_recorder(lambda *a: status))
+        monkeypatch.setattr(policy, "_acl", acl)
         user = UserFactory.create()
-        request = pretend.stub(identity=user)
-        context = pretend.stub()
-        permission = pretend.stub()
-        assert policy.permits(request, context, permission) is denied
+
+        # A parameter of None indicates that the ACL value should be passed through.
+        if expected is None:
+            expected = status
+
+        result = policy.permits(
+            pretend.stub(identity=user), pretend.stub(), pretend.stub()
+        )
+        assert result == expected
+        assert result.s == expected.s
 
     def test_permits_oidc_publisher(self, db_request, monkeypatch):
         status = pretend.stub()

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -20,7 +20,6 @@ from warehouse.accounts.models import User
 from warehouse.accounts.security_policy import (
     BasicAuthSecurityPolicy,
     SessionSecurityPolicy,
-    TwoFactorSecurityPolicy,
 )
 from warehouse.accounts.services import (
     HaveIBeenPwnedEmailBreachedService,
@@ -31,8 +30,8 @@ from warehouse.accounts.services import (
     database_login_factory,
 )
 from warehouse.admin.flags import AdminFlagValue
-from warehouse.oidc.utils import OIDCContext
 from warehouse.macaroons.security_policy import MacaroonSecurityPolicy
+from warehouse.oidc.utils import OIDCContext
 from warehouse.organizations.services import IOrganizationService
 from warehouse.rate_limiting import IRateLimiter, RateLimit
 from warehouse.utils.security_policy import MultiSecurityPolicy
@@ -129,7 +128,6 @@ def includeme(config):
                 SessionSecurityPolicy(),
                 BasicAuthSecurityPolicy(),
                 MacaroonSecurityPolicy(),
-                TwoFactorSecurityPolicy(),
             ],
         )
     )

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -202,13 +202,6 @@ class User(SitemapMixin, HasEvents, db.Model):
         if self.is_psf_staff or self.is_superuser:
             principals.append("group:psf_staff")
 
-        # user must have base admin access if any admin permission
-        # TODO: This feels wrong? Why are we using a group to add dashboard
-        #       access and not a permission? Why are we adding it to every
-        #       user? Something is weird, and we should figure it out.
-        if principals:
-            principals.append("group:with_admin_dashboard_access")
-
         return principals
 
     def __acl__(self):

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -14,7 +14,7 @@ import datetime
 import enum
 
 from citext import CIText
-from pyramid.authorization import Authenticated, Allow
+from pyramid.authorization import Allow, Authenticated
 from sqlalchemy import (
     Boolean,
     CheckConstraint,

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -55,7 +55,6 @@ def _basic_auth_check(username, password, request):
     breach_service = request.find_service(IPasswordBreachedService, context=None)
 
     userid = login_service.find_userid(username)
-    # TODO: Why are we stashing this here?
     request._unauthenticated_userid = userid
     if userid is not None:
         user = login_service.get_user(userid)
@@ -147,7 +146,6 @@ class SessionSecurityPolicy:
             return None
 
         userid = self._session_helper.authenticated_userid(request)
-        # TODO: Why are we stashing this here?
         request._unauthenticated_userid = userid
 
         if userid is None:

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -295,7 +295,7 @@ def _check_for_mfa(request, context) -> WarehouseDenied | None:
         if (
             request.registry.settings["warehouse.two_factor_mandate.available"]
             and context.pypi_mandates_2fa
-            and not request.user.has_two_factor
+            and not request.identity.has_two_factor
         ):
             request.session.flash(
                 "This project is included in PyPI's two-factor mandate "

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -16,7 +16,7 @@ from pyramid.authentication import (
     SessionAuthenticationHelper,
     extract_http_basic_credentials,
 )
-from pyramid.authorization import ACLHelper, Authenticated
+from pyramid.authorization import ACLHelper
 from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.interfaces import ISecurityPolicy
 from pyramid.security import Allowed
@@ -303,3 +303,5 @@ def _check_for_mfa(request, context) -> WarehouseDenied | None:
                 "perform this action without enabling 2FA for your account",
                 queue="warning",
             )
+
+    return None

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -238,7 +238,7 @@ def _permits_for_user_policy(acl, request, context, permission):
     assert isinstance(request.identity, User)
 
     # Dispatch to our ACL
-    # NOTE: These parameters are in a different order
+    # NOTE: These parameters are in a different order than the signature of this method.
     res = acl.permits(context, principals_for(request.identity), permission)
 
     # If our underlying permits allowed this, we will check our 2FA status,

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -58,8 +58,11 @@ class RootFactory:
 
     __acl__ = [
         (Allow, "group:admins", "admin"),
+        (Allow, "group:admins", "admin_dashboard_access"),
         (Allow, "group:moderators", "moderator"),
+        (Allow, "group:moderators", "admin_dashboard_access"),
         (Allow, "group:psf_staff", "psf_staff"),
+        (Allow, "group:psf_staff", "admin_dashboard_access"),
         (Allow, Authenticated, "manage:user"),
     ]
 

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -60,7 +60,6 @@ class RootFactory:
         (Allow, "group:admins", "admin"),
         (Allow, "group:moderators", "moderator"),
         (Allow, "group:psf_staff", "psf_staff"),
-        (Allow, "group:with_admin_dashboard_access", "admin_dashboard_access"),
         (Allow, Authenticated, "manage:user"),
     ]
 

--- a/warehouse/macaroons/security_policy.py
+++ b/warehouse/macaroons/security_policy.py
@@ -125,16 +125,6 @@ class MacaroonSecurityPolicy:
         raise NotImplementedError
 
     def permits(self, request, context, permission):
-        # Our request could possibly be a None, if there isn't an active request, in
-        # that case we're going to always deny, because without a request, we can't
-        # determine if this request is authorized or not.
-        # TODO: This is weird? This feels like it comes from the old AuthZ policies
-        #       which didn't have access to the request.
-        if request is None:
-            return WarehouseDenied(
-                "There was no active request.", reason="no_active_request"
-            )
-
         # Re-extract our Macaroon from the request, it sucks to have to do this work
         # twice, but I believe it is inevitable unless we pass the Macaroon back as
         # a principal-- which doesn't seem to be the right fit for it.

--- a/warehouse/macaroons/security_policy.py
+++ b/warehouse/macaroons/security_policy.py
@@ -136,7 +136,7 @@ class MacaroonSecurityPolicy:
 
         # Check to make sure that the permission we're attempting to permit is one that
         # is allowed to be used for macaroons.
-        # TODO: This should be moved out of there and into the acaroons themselves, it
+        # TODO: This should be moved out of there and into the macaroons themselves, it
         #       doesn't really make a lot of sense here and it makes things more
         #       complicated if we want to allow the use of macaroons for actions other
         #       than uploading.
@@ -160,5 +160,5 @@ class MacaroonSecurityPolicy:
 
         # The macaroon is valid, so we can actually see if request.identity is
         # authorized now or not.
-        # NOTE: These parameters are in a different order
+        # NOTE: These parameters are in a different order than the signature of this method.
         return self._acl.permits(context, principals_for(request.identity), permission)

--- a/warehouse/macaroons/security_policy.py
+++ b/warehouse/macaroons/security_policy.py
@@ -160,5 +160,6 @@ class MacaroonSecurityPolicy:
 
         # The macaroon is valid, so we can actually see if request.identity is
         # authorized now or not.
-        # NOTE: These parameters are in a different order than the signature of this method.
+        # NOTE: These parameters are in a different order than the signature of this
+        #       method.
         return self._acl.permits(context, principals_for(request.identity), permission)

--- a/warehouse/oidc/utils.py
+++ b/warehouse/oidc/utils.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pyramid.authorization import Authenticated
 from sqlalchemy.sql.expression import func, literal
 
 from warehouse.oidc.interfaces import SignedClaims
@@ -117,3 +118,6 @@ class OIDCContext:
     """
     Pertinent OIDC claims from the token, if they exist.
     """
+
+    def __principals__(self) -> list[str]:
+        principals = [Authenticated, f"oidc:{self.publisher.id}"]

--- a/warehouse/oidc/utils.py
+++ b/warehouse/oidc/utils.py
@@ -120,4 +120,4 @@ class OIDCContext:
     """
 
     def __principals__(self) -> list[str]:
-        principals = [Authenticated, f"oidc:{self.publisher.id}"]
+        return [Authenticated, f"oidc:{self.publisher.id}"]

--- a/warehouse/utils/security_policy.py
+++ b/warehouse/utils/security_policy.py
@@ -83,10 +83,6 @@ class MultiSecurityPolicy:
                 return str(ident.id)
         return None
 
-    def unauthenticated_userid(self, request):
-        # This is deprecated and we shouldn't use it
-        raise NotImplementedError
-
     def forget(self, request, **kw):
         headers = []
         for policy in self._policies:

--- a/warehouse/utils/security_policy.py
+++ b/warehouse/utils/security_policy.py
@@ -12,14 +12,12 @@
 
 import enum
 
-from pyramid.authorization import ACLHelper, Authenticated
 from pyramid.interfaces import ISecurityPolicy
 from pyramid.request import RequestLocalCache
 from pyramid.security import Denied
 from zope.interface import implementer
 
 from warehouse.accounts.models import User
-from warehouse.oidc.utils import OIDCContext
 
 
 # NOTE: Is there a better place for this to live? It may not even need to exist


### PR DESCRIPTION
This refactors our use of the legacy `IAuthorizationPolicy` to migrate fully onto `ISecurityPolicy`.

Important things to note:

- The `MultiSecurityPolicy` remembers what policy provided an identity, and will *only* dispatch to that policy to call `permits()`.
    - This works using a `RequestLocalCache` which will store a weak reference to the request and return the same results each time, this keeps the logic encapsulated inside `MultiSecurityPolicy`.
    - All of our security policies ultimately dispatch to Pyramid's ACL system, so permissions are the same across all the security policies except for the policy specific bits (Macaroons, 2FA, etc).
    - This keeps  each security policy focused, you no longer have to figure out a complex interaction between multiple authorization policies that wrap each other.
- 2FA enforcement is no longer it's own AuthZ policy, but part of the Basic Auth and Session policies.
- Any object that we use for `request.identity` now knows how to generate it's own principals, this keeps ACLs and Principals both "near" the objects that implement them.
- ~~Removed some `group:with_admin_dashboard_access` group and related permission that, as far as I can tell, were not used for anything and were being granted to every logged in user, which felt wrong and confusing to me.~~
- Removed the `group:with_admin_dashboard_access` and granted the `admin_dashboard_access` permission to our 3 admin groups.


Making this a draft because I want to do some manual testing tomorrow when I'm more awake.


Thanks to @tnytown for a great start with #13754!

Closes #13754
Fixed #13690