### PR TITLE
chore: remove view transcript for 404 pages

### DIFF
--- a/warehouse/templates/404.html
+++ b/warehouse/templates/404.html
@@ -31,6 +31,7 @@
         <div class="viewport-section__video-container">
           <iframe title="{% trans %}Monty Python - The Cheese Shop Sketch{% endtrans %}" width="560" height="315" src="https://www.youtube-nocookie.com/embed/zB8pbUW5n1g?rel=0&enablejsapi=1&showinfo=0&iv_load_policy=3&origin={{ request.host_url }}" frameborder="0" allowfullscreen></iframe>
         </div>
+        <p><a href="https://people.cs.rutgers.edu/~mdstone/class/440-fall-99/cheeseshop.html" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}View video transcript{% endtrans %}</a></p>
       </div>
     </div>
   </div>

--- a/warehouse/templates/404.html
+++ b/warehouse/templates/404.html
@@ -31,7 +31,6 @@
         <div class="viewport-section__video-container">
           <iframe title="{% trans %}Monty Python - The Cheese Shop Sketch{% endtrans %}" width="560" height="315" src="https://www.youtube-nocookie.com/embed/zB8pbUW5n1g?rel=0&enablejsapi=1&showinfo=0&iv_load_policy=3&origin={{ request.host_url }}" frameborder="0" allowfullscreen></iframe>
         </div>
-        <p><a href="http://www.montypython.net/scripts/cheese.php" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}View video transcript{% endtrans %}</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This read transcript link on 404 pages http://www.montypython.net/scripts/cheese.php leads to a casino site.

Proposing to remove it as it might be seen as the pypi promotes gambling.

![Selection_004](https://github.com/pypi/warehouse/assets/22630684/2d1e1e9f-cfb1-4d45-8c12-4ff8c5961913)

I haven't found a replacement yet.