### PR TITLE
chore: make insecure algorithm use explicit

### DIFF
--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -778,7 +778,11 @@ class HaveIBeenPwnedPasswordBreachedService:
         self._metrics_increment("warehouse.compromised_password_check.start", tags=tags)
 
         # To work with the HIBP API, we need the sha1 of the UTF8 encoded password.
-        hashed_password = hashlib.sha1(password.encode("utf8")).hexdigest().lower()
+        hashed_password = (
+            hashlib.sha1(password.encode("utf8"), usedforsecurity=False)
+            .hexdigest()
+            .lower()
+        )
 
         # Fetch the passwords from the HIBP data set.
         try:

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1247,7 +1247,7 @@ def file_upload(request):
         with open(temporary_filename, "wb") as fp:
             file_size = 0
             file_hashes = {
-                "md5": hashlib.md5(),
+                "md5": hashlib.md5(usedforsecurity=False),
                 "sha256": hashlib.sha256(),
                 "blake2_256": hashlib.blake2b(digest_size=256 // 8),
             }

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -72,7 +72,9 @@ class GenericLocalBlobStorage:
         return json.loads(open(os.path.join(self.base, path + ".meta")).read())
 
     def get_checksum(self, path):
-        return hashlib.md5(open(os.path.join(self.base, path), "rb").read()).hexdigest()
+        return hashlib.md5(
+            open(os.path.join(self.base, path), "rb").read(), usedforsecurity=False
+        ).hexdigest()
 
     def store(self, path, file_path, *, meta=None):
         destination = os.path.join(self.base, path)

--- a/warehouse/utils/compression.py
+++ b/warehouse/utils/compression.py
@@ -66,7 +66,9 @@ def _compressor(request, response):
         # ;gzip to this because we don't want people to try and use it to infer
         # any information about it.
         if response.etag is not None:
-            md5_digest = hashlib.md5((response.etag + ";gzip").encode("utf8"))
+            md5_digest = hashlib.md5(
+                (response.etag + ";gzip").encode("utf8"), usedforsecurity=False
+            )
             md5_digest = md5_digest.digest()
             md5_digest = base64.b64encode(md5_digest)
             md5_digest = md5_digest.replace(b"\n", b"").decode("utf8")

--- a/warehouse/utils/gravatar.py
+++ b/warehouse/utils/gravatar.py
@@ -18,7 +18,9 @@ def _hash(email):
     if email is None:
         email = ""
 
-    return hashlib.md5(email.strip().lower().encode("utf8")).hexdigest()
+    return hashlib.md5(
+        email.strip().lower().encode("utf8"), usedforsecurity=False
+    ).hexdigest()
 
 
 def gravatar(request, email, size=80):


### PR DESCRIPTION
When analyzing the codebase with security focused tools, usage of SHA-1 and MD5 algorithms trigger warnings that these algos should not be used in a secure context, which they are not.

Since scanners have no way of knowing, use the `usedforsecurity` boolean introduced in Python 3.9 to signal that these are not for security purposes.

They are used for either filename hashing, or required conformance to an external API structure.