### PR TITLE
Refactor OIDC mint token endpoint

### DIFF
--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -122,7 +122,8 @@ def test_mint_token_from_github_oidc_invalid_payload(body):
             return json.dumps(body)
 
     req = Request()
-    resp = views.mint_token_from_oidc_github(req)
+    oidc_service = pretend.stub()
+    resp = views.mint_token(oidc_service, req)
 
     assert req.response.status == 422
     assert resp["message"] == "Token request failed"
@@ -144,7 +145,7 @@ def test_mint_token_from_trusted_publisher_verify_jwt_signature_fails():
         flags=pretend.stub(disallow_oidc=lambda *a: False),
     )
 
-    response = views.mint_token(oidc_service, request, "faketoken")
+    response = views.mint_token(oidc_service, request)
     assert request.response.status == 422
     assert response == {
         "message": "Token request failed",
@@ -215,7 +216,7 @@ def test_mint_token_from_oidc_pending_publisher_project_already_exists(db_reques
     )
     db_request.find_service = pretend.call_recorder(lambda *a, **kw: oidc_service)
 
-    resp = views.mint_token(oidc_service, db_request, "faketoken")
+    resp = views.mint_token(oidc_service, db_request)
     assert db_request.response.status_code == 422
     assert resp == {
         "message": "Token request failed",
@@ -351,7 +352,7 @@ def test_mint_token_from_pending_trusted_publisher_invalidates_others(
 
     oidc_service = db_request.find_service(IOIDCPublisherService, name="github")
 
-    resp = views.mint_token(oidc_service, db_request, token)
+    resp = views.mint_token(oidc_service, db_request)
     assert resp["success"]
     assert resp["token"].startswith("pypi-")
 
@@ -433,7 +434,7 @@ def test_mint_token_from_oidc_no_pending_publisher_ok(
         flags=pretend.stub(disallow_oidc=lambda *a: False),
     )
 
-    response = views.mint_token(oidc_service, request, "faketoken")
+    response = views.mint_token(oidc_service, request)
     assert response == {
         "success": True,
         "token": "raw-macaroon",

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -232,7 +232,9 @@ class OIDCPublisherMixin:
         # Only concrete subclasses are constructed.
         raise NotImplementedError
 
-    def publisher_url(self, claims=None) -> str | None:  # pragma: no cover
+    def publisher_url(
+        self, claims: SignedClaims | None = None
+    ) -> str:  # pragma: no cover
         """
         NOTE: This is **NOT** a `@property` because we pass `claims` to it.
         When calling, make sure to use `publisher_url()`

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -234,7 +234,7 @@ class OIDCPublisherMixin:
 
     def publisher_url(
         self, claims: SignedClaims | None = None
-    ) -> str:  # pragma: no cover
+    ) -> str | None:  # pragma: no cover
         """
         NOTE: This is **NOT** a `@property` because we pass `claims` to it.
         When calling, make sure to use `publisher_url()`

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -283,6 +283,7 @@ class OIDCPublisherService:
     def find_publisher(
         self, signed_claims: SignedClaims, *, pending: bool = False
     ) -> OIDCPublisher | PendingOIDCPublisher:
+        """Returns a publisher for the given claims, or raises an error."""
         metrics_tags = [f"publisher:{self.publisher}"]
         self.metrics.increment(
             "warehouse.oidc.find_publisher.attempt",
@@ -306,7 +307,7 @@ class OIDCPublisherService:
             )
             raise e
 
-    def reify_pending_publisher(self, pending_publisher, project):
+    def reify_pending_publisher(self, pending_publisher, project) -> OIDCPublisher:
         new_publisher = pending_publisher.reify(self.db)
         project.oidc_publishers.append(new_publisher)
         return new_publisher

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -282,7 +282,7 @@ class OIDCPublisherService:
 
     def find_publisher(
         self, signed_claims: SignedClaims, *, pending: bool = False
-    ) -> OIDCPublisher | PendingOIDCPublisher | None:
+    ) -> OIDCPublisher | PendingOIDCPublisher:
         metrics_tags = [f"publisher:{self.publisher}"]
         self.metrics.increment(
             "warehouse.oidc.find_publisher.attempt",

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -13,8 +13,10 @@
 import time
 
 from datetime import datetime
+from typing import TypedDict
 
 from pydantic import BaseModel, StrictStr, ValidationError
+from pyramid.request import Request
 from pyramid.response import Response
 from pyramid.view import view_config
 from sqlalchemy import func
@@ -24,19 +26,32 @@ from warehouse.email import send_pending_trusted_publisher_invalidated_email
 from warehouse.events.tags import EventTag
 from warehouse.macaroons import caveats
 from warehouse.macaroons.interfaces import IMacaroonService
-from warehouse.oidc.errors import InvalidPublisherError
+from warehouse.macaroons.services import DatabaseMacaroonService
 from warehouse.oidc.interfaces import IOIDCPublisherService
-from warehouse.oidc.models import PendingOIDCPublisher
+from warehouse.oidc.models import OIDCPublisher, PendingOIDCPublisher
+from warehouse.oidc.services import OIDCPublisherService
 from warehouse.packaging.interfaces import IProjectService
 from warehouse.packaging.models import ProjectFactory
 from warehouse.rate_limiting.interfaces import IRateLimiter
+
+
+class Error(TypedDict):
+    code: str
+    description: str
+
+
+class JsonRespone(TypedDict, total=False):
+    message: str | None
+    errors: list[Error] | None
+    token: StrictStr | None
+    success: bool | None
 
 
 class TokenPayload(BaseModel):
     token: StrictStr
 
 
-def _ratelimiters(request):
+def _ratelimiters(request: Request) -> dict[str, IRateLimiter]:
     return {
         "user.oidc": request.find_service(
             IRateLimiter, name="user_oidc.publisher.register"
@@ -47,6 +62,15 @@ def _ratelimiters(request):
     }
 
 
+def _invalid(errors: list[Error], request: Request) -> JsonRespone:
+    request.response.status = 422
+
+    return {
+        "message": "Token request failed",
+        "errors": errors,
+    }
+
+
 @view_config(
     route_name="oidc.audience",
     require_methods=["GET"],
@@ -54,13 +78,13 @@ def _ratelimiters(request):
     require_csrf=False,
     has_translations=False,
 )
-def oidc_audience(request):
+def oidc_audience(request: Request):
     if request.flags.disallow_oidc():
         return Response(
             status=403, json={"message": "Trusted publishing functionality not enabled"}
         )
 
-    audience = request.registry.settings["warehouse.oidc.audience"]
+    audience: str = request.registry.settings["warehouse.oidc.audience"]
     return {"audience": audience}
 
 
@@ -71,96 +95,109 @@ def oidc_audience(request):
     require_csrf=False,
     has_translations=True,
 )
-def mint_token_from_oidc(request):
-    def _invalid(errors):
-        request.response.status = 422
-        return {"message": "Token request failed", "errors": errors}
-
+def mint_token_from_oidc_github(request: Request):
     if request.flags.disallow_oidc(AdminFlagValue.DISALLOW_GITHUB_OIDC):
         return _invalid(
             errors=[
                 {
                     "code": "not-enabled",
-                    "description": (
-                        "GitHub-based trusted publishing functionality not enabled"
-                    ),
+                    "description": "GitHub-based trusted publishing functionality not enabled",  # noqa
                 }
-            ]
+            ],
+            request=request,
         )
 
     try:
         payload = TokenPayload.model_validate_json(request.body)
         unverified_jwt = payload.token
     except ValidationError as exc:
-        return _invalid(errors=[{"code": "invalid-payload", "description": str(exc)}])
+        return _invalid(
+            errors=[{"code": "invalid-payload", "description": str(exc)}],
+            request=request,
+        )
 
     # For the time being, GitHub is our only OIDC publisher.
     # In the future, this should locate the correct service based on an
     # identifier in the request body.
-    oidc_service = request.find_service(IOIDCPublisherService, name="github")
+    oidc_service: OIDCPublisherService = request.find_service(
+        IOIDCPublisherService, name="github"
+    )
+
+    return mint_token(oidc_service, request, unverified_jwt)
+
+
+def mint_token(
+    oidc_service: OIDCPublisherService, request: Request, unverified_jwt: str
+) -> JsonRespone:
     claims = oidc_service.verify_jwt_signature(unverified_jwt)
     if not claims:
         return _invalid(
             errors=[
                 {"code": "invalid-token", "description": "malformed or invalid token"}
-            ]
+            ],
+            request=request,
         )
 
     # First, try to find a pending publisher.
     try:
         pending_publisher = oidc_service.find_publisher(claims, pending=True)
-        factory = ProjectFactory(request)
+        if isinstance(pending_publisher, PendingOIDCPublisher):
+            factory = ProjectFactory(request)
 
-        # If the project already exists, this pending publisher is no longer
-        # valid and needs to be removed.
-        # NOTE: This is mostly a sanity check, since we dispose of invalidated
-        # pending publishers below.
-        if pending_publisher.project_name in factory:
-            request.db.delete(pending_publisher)
-            return _invalid(
-                errors=[
-                    {
-                        "code": "invalid-pending-publisher",
-                        "description": "valid token, but project already exists",
-                    }
-                ]
-            )
+            # If the project already exists, this pending publisher is no longer
+            # valid and needs to be removed.
+            # NOTE: This is mostly a sanity check, since we dispose of invalidated
+            # pending publishers below.
+            if pending_publisher.project_name in factory:
+                request.db.delete(pending_publisher)
+                return _invalid(
+                    errors=[
+                        {
+                            "code": "invalid-pending-publisher",
+                            "description": "valid token, but project already exists",
+                        }
+                    ],
+                    request=request,
+                )
 
-        # Create the new project, and reify the pending publisher against it.
-        project_service = request.find_service(IProjectService)
-        new_project = project_service.create_project(
-            pending_publisher.project_name,
-            pending_publisher.added_by,
-            request,
-            ratelimited=False,
-        )
-        oidc_service.reify_pending_publisher(pending_publisher, new_project)
-
-        # Successfully converting a pending publisher into a normal publisher
-        # is a positive signal, so we reset the associated ratelimits.
-        ratelimiters = _ratelimiters(request)
-        ratelimiters["user.oidc"].clear(pending_publisher.added_by.id)
-        ratelimiters["ip.oidc"].clear(request.remote_addr)
-
-        # There might be other pending publishers for the same project name,
-        # which we've now invalidated by creating the project. These would
-        # be disposed of on use, but we explicitly dispose of them here while
-        # also sending emails to their owners.
-        stale_pending_publishers = (
-            request.db.query(PendingOIDCPublisher)
-            .filter(
-                func.normalize_pep426_name(PendingOIDCPublisher.project_name)
-                == func.normalize_pep426_name(pending_publisher.project_name)
-            )
-            .all()
-        )
-        for stale_publisher in stale_pending_publishers:
-            send_pending_trusted_publisher_invalidated_email(
+            # Create the new project, and reify the pending publisher against it.
+            project_service = request.find_service(IProjectService)
+            new_project = project_service.create_project(
+                pending_publisher.project_name,
+                pending_publisher.added_by,
                 request,
-                stale_publisher.added_by,
-                project_name=stale_publisher.project_name,
+                ratelimited=False,
             )
-            request.db.delete(stale_publisher)
+
+            publisher = oidc_service.reify_pending_publisher(
+                pending_publisher, new_project
+            )
+
+            # Successfully converting a pending publisher into a normal publisher
+            # is a positive signal, so we reset the associated ratelimits.
+            ratelimiters = _ratelimiters(request)
+            ratelimiters["user.oidc"].clear(pending_publisher.added_by.id)
+            ratelimiters["ip.oidc"].clear(request.remote_addr)
+
+            # There might be other pending publishers for the same project name,
+            # which we've now invalidated by creating the project. These would
+            # be disposed of on use, but we explicitly dispose of them here while
+            # also sending emails to their owners.
+            stale_pending_publishers = (
+                request.db.query(PendingOIDCPublisher)
+                .filter(
+                    func.normalize_pep426_name(PendingOIDCPublisher.project_name)
+                    == func.normalize_pep426_name(pending_publisher.project_name)
+                )
+                .all()
+            )
+            for stale_publisher in stale_pending_publishers:
+                send_pending_trusted_publisher_invalidated_email(
+                    request,
+                    stale_publisher.added_by,
+                    project_name=stale_publisher.project_name,
+                )
+                request.db.delete(stale_publisher)
     except InvalidPublisherError:
         # If the claim set isn't valid for a pending publisher, it's OK, we
         # will try finding a regular publisher
@@ -178,40 +215,44 @@ def mint_token_from_oidc(request):
                     "code": "invalid-publisher",
                     "description": f"valid token, but no corresponding publisher ({e})",
                 }
-            ]
+            ],
+            request=request,
         )
 
