### PR TITLE
fix: remove explicit commit from task

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -246,7 +246,7 @@ def test_configure(monkeypatch, settings, environment):
         "site.name": "Warehouse",
         "token.two_factor.max_age": 300,
         "token.default.max_age": 21600,
-        "pythondotorg.host": "python.org",
+        "pythondotorg.host": "https://www.python.org",
         "warehouse.xmlrpc.client.ratelimit_string": "3600 per hour",
         "warehouse.xmlrpc.search.enabled": True,
         "github.token_scanning_meta_api.url": (

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -259,7 +259,12 @@ def configure(settings=None):
     )
 
     # Pythondotorg integration settings
-    maybe_set(settings, "pythondotorg.host", "PYTHONDOTORG_HOST", default="python.org")
+    maybe_set(
+        settings,
+        "pythondotorg.host",
+        "PYTHONDOTORG_HOST",
+        default="https://www.python.org",
+    )
     maybe_set(settings, "pythondotorg.api_token", "PYTHONDOTORG_API_TOKEN")
 
     # Helpscout integration settings

--- a/warehouse/sponsors/tasks.py
+++ b/warehouse/sponsors/tasks.py
@@ -64,5 +64,3 @@ def update_pypi_sponsors(request):
         sponsor.is_active = True
         sponsor.psf_sponsor = True
         sponsor.origin = "remote"
-
-    request.db.commit()


### PR DESCRIPTION
We have implicit commits, and calling this directly fails with:

    AssertionError: Transaction must be committed using the transaction manager

Resolves WAREHOUSE-PRODUCTION-1DS