### PR TITLE
feat: disallow management actions without a verified primary email

### DIFF
--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -259,6 +259,33 @@ class TestForbiddenView:
             )
         ]
 
+    @pytest.mark.parametrize(
+        "requested_path",
+        ("/manage/projects/", "/manage/account/two-factor/", "/manage/organizations/"),
+    )
+    def test_unverified_email_redirects(self, requested_path):
+        result = WarehouseDenied("Some summary", reason="unverified_email")
+        exc = pretend.stub(result=result)
+        request = pretend.stub(
+            authenticated_userid=1,
+            session=pretend.stub(flash=pretend.call_recorder(lambda x, queue: None)),
+            path_qs=requested_path,
+            route_url=pretend.call_recorder(lambda route, _query: "/manage/account/"),
+            _=lambda x: x,
+        )
+
+        resp = forbidden(exc, request)
+
+        assert resp.status_code == 303
+        assert resp.location == "/manage/account/"
+        assert request.session.flash.calls == [
+            pretend.call(
+                "You must verify your **primary** email address before you "
+                "can perform this action."
+                queue="error",
+            )
+        ]
+
     def test_generic_warehousedeined(self, pyramid_config):
         result = WarehouseDenied(
             "This project requires two factor authentication to be enabled "

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -281,7 +281,7 @@ class TestForbiddenView:
         assert request.session.flash.calls == [
             pretend.call(
                 "You must verify your **primary** email address before you "
-                "can perform this action."
+                "can perform this action.",
                 queue="error",
             )
         ]

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1,10 +1,16 @@
 #: warehouse/views.py:141
 msgid ""
+"You must verify your **primary** email address before you can perform "
+"this action."
+msgstr ""
+
+#: warehouse/views.py:157
+msgid ""
 "Two-factor authentication must be enabled on your account to perform this"
 " action."
 msgstr ""
 
-#: warehouse/views.py:266
+#: warehouse/views.py:282
 msgid "Locale updated"
 msgstr ""
 


### PR DESCRIPTION
As a way to continue on the path of making user accounts more secured,
require a user to have verified the primary email address prior to performing any
other management actions.

Preserves their ability to manage their own account.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>