### PR TITLE
lint: remove namespace package config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ known_first_party = ['warehouse', 'tests']
 
 [tool.mypy]
 python_version = "3.11"
-namespace_packages = true
 warn_unused_configs = true
 # Plugin order matters. `mypy_zope` must come before `sqlalchemy` to prevent
 # false-positive signature mismatch errors for `zope.interface` instances.


### PR DESCRIPTION
We don't need this configuration, and it's creating some issues with incremental mode/cache.

See https://github.com/sqlalchemy/sqlalchemy/discussions/10019