### PR TITLE
set a timeout on calls to HIBP email breach service

### DIFF
--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -1412,6 +1412,7 @@ class TestHaveIBeenPwnedEmailBreachedService:
             pretend.call(
                 "https://haveibeenpwned.com/api/v3/breachedaccount/foo@example.com",
                 headers={"User-Agent": "PyPI.org", "hibp-api-key": "blowhole"},
+                timeout=(0.25, 0.25),
             )
         ]
 
@@ -1433,6 +1434,7 @@ class TestHaveIBeenPwnedEmailBreachedService:
             pretend.call(
                 "https://haveibeenpwned.com/api/v3/breachedaccount/new-email@gmail.com",
                 headers={"User-Agent": "PyPI.org", "hibp-api-key": "blowhole"},
+                timeout=(0.25, 0.25),
             )
         ]
 

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -865,6 +865,7 @@ class HaveIBeenPwnedEmailBreachedService:
             resp = self._http.get(
                 urllib.parse.urljoin(self._api_base, email),
                 headers={"User-Agent": "PyPI.org", "hibp-api-key": self.api_key},
+                timeout=(0.25, 0.25),
             )
             resp.raise_for_status()
         except requests.RequestException as exc:


### PR DESCRIPTION
has been making loading the admin page painful recently.

maybe we can/should move this to an include that is loaded separately (and concurrently!)