### PR TITLE
Make filename check more strict

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2311,14 +2311,14 @@ class TestFileUpload:
         )
 
     @pytest.mark.parametrize(
-        "project_name",
+        "filename_prefix, project_name",
         [
-            "something_else",  # completely different
-            "no",  # starts with same prefix
+            ("nope", "something_else"),  # completely different
+            ("nope", "no"),  # starts with same prefix
         ],
     )
     def test_upload_fails_with_wrong_filename(
-        self, pyramid_config, db_request, metrics, project_name
+        self, pyramid_config, db_request, metrics, filename_prefix, project_name
     ):
         user = UserFactory.create()
         pyramid_config.testing_securitypolicy(identity=user)
@@ -2335,7 +2335,7 @@ class TestFileUpload:
             IMetricsService: metrics,
         }.get(svc)
 
-        filename = f"nope-{release.version}.tar.gz"
+        filename = filename_prefix + f"-{release.version}.tar.gz"
         file_content = io.BytesIO(_TAR_GZ_PKG_TESTDATA)
 
         db_request.POST = MultiDict(

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2315,6 +2315,7 @@ class TestFileUpload:
         [
             ("nope", "something_else"),  # completely different
             ("nope", "no"),  # starts with same prefix
+            ("no-way", "no"),  # starts with same prefix with hyphen
         ],
     )
     def test_upload_fails_with_wrong_filename(

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2310,12 +2310,21 @@ class TestFileUpload:
             "400 File already exists. See /the/help/url/ for more information."
         )
 
-    def test_upload_fails_with_wrong_filename(self, pyramid_config, db_request):
+    @pytest.mark.parametrize(
+        "project_name",
+        [
+            "something_else",  # completely different
+            "no",  # starts with same prefix
+        ],
+    )
+    def test_upload_fails_with_wrong_filename(
+        self, pyramid_config, db_request, project_name
+    ):
         user = UserFactory.create()
         pyramid_config.testing_securitypolicy(identity=user)
         db_request.user = user
         EmailFactory.create(user=user)
-        project = ProjectFactory.create()
+        project = ProjectFactory.create(name=project_name)
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1208,10 +1208,20 @@ def file_upload(request):
     # Ensure the filename doesn't contain any characters that are too 🌶️spicy🥵
     _validate_filename(filename)
 
+    # Extract the project name from the filename and normalize it.
+    filename_prefix = pkg_resources.safe_name(
+        # For wheels, the project name is normalized and won't contain hyphens, so
+        # we can split on the first hyphen.
+        filename.partition("-")[0]
+        if filename.endswith(".whl")
+        # For source releases, we know that the version should not contain any
+        # hypens, so we can split on the last hypen to get the project name.
+        else filename.rpartition("-")[0]
+    ).lower()
+
     # Make sure that our filename matches the project that it is being uploaded
     # to.
-    prefix = pkg_resources.safe_name(project.name).lower()
-    if not pkg_resources.safe_name(filename).lower().startswith(prefix):
+    if (prefix := pkg_resources.safe_name(project.name).lower()) != filename_prefix:
         raise _exc_with_message(
             HTTPBadRequest,
             f"Start filename for {project.name!r} with {prefix!r}.",


### PR DESCRIPTION
This ensures that the filenames of uploaded files only have the actual project name where the project name should be. Previously, this allowed filenames that started with the project name, so a file `no-way-{version}.tar.gz` could be uploaded to the `no` project, effectively making the filename unusable for the `no-way` project due to our policy on filename reuse.

Towards https://github.com/pypi/warehouse/issues/7811, but doesn't totally fix it.
