### PR TITLE
Nits found while working on SQLAlchemy 2.0 upgrade

### DIFF
--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -222,8 +222,7 @@ class HasEvents:
     def record_event(self, *, tag, request: Request, additional=None):
         """Records an Event record on the associated model."""
         session = orm.object_session(self)
-        if session is None:  # pragma: no cover
-            raise RuntimeError("Cannot record event without a session")
+        assert session is not None
 
         # Get-or-create a new IpAddress object
         ip_address = request.ip_address

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -222,6 +222,8 @@ class HasEvents:
     def record_event(self, *, tag, request: Request, additional=None):
         """Records an Event record on the associated model."""
         session = orm.object_session(self)
+        if session is None:  # pragma: no cover
+            raise RuntimeError("Cannot record event without a session")
 
         # Get-or-create a new IpAddress object
         ip_address = request.ip_address

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -47,7 +47,7 @@ class DatabaseMacaroonService:
 
         return raw_macaroon
 
-    def find_macaroon(self, macaroon_id):
+    def find_macaroon(self, macaroon_id) -> Macaroon | None:
         """
         Returns a macaroon model from the DB by its identifier.
         Returns None if no macaroon has the given ID.
@@ -57,10 +57,14 @@ class DatabaseMacaroonService:
         except ValueError:
             return None
 
-        return self.db.get(
-            Macaroon,
-            macaroon_id,
-            (joinedload(Macaroon.user), joinedload(Macaroon.oidc_publisher)),
+        return (
+            self.db.query(Macaroon)
+            .options(
+                joinedload(Macaroon.user),
+                joinedload(Macaroon.oidc_publisher),
+            )
+            .filter_by(id=macaroon_id)
+            .one_or_none()
         )
 
     def _deserialize_raw_macaroon(self, raw_macaroon):

--- a/warehouse/migrations/versions/99291f0fe9c2_update_release_file_on_insert.py
+++ b/warehouse/migrations/versions/99291f0fe9c2_update_release_file_on_insert.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 """
+Update release_file on insert
 
 The release.requires_python and release_files.requires_python can be out of
 sync if a file is uploaded after the release has been created. It's


### PR DESCRIPTION
As these are not tied to the upgrade path, ship independently to minimize actual changes during the upgrade