### PR TITLE
Fix new email email

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -994,6 +994,7 @@ class TestNewEmailAddedEmails:
             id="id", username="username", name=None, email="foo@example.com"
         )
         stub_email = pretend.stub(id="id", email="email@example.com", verified=False)
+        new_email_address = "new@example.com"
         pyramid_request.method = "POST"
 
         subject_renderer = pyramid_config.testing_add_renderer(
@@ -1026,16 +1027,18 @@ class TestNewEmailAddedEmails:
         pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
 
         result = email.send_new_email_added_email(
-            pyramid_request, (stub_user, stub_email)
+            pyramid_request,
+            (stub_user, stub_email),
+            new_email_address=new_email_address,
         )
 
         assert result == {
             "username": stub_user.username,
-            "email_address": stub_email.email,
+            "new_email_address": new_email_address,
         }
         subject_renderer.assert_()
-        body_renderer.assert_(email_address=stub_email.email)
-        html_renderer.assert_(email_address=stub_email.email)
+        body_renderer.assert_(new_email_address=new_email_address)
+        html_renderer.assert_(new_email_address=new_email_address)
         assert pyramid_request.task.calls == []
         assert send_email.delay.calls == []
 

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -274,7 +274,6 @@ class TestManageAccount:
             id=pretend.stub(),
             record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
-        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
         monkeypatch.setattr(
             views,
             "AddEmailForm",
@@ -314,7 +313,8 @@ class TestManageAccount:
         assert send_new_email_added_email.calls == [
             pretend.call(
                 pyramid_request,
-                (pyramid_request.user, new_email_address),
+                (pyramid_request.user, existing_email),
+                new_email_address=new_email_address,
             ),
         ]
         assert pyramid_request.user.record_event.calls == [
@@ -469,7 +469,7 @@ class TestManageAccount:
         )
         view = views.ManageAccountViews(db_request)
 
-        send_email = pretend.call_recorder(lambda *a: None)
+        send_email = pretend.call_recorder(lambda *a, **kw: None)
         monkeypatch.setattr(views, "send_primary_email_change_email", send_email)
 
         assert isinstance(view.change_primary_email(), HTTPSeeOther)

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -292,12 +292,12 @@ def send_email_verification_email(request, user_and_email):
 
 
 @_email("new-email-added")
-def send_new_email_added_email(request, user_and_email):
-    user, email = user_and_email
+def send_new_email_added_email(request, user_and_email, *, new_email_address):
+    user, _ = user_and_email
 
     return {
         "username": user.username,
-        "email_address": email.email,
+        "new_email_address": new_email_address,
     }
 
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -137,7 +137,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:499 warehouse/manage/views/__init__.py:824
+#: warehouse/accounts/views.py:499 warehouse/manage/views/__init__.py:825
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -271,13 +271,13 @@ msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
 #: warehouse/accounts/views.py:1434 warehouse/accounts/views.py:1582
-#: warehouse/manage/views/__init__.py:1227
+#: warehouse/manage/views/__init__.py:1228
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1451 warehouse/manage/views/__init__.py:1243
+#: warehouse/accounts/views.py:1451 warehouse/manage/views/__init__.py:1244
 msgid ""
 "GitHub-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
@@ -293,13 +293,13 @@ msgstr ""
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1494 warehouse/manage/views/__init__.py:1262
+#: warehouse/accounts/views.py:1494 warehouse/manage/views/__init__.py:1263
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1508 warehouse/manage/views/__init__.py:1276
+#: warehouse/accounts/views.py:1508 warehouse/manage/views/__init__.py:1277
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
@@ -416,98 +416,98 @@ msgstr ""
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:772
+#: warehouse/manage/views/__init__.py:773
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:773
+#: warehouse/manage/views/__init__.py:774
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:879
+#: warehouse/manage/views/__init__.py:880
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1004
+#: warehouse/manage/views/__init__.py:1005
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1126
+#: warehouse/manage/views/__init__.py:1127
 msgid "2FA requirement cannot be disabled for critical projects"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1481
-#: warehouse/manage/views/__init__.py:1782
-#: warehouse/manage/views/__init__.py:1890
+#: warehouse/manage/views/__init__.py:1482
+#: warehouse/manage/views/__init__.py:1783
+#: warehouse/manage/views/__init__.py:1891
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1613
-#: warehouse/manage/views/__init__.py:1698
-#: warehouse/manage/views/__init__.py:1799
-#: warehouse/manage/views/__init__.py:1899
+#: warehouse/manage/views/__init__.py:1614
+#: warehouse/manage/views/__init__.py:1699
+#: warehouse/manage/views/__init__.py:1800
+#: warehouse/manage/views/__init__.py:1900
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1625
+#: warehouse/manage/views/__init__.py:1626
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1710
+#: warehouse/manage/views/__init__.py:1711
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1811
+#: warehouse/manage/views/__init__.py:1812
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1911
+#: warehouse/manage/views/__init__.py:1912
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1915
+#: warehouse/manage/views/__init__.py:1916
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2065
+#: warehouse/manage/views/__init__.py:2066
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2172
+#: warehouse/manage/views/__init__.py:2173
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2239
+#: warehouse/manage/views/__init__.py:2240
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2271
+#: warehouse/manage/views/__init__.py:2272
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2284
+#: warehouse/manage/views/__init__.py:2285
 #: warehouse/manage/views/organizations.py:882
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2349
+#: warehouse/manage/views/__init__.py:2350
 #: warehouse/manage/views/organizations.py:947
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2382
+#: warehouse/manage/views/__init__.py:2383
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2393
+#: warehouse/manage/views/__init__.py:2394
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2425
+#: warehouse/manage/views/__init__.py:2426
 #: warehouse/manage/views/organizations.py:1134
 msgid "Invitation revoked from '${username}'."
 msgstr ""

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -230,6 +230,7 @@ class ManageAccountViews:
                     send_new_email_added_email(
                         self.request,
                         (self.request.user, previously_registered_email),
+                        new_email_address=email.email,
                     )
 
             return HTTPSeeOther(self.request.path)


### PR DESCRIPTION
This fixes an issue from #13866 where we were accidentally including the email we were contacting as the "new email added" rather than the actual email.