### PR TITLE
fix: actually call for the publisher_url

### DIFF
--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -249,7 +249,7 @@
             {% for pub in oidc_publishers %}
             <tr>
               <td>{{ pub.publisher_name }}</td>
-              <td><a href="{{ pub.publisher_url }}">{{ pub.repository }}</a></td>
+              <td><a href="{{ pub.publisher_url() }}">{{ pub.repository }}</a></td>
               <td><code>{{ pub }}</code></td>
             </tr>
             {% endfor %}

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -470,7 +470,7 @@
                 <tr>
                   <td>{{ pub.project_name }}</td>
                   <td>{{ pub.publisher_name }}</td>
-                  <td><a href="{{ pub.publisher_url }}">{{ pub.repository }}</a></td>
+                  <td><a href="{{ pub.publisher_url() }}">{{ pub.repository }}</a></td>
                   <td><code>{{ pub }}</code></td>
                 </tr>
                 {% endfor %}

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -179,6 +179,10 @@ class OIDCPublisherMixin:
         raise NotImplementedError
 
     def publisher_url(self, claims=None):  # pragma: no cover
+        """
+        NOTE: This is **NOT** a `@property` because we pass `claims` to it.
+        When calling, make sure to use `publisher_url()`
+        """
         # Only concrete subclasses are constructed.
         raise NotImplementedError
 

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -516,7 +516,7 @@
     {{ publisher.publisher_name }}
   </td>
   <td scope="row">
-    <a href="{{ publisher.publisher_url }}">{{ publisher.repository }}</a>
+    <a href="{{ publisher.publisher_url() }}">{{ publisher.repository }}</a>
   </td>
   <td scope="row">
     {{ publisher.workflow_filename }}


### PR DESCRIPTION
Without the call, we surface broken links to the end user and admin interfaces.