### PR TITLE
refactor: remove version from search documents

### DIFF
--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -21,7 +21,6 @@ def test_build_search():
     release = pretend.stub(
         name="Foobar",
         normalized_name="foobar",
-        all_versions=["5.0.dev0", "4.0", "3.0", "2.0", "1.0", "dog"],
         latest_version="4.0",
         summary="This is my summary",
         description="This is my description",
@@ -40,7 +39,6 @@ def test_build_search():
 
     assert obj.meta.id == "foobar"
     assert obj["name"] == "Foobar"
-    assert obj["version"] == ["5.0.dev0", "4.0", "3.0", "2.0", "1.0", "dog"]
     assert obj["latest_version"] == "4.0"
     assert obj["summary"] == "This is my summary"
     assert obj["description"] == "This is my description"

--- a/tests/unit/search/test_tasks.py
+++ b/tests/unit/search/test_tasks.py
@@ -62,7 +62,6 @@ def test_project_docs(db_session):
                 "created": p.created,
                 "name": p.name,
                 "normalized_name": p.normalized_name,
-                "version": [r.version for r in prs],
                 "latest_version": first(prs, key=lambda r: not r.is_prerelease).version,
                 "description": first(
                     prs, key=lambda r: not r.is_prerelease
@@ -101,7 +100,6 @@ def test_single_project_doc(db_session):
                 "created": p.created,
                 "name": p.name,
                 "normalized_name": p.normalized_name,
-                "version": [r.version for r in prs],
                 "latest_version": first(prs, key=lambda r: not r.is_prerelease).version,
                 "description": first(
                     prs, key=lambda r: not r.is_prerelease
@@ -141,7 +139,6 @@ def test_project_docs_empty(db_session):
                 "created": p.created,
                 "name": p.name,
                 "normalized_name": p.normalized_name,
-                "version": [r.version for r in prs],
                 "latest_version": first(prs, key=lambda r: not r.is_prerelease).version,
                 "description": first(
                     prs, key=lambda r: not r.is_prerelease

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import packaging_legacy.version
-
 from elasticsearch_dsl import Date, Document, Keyword, Text, analyzer
 
 from warehouse.search.utils import doc_type
@@ -33,7 +31,6 @@ NameAnalyzer = analyzer(
 class Project(Document):
     name = Text()
     normalized_name = Text(analyzer=NameAnalyzer)
-    version = Keyword(multi=True)
     latest_version = Keyword()
     summary = Text(analyzer="snowball")
     description = Text(analyzer="snowball")
@@ -54,11 +51,6 @@ class Project(Document):
         obj = cls(meta={"id": release.normalized_name})
         obj["name"] = release.name
         obj["normalized_name"] = release.normalized_name
-        obj["version"] = sorted(
-            release.all_versions,
-            key=lambda r: packaging_legacy.version.parse(r),
-            reverse=True,
-        )
         obj["latest_version"] = release.latest_version
         obj["summary"] = release.summary
         obj["description"] = release.description

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -22,7 +22,6 @@ import requests_aws4auth
 from elasticsearch.helpers import parallel_bulk
 from elasticsearch_dsl import serializer
 from sqlalchemy import func, text
-from sqlalchemy.orm import aliased
 
 from warehouse import tasks
 from warehouse.packaging.models import (
@@ -54,16 +53,6 @@ def _project_docs(db, project_name=None):
 
     releases_list = releases_list.subquery()
 
-    r = aliased(Release, name="r")
-
-    all_versions = (
-        db.query(func.array_agg(r.version))
-        .filter(r.project_id == Release.project_id)
-        .correlate(Release)
-        .scalar_subquery()
-        .label("all_versions")
-    )
-
     classifiers = (
         db.query(func.array_agg(Classifier.classifier))
         .select_from(release_classifiers)
@@ -78,7 +67,6 @@ def _project_docs(db, project_name=None):
         db.query(
             Description.raw.label("description"),
             Release.version.label("latest_version"),
-            all_versions,
             Release.author,
             Release.author_email,
             Release.maintainer,


### PR DESCRIPTION
We refactored the way we select versions in #1519 when we provided a `latest_version` key based on database query lookup at the time of indexing.

The only usage was in the results.html template that no longer called for `.version`, so we should be able to safely remove this key from the search index, as well as the mechanism to populate it.

Found during efforts to refactor `windowed_query()` to SQLAlchemy 2.0 syntax.