### PR TITLE
chore(ci): fail tests if can't restore cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,5 +99,7 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+          # Since we don't install deps again, we fail if we can't restore the cache (timeout, etc)
+          fail-on-cache-miss: true
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}


### PR DESCRIPTION
With the refactor to make `deps` a common prerequisite, if we cannot obtain the results from that step, there's no point in proceeding.

The failure of not having a cached environment results in a semi-confusing error of "No module named ...", so failing when we cannot restore should provide further clarity as to what happened.

Refs: https://github.com/actions/cache/blob/main/restore/README.md#exit-workflow-on-cache-miss