### PR TITLE
lint: add timeouts to requests calls

### DIFF
--- a/tests/unit/oidc/test_forms.py
+++ b/tests/unit/oidc/test_forms.py
@@ -103,6 +103,7 @@ class TestGitHubPublisherForm:
                     "Authorization": "token fake-token",
                 },
                 allow_redirects=True,
+                timeout=5,
             )
         ]
 
@@ -132,6 +133,7 @@ class TestGitHubPublisherForm:
                     "Authorization": "token fake-token",
                 },
                 allow_redirects=True,
+                timeout=5,
             )
         ]
         assert sentry_sdk.capture_message.calls == [
@@ -168,6 +170,7 @@ class TestGitHubPublisherForm:
                     "Authorization": "token fake-token",
                 },
                 allow_redirects=True,
+                timeout=5,
             )
         ]
 
@@ -243,6 +246,7 @@ class TestGitHubPublisherForm:
                     "Authorization": "token fake-token",
                 },
                 allow_redirects=True,
+                timeout=5,
             )
         ]
         assert response.raise_for_status.calls == [pretend.call()]

--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -353,7 +353,7 @@ class TestOIDCPublisherService:
         monkeypatch.setattr(services.redis, "StrictRedis", mockredis)
 
         requests = pretend.stub(
-            get=pretend.call_recorder(lambda url: pretend.stub(ok=False))
+            get=pretend.call_recorder(lambda url, timeout: pretend.stub(ok=False))
         )
         sentry_sdk = pretend.stub(
             capture_message=pretend.call_recorder(lambda msg: pretend.stub())
@@ -366,7 +366,9 @@ class TestOIDCPublisherService:
         assert keys == {}
         assert metrics.increment.calls == []
         assert requests.get.calls == [
-            pretend.call("https://example.com/.well-known/openid-configuration")
+            pretend.call(
+                "https://example.com/.well-known/openid-configuration", timeout=5
+            )
         ]
         assert sentry_sdk.capture_message.calls == [
             pretend.call(
@@ -390,7 +392,7 @@ class TestOIDCPublisherService:
 
         requests = pretend.stub(
             get=pretend.call_recorder(
-                lambda url: pretend.stub(ok=True, json=lambda: {})
+                lambda url, timeout: pretend.stub(ok=True, json=lambda: {})
             )
         )
         sentry_sdk = pretend.stub(
@@ -404,7 +406,9 @@ class TestOIDCPublisherService:
         assert keys == {}
         assert metrics.increment.calls == []
         assert requests.get.calls == [
-            pretend.call("https://example.com/.well-known/openid-configuration")
+            pretend.call(
+                "https://example.com/.well-known/openid-configuration", timeout=5
+            )
         ]
         assert sentry_sdk.capture_message.calls == [
             pretend.call(
@@ -434,7 +438,7 @@ class TestOIDCPublisherService:
         )
         jwks_resp = pretend.stub(ok=False)
 
-        def get(url):
+        def get(url, timeout=5):
             if url == "https://example.com/.well-known/jwks.json":
                 return jwks_resp
             else:
@@ -452,8 +456,10 @@ class TestOIDCPublisherService:
         assert keys == {}
         assert metrics.increment.calls == []
         assert requests.get.calls == [
-            pretend.call("https://example.com/.well-known/openid-configuration"),
-            pretend.call("https://example.com/.well-known/jwks.json"),
+            pretend.call(
+                "https://example.com/.well-known/openid-configuration", timeout=5
+            ),
+            pretend.call("https://example.com/.well-known/jwks.json", timeout=5),
         ]
         assert sentry_sdk.capture_message.calls == [
             pretend.call(
@@ -483,7 +489,7 @@ class TestOIDCPublisherService:
         )
         jwks_resp = pretend.stub(ok=True, json=lambda: {})
 
-        def get(url):
+        def get(url, timeout=5):
             if url == "https://example.com/.well-known/jwks.json":
                 return jwks_resp
             else:
@@ -501,8 +507,10 @@ class TestOIDCPublisherService:
         assert keys == {}
         assert metrics.increment.calls == []
         assert requests.get.calls == [
-            pretend.call("https://example.com/.well-known/openid-configuration"),
-            pretend.call("https://example.com/.well-known/jwks.json"),
+            pretend.call(
+                "https://example.com/.well-known/openid-configuration", timeout=5
+            ),
+            pretend.call("https://example.com/.well-known/jwks.json", timeout=5),
         ]
         assert sentry_sdk.capture_message.calls == [
             pretend.call("OIDC publisher example returned JWKS JSON but no keys")
@@ -531,7 +539,7 @@ class TestOIDCPublisherService:
             ok=True, json=lambda: {"keys": [{"kid": "fake-key-id", "foo": "bar"}]}
         )
 
-        def get(url):
+        def get(url, timeout=5):
             if url == "https://example.com/.well-known/jwks.json":
                 return jwks_resp
             else:
@@ -549,8 +557,10 @@ class TestOIDCPublisherService:
         assert keys == {"fake-key-id": {"kid": "fake-key-id", "foo": "bar"}}
         assert metrics.increment.calls == []
         assert requests.get.calls == [
-            pretend.call("https://example.com/.well-known/openid-configuration"),
-            pretend.call("https://example.com/.well-known/jwks.json"),
+            pretend.call(
+                "https://example.com/.well-known/openid-configuration", timeout=5
+            ),
+            pretend.call("https://example.com/.well-known/jwks.json", timeout=5),
         ]
         assert sentry_sdk.capture_message.calls == []
 

--- a/tests/unit/sponsors/test_tasks.py
+++ b/tests/unit/sponsors/test_tasks.py
@@ -57,7 +57,9 @@ def test_raise_error_if_invalid_response(monkeypatch, db_request, fake_task_requ
         text="I'm a teapot",
         raise_for_status=pretend.raiser(HTTPError),
     )
-    requests = pretend.stub(get=pretend.call_recorder(lambda url, headers: response))
+    requests = pretend.stub(
+        get=pretend.call_recorder(lambda url, headers, timeout: response)
+    )
     monkeypatch.setattr(tasks, "requests", requests)
 
     with pytest.raises(HTTPError):
@@ -66,7 +68,9 @@ def test_raise_error_if_invalid_response(monkeypatch, db_request, fake_task_requ
     qs = urlencode({"publisher": "pypi", "flight": "sponsors"})
     headers = {"Authorization": "Token API_TOKEN"}
     expected_url = f"https://API_HOST/api/v2/sponsors/logo-placement/?{qs}"
-    assert requests.get.calls == [pretend.call(expected_url, headers=headers)]
+    assert requests.get.calls == [
+        pretend.call(expected_url, headers=headers, timeout=5)
+    ]
 
 
 def test_create_new_sponsor_if_no_matching(
@@ -75,7 +79,9 @@ def test_create_new_sponsor_if_no_matching(
     response = pretend.stub(
         raise_for_status=lambda: None, json=lambda: sponsor_api_data
     )
-    requests = pretend.stub(get=pretend.call_recorder(lambda url, headers: response))
+    requests = pretend.stub(
+        get=pretend.call_recorder(lambda url, headers, timeout: response)
+    )
     monkeypatch.setattr(tasks, "requests", requests)
     assert 0 == len(db_request.db.query(Sponsor).all())
 
@@ -107,7 +113,9 @@ def test_update_remote_sponsor_with_same_name_with_new_logo(
     response = pretend.stub(
         raise_for_status=lambda: None, json=lambda: sponsor_api_data
     )
-    requests = pretend.stub(get=pretend.call_recorder(lambda url, headers: response))
+    requests = pretend.stub(
+        get=pretend.call_recorder(lambda url, headers, timeout: response)
+    )
     monkeypatch.setattr(tasks, "requests", requests)
     created_sponsor = SponsorFactory.create(
         name=sponsor_api_data[0]["sponsor"],
@@ -147,7 +155,9 @@ def test_do_not_update_if_not_psf_sponsor(
     response = pretend.stub(
         raise_for_status=lambda: None, json=lambda: sponsor_api_data
     )
-    requests = pretend.stub(get=pretend.call_recorder(lambda url, headers: response))
+    requests = pretend.stub(
+        get=pretend.call_recorder(lambda url, headers, timeout: response)
+    )
     monkeypatch.setattr(tasks, "requests", requests)
     infra_sponsor = SponsorFactory.create(
         name=sponsor_api_data[0]["sponsor"],
@@ -173,7 +183,9 @@ def test_update_remote_sponsor_with_same_slug_with_new_logo(
     response = pretend.stub(
         raise_for_status=lambda: None, json=lambda: sponsor_api_data
     )
-    requests = pretend.stub(get=pretend.call_recorder(lambda url, headers: response))
+    requests = pretend.stub(
+        get=pretend.call_recorder(lambda url, headers, timeout: response)
+    )
     monkeypatch.setattr(tasks, "requests", requests)
     created_sponsor = SponsorFactory.create(
         slug=sponsor_api_data[0]["sponsor_slug"],
@@ -200,7 +212,9 @@ def test_flag_existing_psf_sponsor_to_false_if_not_present_in_api_response(
     response = pretend.stub(
         raise_for_status=lambda: None, json=lambda: sponsor_api_data
     )
-    requests = pretend.stub(get=pretend.call_recorder(lambda url, headers: response))
+    requests = pretend.stub(
+        get=pretend.call_recorder(lambda url, headers, timeout: response)
+    )
     monkeypatch.setattr(tasks, "requests", requests)
     created_sponsor = SponsorFactory.create(
         slug="other-slug",

--- a/warehouse/oidc/forms.py
+++ b/warehouse/oidc/forms.py
@@ -75,6 +75,7 @@ class GitHubPublisherBase(forms.Form):
                     **self._headers_auth(),
                 },
                 allow_redirects=True,
+                timeout=5,
             )
             response.raise_for_status()
         except requests.HTTPError:

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -136,7 +136,7 @@ class OIDCPublisherService:
 
         oidc_url = f"{self.issuer_url}/.well-known/openid-configuration"
 
-        resp = requests.get(oidc_url)
+        resp = requests.get(oidc_url, timeout=5)
 
         # For whatever reason, an OIDC publisher's configuration URL might be
         # offline. We don't want to completely explode here, since other
@@ -161,7 +161,7 @@ class OIDCPublisherService:
             )
             return keys
 
-        resp = requests.get(jwks_url)
+        resp = requests.get(jwks_url, timeout=5)
 
         # Same reasoning as above.
         if not resp.ok:

--- a/warehouse/sponsors/tasks.py
+++ b/warehouse/sponsors/tasks.py
@@ -32,7 +32,7 @@ def update_pypi_sponsors(request):
 
     qs = urlencode({"publisher": "pypi", "flight": "sponsors"})
     url = f"{host}/api/v2/sponsors/logo-placement/?{qs}"
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=5)
     response.raise_for_status()
 
     # deactivate current PSF sponsors to keep it up to date with API


### PR DESCRIPTION
Resolves B113:request_without_timeout

Chose a 5 second default - happy to change if doesn't meet our needs.