### PR TITLE
feat: split out older releases

### DIFF
--- a/tests/unit/accounts/test_tasks.py
+++ b/tests/unit/accounts/test_tasks.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime, timedelta, timezone
+
 import pretend
 
 from warehouse.accounts.tasks import compute_user_metrics
@@ -18,11 +20,16 @@ from ...common.db.accounts import EmailFactory, UserFactory
 from ...common.db.packaging import ProjectFactory, ReleaseFactory
 
 
-def _create_email_project_with_release(user, verified):
-    EmailFactory.create(user=user, verified=verified)
-    result = ProjectFactory.create()
-    ReleaseFactory.create(project=result, uploader=user)
-    return result
+def _create_old_users_and_releases():
+    users = UserFactory.create_batch(3, is_active=True)
+    for user in users:
+        EmailFactory.create(user=user, verified=False)
+        project = ProjectFactory.create()
+        ReleaseFactory.create(
+            project=project,
+            uploader=user,
+            created=datetime.now(timezone.utc) - timedelta(days=365 * 2 + 1),
+        )
 
 
 def test_compute_user_metrics(db_request, metrics):
@@ -38,21 +45,33 @@ def test_compute_user_metrics(db_request, metrics):
     EmailFactory.create(user=verified_email_user, verified=True)
     # Create a user with a verified email and a release
     verified_email_release_user = UserFactory.create()
-    _create_email_project_with_release(verified_email_release_user, verified=True)
+    EmailFactory.create(user=verified_email_release_user, verified=True)
+    project1 = ProjectFactory.create()
+    ReleaseFactory.create(project=project1, uploader=verified_email_release_user)
     # Create an active user with an unverified email and a release
     unverified_email_release_user = UserFactory.create(is_active=True)
-    _create_email_project_with_release(unverified_email_release_user, verified=False)
+    EmailFactory.create(user=unverified_email_release_user, verified=False)
+    project2 = ProjectFactory.create()
+    ReleaseFactory.create(project=project2, uploader=unverified_email_release_user)
+    # Create active users with unverified emails and releases over two years
+    _create_old_users_and_releases()
+
     compute_user_metrics(db_request)
 
     assert metrics.gauge.calls == [
-        pretend.call("warehouse.users.count", 6),
-        pretend.call("warehouse.users.count", 5, tags=["active:true"]),
+        pretend.call("warehouse.users.count", 9),
+        pretend.call("warehouse.users.count", 8, tags=["active:true"]),
         pretend.call(
-            "warehouse.users.count", 3, tags=["active:true", "verified:false"]
+            "warehouse.users.count", 6, tags=["active:true", "verified:false"]
+        ),
+        pretend.call(
+            "warehouse.users.count",
+            4,
+            tags=["active:true", "verified:false", "releases:true"],
         ),
         pretend.call(
             "warehouse.users.count",
             1,
-            tags=["active:true", "verified:false", "releases:true"],
+            tags=["active:true", "verified:false", "releases:true", "window:2years"],
         ),
     ]

--- a/warehouse/accounts/tasks.py
+++ b/warehouse/accounts/tasks.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime, timedelta, timezone
+
 from sqlalchemy import func
 
 from warehouse import tasks
@@ -59,4 +61,18 @@ def compute_user_metrics(request):
         .filter((Email.verified == None) | (Email.verified == False))  # noqa E711
         .scalar(),
         tags=["active:true", "verified:false", "releases:true"],
+    )
+
+    # Total active users with unverified emails, and have project releases that
+    # were uploaded within the past two years
+    metrics.gauge(
+        "warehouse.users.count",
+        request.db.query(func.count(User.id))
+        .outerjoin(Email)
+        .join(Release, Release.uploader_id == User.id)
+        .filter(User.is_active)
+        .filter((Email.verified == None) | (Email.verified == False))  # noqa E711
+        .filter(Release.created > datetime.now(tz=timezone.utc) - timedelta(days=730))
+        .scalar(),
+        tags=["active:true", "verified:false", "releases:true", "window:2years"],
     )


### PR DESCRIPTION
Since verified emails weren't a "thing" until warehouse existed, there's likely many older releases that don't have a verified email attached to a user.

Adding a time-bound query should show how prevalent the issue is in more recent times.