### PR TITLE
Monotonic journals

### DIFF
--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -352,12 +352,6 @@ class TestUserDelete:
             .one()
         )
         assert remove_journal.name == project.name
-        nuke_journal = (
-            db_request.db.query(JournalEntry)
-            .filter(JournalEntry.action == "nuke user")
-            .one()
-        )
-        assert nuke_journal.name == f"user:{user.username}"
 
     def test_deletes_user_bad_confirm(self, db_request, monkeypatch):
         user = UserFactory.create()

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2086,7 +2086,6 @@ class TestFileUpload:
         )
         assert [(j.name, j.version, j.action, j.submitted_by) for j in journals] == [
             ("example", None, "create", user),
-            ("example", None, f"add Owner {user.username}", user),
             ("example", "1.0", "new release", user),
             ("example", "1.0", "add source file example-1.0.tar.gz", user),
         ]
@@ -3480,7 +3479,6 @@ class TestFileUpload:
         )
         assert [(j.name, j.version, j.action, j.submitted_by) for j in journals] == [
             ("example", None, "create", user),
-            ("example", None, f"add Owner {user.username}", user),
             ("example", "1.0", "new release", user),
             ("example", "1.0", "add source file example-1.0.tar.gz", user),
         ]

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -5441,16 +5441,6 @@ class TestChangeProjectRole:
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        entry = (
-            db_request.db.query(JournalEntry)
-            .options(joinedload(JournalEntry.submitted_by))
-            .one()
-        )
-
-        assert entry.name == project.name
-        assert entry.action == "change Owner testuser to Maintainer"
-        assert entry.submitted_by == db_request.user
-
     def test_change_role_invalid_role_name(self, pyramid_request):
         project = pretend.stub(name="foobar")
 
@@ -5560,16 +5550,6 @@ class TestDeleteProjectRole:
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        entry = (
-            db_request.db.query(JournalEntry)
-            .options(joinedload(JournalEntry.submitted_by))
-            .one()
-        )
-
-        assert entry.name == project.name
-        assert entry.action == "remove Owner testuser"
-        assert entry.submitted_by == db_request.user
-
     def test_delete_missing_role(self, db_request):
         project = ProjectFactory.create(name="foobar")
         missing_role_id = str(uuid.uuid4())
@@ -5656,16 +5636,6 @@ class TestDeleteProjectRole:
         ]
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
-
-        entry = (
-            db_request.db.query(JournalEntry)
-            .options(joinedload(JournalEntry.submitted_by))
-            .one()
-        )
-
-        assert entry.name == project.name
-        assert entry.action == "remove Owner testuser"
-        assert entry.submitted_by == db_request.user
 
     def test_delete_non_owner_role(self, db_request):
         project = ProjectFactory.create(name="foobar")

--- a/tests/unit/manage/views/test_teams.py
+++ b/tests/unit/manage/views/test_teams.py
@@ -40,7 +40,6 @@ from warehouse.organizations.models import (
     TeamProjectRoleType,
     TeamRoleType,
 )
-from warehouse.packaging.models import JournalEntry
 from warehouse.utils.paginate import paginate_url_factory
 
 
@@ -826,16 +825,6 @@ class TestChangeTeamProjectRole:
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
-        entry = (
-            db_request.db.query(JournalEntry)
-            .options(joinedload(JournalEntry.submitted_by))
-            .one()
-        )
-
-        assert entry.name == organization_project.name
-        assert entry.action == f"change Owner {organization_team.name} to Maintainer"
-        assert entry.submitted_by == db_request.user
-
     def test_change_role_invalid_role_name(self, pyramid_request, organization_project):
         pyramid_request.method = "POST"
         pyramid_request.POST = MultiDict(
@@ -1011,16 +1000,6 @@ class TestDeleteTeamProjectRole:
         ]
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
-
-        entry = (
-            db_request.db.query(JournalEntry)
-            .options(joinedload(JournalEntry.submitted_by))
-            .one()
-        )
-
-        assert entry.name == organization_project.name
-        assert entry.action == f"remove Owner {organization_team.name}"
-        assert entry.submitted_by == db_request.user
 
     def test_delete_missing_role(self, db_request, organization_project):
         missing_role_id = str(uuid.uuid4())

--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -155,15 +155,6 @@ def test_destroy_docs(db_request, flash):
 
     destroy_docs(project, db_request, flash=flash)
 
