### PR TITLE
lint: remove the legacy sqlalchemy mypy plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,7 @@ known_first_party = ['warehouse', 'tests']
 [tool.mypy]
 python_version = "3.11"
 warn_unused_configs = true
-# Plugin order matters. `mypy_zope` must come before `sqlalchemy` to prevent
-# false-positive signature mismatch errors for `zope.interface` instances.
-plugins = ["mypy_zope:plugin", "sqlalchemy.ext.mypy.plugin"]
+plugins = ["mypy_zope:plugin"]
 exclude = ["warehouse/locale/.*", "warehouse/migrations/versions.*"]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
The cache corruption issue is confusing, and we're not actually getting any value from this plugin.