### PR TITLE
refactor: replace URLType with Text

### DIFF
--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -22,6 +22,5 @@ types-pytz
 types-redis
 types-requests
 types-setuptools
-types-sqlalchemy-utils
 types-stdlib-list
 types-stripe

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -343,10 +343,6 @@ types-setuptools==67.8.0.0 \
     --hash=sha256:6df73340d96b238a4188b7b7668814b37e8018168aef1eef94a3b1872e3f60ff \
     --hash=sha256:95c9ed61871d6c0e258433373a4e1753c0a7c3627a46f4d4058c7b5a08ab844f
     # via -r requirements/lint.in
-types-sqlalchemy-utils==1.0.1 \
-    --hash=sha256:37016333faa0abab7d253805ecf9f605c24ea107b32dd3643014efb8e49be76d \
-    --hash=sha256:95bc90db15ec4af5b13d64f04a7d31a7e851931250419fc7859354644ab3ea98
-    # via -r requirements/lint.in
 types-stdlib-list==0.8.3.2 \
     --hash=sha256:17ff97316d88257f9b775b4dea2e9ad617325ea66a2737d841946dfd42363470 \
     --hash=sha256:8ed25c53c2df44212cbfd0ea3b4cc63d7ec0c13f5c475b6004e83c69fcd3f15c

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -62,7 +62,6 @@ sentry-sdk
 setuptools
 sqlalchemy[asyncio]>=0.9,<1.5.0  # https://github.com/pypi/warehouse/pull/9228
 sqlalchemy-citext
-sqlalchemy-utils
 stdlib-list
 stripe
 structlog

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1455,14 +1455,9 @@ sqlalchemy[asyncio]==1.4.48 \
     #   alembic
     #   paginate-sqlalchemy
     #   sqlalchemy-citext
-    #   sqlalchemy-utils
     #   zope-sqlalchemy
 sqlalchemy-citext==1.8.0 \
     --hash=sha256:a1740e693a9a334e7c8f60ae731083fe75ce6c1605bb9ca6644a6f1f63b15b77
-    # via -r requirements/main.in
-sqlalchemy-utils==0.41.1 \
-    --hash=sha256:6c96b0768ea3f15c0dc56b363d386138c562752b84f647fb8d31a2223aaab801 \
-    --hash=sha256:a2181bff01eeb84479e38571d2c0718eb52042f9afd8c194d0d02877e84b7d74
     # via -r requirements/main.in
 stdlib-list==0.8.0 \
     --hash=sha256:2ae0712a55b68f3fbbc9e58d6fa1b646a062188f49745b495f94d3310a9fdd3e \

--- a/warehouse/banners/models.py
+++ b/warehouse/banners/models.py
@@ -12,7 +12,6 @@
 from datetime import date
 
 from sqlalchemy import Boolean, Column, Date, String, Text
-from sqlalchemy_utils.types.url import URLType
 
 from warehouse import db
 from warehouse.utils.attrs import make_repr
@@ -29,7 +28,7 @@ class Banner(db.Model):
 
     # banner display configuration
     text = Column(Text, nullable=False)
-    link_url = Column(URLType, nullable=False)
+    link_url = Column(Text, nullable=False)
     link_label = Column(String, nullable=False, default=DEFAULT_BTN_LABEL)
     fa_icon = Column(String, nullable=False, default=DEFAULT_FA_ICON)
 

--- a/warehouse/cli/db/dbml.py
+++ b/warehouse/cli/db/dbml.py
@@ -36,7 +36,6 @@ from sqlalchemy.sql.sqltypes import (
     Text,
     Time,
 )
-from sqlalchemy_utils.types.url import URLType
 
 import warehouse.db
 
@@ -71,7 +70,6 @@ SQLALCHEMY_TO_DBML = {
     TZDateTime: "datetime",
     ARRAY: '"string[]"',
     TIMESTAMP: "datetime",
-    URLType: "varchar",
 }
 
 

--- a/warehouse/migrations/versions/10825786b3df_create_banner_model.py
+++ b/warehouse/migrations/versions/10825786b3df_create_banner_model.py
@@ -18,7 +18,6 @@ Create Date: 2021-06-22 18:16:50.425481
 """
 
 import sqlalchemy as sa
-import sqlalchemy_utils
 
 from alembic import op
 from sqlalchemy.dialects import postgresql
@@ -48,7 +47,7 @@ def upgrade():
         ),
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("text", sa.Text(), nullable=False),
-        sa.Column("link_url", sqlalchemy_utils.types.url.URLType(), nullable=False),
+        sa.Column("link_url", sa.Text(), nullable=False),
         sa.Column("link_label", sa.String(), nullable=False),
         sa.Column("fa_icon", sa.String(), nullable=False),
         sa.Column("active", sa.Boolean(), nullable=False),

--- a/warehouse/migrations/versions/5dcbd2bc748f_create_organizationapplication_model.py
+++ b/warehouse/migrations/versions/5dcbd2bc748f_create_organizationapplication_model.py
@@ -18,7 +18,6 @@ Create Date: 2023-06-02 22:38:01.308198
 """
 
 import sqlalchemy as sa
