### PR TITLE
Remove ip_address from record_event calls

### DIFF
--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -106,7 +106,6 @@ class TestLogin:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
-                ip_address="1.2.3.4",
                 request=pyramid_request,
                 additional={"reason": "invalid_password", "auth_method": "basic"},
             )
@@ -247,7 +246,6 @@ class TestLogin:
         assert service.update_user.calls == [pretend.call(2, last_login=now)]
         assert user.record_event.calls == [
             pretend.call(
-                ip_address="1.2.3.4",
                 request=pyramid_request,
                 tag=EventTag.Account.LoginSuccess,
                 additional={"auth_method": "basic"},

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -219,7 +219,6 @@ class TestLoginForm:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"reason": "invalid_password"},
             )
@@ -904,7 +903,6 @@ class TestTOTPAuthenticationForm:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"reason": "invalid_totp"},
             )
@@ -1009,7 +1007,6 @@ class TestWebAuthnAuthenticationForm:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"reason": "invalid_webauthn"},
             )
@@ -1123,7 +1120,6 @@ class TestRecoveryCodeForm:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.LoginFailure,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"reason": expected_reason},
             )

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -466,7 +466,6 @@ class TestDatabaseUserService:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PasswordDisabled,
-                ip_address="127.0.0.1",
                 request=request,
                 additional={"reason": expected},
             )

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -350,7 +350,6 @@ class TestLogin:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
                 additional={"two_factor_method": None, "two_factor_label": None},
             )
@@ -421,7 +420,6 @@ class TestLogin:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
                 additional={"two_factor_method": None, "two_factor_label": None},
             )
@@ -786,7 +784,6 @@ class TestTwoFactor:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
                 additional={"two_factor_method": "totp", "two_factor_label": "totp"},
             )
@@ -1230,7 +1227,6 @@ class TestRecoveryCode:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
                 additional={
                     "two_factor_method": "recovery-code",
@@ -1239,7 +1235,6 @@ class TestRecoveryCode:
             ),
             pretend.call(
                 tag=EventTag.Account.RecoveryCodesUsed,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
             ),
         ]
@@ -1492,13 +1487,11 @@ class TestRegister:
         assert record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.AccountCreate,
-                ip_address=db_request.remote_addr,
                 request=db_request,
                 additional={"email": "foo@bar.com"},
             ),
             pretend.call(
                 tag=EventTag.Account.LoginSuccess,
-                ip_address=db_request.remote_addr,
                 request=db_request,
                 additional={"two_factor_method": None, "two_factor_label": None},
             ),
@@ -1607,7 +1600,6 @@ class TestRequestPasswordReset:
         assert stub_user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PasswordResetRequest,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
             )
         ]
@@ -1672,7 +1664,6 @@ class TestRequestPasswordReset:
         assert stub_user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PasswordResetRequest,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
             )
         ]
@@ -1748,7 +1739,6 @@ class TestRequestPasswordReset:
         assert stub_user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PasswordResetRequest,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
             )
         ]
@@ -1848,7 +1838,6 @@ class TestRequestPasswordReset:
         assert stub_user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PasswordResetAttempt,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
             )
         ]
@@ -3622,7 +3611,6 @@ class TestManageAccountPublishingViews:
         assert db_request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PendingOIDCPublisherAdded,
-                ip_address="1.2.3.4",
                 request=db_request,
                 additional={
                     "project": "some-project-name",
@@ -3841,7 +3829,6 @@ class TestManageAccountPublishingViews:
         assert db_request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PendingOIDCPublisherRemoved,
-                ip_address="1.2.3.4",
                 request=db_request,
                 additional={
                     "project": "some-project-name",

--- a/tests/unit/events/test_models.py
+++ b/tests/unit/events/test_models.py
@@ -178,17 +178,13 @@ class TestUserAgentInfo:
     def test_summarizes_user_agents(self, db_request, test_input, expected):
         db_request.headers["User-Agent"] = test_input
         file = FileFactory.create()
-        file.record_event(
-            tag=EventTag.File.FileAdd, ip_address=None, request=db_request
-        )
+        file.record_event(tag=EventTag.File.FileAdd, request=db_request)
         assert file.events[0].additional.get("user_agent_info") == expected
 
     def test_bad_parse(self, db_request):
         db_request.headers["User-Agent"] = "nobueno"
         file = FileFactory.create()
-        file.record_event(
-            tag=EventTag.File.FileAdd, ip_address=None, request=db_request
-        )
+        file.record_event(tag=EventTag.File.FileAdd, request=db_request)
         assert file.events[0].additional is None
 
     @pytest.mark.parametrize(
@@ -336,7 +332,5 @@ class TestUserAgentInfo:
     def test_user_agent_info(self, db_request, user_agent, expected):
         db_request.headers["User-Agent"] = user_agent
         file = FileFactory.create()
-        file.record_event(
-            tag=EventTag.File.FileAdd, ip_address=None, request=db_request
-        )
+        file.record_event(tag=EventTag.File.FileAdd, request=db_request)
         assert file.events[0].user_agent_info == expected

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3104,7 +3104,7 @@ class TestFileUpload:
         }.get(svc)
 
         record_event = pretend.call_recorder(
-            lambda self, *, tag, ip_address, request=None, additional: None
+            lambda self, *, tag, request=None, additional: None
         )
         monkeypatch.setattr(HasEvents, "record_event", record_event)
 
@@ -3190,14 +3190,12 @@ class TestFileUpload:
             pretend.call(
                 mock.ANY,
                 tag=EventTag.Project.ReleaseAdd,
-                ip_address=mock.ANY,
                 request=db_request,
                 additional=release_event,
             ),
             pretend.call(
                 mock.ANY,
                 tag=EventTag.File.FileAdd,
-                ip_address=mock.ANY,
                 request=db_request,
                 additional=fileadd_event,
             ),

--- a/tests/unit/integration/github/test_utils.py
+++ b/tests/unit/integration/github/test_utils.py
@@ -609,7 +609,6 @@ def test_analyze_disclosure(monkeypatch):
     assert user.record_event.calls == [
         pretend.call(
             tag=EventTag.Account.APITokenRemovedLeak,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "macaroon_id": "12",

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -310,7 +310,6 @@ class TestManageAccount:
         assert pyramid_request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.EmailAdd,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
                 additional={"email": email_address},
             )
@@ -385,7 +384,6 @@ class TestManageAccount:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.EmailRemove,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"email": email.email},
             )
@@ -478,7 +476,6 @@ class TestManageAccount:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.EmailPrimaryChange,
-                ip_address=db_request.remote_addr,
                 request=db_request,
                 additional={"old_primary": "old", "new_primary": "new"},
             )
