### PR TITLE
A11y: increase dark mode contrast to meet WCAG guidelines

### DIFF
--- a/docs/blog/stylesheets/extra.css
+++ b/docs/blog/stylesheets/extra.css
@@ -2,6 +2,10 @@
   --md-primary-fg-color: #0073b7;
 }
 
+[data-md-color-scheme="slate"] {
+  --md-typeset-a-color: #009ffd;
+}
+
 .md-typeset .blogging-tag code {
   white-space: nowrap;
   display: block;


### PR DESCRIPTION
With the dark theme, the colour contrast of the link text is too low and can be hard to read:

![image](https://github.com/pypi/warehouse/assets/1324225/d49d4c55-aa26-4a0a-a1c2-06ccb85315a9)

I first reported this to https://github.com/squidfunk/mkdocs-material/issues/5599, but they pointed out the `--md-primary-fg-color` had been overridden here. And `--md-typeset-a-color` is also set to `--md-primary-fg-color`.

This PR improves accessibility by fixing the `--md-typeset-a-color` contrast when in dark mode (see issue above for method to find a colour meeting WCAG's AA guidelines):

![image](https://github.com/pypi/warehouse/assets/1324225/11e29df9-699f-49e4-bee0-48cafcac8ea1)

There are a few other parts where contrast should still be fixed (for example, some of the header and footer links) but these haven't been overridden here and should be fixed upstream.