### PR TITLE
test: remove pytest collect hook

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,24 +63,6 @@ from .common.db.accounts import EmailFactory, UserFactory
 from .common.db.ip_addresses import IpAddressFactory
 
 
-def pytest_collection_modifyitems(items):
-    for item in items:
-        if not hasattr(item, "module"):  # e.g.: DoctestTextfile
-            continue
-
-        module_path = os.path.relpath(
-            item.module.__file__, os.path.commonprefix([__file__, item.module.__file__])
-        )
-
-        module_root_dir = module_path.split(os.pathsep)[0]
-        if module_root_dir.startswith("functional"):
-            item.add_marker(pytest.mark.functional)
-        elif module_root_dir.startswith("unit"):
-            item.add_marker(pytest.mark.unit)
-        else:
-            raise RuntimeError(f"Unknown test type (filename = {module_path})")
-
-
 @contextmanager
 def metrics_timing(*args, **kwargs):
     yield None


### PR DESCRIPTION
We don't do anything with these markers, and the line between "unit" and "functional" has gotten blurrier over time.

If we ever redefine and adhere to a standard, we can achieve the same outcome by targeting a subdirectory for tests collection instead of dynamically marking everything on collection phase.

Saves a couple of seconds per test invocation, as this logic doesn't need to run for all of the test modules loaded.