### PR TITLE
feat(admin): add visibility for description

### DIFF
--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -137,14 +137,6 @@
           <td><code>{{ release.summary }}</code></td>
         </tr>
         <tr>
-          <td>Description</td>
-          <td><code>{{ release.description.raw }}</code></td>
-        </tr>
-        <tr>
-          <td>Description-Content-Type</td>
-          <td><code>{{ release.description.content_type }}</code></td>
-        </tr>
-        <tr>
           <td>Keywords</td>
           <td><code>{{ release.keywords }}</code></td>
         </tr>

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -225,4 +225,41 @@
       </table>
     </div>
   </div>
+  <div class="card">
+    <div class="card-header">
+      <h3>Description Rendering</h3>
+    </div>
+    <div class="card-body table-responsive">
+      <table class="table table-hover">
+        <tr>
+          <td>Rendered By Version</td>
+          <td><code>{{ release.description.rendered_by }}</code></td>
+        </tr>
+        <tr>
+          <td>Detected Content-Type</td>
+          <td><code>{{ release.description.content_type }}</code></td>
+        </tr>
+        <tr>
+          <td>Raw Input</td>
+          <td><code>{{ release.description.raw }}</code></td>
+        </tr>
+        <tr>
+          <td>Stored Output</td>
+          <td><code>{{ release.description.html }}</code></td>
+        <tr>
+          <td>Database ID</td>
+          <td><code>{{ release.description.id }}</code></td>
+        </tr>
+      </table>
+    </div>
+    {# TODO: Implement re-render task kick-off.
+     # Look at `warehouse.packaging.tasks.update_description_html`
+     # and `warehouse.admin.views.projects.reindex_project`
+    <div class="card-footer">
+      <p>
+        <a href="#" class="btn btn-primary">Re-render</a>
+      </p>
+    </div>
+     #}
+  </div>
 {% endblock content %}


### PR DESCRIPTION
As an aid to debugging observed readme rendering issues, provide admins a way to see what the current Description model columns contain.

Note: The "Raw Input"/"Stored Output" could get unwieldy, but they are similar in nature to what's already being show in the "Metadata" section of the same page.

Refs: #14064