### PR TITLE
Use `packaging.utils.parse_wheel_filename` instead of `_wheel_file_re`

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -80,6 +80,7 @@ def _get_tar_testdata(compression_type=""):
 
 def _get_whl_testdata(name="fake_package", version="1.0"):
     temp_f = io.BytesIO()
+    name = name.lower().replace(".", "_").replace("-", "_")
     with zipfile.ZipFile(file=temp_f, mode="w") as zfp:
         zfp.writestr(f"{name}-{version}.dist-info/METADATA", "Fake metadata")
     return temp_f.getvalue()
@@ -2788,38 +2789,6 @@ class TestFileUpload:
             pretend.call("warehouse.upload.attempt"),
             pretend.call("warehouse.upload.ok", tags=["filetype:bdist_wheel"]),
         ]
-
-    @pytest.mark.parametrize(
-        "filename, expected",
-        [
-            (
-                "foo-1.0-py3-none-any.whl",
-                {
-                    "namever": "foo-1.0",
-                    "name": "foo",
-                    "ver": "1.0",
-                    "build": None,
-                    "pyver": "py3",
-                    "abi": "none",
-                    "plat": "any",
-                },
-            ),
-            (
-                "typesense_server_wrapper_chunk1-1-py3-none-any.whl",
-                {
-                    "namever": "typesense_server_wrapper_chunk1-1",
-                    "name": "typesense_server_wrapper_chunk1",
-                    "ver": "1",
-                    "build": None,
-                    "pyver": "py3",
-                    "abi": "none",
-                    "plat": "any",
-                },
-            ),
-        ],
-    )
-    def test_wheel_file_re(self, filename, expected):
-        assert legacy._wheel_file_re.match(filename).groupdict() == expected
 
     @pytest.mark.parametrize(
         "project_name, version",

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3122,10 +3122,7 @@ class TestFileUpload:
 
         temp_f = io.BytesIO()
         with zipfile.ZipFile(file=temp_f, mode="w") as zfp:
-            zfp.writestr(
-                f"{project.name.lower()}-{release.version}.dist-info/METADATA",
-                "Fake metadata",
-            )
+            zfp.writestr("some_file", "some_data")
 
         filename = f"{project.name}-{release.version}-cp34-none-any.whl"
         filebody = temp_f.getvalue()

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2790,6 +2790,38 @@ class TestFileUpload:
         ]
 
     @pytest.mark.parametrize(
+        "filename, expected",
+        [
+            (
+                "foo-1.0-py3-none-any.whl",
+                {
+                    "namever": "foo-1.0",
+                    "name": "foo",
+                    "ver": "1.0",
+                    "build": None,
+                    "pyver": "py3",
+                    "abi": "none",
+                    "plat": "any",
+                },
+            ),
+            (
+                "typesense_server_wrapper_chunk1-1-py3-none-any.whl",
+                {
+                    "namever": "typesense_server_wrapper_chunk1-1",
+                    "name": "typesense_server_wrapper_chunk1",
+                    "ver": "1",
+                    "build": None,
+                    "pyver": "py3",
+                    "abi": "none",
+                    "plat": "any",
+                },
+            ),
+        ],
+    )
+    def test_wheel_file_re(self, filename, expected):
+        assert legacy._wheel_file_re.match(filename).groupdict() == expected
+
+    @pytest.mark.parametrize(
         "project_name, version",
         [
             ("foo", "1.0.0"),

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -183,29 +183,9 @@ def _valid_platform_tag(platform_tag):
 
 _error_message_order = ["metadata_version", "name", "version"]
 
-
 _dist_file_re = re.compile(r".+?\.(tar\.gz|zip|whl|egg)$", re.I)
 
-
-_wheel_file_re = re.compile(
-    r"""
-    ^
-    (?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)
-    (
-        (-(?P<build>\d.*?))?
-        -(?P<pyver>.+?)
-        -(?P<abi>.+?)
-        -(?P<plat>.+?)
-        (?:\.whl|\.dist-info)
-    )
-    $
-    """,
-    re.VERBOSE,
-)
-
-
 _legacy_specifier_re = re.compile(r"^(?P<name>\S+)(?: \((?P<specifier>\S+)\))?$")
-
 
 _valid_description_content_types = {"text/plain", "text/x-rst", "text/markdown"}
 
@@ -788,19 +768,6 @@ def _is_duplicate_file(db_session, filename, hashes):
     return None
 
 
-def _extract_wheel_metadata(path):
-    """
-    Extract METADATA file from a wheel and return it as a content.
-    The name of the .whl file is used to find the corresponding .dist-info dir.
-    See https://peps.python.org/pep-0491/#file-contents
-    """
-    filename = os.path.basename(path)
-    name, version, _, __ = packaging.utils.parse_wheel_filename(filename)
-    metafile = f"{name.replace('-', '_')}-{version}.dist-info/METADATA"
-    with zipfile.ZipFile(path) as zfp:
-        return zfp.read(metafile)
-
-
 @view_config(
     route_name="forklift.legacy.file_upload",
     uses_session=True,
@@ -1362,21 +1329,27 @@ def file_upload(request):
 
         # Check that if it's a binary wheel, it's on a supported platform
         if filename.endswith(".whl"):
-            wheel_info = _wheel_file_re.match(filename)
-            plats = wheel_info.group("plat").split(".")
-            for plat in plats:
-                if not _valid_platform_tag(plat):
+            _, __, ___, tags = packaging.utils.parse_wheel_filename(filename)
+            for tag in tags:
+                if not _valid_platform_tag(tag.platform):
                     raise _exc_with_message(
                         HTTPBadRequest,
-                        "Binary wheel '{filename}' has an unsupported "
-                        "platform tag '{plat}'.".format(filename=filename, plat=plat),
+                        f"Binary wheel '{filename}' has an unsupported "
+                        f"platform tag '{tag.platform}'.",
                     )
 
+            """
+            Extract METADATA file from a wheel and return it as a content.
+            The name of the .whl file is used to find the corresponding .dist-info dir.
+            See https://peps.python.org/pep-0491/#file-contents
+            """
+            filename = os.path.basename(temporary_filename)
+            name, version, _, __ = packaging.utils.parse_wheel_filename(filename)
+            metadata_filename = f"{name.replace('-', '_')}-{version}.dist-info/METADATA"
             try:
-                wheel_metadata_contents = _extract_wheel_metadata(temporary_filename)
+                with zipfile.ZipFile(temporary_filename) as zfp:
+                    wheel_metadata_contents = zfp.read(metadata_filename)
             except KeyError:
-                namever = wheel_info.group("namever")
-                metadata_filename = f"{namever}.dist-info/METADATA"
                 raise _exc_with_message(
                     HTTPBadRequest,
                     "Wheel '{filename}' does not contain the required "

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -795,8 +795,8 @@ def _extract_wheel_metadata(path):
     See https://peps.python.org/pep-0491/#file-contents
     """
     filename = os.path.basename(path)
-    namever = _wheel_file_re.match(filename).group("namever")
-    metafile = f"{namever}.dist-info/METADATA"
+    name, version, _, __ = packaging.utils.parse_wheel_filename(filename)
+    metafile = f"{name.replace('-', '_')}-{version}.dist-info/METADATA"
     with zipfile.ZipFile(path) as zfp:
         return zfp.read(metafile)
 


### PR DESCRIPTION
The existing `_wheel_file_re` regex did not correctly handle single-digit version numbers. Rather than update the regex, this PR switches us to using [`packaging.utils.parse_wheel_filename`](https://packaging.pypa.io/en/stable/utils.html#packaging.utils.parse_wheel_filename) instead, and removes the regex entirely.

Fixes #14192.