### PR TITLE
Add confirmation checks when deleting a file from a release

### DIFF
--- a/tests/frontend/confirm_controller_test.js
+++ b/tests/frontend/confirm_controller_test.js
@@ -42,41 +42,129 @@ describe("Confirm controller", () => {
     application.register("confirm", ConfirmController);
   });
 
-  describe("initial state", function() {
-    describe("the button", function() {
-      it("is disabled", function() {
+  describe("initial state", function () {
+    describe("the button", function () {
+      it("is disabled", function () {
         const buttonTarget = document.getElementById("button-target");
         expect(buttonTarget).toHaveAttribute("disabled");
       });
     });
   });
 
-  describe("functionality", function() {
-    describe("entering expected text", function() {
-      it("enables the button", function() {
-        fireEvent.input(document.getElementById("input-target"), { target: { value: "package" } });
+  describe("functionality", function () {
+    describe("entering expected text", function () {
+      it("enables the button", function () {
+        fireEvent.input(document.getElementById("input-target"), {
+          target: { value: "package" },
+        });
 
         const buttonTarget = document.getElementById("button-target");
         expect(buttonTarget).not.toHaveAttribute("disabled");
       });
     });
 
-    describe("entering incorrect casing text", function() {
-      it("enables the button", function() {
-        fireEvent.input(document.getElementById("input-target"), { target: { value: "PACKAGE" } });
+    describe("entering incorrect casing text", function () {
+      it("enables the button", function () {
+        fireEvent.input(document.getElementById("input-target"), {
+          target: { value: "PACKAGE" },
+        });
 
         const buttonTarget = document.getElementById("button-target");
         expect(buttonTarget).not.toHaveAttribute("disabled");
       });
     });
 
-    describe("entering incorrect text", function() {
-      it("disables the button", function() {
-        fireEvent.input(document.getElementById("input-target"), { target: { value: "foobar" } });
+    describe("entering incorrect text", function () {
+      it("disables the button", function () {
+        fireEvent.input(document.getElementById("input-target"), {
+          target: { value: "foobar" },
+        });
 
         const buttonTarget = document.getElementById("button-target");
         expect(buttonTarget).toHaveAttribute("disabled");
       });
     });
+  });
+});
+
+describe("Confirm controller with checkboxes and text input", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+  <div class="modal" data-controller="confirm">
+    <div class="modal__content" role="dialog">
+      <div class="modal__body">
+        <h3 class="modal__title">Delete package?</h3>
+        <p>Confirm to continue.</p>
+        <label for="package">Delete</label>
+        <input id="input-target" name="package" data-action="input->confirm#check" data-confirm-target="input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off">
+
+        <input type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox" data-test="first-checkbox">
+        <input type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox" data-test="second-checkbox">
+        </div>
+        <div class="modal__footer">
+          <button id="button-target" data-confirm-target="button" data-expected="package" type="submit">
+              Confirm
+          </button>
+      </div>
+      </form>
+    </div>
+  </div>
+    `;
+
+    const application = Application.start();
+    application.register("confirm", ConfirmController);
+  });
+
+  it("should have action disabled by default", () => {
+    const buttonTarget = document.getElementById("button-target");
+    expect(buttonTarget).toHaveAttribute("disabled");
+  });
+
+  it("should have action disabled when checkboxes are not checked and input text check is satisfied", () => {
+    fireEvent.input(document.getElementById("input-target"), {
+      target: { value: "package" },
+    });
+    const buttonTarget = document.getElementById("button-target");
+    // Button should be disabled still as the checkboxes have not been checked yet
+    expect(buttonTarget).toHaveAttribute("disabled");
+  });
+
+  it("should have action disabled when checkboxes are checked and input text check is not satisfied", () => {
+    fireEvent.input(document.querySelector("[data-test=first-checkbox]"), {
+      target: { checked: true },
+    });
+    fireEvent.input(document.querySelector("[data-test=second-checkbox]"), {
+      target: { checked: true },
+    });
+    const buttonTarget = document.getElementById("button-target");
+    // Button should be disabled still as the input field doesn't have the correct text yet
+    expect(buttonTarget).toHaveAttribute("disabled");
+  });
+
+  it("should have action disabled when only some of the checkboxes are checked", () => {
+    fireEvent.input(document.getElementById("input-target"), {
+      target: { value: "package" },
+    });
+    fireEvent.input(document.querySelector("[data-test=second-checkbox]"), {
+      target: { checked: true },
+    });
+    const buttonTarget = document.getElementById("button-target");
+    // Button should be disabled still as the input field doesn't have the correct text yet
+    expect(buttonTarget).toHaveAttribute("disabled");
+  });
+
+  it("should have action enabled when both checkboxes are checked and input text checks are satisfied", () => {
+    fireEvent.input(document.querySelector("[data-test=first-checkbox]"), {
+      target: { checked: true },
+    });
+    fireEvent.input(document.querySelector("[data-test=second-checkbox]"), {
+      target: { checked: true },
+    });
+    fireEvent.input(document.getElementById("input-target"), {
+      target: { value: "package" },
+    });
+    const buttonTarget = document.getElementById("button-target");
+    // Button should now be enabled -- both checkboxes are selected, and the input field has the correct text
+    expect(buttonTarget).not.toHaveAttribute("disabled");
   });
 });

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -672,8 +672,8 @@ msgstr ""
 #: warehouse/templates/manage/account/webauthn-provision.html:53
 #: warehouse/templates/manage/account/webauthn-provision.html:74
 #: warehouse/templates/manage/manage_base.html:185
-#: warehouse/templates/manage/project/release.html:138
-#: warehouse/templates/manage/project/release.html:194
+#: warehouse/templates/manage/project/release.html:144
+#: warehouse/templates/manage/project/release.html:200
 #: warehouse/templates/manage/project/releases.html:140
 #: warehouse/templates/manage/project/releases.html:179
 #: warehouse/templates/packaging/detail.html:364
@@ -913,7 +913,7 @@ msgstr ""
 #: warehouse/templates/manage/organization/settings.html:250
 #: warehouse/templates/manage/organization/settings.html:256
 #: warehouse/templates/manage/project/documentation.html:27
-#: warehouse/templates/manage/project/release.html:182
+#: warehouse/templates/manage/project/release.html:188
 #: warehouse/templates/manage/project/settings.html:126
 #: warehouse/templates/manage/project/settings.html:175
 #: warehouse/templates/manage/project/settings.html:247
@@ -2571,7 +2571,7 @@ msgstr ""
 #: warehouse/templates/manage/account.html:211
 #: warehouse/templates/manage/manage_base.html:306
 #: warehouse/templates/manage/manage_base.html:308
-#: warehouse/templates/manage/project/release.html:137
+#: warehouse/templates/manage/project/release.html:143
 #: warehouse/templates/manage/project/releases.html:178
 #: warehouse/templates/manage/project/settings.html:111
 #: warehouse/templates/search/results.html:198
@@ -5194,7 +5194,7 @@ msgid "Destroy Documentation for project"
 msgstr ""
 
 #: warehouse/templates/manage/project/documentation.html:35
-#: warehouse/templates/manage/project/release.html:123
+#: warehouse/templates/manage/project/release.html:129
 #: warehouse/templates/pages/stats.html:42
 msgid "Project name"
 msgstr ""
@@ -5490,38 +5490,62 @@ msgstr ""
 msgid "Delete file"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:133
+#: warehouse/templates/manage/project/release.html:120
+msgid ""
+"I understand that my users will no longer be able to install this file "
+"for this release of this project."
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:121
+#, python-format
+msgid ""
+"I understand that I will <a href=%(href)s target=\"_blank\" "
+"rel=\"noopener\">not be able to re-upload a file using the same file "
+"name</a> %(filename)s."
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:122
+#: warehouse/templates/manage/project/release.html:205
+msgid "I understand that I will not be able to undo this."
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:123
+#: warehouse/templates/manage/project/release.html:206
+msgid "I understand that the PyPI administrators will not be able to undo this."
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:139
 msgid "Uploading new files"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:135
+#: warehouse/templates/manage/project/release.html:141
 msgid "No files found"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:137
+#: warehouse/templates/manage/project/release.html:143
 #: warehouse/templates/manage/project/releases.html:178
 #: warehouse/templates/manage/project/settings.html:111
 msgid "Dismiss"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:138
+#: warehouse/templates/manage/project/release.html:144
 #, python-format
 msgid ""
 "Learn how to upload files on the <a href=\"%(href)s\" title=\"%(title)s\""
 " target=\"_blank\" rel=\"noopener\">Python Packaging User Guide</a>"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:141
+#: warehouse/templates/manage/project/release.html:147
 msgid "Release settings"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:145
-#: warehouse/templates/manage/project/release.html:175
+#: warehouse/templates/manage/project/release.html:151
+#: warehouse/templates/manage/project/release.html:181
 #: warehouse/templates/manage/project/releases.html:123
 msgid "Yank release"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:148
+#: warehouse/templates/manage/project/release.html:154
 #, python-format
 msgid ""
 "Yanking will mark this release (and %(count)s file within it) to be "
@@ -5532,25 +5556,25 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/project/release.html:154
+#: warehouse/templates/manage/project/release.html:160
 msgid ""
 "Yanking will mark this release to be ignored when installing in most "
 "common scenarios."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:158
+#: warehouse/templates/manage/project/release.html:164
 #, python-format
 msgid ""
 "This release will still be installable for users pinning to this exact "
 "version, e.g. when using <code>%(project_name)s==%(version)s</code>."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:161
+#: warehouse/templates/manage/project/release.html:167
 #, python-format
 msgid "For more information, see <a href=\"%(href)s\">PEP 592</a>."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:168
+#: warehouse/templates/manage/project/release.html:174
 #: warehouse/templates/manage/project/releases.html:126
 #, python-format
 msgid ""
@@ -5559,13 +5583,13 @@ msgid ""
 "<code>%(project_name)s==%(version)s</code>."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:172
+#: warehouse/templates/manage/project/release.html:178
 #: warehouse/templates/manage/project/releases.html:130
 msgid "Reason (optional)"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:175
-#: warehouse/templates/manage/project/release.html:203
+#: warehouse/templates/manage/project/release.html:181
+#: warehouse/templates/manage/project/release.html:209
 #: warehouse/templates/manage/project/releases.html:23
 #: warehouse/templates/manage/project/releases.html:120
 #: warehouse/templates/manage/project/releases.html:133
@@ -5573,31 +5597,31 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:180
-#: warehouse/templates/manage/project/release.html:203
+#: warehouse/templates/manage/project/release.html:186
+#: warehouse/templates/manage/project/release.html:209
 #: warehouse/templates/manage/project/releases.html:136
 msgid "Delete release"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:184
+#: warehouse/templates/manage/project/release.html:190
 #, python-format
 msgid "Deleting will irreversibly delete this release along with %(count)s file."
 msgid_plural "Deleting will irreversibly delete this release along with %(count)s files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/project/release.html:190
+#: warehouse/templates/manage/project/release.html:196
 msgid "Deleting will irreversibly delete this release."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:192
+#: warehouse/templates/manage/project/release.html:198
 #: warehouse/templates/manage/project/releases.html:138
 msgid ""
 "You will not be able to re-upload a new distribution of the same type "
 "with the same version number."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:193
+#: warehouse/templates/manage/project/release.html:199
 #: warehouse/templates/manage/project/releases.html:139
 msgid ""
 "Deletion will break any downstream projects relying on a pinned version "
@@ -5605,7 +5629,7 @@ msgid ""
 "or remove harmful releases."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:194
+#: warehouse/templates/manage/project/release.html:200
 #: warehouse/templates/manage/project/releases.html:140
 #, python-format
 msgid ""
@@ -5615,33 +5639,25 @@ msgid ""
 "rel=\"noopener\">post release</a> instead."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:196
+#: warehouse/templates/manage/project/release.html:202
 #, python-format
 msgid ""
 "I understand that I am permanently deleting all files for the "
 "%(release_version)s release of this project."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:197
+#: warehouse/templates/manage/project/release.html:203
 msgid ""
 "I understand that my users will no longer be able to install this release"
 " of this project."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:198
+#: warehouse/templates/manage/project/release.html:204
 #, python-format
 msgid ""
 "I understand that I will <a href=\"%(href)s\" target=\"_blank\" "
 "rel=\"noopener\">not be able to re-upload any deleted files using the "
 "same file names</a>."
-msgstr ""
-
-#: warehouse/templates/manage/project/release.html:199
-msgid "I understand that I will not be able to undo this."
-msgstr ""
-
-#: warehouse/templates/manage/project/release.html:200
-msgid "I understand that the PyPI administrators will not be able to undo this."
 msgstr ""
 
 #: warehouse/templates/manage/project/releases.html:20

--- a/warehouse/static/js/warehouse/controllers/confirm_controller.js
+++ b/warehouse/static/js/warehouse/controllers/confirm_controller.js
@@ -12,18 +12,36 @@
  * limitations under the License.
  */
 
-
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = [ "input", "button" ];
+  static targets = ["input", "button", "checkbox"];
 
   connect() {
     this.buttonTarget.disabled = true;
   }
 
+  checkCheckboxes() {
+    // Check if all checkbox targets have been checked. If there are no checkboxes defined to check,
+    // this will return true.
+    if (this.checkboxTargets && this.checkboxTargets.length > 0) {
+      return this.checkboxTargets.every((input) => input.checked);
+    } else {
+      return true;
+    }
+  }
+
+  checkInputString() {
+    // Check if the current value of the input text field matches what we expect it to. If so, this
+    // will return true
+    return (
+      this.inputTarget.value.toLowerCase() ===
+      this.buttonTarget.dataset.expected.toLowerCase()
+    );
+  }
+
   check() {
-    if (this.inputTarget.value.toLowerCase() === this.buttonTarget.dataset.expected.toLowerCase()) {
+    if (this.checkCheckboxes() && this.checkInputString()) {
       this.buttonTarget.disabled = false;
     } else {
       this.buttonTarget.disabled = true;

--- a/warehouse/static/sass/blocks/_modal.scss
+++ b/warehouse/static/sass/blocks/_modal.scss
@@ -123,6 +123,12 @@
       width: auto;
       margin: 0;
     }
+
+    .inline-checkbox {
+      // Resets width for checkboxes in modal
+      width: auto;
+      min-width: auto;
+    }
   }
 
   &--wide {

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -53,7 +53,6 @@
 @import "base/tables";
 @import "base/typography";
 
-
 // LAYOUT HELPERS LAYER: reusable layout helpers
 @import "layout-helpers/banner";
 @import "layout-helpers/columns";
@@ -203,6 +202,11 @@
   margin-bottom: 0;
 }
 
+// Remove left margin on selected blocks
+.no-left-margin {
+  margin-left: 0;
+}
+
 // Add small margin to the top of elements
 .margin-top {
   margin-top: $quarter-spacing-unit;
@@ -319,7 +323,7 @@ time {
 
 // force email select to display ltr
 // Remove when/if this is marked for translation
-#public_email {  // stylelint-disable-line selector-id-pattern -- remove when translated
+#public_email { // stylelint-disable-line selector-id-pattern -- remove when translated
   direction: ltr;
 }
 

--- a/warehouse/templates/manage/project/release.html
+++ b/warehouse/templates/manage/project/release.html
@@ -120,7 +120,7 @@
                     <li class="margin-bottom"><input class="inline-checkbox" type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox"> {% trans %}I understand that my users will no longer be able to install this file for this release of this project.{% endtrans %}</li>
                     <li class="margin-bottom"><input class="inline-checkbox" type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox"> {% trans filename=file.filename, href="https://pypi.org/help/#file-name-reuse" %}I understand that I will <a href={{ href }} target="_blank" rel="noopener">not be able to re-upload a file using the same file name</a> {{ filename }}.{% endtrans %}</li>
                     <li class="margin-bottom"><input class="inline-checkbox" type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox"> {% trans %}I understand that I will not be able to undo this.{% endtrans %}</li>
-                    <li class="margin-bottom"><input class="inline-checkbox" type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox"> {% trans %}I understand that the PyPI administrators will not be able to undo this.{% endtrans %}</li>
+                    <li><input class="inline-checkbox" type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox"> {% trans %}I understand that the PyPI administrators will not be able to undo this.{% endtrans %}</li>
                   </ul>
                 {% endset %}
               </li>

--- a/warehouse/templates/manage/project/release.html
+++ b/warehouse/templates/manage/project/release.html
@@ -116,6 +116,12 @@
                 {% endset %}
                 {% set extra_description %}
                   <p><strong>{% trans %}Filename:{% endtrans %}</strong> {{ file.filename }}</p>
+                  <ul class="no-bullets no-left-margin">
+                    <li class="margin-bottom"><input class="inline-checkbox" type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox"> {% trans %}I understand that my users will no longer be able to install this file for this release of this project.{% endtrans %}</li>
+                    <li class="margin-bottom"><input class="inline-checkbox" type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox"> {% trans filename=file.filename, href="https://pypi.org/help/#file-name-reuse" %}I understand that I will <a href={{ href }} target="_blank" rel="noopener">not be able to re-upload a file using the same file name</a> {{ filename }}.{% endtrans %}</li>
+                    <li class="margin-bottom"><input class="inline-checkbox" type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox"> {% trans %}I understand that I will not be able to undo this.{% endtrans %}</li>
+                    <li class="margin-bottom"><input class="inline-checkbox" type="checkbox" data-action="input->confirm#check" data-confirm-target="checkbox"> {% trans %}I understand that the PyPI administrators will not be able to undo this.{% endtrans %}</li>
+                  </ul>
                 {% endset %}
               </li>
             </ul>


### PR DESCRIPTION
This PR addresses #13935 by adding additional checks the user has to go through to confirm the intent of their actions when deleting a file from a specific release. With these updates, a user has to check all the checkboxes within the file deletion modal, **and** confirm the project name before being able to delete the file.

To accomplish this, the `ConfirmController` needed an update to be able to check multiple types of input (besides the existing text input field) Existing uses of the controller will work as intended. With this PR, if you mark a checkbox input element as a `checkbox` target within a modal connected to this controller, its `checked` property will be considered when allowing the button target to be enabled/disabled.

A lil video of this in action:

https://github.com/pypi/warehouse/assets/639901/cd5221ff-f1bf-48f6-bd6f-b2389fb4cb1f