-    # At this point, we've verified that the given JWT is valid for the given
-    # project. All we need to do is mint a new token.
-    # NOTE: For OIDC-minted API tokens, the Macaroon's description string
-    # is purely an implementation detail and is not displayed to the user.
-    macaroon_service = request.find_service(IMacaroonService, context=None)
-    not_before = int(time.time())
-    expires_at = not_before + 900
-    serialized, dm = macaroon_service.create_macaroon(
-        request.domain,
-        (
-            f"OpenID token: {str(publisher)} "
-            f"({datetime.fromtimestamp(not_before).isoformat()})"
-        ),
-        [
-            caveats.OIDCPublisher(
-                oidc_publisher_id=str(publisher.id),
-            ),
-            caveats.ProjectID(project_ids=[str(p.id) for p in publisher.projects]),
-            caveats.Expiration(expires_at=expires_at, not_before=not_before),
-        ],
-        oidc_publisher_id=publisher.id,
-        additional={"oidc": {"ref": claims.get("ref"), "sha": claims.get("sha")}},
-    )
-    for project in publisher.projects:
-        project.record_event(
-            tag=EventTag.Project.ShortLivedAPITokenAdded,
-            request=request,
-            additional={
-                "expires": expires_at,
-                "publisher_name": publisher.publisher_name,
-                "publisher_url": publisher.publisher_url(),
-            },
+    if isinstance(publisher, OIDCPublisher):
+        # At this point, we've verified that the given JWT is valid for the given
+        # project. All we need to do is mint a new token.
+        # NOTE: For OIDC-minted API tokens, the Macaroon's description string
+        # is purely an implementation detail and is not displayed to the user.
+        macaroon_service: DatabaseMacaroonService = request.find_service(
+            IMacaroonService, context=None
         )
-    return {"success": True, "token": serialized}
+        not_before = int(time.time())
+        expires_at = not_before + 900
+        serialized, dm = macaroon_service.create_macaroon(
+            request.domain,
+            (
+                f"OpenID token: {str(publisher)} "
+                f"({datetime.fromtimestamp(not_before).isoformat()})"
+            ),
+            [
+                caveats.OIDCPublisher(
+                    oidc_publisher_id=str(publisher.id),
+                ),
+                caveats.ProjectID(project_ids=[str(p.id) for p in publisher.projects]),
+                caveats.Expiration(expires_at=expires_at, not_before=not_before),
+            ],
+            oidc_publisher_id=publisher.id,
+            additional={"oidc": {"ref": claims.get("ref"), "sha": claims.get("sha")}},
+        )
+        for project in publisher.projects:
+            project.record_event(
+                tag=EventTag.Project.ShortLivedAPITokenAdded,
+                request=request,
+                additional={
+                    "expires": expires_at,
+                    "publisher_name": publisher.publisher_name,
+                    "publisher_url": publisher.publisher_url(),
+                },
+            )
+        return {"success": True, "token": serialized}


### PR DESCRIPTION
Make it easier to mint tokens with additional publishers

This PR splits warehouse.oidc.view.mint_token_from_oidc into two functions.  1, `mint_token`, is OIDC provider specific.  The other, `mint_token_from_oidc_*` that is OIDC provider agnostic.  This should make it easier to add more OIDC provider token handlers.

ActiveState Internal work tracking ID: DS-1722