### PR TITLE
Update filename check for eggs

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2316,12 +2316,15 @@ class TestFileUpload:
             # completely different
             ("nope-{version}.tar.gz", "something_else"),
             ("nope-{version}-py3-none-any.whl", "something_else"),
+            ("nope-{version}-py3-none-any.egg", "something_else"),
             # starts with same prefix
             ("nope-{version}.tar.gz", "no"),
             ("nope-{version}-py3-none-any.whl", "no"),
+            ("nope-{version}-py3-none-any.egg", "no"),
             # starts with same prefix with hyphen
             ("no-way-{version}.tar.gz", "no"),
             ("no_way-{version}-py3-none-any.whl", "no"),
+            ("no_way-{version}-py3-none-any.egg", "no"),
         ],
     )
     def test_upload_fails_with_wrong_filename(

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1213,7 +1213,7 @@ def file_upload(request):
         # For wheels, the project name is normalized and won't contain hyphens, so
         # we can split on the first hyphen.
         filename.partition("-")[0]
-        if filename.endswith(".whl")
+        if filename.endswith((".egg", ".whl"))
         # For source releases, we know that the version should not contain any
         # hyphens, so we can split on the last hyphen to get the project name.
         else filename.rpartition("-")[0]

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1215,7 +1215,7 @@ def file_upload(request):
         filename.partition("-")[0]
         if filename.endswith(".whl")
         # For source releases, we know that the version should not contain any
-        # hypens, so we can split on the last hypen to get the project name.
+        # hyphens, so we can split on the last hyphen to get the project name.
         else filename.rpartition("-")[0]
     ).lower()
 


### PR DESCRIPTION
Unfortunately we still need to support `.egg` files for now. Eggs basically take the same filename format as wheels here, so we can apply the same check.