@@ -514,7 +511,6 @@ class TestManageAccount:
         assert db_request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.EmailPrimaryChange,
-                ip_address=db_request.remote_addr,
                 request=db_request,
                 additional={"old_primary": None, "new_primary": new_primary.email},
             )
@@ -582,7 +578,6 @@ class TestManageAccount:
         assert email.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.EmailReverify,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"email": email.email},
             )
@@ -747,7 +742,6 @@ class TestManageAccount:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.PasswordChange,
-                ip_address=request.remote_addr,
                 request=request,
             )
         ]
@@ -1153,7 +1147,6 @@ class TestProvisionTOTP:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.TwoFactorMethodAdded,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"method": "totp"},
             )
@@ -1311,7 +1304,6 @@ class TestProvisionTOTP:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.TwoFactorMethodRemoved,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"method": "totp"},
             )
@@ -1528,7 +1520,6 @@ class TestProvisionWebAuthn:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.TwoFactorMethodAdded,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "method": "webauthn",
@@ -1621,7 +1612,6 @@ class TestProvisionWebAuthn:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.TwoFactorMethodRemoved,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "method": "webauthn",
@@ -1712,7 +1702,6 @@ class TestProvisionRecoveryCodes:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.RecoveryCodesGenerated,
-                ip_address=request.remote_addr,
                 request=request,
             )
         ]
@@ -1786,7 +1775,6 @@ class TestProvisionRecoveryCodes:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.RecoveryCodesRegenerated,
-                ip_address=request.remote_addr,
                 request=request,
             )
         ]
@@ -2089,7 +2077,6 @@ class TestProvisionMacaroonViews:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.APITokenAdded,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "description": create_macaroon_obj.description.data,
@@ -2187,7 +2174,6 @@ class TestProvisionMacaroonViews:
         assert request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.APITokenAdded,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "description": create_macaroon_obj.description.data,