-    journal_entry = (
-        db_request.db.query(JournalEntry)
-        .options(joinedload(JournalEntry.submitted_by))
-        .filter(JournalEntry.name == "foo")
-        .one()
-    )
-    assert journal_entry.action == "docdestroy"
-    assert journal_entry.submitted_by == db_request.user
-
     assert not (
         db_request.db.query(Project)
         .filter(Project.name == project.name)

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1157,14 +1157,7 @@ def verify_project_role(request):
 
     request.db.add(Role(user=user, project=project, role_name=desired_role))
     request.db.delete(role_invite)
-    request.db.add(
-        JournalEntry.create_with_lock(
-            request.db,
-            name=project.name,
-            action=f"accepted {desired_role} {user.username}",
-            submitted_by=request.user,
-        )
-    )
+
     project.record_event(
         tag=EventTag.Project.RoleAdd,
         request=request,

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1158,7 +1158,8 @@ def verify_project_role(request):
     request.db.add(Role(user=user, project=project, role_name=desired_role))
     request.db.delete(role_invite)
     request.db.add(
-        JournalEntry(
+        JournalEntry.create_with_lock(
+            request.db,
             name=project.name,
             action=f"accepted {desired_role} {user.username}",
             submitted_by=request.user,

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -399,15 +399,6 @@ def add_role(project, request):
             )
         )
 
-    request.db.add(
-        JournalEntry.create_with_lock(
-            request.db,
-            name=project.name,
-            action=f"add {role_name} {user.username}",
-            submitted_by=request.user,
-        )
-    )
-
     request.db.add(Role(role_name=role_name, user=user, project=project))
 
     request.session.flash(
@@ -449,14 +440,6 @@ def delete_role(project, request):
     request.session.flash(
         f"Removed '{role.user.username}' as '{role.role_name}' on '{project.name}'",
         queue="success",
-    )
-    request.db.add(
-        JournalEntry.create_with_lock(
-            request.db,
-            name=project.name,
-            action=f"remove {role.role_name} {role.user.username}",
-            submitted_by=request.user,
-        )
     )
 
     request.db.delete(role)

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -400,7 +400,8 @@ def add_role(project, request):
         )
 
     request.db.add(
-        JournalEntry(
+        JournalEntry.create_with_lock(
+            request.db,
             name=project.name,
             action=f"add {role_name} {user.username}",
             submitted_by=request.user,
@@ -450,7 +451,8 @@ def delete_role(project, request):
         queue="success",
     )
     request.db.add(
-        JournalEntry(
+        JournalEntry.create_with_lock(
+            request.db,
             name=project.name,
             action=f"remove {role.role_name} {role.user.username}",
             submitted_by=request.user,

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -234,14 +234,6 @@ def _nuke_user(user, request):
 
     # Delete the user
     request.db.delete(user)
-    request.db.add(
-        JournalEntry.create_with_lock(
-            request.db,
-            name=f"user:{user.username}",
-            action="nuke user",
-            submitted_by=request.user,
-        )
-    )
 
 
 @view_config(

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -203,7 +203,8 @@ def _nuke_user(user, request):
     )
     for project in projects:
         request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                request.db,
                 name=project.name,
                 action="remove project",
                 submitted_by=request.user,
@@ -234,7 +235,8 @@ def _nuke_user(user, request):
     # Delete the user
     request.db.delete(user)
     request.db.add(
-        JournalEntry(
+        JournalEntry.create_with_lock(
+            request.db,
             name=f"user:{user.username}",
             action="nuke user",
             submitted_by=request.user,

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1155,7 +1155,8 @@ def file_upload(request):
         #       a SQLAlchemy hook or the like instead of doing it inline in
         #       this view.
         request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                request.db,
                 name=release.project.name,
                 version=release.version,
                 action="new release",
@@ -1427,7 +1428,8 @@ def file_upload(request):
         #       SQLAlchemy hook or the like instead of doing it inline in this
         #       view.
         request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                request.db,
                 name=release.project.name,
                 version=release.version,
                 action="add {python_version} file {filename}".format(

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -1641,7 +1641,8 @@ class ManageProjectRelease:
         )
 
         self.request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                self.request.db,
                 name=self.release.project.name,
                 action="yank release",
                 version=self.release.version,
@@ -1726,7 +1727,8 @@ class ManageProjectRelease:
         )
 
         self.request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                self.request.db,
                 name=self.release.project.name,
                 action="unyank release",
                 version=self.release.version,
@@ -1827,7 +1829,8 @@ class ManageProjectRelease:
         )
 
         self.request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                self.request.db,
                 name=self.release.project.name,
                 action="remove release",
                 version=self.release.version,
@@ -1919,7 +1922,8 @@ class ManageProjectRelease:
             )
 
         self.request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                self.request.db,
                 name=self.release.project.name,
                 action=f"remove file {release_file.filename}",
                 version=self.release.version,
@@ -2078,7 +2082,8 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
 
         # Add journal entry.
         request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                request.db,
                 name=project.name,
                 action=f"add {role_name.value} {team_name}",
                 submitted_by=request.user,
@@ -2188,7 +2193,8 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
 
         # Add journal entry.
         request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                request.db,
                 name=project.name,
                 action=f"add {role_name} {user.username}",
                 submitted_by=request.user,
@@ -2312,7 +2318,8 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                 )
 
             request.db.add(
-                JournalEntry(
+                JournalEntry.create_with_lock(
+                    request.db,
                     name=project.name,
                     action=f"invite {role_name} {username}",
                     submitted_by=request.user,
@@ -2397,7 +2404,8 @@ def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm)
     role_name = token_data.get("desired_role")
 
     request.db.add(
-        JournalEntry(
+        JournalEntry.create_with_lock(
+            request.db,
             name=project.name,
             action=f"revoke_invite {role_name} {user.username}",
             submitted_by=request.user,
@@ -2459,7 +2467,8 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
                 request.session.flash("Cannot remove yourself as Owner", queue="error")
             else:
                 request.db.add(
-                    JournalEntry(
+                    JournalEntry.create_with_lock(
+                        request.db,
                         name=project.name,
                         action="change {} {} to {}".format(
                             role.role_name, role.user.username, form.role_name.data
@@ -2545,7 +2554,8 @@ def delete_project_role(project, request):
         else:
             request.db.delete(role)
             request.db.add(
-                JournalEntry(
+                JournalEntry.create_with_lock(
+                    request.db,
                     name=project.name,
                     action=f"remove {role.role_name} {role.user.username}",
                     submitted_by=request.user,

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -2080,16 +2080,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
         # Add internal team.
         organization_service.add_team_project_role(team.id, project.id, role_name)
 
-        # Add journal entry.
-        request.db.add(
-            JournalEntry.create_with_lock(
-                request.db,
-                name=project.name,
-                action=f"add {role_name.value} {team_name}",
-                submitted_by=request.user,
-            )
-        )
-
         # Record events.
         project.record_event(
             tag=EventTag.Project.TeamProjectRoleAdd,
@@ -2190,16 +2180,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
     if enable_internal_collaborator and user in internal_users:
         # Add internal member.
         request.db.add(Role(user=user, project=project, role_name=role_name))
-
-        # Add journal entry.
-        request.db.add(
-            JournalEntry.create_with_lock(
-                request.db,
-                name=project.name,
-                action=f"add {role_name} {user.username}",
-                submitted_by=request.user,
-            )
-        )
 
         # Record events.
         project.record_event(
@@ -2317,14 +2297,6 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                     )
                 )
 
-            request.db.add(
-                JournalEntry.create_with_lock(
-                    request.db,
-                    name=project.name,
-                    action=f"invite {role_name} {username}",
-                    submitted_by=request.user,
-                )
-            )
             send_project_role_verification_email(
                 request,
                 user,
@@ -2403,14 +2375,6 @@ def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm)
         )
     role_name = token_data.get("desired_role")
 
-    request.db.add(
-        JournalEntry.create_with_lock(
-            request.db,
-            name=project.name,
-            action=f"revoke_invite {role_name} {user.username}",
-            submitted_by=request.user,
-        )
-    )
     project.record_event(
         tag=EventTag.Project.RoleRevokeInvite,
         request=request,
@@ -2466,16 +2430,6 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
             if role.role_name == "Owner" and role.user == request.user:
                 request.session.flash("Cannot remove yourself as Owner", queue="error")
             else:
-                request.db.add(
-                    JournalEntry.create_with_lock(
-                        request.db,
-                        name=project.name,
-                        action="change {} {} to {}".format(
-                            role.role_name, role.user.username, form.role_name.data
-                        ),
-                        submitted_by=request.user,
-                    )
-                )
                 role.role_name = form.role_name.data
                 project.record_event(
                     tag=EventTag.Project.RoleChange,
@@ -2553,14 +2507,7 @@ def delete_project_role(project, request):
             request.session.flash("Cannot remove yourself as Sole Owner", queue="error")
         else:
             request.db.delete(role)
-            request.db.add(
-                JournalEntry.create_with_lock(
-                    request.db,
-                    name=project.name,
-                    action=f"remove {role.role_name} {role.user.username}",
-                    submitted_by=request.user,
-                )
-            )
+
             project.record_event(
                 tag=EventTag.Project.RoleRemove,
                 request=request,

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -745,14 +745,7 @@ class ManageOrganizationProjectsViews:
             )
             if role:
                 self.request.db.delete(role)
-                self.request.db.add(
-                    JournalEntry.create_with_lock(
-                        self.request.db,
-                        name=project.name,
-                        action=f"remove {role.role_name} {role.user.username}",
-                        submitted_by=self.request.user,
-                    )
-                )
+
                 project.record_event(
                     tag=EventTag.Project.RoleRemove,
                     request=self.request,
@@ -1524,14 +1517,6 @@ def transfer_organization_project(project, request):
     )
     if role:
         request.db.delete(role)
-        request.db.add(
-            JournalEntry.create_with_lock(
-                request.db,
-                name=project.name,
-                action=f"remove {role.role_name} {role.user.username}",
-                submitted_by=request.user,
-            )
-        )
         project.record_event(
             tag=EventTag.Project.RoleRemove,
             request=request,

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -746,7 +746,8 @@ class ManageOrganizationProjectsViews:
             if role:
                 self.request.db.delete(role)
                 self.request.db.add(
-                    JournalEntry(
+                    JournalEntry.create_with_lock(
+                        self.request.db,
                         name=project.name,
                         action=f"remove {role.role_name} {role.user.username}",
                         submitted_by=self.request.user,
@@ -1524,7 +1525,8 @@ def transfer_organization_project(project, request):
     if role:
         request.db.delete(role)
         request.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                request.db,
                 name=project.name,
                 action=f"remove {role.role_name} {role.user.username}",
                 submitted_by=request.user,

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -524,7 +524,8 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
             else:
                 # Add journal entry.
                 request.db.add(
-                    JournalEntry(
+                    JournalEntry.create_with_lock(
+                        request.db,
                         name=project.name,
                         action="change {} {} to {}".format(
                             role.role_name.value,
@@ -633,7 +634,8 @@ def delete_team_project_role(project, request):
 
             # Add journal entry.
             request.db.add(
-                JournalEntry(
+                JournalEntry.create_with_lock(
+                    request.db,
                     name=project.name,
                     action=f"remove {role_name.value} {team.name}",
                     submitted_by=request.user,

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -522,20 +522,6 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
                     queue="error",
                 )
             else:
-                # Add journal entry.
-                request.db.add(
-                    JournalEntry.create_with_lock(
-                        request.db,
-                        name=project.name,
-                        action="change {} {} to {}".format(
-                            role.role_name.value,
-                            role.team.name,
-                            form.team_project_role_name.data.value,
-                        ),
-                        submitted_by=request.user,
-                    )
-                )
-
                 # Change team project role.
                 role.role_name = form.team_project_role_name.data
 
@@ -631,16 +617,6 @@ def delete_team_project_role(project, request):
 
             # Delete role.
             request.db.delete(role)
-
-            # Add journal entry.
-            request.db.add(
-                JournalEntry.create_with_lock(
-                    request.db,
-                    name=project.name,
-                    action=f"remove {role_name.value} {team.name}",
-                    submitted_by=request.user,
-                )
-            )
 
             # Record event.
             project.record_event(

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -758,6 +758,20 @@ class JournalEntry(db.ModelBase):
 
     @classmethod
     def create_with_lock(cls, session, *args, **kwargs):
+        # We rely on `journals.id` to be a monotonically increasing integer,
+        # however the way that SERIAL is implemented, it does not guarentee
+        # that is the case.
+        #
+        # Ultimately SERIAL fetches the next integer regardless of what happens
+        # inside of the transaction. So journals.id will get filled in, in order
+        # of when the `INSERT` statements were executed, but not in the order
+        # that transactions were committed.
+        #
+        # The way this works, not even the SERIALIZABLE transaction types give
+        # us this property. Instead we have to implement our own locking that
+        # ensures that each new journal entry will be serialized.
+        #
+        # See: https://mattjames.dev/auto-increment-ids-are-not-strictly-monotonic/
         hashed = hashlib.blake2b(b"table:journals").digest()[:8]
         key = int.from_bytes(hashed, "little", signed=True)
         session.execute(select(func.pg_advisory_xact_lock(cast(key, BigInteger))))

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import enum
+import hashlib
 
 from collections import OrderedDict
 from urllib.parse import urlparse
@@ -36,8 +37,10 @@ from sqlalchemy import (
     Table,
     Text,
     UniqueConstraint,
+    cast,
     func,
     orm,
+    select,
     sql,
 )
 from sqlalchemy.dialects.postgresql import UUID
@@ -752,6 +755,14 @@ class JournalEntry(db.ModelBase):
         nullable=True,
     )
     submitted_by = orm.relationship(User, lazy="raise_on_sql")
+
+    @classmethod
+    def create_with_lock(cls, session, *args, **kwargs):
+        hashed = hashlib.blake2b(b"table:journals").digest()[:8]
+        key = int.from_bytes(hashed, "little", signed=True)
+        session.execute(select(func.pg_advisory_xact_lock(cast(key, BigInteger))))
+
+        return cls(*args, **kwargs)
 
 
 class ProhibitedProjectName(db.Model):

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -421,7 +421,8 @@ class ProjectService:
         #       SQLAlchemy hook or the like instead of doing it inline in this
         #       service.
         self.db.add(
-            JournalEntry(
+            JournalEntry.create_with_lock(
+                request.db,
                 name=project.name,
                 action="create",
                 submitted_by=creator,
@@ -440,7 +441,8 @@ class ProjectService:
             #       SQLAlchemy hook or the like instead of doing it inline in this
             #       service.
             self.db.add(
-                JournalEntry(
+                JournalEntry.create_with_lock(
+                    request.db,
                     name=project.name,
                     action=f"add Owner {creator.username}",
                     submitted_by=creator,

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -437,17 +437,7 @@ class ProjectService:
         # Mark the creator as the newly created project's owner, if configured.
         if creator_is_owner:
             self.db.add(Role(user=creator, project=project, role_name="Owner"))
-            # TODO: This should be handled by some sort of database trigger or a
-            #       SQLAlchemy hook or the like instead of doing it inline in this
-            #       service.
-            self.db.add(
-                JournalEntry.create_with_lock(
-                    request.db,
-                    name=project.name,
-                    action=f"add Owner {creator.username}",
-                    submitted_by=creator,
-                )
-            )
+
             project.record_event(
                 tag=EventTag.Project.RoleAdd,
                 request=request,

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -204,15 +204,6 @@ def remove_project(project, request, flash=True):
 
 
 def destroy_docs(project, request, flash=True):
-    request.db.add(
-        JournalEntry.create_with_lock(
-            request.db,
-            name=project.name,
-            action="docdestroy",
-            submitted_by=request.user,
-        )
-    )
-
     request.task(remove_documentation).delay(project.name)
 
     project.has_docs = False

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -188,7 +188,8 @@ def remove_project(project, request, flash=True):
     #       some kind of garbage collection at some point.
 
     request.db.add(
-        JournalEntry(
+        JournalEntry.create_with_lock(
+            request.db,
             name=project.name,
             action="remove project",
             submitted_by=request.user,
@@ -204,7 +205,8 @@ def remove_project(project, request, flash=True):
 
 def destroy_docs(project, request, flash=True):
     request.db.add(
-        JournalEntry(
+        JournalEntry.create_with_lock(
+            request.db,
             name=project.name,
             action="docdestroy",
             submitted_by=request.user,


### PR DESCRIPTION
Our mirroring support currently assumes that the `journals.id` field is a monotonically increasing integer.

However, the way that `SERIAL` is implemented in PostgreSQL, this isn't actually true. The fetching of the next value from a `SERIAL` ignores the transaction. In addition, we have no control over what order the transactions will commit in, this means something like:

TXN A does an `INSERT`, gets `journals.id = 100`.
TXN B does an `INSERT`, gets `journals.id = 101`.
TXN B `COMMIT`, makes last serial = 101.
Bandersnatch makes a request, and notes that the last serial is 101.
TXN A `COMMIT`, the last serial is still 101.
Bandersnatch never sees 100.

What this does is wherever we create a `JournalEntry`, we first take an advisory lock (scoped to the transaction). This will have the effect of forcing journal entry insertion to be serialized, without affecting our table locking otherwise.

The downside to this is it can cause scalability concerns, but AFAIK it's the only real way we have to make sure that our last serial is monotonically increasing.

To try and reduce the negative effects, we also go through and stop emitting any journal event that our mirroring support doesn't mean. Specifically this is any journal event that isn't correlated with a change in the output of the `/simple/$name/` page.

Each "type" of journal event that we stop emitting is in it's own commit, so if we disagree with any of them, it should be easy to revert.

This will fix (hopefully) https://github.com/pypi/warehouse/issues/12214, https://github.com/pypi/warehouse/issues/4892, and https://github.com/pypi/warehouse/issues/12933.

This will move us closer to https://github.com/pypi/warehouse/issues/11918.