### PR TITLE
fix: convert dicts to lists

### DIFF
--- a/tests/unit/accounts/test_tasks.py
+++ b/tests/unit/accounts/test_tasks.py
@@ -46,13 +46,13 @@ def test_compute_user_metrics(db_request, metrics):
 
     assert metrics.gauge.calls == [
         pretend.call("warehouse.users.count", 6),
-        pretend.call("warehouse.users.count", 5, tags={"active": "true"}),
+        pretend.call("warehouse.users.count", 5, tags=["active:true"]),
         pretend.call(
-            "warehouse.users.count", 3, tags={"active": "true", "verified": "false"}
+            "warehouse.users.count", 3, tags=["active:true", "verified:false"]
         ),
         pretend.call(
             "warehouse.users.count",
             1,
-            tags={"active": "true", "verified": "false", "releases": "true"},
+            tags=["active:true", "verified:false", "releases:true"],
         ),
     ]

--- a/warehouse/accounts/tasks.py
+++ b/warehouse/accounts/tasks.py
@@ -35,7 +35,7 @@ def compute_user_metrics(request):
     metrics.gauge(
         "warehouse.users.count",
         request.db.query(func.count(User.id)).filter(User.is_active).scalar(),
-        tags={"active": "true"},
+        tags=["active:true"],
     )
 
     # Total active users with unverified emails
@@ -46,7 +46,7 @@ def compute_user_metrics(request):
         .filter(User.is_active)
         .filter((Email.verified == None) | (Email.verified == False))  # noqa E711
         .scalar(),
-        tags={"active": "true", "verified": "false"},
+        tags=["active:true", "verified:false"],
     )
 
     # Total active users with unverified emails, and have project releases
@@ -58,5 +58,5 @@ def compute_user_metrics(request):
         .filter(User.is_active)
         .filter((Email.verified == None) | (Email.verified == False))  # noqa E711
         .scalar(),
-        tags={"active": "true", "verified": "false", "releases": "true"},
+        tags=["active:true", "verified:false", "releases:true"],
     )


### PR DESCRIPTION
I spent some time trying to figure out why type hinting additions wouldn't catch this, and elected to defer until later, since it involves `zope.interface` which is... different.

Fixes WAREHOUSE-PRODUCTION-1JV
Fixes WAREHOUSE-STAGING-MJ