### PR TITLE
Pass `Email` object, not string to `send_email` function

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -305,9 +305,7 @@ class TestManageAccount:
         ]
         assert send_email.calls == [
             pretend.call(pyramid_request, (pyramid_request.user, email)),
-            pretend.call(
-                pyramid_request, (pyramid_request.user, existing_email_address)
-            ),
+            pretend.call(pyramid_request, (pyramid_request.user, existing_email)),
         ]
         assert pyramid_request.user.record_event.calls == [
             pretend.call(

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -230,7 +230,7 @@ class ManageAccountViews:
                 if previously_registered_email != email:
                     send_new_email_added_email(
                         self.request,
-                        (self.request.user, previously_registered_email.email),
+                        (self.request.user, previously_registered_email),
                     )
 
             return HTTPSeeOther(self.request.path)


### PR DESCRIPTION
Fixes https://python-software-foundation.sentry.io/issues/4236739162/