@@ -2204,7 +2190,6 @@ class TestProvisionMacaroonViews:
         assert record_project_event.calls == [
             pretend.call(
                 tag=EventTag.Project.APITokenAdded,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "description": create_macaroon_obj.description.data,
@@ -2213,7 +2198,6 @@ class TestProvisionMacaroonViews:
             ),
             pretend.call(
                 tag=EventTag.Project.APITokenAdded,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "description": create_macaroon_obj.description.data,
@@ -2346,7 +2330,6 @@ class TestProvisionMacaroonViews:
         assert pyramid_request.user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.APITokenRemoved,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
                 additional={"macaroon_id": delete_macaroon_obj.macaroon_id.data},
             )
@@ -2414,7 +2397,6 @@ class TestProvisionMacaroonViews:
         ]
         assert pyramid_request.user.record_event.calls == [
             pretend.call(
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
                 tag=EventTag.Account.APITokenRemoved,
                 additional={"macaroon_id": delete_macaroon_obj.macaroon_id.data},
@@ -2423,7 +2405,6 @@ class TestProvisionMacaroonViews:
         assert record_project_event.calls == [
             pretend.call(
                 tag=EventTag.Project.APITokenRemoved,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
                 additional={
                     "description": "fake macaroon",
@@ -2432,7 +2413,6 @@ class TestProvisionMacaroonViews:
             ),
             pretend.call(
                 tag=EventTag.Project.APITokenRemoved,
-                ip_address=pyramid_request.remote_addr,
                 request=pyramid_request,
                 additional={
                     "description": "fake macaroon",
@@ -3995,7 +3975,6 @@ class TestManageProjectRelease:
         assert release.project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.ReleaseYank,
-                ip_address=db_request.remote_addr,
                 request=db_request,
                 additional={
                     "submitted_by": db_request.user.username,
@@ -4151,7 +4130,6 @@ class TestManageProjectRelease:
         assert release.project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.ReleaseUnyank,
-                ip_address=db_request.remote_addr,
                 request=db_request,
                 additional={
                     "submitted_by": db_request.user.username,
@@ -4310,7 +4288,6 @@ class TestManageProjectRelease:
         assert release.project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.ReleaseRemove,
-                ip_address=db_request.remote_addr,
                 request=db_request,
                 additional={
                     "submitted_by": db_request.user.username,
@@ -6139,7 +6116,6 @@ class TestManageOIDCPublisherViews:
         assert project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.OIDCPublisherAdded,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "publisher": "GitHub",
@@ -6237,7 +6213,6 @@ class TestManageOIDCPublisherViews:
         assert project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.OIDCPublisherAdded,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "publisher": "GitHub",
@@ -6517,7 +6492,6 @@ class TestManageOIDCPublisherViews:
         assert project.record_event.calls == [
             pretend.call(
                 tag=EventTag.Project.OIDCPublisherRemoved,
-                ip_address=db_request.remote_addr,
                 request=db_request,
                 additional={
                     "publisher": publisher.publisher_name,

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -455,7 +455,6 @@ def test_mint_token_from_oidc_no_pending_publisher_ok(
     assert project.record_event.calls == [
         pretend.call(
             tag=EventTag.Project.ShortLivedAPITokenAdded,
-            ip_address="0.0.0.0",
             request=request,
             additional={
                 "expires": 900,

--- a/tests/unit/organizations/test_models.py
+++ b/tests/unit/organizations/test_models.py
@@ -196,7 +196,6 @@ class TestOrganization:
 
         organization.record_event(
             tag="",
-            ip_address=db_request.ip_address.ip_address,
             request=db_request,
             additional={},
         )
@@ -213,7 +212,6 @@ class TestOrganization:
         organization = DBOrganizationFactory.create()
         organization.record_event(
             tag="",
-            ip_address=db_request.ip_address.ip_address,
             request=db_request,
             additional={},
         )
@@ -231,7 +229,6 @@ class TestOrganization:
         organization = DBOrganizationFactory.create()
         organization.record_event(
             tag="",
-            ip_address=db_request.ip_address.ip_address,
             request=db_request,
             additional={},
         )

--- a/tests/unit/organizations/test_tasks.py
+++ b/tests/unit/organizations/test_tasks.py
@@ -69,7 +69,6 @@ class TestUpdateInvitationStatus:
         assert user.record_event.calls == [
             pretend.call(
                 tag=EventTag.Account.OrganizationRoleExpireInvite,
-                ip_address="1.2.3.4",
                 request=db_request,
                 additional={"organization_name": invite.organization.name},
             )
@@ -77,7 +76,6 @@ class TestUpdateInvitationStatus:
         assert organization.record_event.calls == [
             pretend.call(
                 tag=EventTag.Organization.OrganizationRoleExpireInvite,
-                ip_address="1.2.3.4",
                 request=db_request,
                 additional={"target_user_id": str(invite.user.id)},
             )

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -159,7 +159,6 @@ class PasswordMixin:
                     user = self.user_service.get_user(userid)
                     user.record_event(
                         tag=f"account:{self.action}:failure",
-                        ip_address=self.request.remote_addr,
                         request=self.request,
                         additional={"reason": "invalid_password"},
                     )
@@ -375,7 +374,6 @@ class TOTPAuthenticationForm(TOTPValueMixin, _TwoFactorAuthenticationForm):
             user = self.user_service.get_user(self.user_id)
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"reason": "invalid_totp"},
             )
@@ -412,7 +410,6 @@ class WebAuthnAuthenticationForm(WebAuthnCredentialMixin, _TwoFactorAuthenticati
             user = self.user_service.get_user(self.user_id)
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"reason": "invalid_webauthn"},
             )
@@ -454,7 +451,6 @@ class RecoveryCodeAuthenticationForm(
             user = self.user_service.get_user(self.user_id)
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"reason": "invalid_recovery_code"},
             )
@@ -463,7 +459,6 @@ class RecoveryCodeAuthenticationForm(
             user = self.user_service.get_user(self.user_id)
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"reason": "burned_recovery_code"},
             )

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -97,7 +97,6 @@ def _basic_auth_check(username, password, request):
             login_service.update_user(user.id, last_login=datetime.datetime.utcnow())
             user.record_event(
                 tag=EventTag.Account.LoginSuccess,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"auth_method": "basic"},
             )
@@ -105,7 +104,6 @@ def _basic_auth_check(username, password, request):
         else:
             user.record_event(
                 tag=EventTag.Account.LoginFailure,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={"reason": "invalid_password", "auth_method": "basic"},
             )

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -321,7 +321,6 @@ class DatabaseUserService:
         user.disabled_for = reason
         user.record_event(
             tag=EventTag.Account.PasswordDisabled,
-            ip_address=request.remote_addr,
             request=request,
             additional={"reason": reason.value if reason else None},
         )

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -492,7 +492,6 @@ def recovery_code(request, _form_class=RecoveryCodeAuthenticationForm):
             user = user_service.get_user(userid)
             user.record_event(
                 tag=EventTag.Account.RecoveryCodesUsed,
-                ip_address=request.remote_addr,
                 request=request,
             )
 
@@ -623,7 +622,6 @@ def register(request, _form_class=RegistrationForm):
         email = user_service.add_email(user.id, form.email.data, primary=True)
         user.record_event(
             tag=EventTag.Account.AccountCreate,
-            ip_address=request.remote_addr,
             request=request,
             additional={"email": form.email.data},
         )
@@ -671,7 +669,6 @@ def request_password_reset(request, _form_class=RequestPasswordResetForm):
             send_password_reset_email(request, (user, email))
             user.record_event(
                 tag=EventTag.Account.PasswordResetRequest,
-                ip_address=request.remote_addr,
                 request=request,
             )
             user_service.ratelimiters["password.reset"].hit(user.id)
@@ -682,7 +679,6 @@ def request_password_reset(request, _form_class=RequestPasswordResetForm):
         else:
             user.record_event(
                 tag=EventTag.Account.PasswordResetAttempt,
-                ip_address=request.remote_addr,
                 request=request,
             )
             request.session.flash(
@@ -788,7 +784,6 @@ def reset_password(request, _form_class=ResetPasswordForm):
         user_service.update_user(user.id, password=form.new_password.data)
         user.record_event(
             tag=EventTag.Account.PasswordReset,
-            ip_address=request.remote_addr,
             request=request,
         )
         password_reset_limiter.clear(user.id)
@@ -853,7 +848,6 @@ def verify_email(request):
     email.transient_bounces = 0
     email.user.record_event(
         tag=EventTag.Account.EmailVerified,
-        ip_address=request.remote_addr,
         request=request,
         additional={"email": email.email, "primary": email.primary},
     )
@@ -962,7 +956,6 @@ def verify_organization_role(request):
         message = request.params.get("message", "")
         organization.record_event(
             tag=EventTag.Organization.OrganizationRoleDeclineInvite,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(submitter_user.id),
@@ -972,7 +965,6 @@ def verify_organization_role(request):
         )
         user.record_event(
             tag=EventTag.Account.OrganizationRoleDeclineInvite,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(submitter_user.id),
@@ -1017,7 +1009,6 @@ def verify_organization_role(request):
     submitter_user = user_service.get_user(data.get("submitter_id"))
     organization.record_event(
         tag=EventTag.Organization.OrganizationRoleAdd,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by_user_id": str(submitter_user.id),
@@ -1027,7 +1018,6 @@ def verify_organization_role(request):
     )
     user.record_event(
         tag=EventTag.Account.OrganizationRoleAdd,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by_user_id": str(submitter_user.id),
@@ -1140,7 +1130,6 @@ def verify_project_role(request):
         submitter_user = user_service.get_user(data.get("submitter_id"))
         project.record_event(
             tag=EventTag.Project.RoleDeclineInvite,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by": submitter_user.username,
@@ -1150,7 +1139,6 @@ def verify_project_role(request):
         )
         user.record_event(
             tag=EventTag.Account.RoleDeclineInvite,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by": submitter_user.username,
@@ -1178,7 +1166,6 @@ def verify_project_role(request):
     )
     project.record_event(
         tag=EventTag.Project.RoleAdd,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by": request.user.username,
@@ -1188,7 +1175,6 @@ def verify_project_role(request):
     )
     user.record_event(
         tag=EventTag.Account.RoleAdd,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by": request.user.username,
@@ -1290,7 +1276,6 @@ def _login_user(request, userid, two_factor_method=None, two_factor_label=None):
     user = user_service.get_user(userid)
     user.record_event(
         tag=EventTag.Account.LoginSuccess,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "two_factor_method": two_factor_method,
@@ -1562,7 +1547,6 @@ class ManageAccountPublishingViews:
 
         self.request.user.record_event(
             tag=EventTag.Account.PendingOIDCPublisherAdded,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "project": pending_publisher.project_name,
@@ -1649,7 +1633,6 @@ class ManageAccountPublishingViews:
 
         self.request.user.record_event(
             tag=EventTag.Account.PendingOIDCPublisherRemoved,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "project": pending_publisher.project_name,

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -219,16 +219,16 @@ class HasEvents:
             back_populates="source",
         )
 
-    def record_event(self, *, tag, ip_address, request: Request, additional=None):
+    def record_event(self, *, tag, request: Request, additional=None):
         """Records an Event record on the associated model."""
         session = orm.object_session(self)
 
         # Get-or-create a new IpAddress object
-        ip_address_obj = request.ip_address
+        ip_address = request.ip_address
         # Add `request.ip_address.geoip_info` data to `Event.additional`
-        if ip_address_obj.geoip_info is not None:
+        if ip_address.geoip_info is not None:
             additional = additional or {}
-            additional["geoip_info"] = ip_address_obj.geoip_info
+            additional["geoip_info"] = ip_address.geoip_info
 
         if user_agent := request.headers.get("User-Agent"):
             try:
@@ -265,7 +265,7 @@ class HasEvents:
         event = self.Event(
             source=self,
             tag=tag,
-            ip_address=ip_address_obj,
+            ip_address=ip_address,
             additional=additional,
         )
 

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1165,7 +1165,6 @@ def file_upload(request):
 
         project.record_event(
             tag=EventTag.Project.ReleaseAdd,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by": request.user.username
@@ -1408,7 +1407,6 @@ def file_upload(request):
 
         file_.record_event(
             tag=EventTag.File.FileAdd,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "filename": file_.filename,

--- a/warehouse/integrations/github/utils.py
+++ b/warehouse/integrations/github/utils.py
@@ -244,7 +244,6 @@ def _analyze_disclosure(request, disclosure_record, origin):
 
     database_macaroon.user.record_event(
         tag=EventTag.Account.APITokenRemovedLeak,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "macaroon_id": str(database_macaroon.id),

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -41,62 +41,62 @@ msgid ""
 "different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:137 warehouse/accounts/forms.py:186
-#: warehouse/accounts/forms.py:199
+#: warehouse/accounts/forms.py:137 warehouse/accounts/forms.py:185
+#: warehouse/accounts/forms.py:198
 msgid "Password too long."
 msgstr ""
 
-#: warehouse/accounts/forms.py:174
+#: warehouse/accounts/forms.py:173
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for ${time}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/forms.py:202
+#: warehouse/accounts/forms.py:201
 msgid "Your passwords don't match. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:234 warehouse/accounts/forms.py:245
+#: warehouse/accounts/forms.py:233 warehouse/accounts/forms.py:244
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:253
+#: warehouse/accounts/forms.py:252
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:264
+#: warehouse/accounts/forms.py:263
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:271
+#: warehouse/accounts/forms.py:270
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:292 warehouse/manage/forms.py:139
+#: warehouse/accounts/forms.py:291 warehouse/manage/forms.py:139
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:382
+#: warehouse/accounts/forms.py:380
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:399
+#: warehouse/accounts/forms.py:397
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:461
+#: warehouse/accounts/forms.py:457
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:471
+#: warehouse/accounts/forms.py:466
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:490
+#: warehouse/accounts/forms.py:485
 msgid "No user found with that username or email"
 msgstr ""
 
@@ -133,188 +133,188 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:500 warehouse/manage/views/__init__.py:831
+#: warehouse/accounts/views.py:499 warehouse/manage/views/__init__.py:820
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:592
+#: warehouse/accounts/views.py:591
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:726
+#: warehouse/accounts/views.py:722
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:728
+#: warehouse/accounts/views.py:724
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:730 warehouse/accounts/views.py:833
-#: warehouse/accounts/views.py:933 warehouse/accounts/views.py:1106
+#: warehouse/accounts/views.py:726 warehouse/accounts/views.py:828
+#: warehouse/accounts/views.py:927 warehouse/accounts/views.py:1096
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:734
+#: warehouse/accounts/views.py:730
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:739
+#: warehouse/accounts/views.py:735
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:750
+#: warehouse/accounts/views.py:746
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:768
+#: warehouse/accounts/views.py:764
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:801
+#: warehouse/accounts/views.py:796
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:829
+#: warehouse/accounts/views.py:824
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:831
+#: warehouse/accounts/views.py:826
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:837
+#: warehouse/accounts/views.py:832
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:846
+#: warehouse/accounts/views.py:841
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:849
+#: warehouse/accounts/views.py:844
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:867
+#: warehouse/accounts/views.py:861
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:871
+#: warehouse/accounts/views.py:865
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:876
+#: warehouse/accounts/views.py:870
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:929
+#: warehouse/accounts/views.py:923
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:931
+#: warehouse/accounts/views.py:925
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:937
+#: warehouse/accounts/views.py:931
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:941
+#: warehouse/accounts/views.py:935
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:950
+#: warehouse/accounts/views.py:944
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1003
+#: warehouse/accounts/views.py:995
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1068
+#: warehouse/accounts/views.py:1058
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1102
+#: warehouse/accounts/views.py:1092
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1104
+#: warehouse/accounts/views.py:1094
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1110
+#: warehouse/accounts/views.py:1100
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1114
+#: warehouse/accounts/views.py:1104
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1129
+#: warehouse/accounts/views.py:1119
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1162
+#: warehouse/accounts/views.py:1150
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1230
+#: warehouse/accounts/views.py:1216
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1449 warehouse/accounts/views.py:1598
-#: warehouse/manage/views/__init__.py:1240
+#: warehouse/accounts/views.py:1434 warehouse/accounts/views.py:1582
+#: warehouse/manage/views/__init__.py:1223
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1466 warehouse/manage/views/__init__.py:1256
+#: warehouse/accounts/views.py:1451 warehouse/manage/views/__init__.py:1239
 msgid ""
 "GitHub-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1480
+#: warehouse/accounts/views.py:1465
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1493
+#: warehouse/accounts/views.py:1478
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1509 warehouse/manage/views/__init__.py:1275
+#: warehouse/accounts/views.py:1494 warehouse/manage/views/__init__.py:1258
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1523 warehouse/manage/views/__init__.py:1289
+#: warehouse/accounts/views.py:1508 warehouse/manage/views/__init__.py:1272
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1542
+#: warehouse/accounts/views.py:1527
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1578
+#: warehouse/accounts/views.py:1562
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1612 warehouse/accounts/views.py:1625
-#: warehouse/accounts/views.py:1632
+#: warehouse/accounts/views.py:1596 warehouse/accounts/views.py:1609
+#: warehouse/accounts/views.py:1616
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1638
+#: warehouse/accounts/views.py:1622
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -408,126 +408,126 @@ msgstr ""
 msgid "Account details updated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:221
+#: warehouse/manage/views/__init__.py:220
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:777
+#: warehouse/manage/views/__init__.py:768
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:778
+#: warehouse/manage/views/__init__.py:769
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:886
+#: warehouse/manage/views/__init__.py:875
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1015
+#: warehouse/manage/views/__init__.py:1000
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1137
+#: warehouse/manage/views/__init__.py:1122
 msgid "2FA requirement cannot be disabled for critical projects"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1496
-#: warehouse/manage/views/__init__.py:1799
-#: warehouse/manage/views/__init__.py:1908
+#: warehouse/manage/views/__init__.py:1477
+#: warehouse/manage/views/__init__.py:1778
+#: warehouse/manage/views/__init__.py:1886
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1628
-#: warehouse/manage/views/__init__.py:1714
-#: warehouse/manage/views/__init__.py:1816
-#: warehouse/manage/views/__init__.py:1917
+#: warehouse/manage/views/__init__.py:1609
+#: warehouse/manage/views/__init__.py:1694
+#: warehouse/manage/views/__init__.py:1795
+#: warehouse/manage/views/__init__.py:1895
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1640
+#: warehouse/manage/views/__init__.py:1621
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1726
+#: warehouse/manage/views/__init__.py:1706
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1828
+#: warehouse/manage/views/__init__.py:1807
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1929
+#: warehouse/manage/views/__init__.py:1907
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1933
+#: warehouse/manage/views/__init__.py:1911
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2084
+#: warehouse/manage/views/__init__.py:2061
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2194
+#: warehouse/manage/views/__init__.py:2168
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2263
+#: warehouse/manage/views/__init__.py:2235
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2295
+#: warehouse/manage/views/__init__.py:2267
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2308
-#: warehouse/manage/views/organizations.py:891
+#: warehouse/manage/views/__init__.py:2280
+#: warehouse/manage/views/organizations.py:882
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2375
-#: warehouse/manage/views/organizations.py:958
+#: warehouse/manage/views/__init__.py:2345
+#: warehouse/manage/views/organizations.py:947
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2408
+#: warehouse/manage/views/__init__.py:2378
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2419
+#: warehouse/manage/views/__init__.py:2389
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2453
-#: warehouse/manage/views/organizations.py:1147
+#: warehouse/manage/views/__init__.py:2421
+#: warehouse/manage/views/organizations.py:1134
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:867
+#: warehouse/manage/views/organizations.py:858
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:878
+#: warehouse/manage/views/organizations.py:869
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1041
-#: warehouse/manage/views/organizations.py:1083
+#: warehouse/manage/views/organizations.py:1030
+#: warehouse/manage/views/organizations.py:1072
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1051
+#: warehouse/manage/views/organizations.py:1040
 msgid "Organization invitation could not be re-sent."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1098
+#: warehouse/manage/views/organizations.py:1087
 msgid "Expired invitation for '${username}' deleted."
 msgstr ""
 

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -210,7 +210,6 @@ class ManageAccountViews:
             email = self.user_service.add_email(self.request.user.id, form.email.data)
             self.request.user.record_event(
                 tag=EventTag.Account.EmailAdd,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"email": email.email},
             )
@@ -262,7 +261,6 @@ class ManageAccountViews:
             self.request.user.emails.remove(email)
             self.request.user.record_event(
                 tag=EventTag.Account.EmailRemove,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"email": email.email},
             )
@@ -299,7 +297,6 @@ class ManageAccountViews:
         new_primary_email.primary = True
         self.request.user.record_event(
             tag=EventTag.Account.EmailPrimaryChange,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "old_primary": previous_primary_email.email
@@ -346,7 +343,6 @@ class ManageAccountViews:
                 verify_email_ratelimit.hit(self.request.user.id)
                 email.user.record_event(
                     tag=EventTag.Account.EmailReverify,
-                    ip_address=self.request.remote_addr,
                     request=self.request,
                     additional={"email": email.email},
                 )
@@ -385,7 +381,6 @@ class ManageAccountViews:
             )
             self.request.user.record_event(
                 tag=EventTag.Account.PasswordChange,
-                ip_address=self.request.remote_addr,
                 request=self.request,
             )
             send_password_change_email(self.request, self.request.user)
@@ -565,7 +560,6 @@ class ProvisionTOTPViews:
             self.request.session.clear_totp_secret()
             self.request.user.record_event(
                 tag=EventTag.Account.TwoFactorMethodAdded,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"method": "totp"},
             )
@@ -608,7 +602,6 @@ class ProvisionTOTPViews:
             self.user_service.update_user(self.request.user.id, totp_secret=None)
             self.request.user.record_event(
                 tag=EventTag.Account.TwoFactorMethodRemoved,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"method": "totp"},
             )
@@ -696,7 +689,6 @@ class ProvisionWebAuthnViews:
             )
             self.request.user.record_event(
                 tag=EventTag.Account.TwoFactorMethodAdded,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"method": "webauthn", "label": form.label.data},
             )
@@ -737,7 +729,6 @@ class ProvisionWebAuthnViews:
             self.request.user.webauthn.remove(form.webauthn)
             self.request.user.record_event(
                 tag=EventTag.Account.TwoFactorMethodRemoved,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"method": "webauthn", "label": form.label.data},
             )
@@ -784,7 +775,6 @@ class ProvisionRecoveryCodesViews:
         send_recovery_codes_generated_email(self.request, self.request.user)
         self.request.user.record_event(
             tag=EventTag.Account.RecoveryCodesGenerated,
-            ip_address=self.request.remote_addr,
             request=self.request,
         )
 
@@ -801,7 +791,6 @@ class ProvisionRecoveryCodesViews:
         send_recovery_codes_generated_email(self.request, self.request.user)
         self.request.user.record_event(
             tag=EventTag.Account.RecoveryCodesRegenerated,
-            ip_address=self.request.remote_addr,
             request=self.request,
         )
 
@@ -928,7 +917,6 @@ class ProvisionMacaroonViews:
             )
             self.request.user.record_event(
                 tag=EventTag.Account.APITokenAdded,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={
                     "description": form.description.data,
@@ -948,7 +936,6 @@ class ProvisionMacaroonViews:
                     # isn't aware of.
                     project.record_event(
                         tag=EventTag.Project.APITokenAdded,
-                        ip_address=self.request.remote_addr,
                         request=self.request,
                         additional={
                             "description": form.description.data,
@@ -985,7 +972,6 @@ class ProvisionMacaroonViews:
             self.macaroon_service.delete_macaroon(form.macaroon_id.data)
             self.request.user.record_event(
                 tag=EventTag.Account.APITokenRemoved,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"macaroon_id": form.macaroon_id.data},
             )
@@ -999,7 +985,6 @@ class ProvisionMacaroonViews:
                 for project in projects:
                     project.record_event(
                         tag=EventTag.Project.APITokenRemoved,
-                        ip_address=self.request.remote_addr,
                         request=self.request,
                         additional={
                             "description": macaroon.description,
@@ -1143,7 +1128,6 @@ class ManageProjectSettingsViews:
             self.project.owners_require_2fa = False
             self.project.record_event(
                 tag=EventTag.Project.OwnersRequire2FADisabled,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"modified_by": self.request.user.username},
             )
@@ -1155,7 +1139,6 @@ class ManageProjectSettingsViews:
             self.project.owners_require_2fa = True
             self.project.record_event(
                 tag=EventTag.Project.OwnersRequire2FAEnabled,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"modified_by": self.request.user.username},
             )
@@ -1338,7 +1321,6 @@ class ManageOIDCPublisherViews:
 
         self.project.record_event(
             tag=EventTag.Project.OIDCPublisherAdded,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "publisher": publisher.publisher_name,
@@ -1400,7 +1382,6 @@ class ManageOIDCPublisherViews:
 
             self.project.record_event(
                 tag=EventTag.Project.OIDCPublisherRemoved,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={
                     "publisher": publisher.publisher_name,
@@ -1666,7 +1647,6 @@ class ManageProjectRelease:
 
         self.release.project.record_event(
             tag=EventTag.Project.ReleaseYank,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "submitted_by": self.request.user.username,
@@ -1752,7 +1732,6 @@ class ManageProjectRelease:
 
         self.release.project.record_event(
             tag=EventTag.Project.ReleaseUnyank,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "submitted_by": self.request.user.username,
@@ -1854,7 +1833,6 @@ class ManageProjectRelease:
 
         self.release.project.record_event(
             tag=EventTag.Project.ReleaseRemove,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "submitted_by": self.request.user.username,
@@ -1947,7 +1925,6 @@ class ManageProjectRelease:
 
         release_file.record_event(
             tag=EventTag.File.FileRemove,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "submitted_by": self.request.user.username,
@@ -2107,7 +2084,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         # Record events.
         project.record_event(
             tag=EventTag.Project.TeamProjectRoleAdd,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -2117,7 +2093,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         )
         team.organization.record_event(
             tag=EventTag.Organization.TeamProjectRoleAdd,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -2128,7 +2103,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         )
         team.record_event(
             tag=EventTag.Team.TeamProjectRoleAdd,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -2220,7 +2194,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         # Record events.
         project.record_event(
             tag=EventTag.Project.RoleAdd,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by": request.user.username,
@@ -2230,7 +2203,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         )
         user.record_event(
             tag=EventTag.Account.RoleAdd,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by": request.user.username,
@@ -2353,7 +2325,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
             )
             project.record_event(
                 tag=EventTag.Project.RoleInvite,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "submitted_by": request.user.username,
@@ -2363,7 +2334,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
             )
             user.record_event(
                 tag=EventTag.Account.RoleInvite,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "submitted_by": request.user.username,
@@ -2431,7 +2401,6 @@ def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm)
     )
     project.record_event(
         tag=EventTag.Project.RoleRevokeInvite,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by": request.user.username,
@@ -2441,7 +2410,6 @@ def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm)
     )
     user.record_event(
         tag=EventTag.Account.RoleRevokeInvite,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by": request.user.username,
@@ -2498,7 +2466,6 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
                 role.role_name = form.role_name.data
                 project.record_event(
                     tag=EventTag.Project.RoleChange,
-                    ip_address=request.remote_addr,
                     request=request,
                     additional={
                         "submitted_by": request.user.username,
@@ -2508,7 +2475,6 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
                 )
                 role.user.record_event(
                     tag=EventTag.Account.RoleChange,
-                    ip_address=request.remote_addr,
                     request=request,
                     additional={
                         "submitted_by": request.user.username,
@@ -2583,7 +2549,6 @@ def delete_project_role(project, request):
             )
             project.record_event(
                 tag=EventTag.Project.RoleRemove,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "submitted_by": request.user.username,

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -369,13 +369,11 @@ class ManageOrganizationSettingsViews:
             )
             self.organization.record_event(
                 tag=EventTag.Organization.CatalogEntryAdd,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={"submitted_by_user_id": str(self.request.user.id)},
             )
             self.organization.record_event(
                 tag=EventTag.Organization.OrganizationRename,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={
                     "previous_organization_name": previous_organization_name,
@@ -424,7 +422,6 @@ class ManageOrganizationSettingsViews:
         # Record event before deleting organization.
         self.organization.record_event(
             tag=EventTag.Organization.OrganizationDelete,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "deleted_by_user_id": str(self.request.user.id),
@@ -624,7 +621,6 @@ class ManageOrganizationTeamsViews:
         # Record events.
         self.organization.record_event(
             tag=EventTag.Organization.TeamCreate,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "created_by_user_id": str(self.request.user.id),
@@ -633,7 +629,6 @@ class ManageOrganizationTeamsViews:
         )
         team.record_event(
             tag=EventTag.Team.TeamCreate,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "created_by_user_id": str(self.request.user.id),
@@ -759,7 +754,6 @@ class ManageOrganizationProjectsViews:
                 )
                 project.record_event(
                     tag=EventTag.Project.RoleRemove,
-                    ip_address=self.request.remote_addr,
                     request=self.request,
                     additional={
                         "submitted_by": self.request.user.username,
@@ -769,7 +763,6 @@ class ManageOrganizationProjectsViews:
                 )
                 role.user.record_event(
                     tag=EventTag.Account.RoleRemove,
-                    ip_address=self.request.remote_addr,
                     request=self.request,
                     additional={
                         "submitted_by": self.request.user.username,
@@ -806,7 +799,6 @@ class ManageOrganizationProjectsViews:
         # Record events.
         self.organization.record_event(
             tag=EventTag.Organization.OrganizationProjectAdd,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "submitted_by_user_id": str(self.request.user.id),
@@ -815,7 +807,6 @@ class ManageOrganizationProjectsViews:
         )
         project.record_event(
             tag=EventTag.Project.OrganizationProjectAdd,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "submitted_by_user_id": str(self.request.user.id),
@@ -916,7 +907,6 @@ def _send_organization_invitation(request, organization, role_name, user):
             )
         organization.record_event(
             tag=EventTag.Organization.OrganizationRoleInvite,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -926,7 +916,6 @@ def _send_organization_invitation(request, organization, role_name, user):
         )
         user.record_event(
             tag=EventTag.Account.OrganizationRoleInvite,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -1111,7 +1100,6 @@ def revoke_organization_invitation(organization, request):
 
     organization.record_event(
         tag=EventTag.Organization.OrganizationRoleRevokeInvite,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by_user_id": str(request.user.id),
@@ -1121,7 +1109,6 @@ def revoke_organization_invitation(organization, request):
     )
     user.record_event(
         tag=EventTag.Account.OrganizationRoleRevokeInvite,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by_user_id": str(request.user.id),
@@ -1208,7 +1195,6 @@ def change_organization_role(
 
             organization.record_event(
                 tag=EventTag.Organization.OrganizationRoleChange,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
@@ -1218,7 +1204,6 @@ def change_organization_role(
             )
             role.user.record_event(
                 tag=EventTag.Account.OrganizationRoleChange,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
@@ -1274,7 +1259,6 @@ def delete_organization_role(organization, request):
         organization_service.delete_organization_role(role.id)
         organization.record_event(
             tag=EventTag.Organization.OrganizationRoleRemove,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -1284,7 +1268,6 @@ def delete_organization_role(organization, request):
         )
         role.user.record_event(
             tag=EventTag.Account.OrganizationRoleRemove,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -1415,7 +1398,6 @@ def remove_organization_project(project, request):
         organization_service.delete_organization_project(organization.id, project.id)
         organization.record_event(
             tag=EventTag.Organization.OrganizationProjectRemove,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -1424,7 +1406,6 @@ def remove_organization_project(project, request):
         )
         project.record_event(
             tag=EventTag.Project.OrganizationProjectRemove,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -1551,7 +1532,6 @@ def transfer_organization_project(project, request):
         )
         project.record_event(
             tag=EventTag.Project.RoleRemove,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by": request.user.username,
@@ -1566,7 +1546,6 @@ def transfer_organization_project(project, request):
         organization_service.delete_organization_project(organization.id, project.id)
         organization.record_event(
             tag=EventTag.Organization.OrganizationProjectRemove,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -1575,7 +1554,6 @@ def transfer_organization_project(project, request):
         )
         project.record_event(
             tag=EventTag.Project.OrganizationProjectRemove,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "submitted_by_user_id": str(request.user.id),
@@ -1602,7 +1580,6 @@ def transfer_organization_project(project, request):
     organization_service.add_organization_project(organization.id, project.id)
     organization.record_event(
         tag=EventTag.Organization.OrganizationProjectAdd,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by_user_id": str(request.user.id),
@@ -1611,7 +1588,6 @@ def transfer_organization_project(project, request):
     )
     project.record_event(
         tag=EventTag.Project.OrganizationProjectAdd,
-        ip_address=request.remote_addr,
         request=request,
         additional={
             "submitted_by_user_id": str(request.user.id),

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -108,7 +108,6 @@ class ManageTeamSettingsViews:
             self.organization_service.rename_team(self.team.id, name)
             self.team.organization.record_event(
                 tag=EventTag.Organization.TeamRename,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={
                     "team_name": self.team.name,
@@ -118,7 +117,6 @@ class ManageTeamSettingsViews:
             )
             self.team.record_event(
                 tag=EventTag.Team.TeamRename,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={
                     "previous_team_name": previous_team_name,
@@ -148,7 +146,6 @@ class ManageTeamSettingsViews:
         # Record events.
         organization.record_event(
             tag=EventTag.Organization.TeamDelete,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "deleted_by_user_id": str(self.request.user.id),
@@ -157,7 +154,6 @@ class ManageTeamSettingsViews:
         )
         self.team.record_event(
             tag=EventTag.Team.TeamDelete,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "deleted_by_user_id": str(self.request.user.id),
@@ -304,7 +300,6 @@ class ManageTeamRolesViews:
         # Record events.
         self.team.organization.record_event(
             tag=EventTag.Organization.TeamRoleAdd,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "submitted_by_user_id": str(self.request.user.id),
@@ -315,7 +310,6 @@ class ManageTeamRolesViews:
         )
         self.team.record_event(
             tag=EventTag.Team.TeamRoleAdd,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "submitted_by_user_id": str(self.request.user.id),
@@ -325,7 +319,6 @@ class ManageTeamRolesViews:
         )
         role.user.record_event(
             tag=EventTag.Account.TeamRoleAdd,
-            ip_address=self.request.remote_addr,
             request=self.request,
             additional={
                 "submitted_by_user_id": str(self.request.user.id),
@@ -392,7 +385,6 @@ class ManageTeamRolesViews:
             # Record events.
             self.team.organization.record_event(
                 tag=EventTag.Organization.TeamRoleRemove,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={
                     "submitted_by_user_id": str(self.request.user.id),
@@ -403,7 +395,6 @@ class ManageTeamRolesViews:
             )
             self.team.record_event(
                 tag=EventTag.Team.TeamRoleRemove,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={
                     "submitted_by_user_id": str(self.request.user.id),
@@ -413,7 +404,6 @@ class ManageTeamRolesViews:
             )
             role.user.record_event(
                 tag=EventTag.Account.TeamRoleRemove,
-                ip_address=self.request.remote_addr,
                 request=self.request,
                 additional={
                     "submitted_by_user_id": str(self.request.user.id),
@@ -551,7 +541,6 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
                 # Record events.
                 project.record_event(
                     tag=EventTag.Project.TeamProjectRoleChange,
-                    ip_address=request.remote_addr,
                     request=request,
                     additional={
                         "submitted_by_user_id": str(request.user.id),
@@ -561,7 +550,6 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
                 )
                 role.team.organization.record_event(
                     tag=EventTag.Organization.TeamProjectRoleChange,
-                    ip_address=request.remote_addr,
                     request=request,
                     additional={
                         "submitted_by_user_id": str(request.user.id),
@@ -572,7 +560,6 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
                 )
                 role.team.record_event(
                     tag=EventTag.Team.TeamProjectRoleChange,
-                    ip_address=request.remote_addr,
                     request=request,
                     additional={
                         "submitted_by_user_id": str(request.user.id),
@@ -656,7 +643,6 @@ def delete_team_project_role(project, request):
             # Record event.
             project.record_event(
                 tag=EventTag.Project.TeamProjectRoleRemove,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
@@ -666,7 +652,6 @@ def delete_team_project_role(project, request):
             )
             team.organization.record_event(
                 tag=EventTag.Organization.TeamProjectRoleRemove,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "submitted_by_user_id": str(request.user.id),
@@ -677,7 +662,6 @@ def delete_team_project_role(project, request):
             )
             team.record_event(
                 tag=EventTag.Team.TeamProjectRoleRemove,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "submitted_by_user_id": str(request.user.id),

--- a/warehouse/migrations/versions/4a0276f260c7_drop_ip_address_string_from_events_.py
+++ b/warehouse/migrations/versions/4a0276f260c7_drop_ip_address_string_from_events_.py
@@ -1,0 +1,66 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+drop ip_address_string from events tables
+
+Revision ID: 4a0276f260c7
+Revises: 34cccbcab226
+Create Date: 2023-06-11 12:03:05.180213
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "4a0276f260c7"
+down_revision = "34cccbcab226"
+
+
+def upgrade():
+    op.drop_column("file_events", "ip_address_string")
+    op.drop_column("organization_events", "ip_address_string")
+    op.drop_column("project_events", "ip_address_string")
+    op.drop_column("team_events", "ip_address_string")
+    op.drop_column("user_events", "ip_address_string")
+
+
+def downgrade():
+    op.add_column(
+        "user_events",
+        sa.Column(
+            "ip_address_string", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        "team_events",
+        sa.Column(
+            "ip_address_string", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        "project_events",
+        sa.Column(
+            "ip_address_string", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        "organization_events",
+        sa.Column(
+            "ip_address_string", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        "file_events",
+        sa.Column(
+            "ip_address_string", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -201,7 +201,6 @@ def mint_token_from_oidc(request):
     for project in publisher.projects:
         project.record_event(
             tag=EventTag.Project.ShortLivedAPITokenAdded,
-            ip_address=request.remote_addr,
             request=request,
             additional={
                 "expires": expires_at,

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -320,13 +320,10 @@ class Organization(OrganizationMixin, HasEvents, db.Model):
             .all()
         )
 
-    def record_event(
-        self, *, tag, ip_address, request: Request = None, additional=None
-    ):
+    def record_event(self, *, tag, request: Request = None, additional=None):
         """Record organization name in events in case organization is ever deleted."""
         super().record_event(
             tag=tag,
-            ip_address=ip_address,
             request=request,
             additional={"organization_name": self.name, **additional},
         )
@@ -682,13 +679,10 @@ class Team(HasEvents, db.Model):
         "Project", secondary=TeamProjectRole.__table__, backref="teams", viewonly=True  # type: ignore # noqa
     )
 
-    def record_event(
-        self, *, tag, ip_address, request: Request = None, additional=None
-    ):
+    def record_event(self, *, tag, request: Request = None, additional=None):
         """Record org and team name in events in case they are ever deleted."""
         super().record_event(
             tag=tag,
-            ip_address=ip_address,
             request=request,
             additional={
                 "organization_name": self.organization.name,

--- a/warehouse/organizations/services.py
+++ b/warehouse/organizations/services.py
@@ -166,7 +166,6 @@ class DatabaseOrganizationService:
         self.db.add(organization)
         organization.record_event(
             tag=EventTag.Organization.OrganizationCreate,
-            ip_address=None,
             request=request,
             additional={
                 "created_by_user_id": str(organization_application.submitted_by.id),
@@ -181,7 +180,6 @@ class DatabaseOrganizationService:
         self.add_catalog_entry(organization.id)
         organization.record_event(
             tag=EventTag.Organization.CatalogEntryAdd,
-            ip_address=None,
             request=request,
             additional={
                 "submitted_by_user_id": str(organization_application.submitted_by.id),
@@ -196,7 +194,6 @@ class DatabaseOrganizationService:
         )
         organization.record_event(
             tag=EventTag.Organization.OrganizationRoleAdd,
-            ip_address=None,
             request=request,
             additional={
                 "submitted_by_user_id": str(organization_application.submitted_by.id),
@@ -207,7 +204,6 @@ class DatabaseOrganizationService:
         )
         organization_application.submitted_by.record_event(
             tag=EventTag.Account.OrganizationRoleAdd,
-            ip_address=None,
             request=request,
             additional={
                 "submitted_by_user_id": str(organization_application.submitted_by.id),
@@ -218,7 +214,6 @@ class DatabaseOrganizationService:
         )
         organization.record_event(
             tag=EventTag.Organization.OrganizationApprove,
-            ip_address=request.remote_addr,
             request=request,
             additional={"approved_by_user_id": str(request.user.id)},
         )

--- a/warehouse/organizations/tasks.py
+++ b/warehouse/organizations/tasks.py
@@ -44,7 +44,6 @@ def update_organization_invitation_status(request):
         except TokenExpired:
             invite.user.record_event(
                 tag=EventTag.Account.OrganizationRoleExpireInvite,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "organization_name": invite.organization.name,
@@ -52,7 +51,6 @@ def update_organization_invitation_status(request):
             )
             invite.organization.record_event(
                 tag=EventTag.Organization.OrganizationRoleExpireInvite,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "target_user_id": str(invite.user.id),
@@ -78,7 +76,6 @@ def delete_declined_organizations(request):
         # TODO: Cannot call this after deletion so how exactly do we handle this?
         organization.record_event(
             tag=EventTag.Organization.OrganizationDelete,
-            ip_address=request.remote_addr,
             request=request,
             additional={"deleted_by": "CRON"},
         )

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -429,7 +429,6 @@ class ProjectService:
         )
         project.record_event(
             tag=EventTag.Project.ProjectCreate,
-            ip_address=request.remote_addr,
             request=request,
             additional={"created_by": creator.username},
         )
@@ -449,7 +448,6 @@ class ProjectService:
             )
             project.record_event(
                 tag=EventTag.Project.RoleAdd,
-                ip_address=request.remote_addr,
                 request=request,
                 additional={
                     "submitted_by": creator.username,


### PR DESCRIPTION
Follows up on #13842, drops the columns it deprecates and removes ip_address from the record_event call altogether.