### PR TITLE
Record if an API Token was made with 2FA

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -2021,7 +2021,8 @@ class TestProvisionMacaroonViews:
         }
         assert macaroon_service.create_macaroon.calls == []
 
-    def test_create_macaroon(self, monkeypatch):
+    @pytest.mark.parametrize("has_2fa", [True, False])
+    def test_create_macaroon(self, monkeypatch, has_2fa):
         macaroon = pretend.stub()
         macaroon_service = pretend.stub(
             create_macaroon=pretend.call_recorder(
@@ -2036,6 +2037,7 @@ class TestProvisionMacaroonViews:
                 id="a user id",
                 has_primary_verified_email=True,
                 record_event=pretend.call_recorder(lambda *a, **kw: None),
+                has_two_factor=has_2fa,
             ),
             find_service=lambda interface, **kw: {
                 IMacaroonService: macaroon_service,
@@ -2075,6 +2077,7 @@ class TestProvisionMacaroonViews:
                 scopes=[
                     caveats.RequestUser(user_id="a user id"),
                 ],
+                additional={"made_with_2fa": has_2fa},
             )
         ]
         assert result == {
@@ -2116,6 +2119,7 @@ class TestProvisionMacaroonViews:
                 id=pretend.stub(),
                 has_primary_verified_email=True,
                 username=pretend.stub(),
+                has_two_factor=False,
                 projects=[
                     pretend.stub(
                         id=uuid.uuid4(),
@@ -2171,6 +2175,7 @@ class TestProvisionMacaroonViews:
                         project_ids=[str(p.id) for p in request.user.projects]
                     ),
                 ],
+                additional={"made_with_2fa": False},
             )
         ]
         assert result == {

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -267,13 +267,13 @@ msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
 #: warehouse/accounts/views.py:1449 warehouse/accounts/views.py:1598
-#: warehouse/manage/views/__init__.py:1239
+#: warehouse/manage/views/__init__.py:1240
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1466 warehouse/manage/views/__init__.py:1255
+#: warehouse/accounts/views.py:1466 warehouse/manage/views/__init__.py:1256
 msgid ""
 "GitHub-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
@@ -289,13 +289,13 @@ msgstr ""
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1509 warehouse/manage/views/__init__.py:1274
+#: warehouse/accounts/views.py:1509 warehouse/manage/views/__init__.py:1275
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1523 warehouse/manage/views/__init__.py:1288
+#: warehouse/accounts/views.py:1523 warehouse/manage/views/__init__.py:1289
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
@@ -424,86 +424,86 @@ msgstr ""
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1014
+#: warehouse/manage/views/__init__.py:1015
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1136
+#: warehouse/manage/views/__init__.py:1137
 msgid "2FA requirement cannot be disabled for critical projects"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1495
-#: warehouse/manage/views/__init__.py:1798
-#: warehouse/manage/views/__init__.py:1907
+#: warehouse/manage/views/__init__.py:1496
+#: warehouse/manage/views/__init__.py:1799
+#: warehouse/manage/views/__init__.py:1908
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1627
-#: warehouse/manage/views/__init__.py:1713
-#: warehouse/manage/views/__init__.py:1815
-#: warehouse/manage/views/__init__.py:1916
+#: warehouse/manage/views/__init__.py:1628
+#: warehouse/manage/views/__init__.py:1714
+#: warehouse/manage/views/__init__.py:1816
+#: warehouse/manage/views/__init__.py:1917
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1639
+#: warehouse/manage/views/__init__.py:1640
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1725
+#: warehouse/manage/views/__init__.py:1726
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1827
+#: warehouse/manage/views/__init__.py:1828
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1928
+#: warehouse/manage/views/__init__.py:1929
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1932
+#: warehouse/manage/views/__init__.py:1933
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2083
+#: warehouse/manage/views/__init__.py:2084
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2193
+#: warehouse/manage/views/__init__.py:2194
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2262
+#: warehouse/manage/views/__init__.py:2263
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2294
+#: warehouse/manage/views/__init__.py:2295
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2307
+#: warehouse/manage/views/__init__.py:2308
 #: warehouse/manage/views/organizations.py:891
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2374
+#: warehouse/manage/views/__init__.py:2375
 #: warehouse/manage/views/organizations.py:958
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2407
+#: warehouse/manage/views/__init__.py:2408
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2418
+#: warehouse/manage/views/__init__.py:2419
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2452
+#: warehouse/manage/views/__init__.py:2453
 #: warehouse/manage/views/organizations.py:1147
 msgid "Invitation revoked from '${username}'."
 msgstr ""

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -924,6 +924,7 @@ class ProvisionMacaroonViews:
                 description=form.description.data,
                 scopes=macaroon_caveats,
                 user_id=self.request.user.id,
+                additional={"made_with_2fa": self.request.user.has_two_factor},
             )
             self.request.user.record_event(
                 tag=EventTag.Account.APITokenAdded,


### PR DESCRIPTION
Records in the additional data if a particular API Token was made with 2FA enabled for the user or not.

Does not currently *do* anything with that data, just starts storing it for any future use (warning users to consider rotating those credentials maybe?).

Fixes #13772