-import sqlalchemy_utils.types.url
 
 from alembic import op
 from sqlalchemy.dialects import postgresql
@@ -50,7 +49,7 @@ def upgrade():
         ),
         sa.Column(
             "link_url",
-            sqlalchemy_utils.types.url.URLType(),
+            sa.Text(),
             nullable=False,
             comment="External URL associated with the organization",
         ),

--- a/warehouse/migrations/versions/614a7fcb40ed_create_organization_models.py
+++ b/warehouse/migrations/versions/614a7fcb40ed_create_organization_models.py
@@ -18,7 +18,6 @@ Create Date: 2022-04-13 17:23:17.396325
 """
 
 import sqlalchemy as sa
-import sqlalchemy_utils
 
 from alembic import op
 from sqlalchemy.dialects import postgresql
@@ -49,7 +48,7 @@ def upgrade():
         sa.Column("name", sa.Text(), nullable=False),
         sa.Column("display_name", sa.Text(), nullable=False),
         sa.Column("orgtype", sa.Text(), nullable=False),
-        sa.Column("link_url", sqlalchemy_utils.types.url.URLType(), nullable=False),
+        sa.Column("link_url", sa.Text(), nullable=False),
         sa.Column("description", sa.Text(), nullable=False),
         sa.Column(
             "is_active", sa.Boolean(), nullable=False, server_default=sa.sql.false()

--- a/warehouse/migrations/versions/d0c22553b338_sponsor_model.py
+++ b/warehouse/migrations/versions/d0c22553b338_sponsor_model.py
@@ -18,7 +18,6 @@ Create Date: 2021-05-26 18:23:27.021443
 """
 
 import sqlalchemy as sa
-import sqlalchemy_utils
 
 from alembic import op
 from sqlalchemy.dialects import postgresql
@@ -49,13 +48,9 @@ def upgrade():
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("service", sa.String(), nullable=True),
         sa.Column("activity_markdown", sa.Text(), nullable=True),
-        sa.Column("link_url", sqlalchemy_utils.types.url.URLType(), nullable=False),
-        sa.Column(
-            "color_logo_url", sqlalchemy_utils.types.url.URLType(), nullable=False
-        ),
-        sa.Column(
-            "white_logo_url", sqlalchemy_utils.types.url.URLType(), nullable=True
-        ),
+        sa.Column("link_url", sa.Text(), nullable=False),
+        sa.Column("color_logo_url", sa.Text(), nullable=False),
+        sa.Column("white_logo_url", sa.Text(), nullable=True),
         sa.Column("is_active", sa.Boolean(), nullable=False),
         sa.Column("footer", sa.Boolean(), nullable=False),
         sa.Column("psf_sponsor", sa.Boolean(), nullable=False),

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -33,7 +33,6 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy_utils.types.url import URLType
 
 from warehouse import db
 from warehouse.accounts.models import User
@@ -243,7 +242,7 @@ class OrganizationMixin:
         comment="What type of organization such as Community or Company",
     )
     link_url = Column(
-        URLType, nullable=False, comment="External URL associated with the organization"
+        Text, nullable=False, comment="External URL associated with the organization"
     )
     description = Column(
         Text,

--- a/warehouse/sponsors/models.py
+++ b/warehouse/sponsors/models.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 from sqlalchemy import Boolean, Column, Integer, String, Text
-from sqlalchemy_utils.types.url import URLType
 
 from warehouse import db
 from warehouse.utils import readme
@@ -26,9 +25,9 @@ class Sponsor(db.Model):
     service = Column(String)
     activity_markdown = Column(Text)
 
-    link_url = Column(URLType, nullable=False)
-    color_logo_url = Column(URLType, nullable=False)
-    white_logo_url = Column(URLType)
+    link_url = Column(Text, nullable=False)
+    color_logo_url = Column(Text, nullable=False)
+    white_logo_url = Column(Text)
 
     # control flags
     is_active = Column(Boolean, default=False, nullable=False)


### PR DESCRIPTION
The underlying datatype for URLType is `Text` and we don't use any of the functionality from the type at all.

Introduced in #9512

We don't need to carry the library any further.