### PR TITLE
Generalize trusted publishing emails

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -3627,7 +3627,7 @@ class TestManageAccountPublishingViews:
 
         assert db_request.session.flash.calls == [
             pretend.call(
-                "Registered a new publishing publisher to create "
+                "Registered a new pending publisher to create "
                 "the project 'some-project-name'.",
                 queue="success",
             )

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -5819,11 +5819,7 @@ class TestTrustedPublisherEmails:
         assert result == {
             "username": stub_user.username,
             "project_name": project_name,
-            "publisher_name": "fakepublisher",
-            "publisher_workflow": "fakespecifier",
-            "publisher_repository_owner": "fakeowner",
-            "publisher_repository_name": "fakerepository",
-            "publisher_environment": "fakeenvironment",
+            "publisher": fakepublisher,
         }
         subject_renderer.assert_()
         body_renderer.assert_(username=stub_user.username, project_name=project_name)

--- a/tests/unit/oidc/models/test_google.py
+++ b/tests/unit/oidc/models/test_google.py
@@ -35,7 +35,7 @@ class TestGooglePublisher:
     def test_publisher_url(self):
         publisher = google.GooglePublisher(email="fake@example.com")
 
-        assert publisher.publisher_url() == "https://accounts.google.com"
+        assert publisher.publisher_url() is None
 
     def test_stringifies_as_email(self):
         publisher = google.GooglePublisher(email="fake@example.com")

--- a/tests/unit/oidc/models/test_google.py
+++ b/tests/unit/oidc/models/test_google.py
@@ -27,6 +27,16 @@ def test_lookup_strategies():
 
 
 class TestGooglePublisher:
+    def test_publisher_name(self):
+        publisher = google.GooglePublisher(email="fake@example.com")
+
+        assert publisher.publisher_name == "Google"
+
+    def test_publisher_url(self):
+        publisher = google.GooglePublisher(email="fake@example.com")
+
+        assert publisher.publisher_url() == "https://accounts.google.com"
+
     def test_stringifies_as_email(self):
         publisher = google.GooglePublisher(email="fake@example.com")
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1584,7 +1584,7 @@ class ManageAccountPublishingViews:
 
         self.request.session.flash(
             self.request._(
-                "Registered a new publishing publisher to create "
+                "Registered a new pending publisher to create "
                 f"the project '{pending_publisher.project_name}'."
             ),
             queue="success",

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -249,7 +249,11 @@
             {% for pub in oidc_publishers %}
             <tr>
               <td>{{ pub.publisher_name }}</td>
-              <td><a href="{{ pub.publisher_url() }}">{{ pub.repository }}</a></td>
+              {% if pub.publisher_url() %}
+              <td><a href="{{ pub.publisher_url() }}">{{ pub.publisher_url() }}</a></td>
+              {% else %}
+              <td>N/A</td>
+              {% endif %}
               <td><code>{{ pub }}</code></td>
             </tr>
             {% endfor %}

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -470,7 +470,11 @@
                 <tr>
                   <td>{{ pub.project_name }}</td>
                   <td>{{ pub.publisher_name }}</td>
-                  <td><a href="{{ pub.publisher_url() }}">{{ pub.repository }}</a></td>
+                  {% if pub.publisher_url() %}
+                  <td><a href="{{ pub.publisher_url() }}">{{ pub.publisher_url() }}</a></td>
+                  {% else %}
+                  <td>N/A</td>
+                  {% endif %}
                   <td><code>{{ pub }}</code></td>
                 </tr>
                 {% endfor %}

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -992,11 +992,7 @@ def send_trusted_publisher_added_email(request, user, project_name, publisher):
     return {
         "username": request.user.username,
         "project_name": project_name,
-        "publisher_name": publisher.publisher_name,
-        "publisher_workflow": str(publisher),
-        "publisher_repository_owner": publisher.repository_owner,
-        "publisher_repository_name": publisher.repository_name,
-        "publisher_environment": publisher.environment,
+        "publisher": publisher,
     }
 
 
@@ -1006,11 +1002,7 @@ def send_trusted_publisher_removed_email(request, user, project_name, publisher)
     return {
         "username": request.user.username,
         "project_name": project_name,
-        "publisher_name": publisher.publisher_name,
-        "publisher_workflow": str(publisher),
-        "publisher_repository_owner": publisher.repository_owner,
-        "publisher_repository_name": publisher.repository_name,
-        "publisher_environment": publisher.environment,
+        "publisher": publisher,
     }
 
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3168,7 +3168,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:504
 #: warehouse/templates/manage/account.html:523
-#: warehouse/templates/manage/project/history.html:268
+#: warehouse/templates/manage/project/history.html:272
 msgid "Reason:"
 msgstr ""
 
@@ -3309,13 +3309,13 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:620
 #: warehouse/templates/manage/account.html:643
-#: warehouse/templates/manage/project/history.html:259
-#: warehouse/templates/manage/project/history.html:266
+#: warehouse/templates/manage/project/history.html:263
+#: warehouse/templates/manage/project/history.html:270
 msgid "Token name:"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:637
-#: warehouse/templates/manage/project/history.html:261
+#: warehouse/templates/manage/project/history.html:265
 msgid "API token removed"
 msgstr ""
 
@@ -3367,7 +3367,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:683
 #: warehouse/templates/manage/organization/history.html:201
-#: warehouse/templates/manage/project/history.html:300
+#: warehouse/templates/manage/project/history.html:304
 #: warehouse/templates/manage/team/history.html:108
 msgid "Event"
 msgstr ""
@@ -3375,8 +3375,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:684
 #: warehouse/templates/manage/organization/history.html:202
 #: warehouse/templates/manage/organization/history.html:211
-#: warehouse/templates/manage/project/history.html:301
-#: warehouse/templates/manage/project/history.html:310
+#: warehouse/templates/manage/project/history.html:305
+#: warehouse/templates/manage/project/history.html:314
 #: warehouse/templates/manage/team/history.html:109
 #: warehouse/templates/manage/team/history.html:118
 msgid "Time"
@@ -3399,7 +3399,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:698
 #: warehouse/templates/manage/organization/history.html:217
-#: warehouse/templates/manage/project/history.html:316
+#: warehouse/templates/manage/project/history.html:320
 #: warehouse/templates/manage/team/history.html:124
 msgid "Device Info"
 msgstr ""
@@ -3735,7 +3735,7 @@ msgid "Submitted by:"
 msgstr ""
 
 #: warehouse/templates/manage/manage_base.html:546
-#: warehouse/templates/manage/project/history.html:243
+#: warehouse/templates/manage/project/history.html:247
 msgid "Workflow:"
 msgstr ""
 
@@ -4707,7 +4707,7 @@ msgid "Revoked by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:198
-#: warehouse/templates/manage/project/history.html:297
+#: warehouse/templates/manage/project/history.html:301
 #: warehouse/templates/manage/team/history.html:105
 #, python-format
 msgid "Security history for %(source_name)s"
@@ -5311,13 +5311,13 @@ msgid "Short-lived API token created"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:222
-#: warehouse/templates/manage/project/history.html:248
-#: warehouse/templates/manage/project/history.html:262
+#: warehouse/templates/manage/project/history.html:252
+#: warehouse/templates/manage/project/history.html:266
 msgid "Permissions: Can upload to this project"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:225
-#: warehouse/templates/manage/project/history.html:256
+#: warehouse/templates/manage/project/history.html:260
 msgid "Expiration:"
 msgstr ""
 
@@ -5330,47 +5330,47 @@ msgid "Expired"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:237
-msgid "Creator:"
-msgstr ""
-
-#: warehouse/templates/manage/project/history.html:247
-msgid "API token created"
+msgid "Creator"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:251
-#: warehouse/templates/manage/project/history.html:264
+msgid "API token created"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:255
+#: warehouse/templates/manage/project/history.html:268
 msgid "Controlled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:273
+#: warehouse/templates/manage/project/history.html:277
 msgid "Trusted publisher added"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:276
+#: warehouse/templates/manage/project/history.html:280
 msgid "Trusted publisher removed"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:281
+#: warehouse/templates/manage/project/history.html:285
 msgid "2FA requirement enabled"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:283
+#: warehouse/templates/manage/project/history.html:287
 msgid "Enabled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:286
+#: warehouse/templates/manage/project/history.html:290
 msgid "2FA requirement disabled"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:288
+#: warehouse/templates/manage/project/history.html:292
 msgid "Disabled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:302
+#: warehouse/templates/manage/project/history.html:306
 msgid "Additional info"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:314
+#: warehouse/templates/manage/project/history.html:318
 #: warehouse/templates/manage/team/history.html:122
 msgid "Location info"
 msgstr ""

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -301,7 +301,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/accounts/views.py:1586
-msgid "Registered a new publishing publisher to create "
+msgid "Registered a new pending publisher to create "
 msgstr ""
 
 #: warehouse/accounts/views.py:1623 warehouse/accounts/views.py:1636
@@ -2375,15 +2375,15 @@ msgstr ""
 msgid "Publisher name"
 msgstr ""
 
-#: warehouse/templates/email/trusted-publisher-added/body.html:31
-#: warehouse/templates/email/trusted-publisher-removed/body.html:29
+#: warehouse/templates/email/trusted-publisher-added/body.html:32
+#: warehouse/templates/email/trusted-publisher-removed/body.html:30
 #: warehouse/templates/manage/account/publishing.html:173
 #: warehouse/templates/manage/project/publishing.html:46
 msgid "Workflow"
 msgstr ""
 
-#: warehouse/templates/email/trusted-publisher-added/body.html:32
-#: warehouse/templates/email/trusted-publisher-removed/body.html:30
+#: warehouse/templates/email/trusted-publisher-added/body.html:33
+#: warehouse/templates/email/trusted-publisher-removed/body.html:31
 #: warehouse/templates/includes/packaging/project-data.html:117
 #: warehouse/templates/manage/account/publishing.html:47
 #: warehouse/templates/manage/organization/roles.html:53
@@ -2399,27 +2399,38 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: warehouse/templates/email/trusted-publisher-added/body.html:33
-#: warehouse/templates/email/trusted-publisher-removed/body.html:31
+#: warehouse/templates/email/trusted-publisher-added/body.html:34
+#: warehouse/templates/email/trusted-publisher-removed/body.html:32
 #: warehouse/templates/manage/account/publishing.html:172
 #: warehouse/templates/manage/project/publishing.html:45
 msgid "Repository"
 msgstr ""
 
-#: warehouse/templates/email/trusted-publisher-added/body.html:35
-#: warehouse/templates/email/trusted-publisher-removed/body.html:33
+#: warehouse/templates/email/trusted-publisher-added/body.html:36
+#: warehouse/templates/email/trusted-publisher-removed/body.html:34
 msgid "Environment"
 msgstr ""
 
+#: warehouse/templates/email/trusted-publisher-added/body.html:39
+#: warehouse/templates/email/trusted-publisher-removed/body.html:37
+#: warehouse/templates/includes/accounts/profile-public-email.html:17
+msgid "Email"
+msgstr ""
+
 #: warehouse/templates/email/trusted-publisher-added/body.html:41
+#: warehouse/templates/email/trusted-publisher-removed/body.html:39
+msgid "Subject"
+msgstr ""
+
+#: warehouse/templates/email/trusted-publisher-added/body.html:48
 msgid ""
 "If you did not make this change and you think it was made maliciously, "
 "you can remove it from the project via the \"Publishing\" tab on the "
 "project's page."
 msgstr ""
 
-#: warehouse/templates/email/trusted-publisher-added/body.html:48
-#: warehouse/templates/email/trusted-publisher-removed/body.html:46
+#: warehouse/templates/email/trusted-publisher-added/body.html:55
+#: warehouse/templates/email/trusted-publisher-removed/body.html:53
 #, python-format
 msgid ""
 "If you are unable to revert the change and need to do so, you can email "
@@ -2434,7 +2445,7 @@ msgid ""
 "from a project (<strong>%(project_name)s</strong>) that you manage."
 msgstr ""
 
-#: warehouse/templates/email/trusted-publisher-removed/body.html:39
+#: warehouse/templates/email/trusted-publisher-removed/body.html:46
 msgid ""
 "If you did not make this change and you think it was made in error, you "
 "can check the \"Security history\" tab on the project's page."
@@ -2674,10 +2685,6 @@ msgstr ""
 #: warehouse/templates/includes/accounts/profile-callout.html:23
 #, python-format
 msgid "%(username)s has not uploaded any projects to PyPI, yet."
-msgstr ""
-
-#: warehouse/templates/includes/accounts/profile-public-email.html:17
-msgid "Email"
 msgstr ""
 
 #: warehouse/templates/includes/manage/manage-organization-menu.html:14

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -211,7 +211,7 @@ class OIDCPublisherMixin:
         # Only concrete subclasses are constructed.
         raise NotImplementedError
 
-    def publisher_url(self, claims=None) -> str:  # pragma: no cover
+    def publisher_url(self, claims=None) -> str | None:  # pragma: no cover
         """
         NOTE: This is **NOT** a `@property` because we pass `claims` to it.
         When calling, make sure to use `publisher_url()`

--- a/warehouse/oidc/models/google.py
+++ b/warehouse/oidc/models/google.py
@@ -82,7 +82,7 @@ class GooglePublisherMixin:
         return "Google"
 
     def publisher_url(self, claims=None):
-        return "https://accounts.google.com"
+        return None
 
     @property
     def email_verified(self):

--- a/warehouse/oidc/models/google.py
+++ b/warehouse/oidc/models/google.py
@@ -78,6 +78,13 @@ class GooglePublisherMixin:
     ]
 
     @property
+    def publisher_name(self):
+        return "Google"
+
+    def publisher_url(self, claims=None):
+        return "https://accounts.google.com"
+
+    @property
     def email_verified(self):
         # We don't consider a claim set valid unless `email_verified` is true;
         # no other states are possible.

--- a/warehouse/templates/email/trusted-publisher-added/body.html
+++ b/warehouse/templates/email/trusted-publisher-added/body.html
@@ -27,12 +27,19 @@
 <p>
   {% trans %}Publisher information{% endtrans %}:
   <ul>
-    <li>{% trans %}Publisher name{% endtrans %}: {{ publisher_name }}</li>
-    <li>{% trans %}Workflow{% endtrans %}: {{ publisher_workflow }}</li>
-    <li>{% trans %}Owner{% endtrans %}: {{ publisher_repository_owner }}</li>
-    <li>{% trans %}Repository{% endtrans %}: {{ publisher_repository_name }}</li>
-    {% if publisher_environment %}
-    <li>{% trans %}Environment{% endtrans %}: {{ publisher_environment }}</li>
+    <li>{% trans %}Publisher name{% endtrans %}: {{ publisher.publisher_name }}</li>
+    {% if publisher.publisher_name == "GitHub" %}
+    <li>{% trans %}Workflow{% endtrans %}: {{ publisher }}</li>
+    <li>{% trans %}Owner{% endtrans %}: {{ publisher.repository_owner }}</li>
+    <li>{% trans %}Repository{% endtrans %}: {{ publisher.repository_name }}</li>
+    {% if publisher.environment %}
+    <li>{% trans %}Environment{% endtrans %}: {{ publisher.environment }}</li>
+    {% endif %}
+    {% elif publisher.publisher_name == "Google" %}
+    <li>{% trans %}Email{% endtrans %}: {{ publisher.email }}</li>
+    {% if publisher.sub %}
+    <li>{% trans %}Subject{% endtrans %}: {{ publisher.sub }}</li>
+    {% endif %}
     {% endif %}
   </ul>
 </p>

--- a/warehouse/templates/email/trusted-publisher-added/body.txt
+++ b/warehouse/templates/email/trusted-publisher-added/body.txt
@@ -22,12 +22,19 @@ users and can create project releases automatically.
 
 {% trans %}Publisher information{% endtrans %}:
 
-* {% trans %}Publisher{% endtrans %}: {{ publisher_name }}
-* {% trans %}Workflow{% endtrans %}: {{ publisher_workflow }}
-* {% trans %}Owner{% endtrans %}: {{ publisher_repository_owner }}
-* {% trans %}Repository{% endtrans %}: {{ publisher_repository_name }}
-{%- if publisher_environment %}
-* {% trans %}Environment{% endtrans %}: {{ publisher_environment }}
+* {% trans %}Publisher{% endtrans %}: {{ publisher.publisher_name }}
+{%- if publisher.publisher_name == "GitHub" %}
+* {% trans %}Workflow{% endtrans %}: {{ publisher }}
+* {% trans %}Owner{% endtrans %}: {{ publisher.repository_owner }}
+* {% trans %}Repository{% endtrans %}: {{ publisher.repository_name }}
+{%- if publisher.environment %}
+* {% trans %}Environment{% endtrans %}: {{ publisher.environment }}
+{%- endif %}
+{%- elif publisher.publisher_name == "Google" %}
+* {% trans %}Email{% endtrans %}: {{ publisher.email }}
+{%- if publisher.sub %}
+* {% trans %}Subject{% endtrans %}: {{ publisher.sub }}
+{%- endif %}
 {%- endif %}
 
 {% trans %}

--- a/warehouse/templates/email/trusted-publisher-removed/body.html
+++ b/warehouse/templates/email/trusted-publisher-removed/body.html
@@ -25,12 +25,19 @@
 <p>
   {% trans %}Publisher information{% endtrans %}:
   <ul>
-    <li>{% trans %}Publisher name{% endtrans %}: {{ publisher_name }}</li>
-    <li>{% trans %}Workflow{% endtrans %}: {{ publisher_workflow }}</li>
-    <li>{% trans %}Owner{% endtrans %}: {{ publisher_repository_owner }}</li>
-    <li>{% trans %}Repository{% endtrans %}: {{ publisher_repository_name }}</li>
-    {% if publisher_environment %}
-    <li>{% trans %}Environment{% endtrans %}: {{ publisher_environment }}</li>
+    <li>{% trans %}Publisher name{% endtrans %}: {{ publisher.publisher_name }}</li>
+    {% if publisher.publisher_name == "GitHub" %}
+    <li>{% trans %}Workflow{% endtrans %}: {{ publisher }}</li>
+    <li>{% trans %}Owner{% endtrans %}: {{ publisher.repository_owner }}</li>
+    <li>{% trans %}Repository{% endtrans %}: {{ publisher.repository_name }}</li>
+    {% if publisher.environment %}
+    <li>{% trans %}Environment{% endtrans %}: {{ publisher.environment }}</li>
+    {% endif %}
+    {% elif publisher.publisher_name == "Google" %}
+    <li>{% trans %}Email{% endtrans %}: {{ publisher.email }}</li>
+    {% if publisher.sub %}
+    <li>{% trans %}Subject{% endtrans %}: {{ publisher.sub }}</li>
+    {% endif %}
     {% endif %}
   </ul>
 </p>

--- a/warehouse/templates/email/trusted-publisher-removed/body.txt
+++ b/warehouse/templates/email/trusted-publisher-removed/body.txt
@@ -21,13 +21,20 @@ PyPI user {{ username }} has removed a trusted publisher from a project
 
 {% trans %}Publisher information{% endtrans %}:
 
-* {% trans %}Publisher{% endtrans %}: {{ publisher_name }}
-* {% trans %}Workflow{% endtrans %}: {{ publisher_workflow }}
-* {% trans %}Owner{% endtrans %}: {{ publisher_repository_owner }}
-* {% trans %}Repository{% endtrans %}: {{ publisher_repository_name }}
-{%- if publisher_environment %}
-* {% trans %}Environment{% endtrans %}: {{ publisher_environment }}
-{% endif %}
+* {% trans %}Publisher{% endtrans %}: {{ publisher.publisher_name }}
+{%- if publisher.publisher_name == "GitHub" %}
+* {% trans %}Workflow{% endtrans %}: {{ publisher }}
+* {% trans %}Owner{% endtrans %}: {{ publisher.repository_owner }}
+* {% trans %}Repository{% endtrans %}: {{ publisher.repository_name }}
+{%- if publisher.environment %}
+* {% trans %}Environment{% endtrans %}: {{ publisher.environment }}
+{%- endif %}
+{%- elif publisher.publisher_name == "Google" %}
+* {% trans %}Email{% endtrans %}: {{ publisher.email }}
+{%- if publisher.sub %}
+* {% trans %}Subject{% endtrans %}: {{ publisher.sub }}
+{%- endif %}
+{%- endif %}
 
 {% trans %}
 If you did not make this change and you think it was made in error, you can

--- a/warehouse/templates/manage/project/history.html
+++ b/warehouse/templates/manage/project/history.html
@@ -234,11 +234,15 @@
     </small>
     {% endif %}
     <small>
-      {% trans %}Creator: {% endtrans %}
+      {% trans %}Creator{% endtrans %}:
+      {% if event.additional.publisher_url %}
       {{ event.additional.publisher_name }}:
       <a href="{{ event.additional.publisher_url }}">
         {{ event.additional.publisher_url }}
       </a>
+      {% else %}
+      {{ event.additional.publisher_name }}
+      {% endif %}
       {% if event.additional.workflow %}
       <small>{% trans %}Workflow:{% endtrans %} {{ event.additional.workflow }}</small>
       {% endif %}


### PR DESCRIPTION
This makes the `trusted-publisher-added` and
`trusted-publisher-removed` email structures a little more
generic, allowing them to be re-used over both
GitHub and Google publishers. Future publishers will require
additional accommodations.

See https://github.com/pypi/warehouse/issues/13551.

Signed-off-by: William Woodruff <william@trailofbits.com>