### PR TITLE
Remember device for 30 days option

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -54,6 +54,7 @@ STATUSPAGE_URL=https://2p66nmmycsj3.statuspage.io
 TOKEN_PASSWORD_SECRET="an insecure password reset secret key"
 TOKEN_EMAIL_SECRET="an insecure email verification secret key"
 TOKEN_TWO_FACTOR_SECRET="an insecure two-factor auth secret key"
+TOKEN_REMEMBER_DEVICE_SECRET="an insecure remember device auth secret key"
 
 WAREHOUSE_LEGACY_DOMAIN=pypi.python.org
 

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -440,6 +440,11 @@ def test_includeme(monkeypatch):
             TokenServiceFactory(name="two_factor"), ITokenService, name="two_factor"
         ),
         pretend.call(
+            TokenServiceFactory(name="remember_device"),
+            ITokenService,
+            name="remember_device",
+        ),
+        pretend.call(
             HaveIBeenPwnedPasswordBreachedService.create_service,
             IPasswordBreachedService,
         ),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -246,6 +246,7 @@ def test_configure(monkeypatch, settings, environment):
         "warehouse.commit": "null",
         "site.name": "Warehouse",
         "token.two_factor.max_age": 300,
+        "token.remember_device.max_age": 2592000,
         "token.default.max_age": 21600,
         "pythondotorg.host": "https://www.python.org",
         "warehouse.xmlrpc.client.ratelimit_string": "3600 per hour",

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -104,6 +104,11 @@ def includeme(config):
     config.register_service_factory(
         TokenServiceFactory(name="two_factor"), ITokenService, name="two_factor"
     )
+    config.register_service_factory(
+        TokenServiceFactory(name="remember_device"),
+        ITokenService,
+        name="remember_device",
+    )
 
     # Register our password breach detection service.
     breached_pw_class = config.maybe_dotted(

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -368,6 +368,8 @@ class _TwoFactorAuthenticationForm(forms.Form):
         self.user_id = user_id
         self.user_service = user_service
 
+    remember_device = wtforms.BooleanField(default=False)
+
 
 class TOTPAuthenticationForm(TOTPValueMixin, _TwoFactorAuthenticationForm):
     def validate_totp_value(self, field):

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -91,6 +91,8 @@ from warehouse.rate_limiting.interfaces import IRateLimiter
 from warehouse.utils.http import is_safe_url
 
 USER_ID_INSECURE_COOKIE = "user_id__insecure"
+REMEMBER_DEVICE_COOKIE = "remember_device"
+REMEMBER_DEVICE_SECONDS = 2592000  # 30 days
 
 
 @view_config(context=TooManyFailedLogins, has_translations=True)
@@ -234,8 +236,12 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
             username = form.username.data
             userid = user_service.find_userid(username)
 
-            # If the user has enabled two factor authentication.
-            if user_service.has_two_factor(userid):
+            # If the user has enabled two-factor authentication and they do not have
+            # a valid saved device.
+            two_factor_required = user_service.has_two_factor(userid) and (
+                not _check_remember_device_token(request, userid)
+            )
+            if two_factor_required:
                 two_factor_data = {"userid": userid}
                 if redirect_to:
                     two_factor_data["redirect_to"] = redirect_to
@@ -330,9 +336,8 @@ def two_factor_and_totp_validate(request, _form_class=TOTPAuthenticationForm):
     if request.method == "POST":
         form = two_factor_state["totp_form"]
         if form.validate():
-            _login_user(
-                request, userid, two_factor_method="totp", two_factor_label="totp"
-            )
+            two_factor_method = "totp"
+            _login_user(request, userid, two_factor_method, two_factor_label="totp")
             user_service.update_user(userid, last_totp_value=form.totp_value.data)
 
             resp = HTTPSeeOther(redirect_to)
@@ -345,6 +350,9 @@ def two_factor_and_totp_validate(request, _form_class=TOTPAuthenticationForm):
 
             if not two_factor_state.get("has_recovery_codes", False):
                 send_recovery_code_reminder_email(request, request.user)
+
+            if form.remember_device.data:
+                _remember_device(request, resp, userid, two_factor_method)
 
             return resp
         else:
@@ -423,12 +431,8 @@ def webauthn_authentication_validate(request):
         )
         webauthn.sign_count = form.validated_credential.new_sign_count
 
-        _login_user(
-            request,
-            userid,
-            two_factor_method="webauthn",
-            two_factor_label=webauthn.label,
-        )
+        two_factor_method = "webauthn"
+        _login_user(request, userid, two_factor_method, two_factor_label=webauthn.label)
 
         request.response.set_cookie(
             USER_ID_INSECURE_COOKIE,
@@ -440,6 +444,9 @@ def webauthn_authentication_validate(request):
         if not request.user.has_recovery_codes:
             send_recovery_code_reminder_email(request, request.user)
 
+        if form.remember_device.data:
+            _remember_device(request, request.response, userid, two_factor_method)
+
         return {
             "success": request._("Successful WebAuthn assertion"),
             "redirect_to": redirect_to,
@@ -447,6 +454,47 @@ def webauthn_authentication_validate(request):
 
     errors = [str(error) for error in form.credential.errors]
     return {"fail": {"errors": errors}}
+
+
+def _check_remember_device_token(request, user_id) -> bool:
+    """
+    Returns true if the given remember device cookie is valid for the given user.
+    """
+    remember_device_token = request.cookies.get(REMEMBER_DEVICE_COOKIE)
+    if not remember_device_token:
+        return False
+    token_service = request.find_service(ITokenService, name="remember_device")
+    try:
+        data = token_service.loads(remember_device_token)
+        user_id_token = data.get("user_id")
+        return user_id_token == str(user_id)
+    except TokenException:
+        return False
+
+
+def _remember_device(request, response, userid, two_factor_method) -> None:
+    """
+    Generates and sets a cookie for remembering this device.
+    """
+    remember_device_data = {"user_id": str(userid)}
+    token_service = request.find_service(ITokenService, name="remember_device")
+    token = token_service.dumps(remember_device_data)
+    response.set_cookie(
+        REMEMBER_DEVICE_COOKIE,
+        token,
+        max_age=REMEMBER_DEVICE_SECONDS,
+        httponly=True,
+        secure=request.scheme == "https",
+        samesite=b"lax",
+        path=request.route_path("accounts.login"),
+    )
+    request.user.record_event(
+        tag=EventTag.Account.TwoFactorDeviceRemembered,
+        request=request,
+        additional={
+            "two_factor_method": two_factor_method,
+        },
+    )
 
 
 @view_config(

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -215,6 +215,7 @@ def configure(settings=None):
     maybe_set(settings, "token.password.secret", "TOKEN_PASSWORD_SECRET")
     maybe_set(settings, "token.email.secret", "TOKEN_EMAIL_SECRET")
     maybe_set(settings, "token.two_factor.secret", "TOKEN_TWO_FACTOR_SECRET")
+    maybe_set(settings, "token.remember_device.secret", "TOKEN_REMEMBER_DEVICE_SECRET")
     maybe_set(
         settings,
         "warehouse.xmlrpc.search.enabled",
@@ -237,6 +238,13 @@ def configure(settings=None):
         "TOKEN_TWO_FACTOR_MAX_AGE",
         coercer=int,
         default=300,
+    )
+    maybe_set(
+        settings,
+        "token.remember_device.max_age",
+        "TOKEN_REMEMBER_DEVICE_MAX_AGE",
+        coercer=int,
+        default=2592000,  # 30 days,
     )
     maybe_set(
         settings,

--- a/warehouse/events/tags.py
+++ b/warehouse/events/tags.py
@@ -98,6 +98,7 @@ class EventTag:
         RoleRevokeInvite = "account:role:revoke_invite"
         TeamRoleAdd = "account:team_role:add"
         TeamRoleRemove = "account:team_role:remove"
+        TwoFactorDeviceRemembered = "account:two_factor:device_remembered"
         TwoFactorMethodAdded = "account:two_factor:method_added"
         TwoFactorMethodRemoved = "account:two_factor:method_removed"
         EmailSent = "account:email:sent"

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -90,241 +90,241 @@ msgstr ""
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:383
+#: warehouse/accounts/forms.py:385
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:400
+#: warehouse/accounts/forms.py:402
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:469
+#: warehouse/accounts/forms.py:471
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:478
+#: warehouse/accounts/forms.py:480
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:497
+#: warehouse/accounts/forms.py:499
 msgid "No user found with that username or email"
 msgstr ""
 
-#: warehouse/accounts/views.py:103
+#: warehouse/accounts/views.py:105
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for {}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:120
+#: warehouse/accounts/views.py:122
 msgid ""
 "Too many emails have been added to this account without verifying them. "
 "Check your inbox and follow the verification links. (IP: ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:132
+#: warehouse/accounts/views.py:134
 msgid ""
 "Too many password resets have been requested for this account without "
 "completing them. Check your inbox and follow the verification links. (IP:"
 " ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:307 warehouse/accounts/views.py:371
-#: warehouse/accounts/views.py:373 warehouse/accounts/views.py:400
-#: warehouse/accounts/views.py:402 warehouse/accounts/views.py:468
+#: warehouse/accounts/views.py:313 warehouse/accounts/views.py:379
+#: warehouse/accounts/views.py:381 warehouse/accounts/views.py:408
+#: warehouse/accounts/views.py:410 warehouse/accounts/views.py:516
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:365
+#: warehouse/accounts/views.py:373
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:444
+#: warehouse/accounts/views.py:451
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:499 warehouse/manage/views/__init__.py:825
+#: warehouse/accounts/views.py:547 warehouse/manage/views/__init__.py:825
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:591
+#: warehouse/accounts/views.py:639
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:722
+#: warehouse/accounts/views.py:770
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:724
+#: warehouse/accounts/views.py:772
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:726 warehouse/accounts/views.py:828
-#: warehouse/accounts/views.py:927 warehouse/accounts/views.py:1096
+#: warehouse/accounts/views.py:774 warehouse/accounts/views.py:876
+#: warehouse/accounts/views.py:975 warehouse/accounts/views.py:1144
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:730
+#: warehouse/accounts/views.py:778
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:735
+#: warehouse/accounts/views.py:783
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:746
+#: warehouse/accounts/views.py:794
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:764
+#: warehouse/accounts/views.py:812
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:796
+#: warehouse/accounts/views.py:844
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:824
+#: warehouse/accounts/views.py:872
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:826
+#: warehouse/accounts/views.py:874
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:832
+#: warehouse/accounts/views.py:880
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:841
+#: warehouse/accounts/views.py:889
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:844
+#: warehouse/accounts/views.py:892
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:861
+#: warehouse/accounts/views.py:909
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:865
+#: warehouse/accounts/views.py:913
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:870
+#: warehouse/accounts/views.py:918
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:923
+#: warehouse/accounts/views.py:971
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:925
+#: warehouse/accounts/views.py:973
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:931
+#: warehouse/accounts/views.py:979
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:935
+#: warehouse/accounts/views.py:983
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:944
+#: warehouse/accounts/views.py:992
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:995
+#: warehouse/accounts/views.py:1043
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1058
+#: warehouse/accounts/views.py:1106
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1092
+#: warehouse/accounts/views.py:1140
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1094
+#: warehouse/accounts/views.py:1142
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1100
+#: warehouse/accounts/views.py:1148
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1104
+#: warehouse/accounts/views.py:1152
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1119
+#: warehouse/accounts/views.py:1167
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1150
+#: warehouse/accounts/views.py:1198
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1216
+#: warehouse/accounts/views.py:1264
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1437 warehouse/accounts/views.py:1585
+#: warehouse/accounts/views.py:1485 warehouse/accounts/views.py:1633
 #: warehouse/manage/views/__init__.py:1231
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1454 warehouse/manage/views/__init__.py:1247
+#: warehouse/accounts/views.py:1502 warehouse/manage/views/__init__.py:1247
 msgid ""
 "GitHub-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1468
+#: warehouse/accounts/views.py:1516
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1481
+#: warehouse/accounts/views.py:1529
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1497 warehouse/manage/views/__init__.py:1266
+#: warehouse/accounts/views.py:1545 warehouse/manage/views/__init__.py:1266
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1511 warehouse/manage/views/__init__.py:1280
+#: warehouse/accounts/views.py:1559 warehouse/manage/views/__init__.py:1280
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1530
+#: warehouse/accounts/views.py:1578
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1565
+#: warehouse/accounts/views.py:1613
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1599 warehouse/accounts/views.py:1612
-#: warehouse/accounts/views.py:1619
+#: warehouse/accounts/views.py:1647 warehouse/accounts/views.py:1660
+#: warehouse/accounts/views.py:1667
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1625
+#: warehouse/accounts/views.py:1673
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -1233,7 +1233,7 @@ msgstr ""
 #: warehouse/templates/accounts/request-password-reset.html:41
 #: warehouse/templates/accounts/reset-password.html:40
 #: warehouse/templates/accounts/reset-password.html:62
-#: warehouse/templates/accounts/two-factor.html:89
+#: warehouse/templates/accounts/two-factor.html:97
 #: warehouse/templates/manage/account.html:270
 #: warehouse/templates/manage/account.html:287
 #: warehouse/templates/manage/account.html:344
@@ -1461,7 +1461,7 @@ msgid "Recovery codes"
 msgstr ""
 
 #: warehouse/templates/accounts/recovery-code.html:24
-#: warehouse/templates/accounts/two-factor.html:129
+#: warehouse/templates/accounts/two-factor.html:144
 msgid "Login using recovery codes"
 msgstr ""
 
@@ -1478,7 +1478,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/accounts/recovery-code.html:58
-#: warehouse/templates/accounts/two-factor.html:112
+#: warehouse/templates/accounts/two-factor.html:120
 #: warehouse/templates/manage/account/recovery_codes-burn.html:83
 msgid "Verify"
 msgstr ""
@@ -1632,20 +1632,25 @@ msgid ""
 " (e.g. USB key)"
 msgstr ""
 
-#: warehouse/templates/accounts/two-factor.html:60
+#: warehouse/templates/accounts/two-factor.html:64
+#: warehouse/templates/accounts/two-factor.html:126
+msgid "Remember this device for 30 days"
+msgstr ""
+
+#: warehouse/templates/accounts/two-factor.html:68
 #, python-format
 msgid "Lost your device? Not working? <a href=\"%(href)s\">Get help</a>."
 msgstr ""
 
-#: warehouse/templates/accounts/two-factor.html:72
+#: warehouse/templates/accounts/two-factor.html:80
 msgid "Authenticate with an app"
 msgstr ""
 
-#: warehouse/templates/accounts/two-factor.html:87
+#: warehouse/templates/accounts/two-factor.html:95
 msgid "Enter authentication code"
 msgstr ""
 
-#: warehouse/templates/accounts/two-factor.html:115
+#: warehouse/templates/accounts/two-factor.html:130
 #, python-format
 msgid ""
 "<p>Generate a code using the authentication application connected to your"
@@ -1654,11 +1659,11 @@ msgid ""
 "help</a>.</p>"
 msgstr ""
 
-#: warehouse/templates/accounts/two-factor.html:127
+#: warehouse/templates/accounts/two-factor.html:142
 msgid "Lost your security key or application?"
 msgstr ""
 
-#: warehouse/templates/accounts/two-factor.html:132
+#: warehouse/templates/accounts/two-factor.html:147
 #, python-format
 msgid ""
 "<p><strong>You have not generated account recovery codes.</strong></p> "

--- a/warehouse/static/js/warehouse/utils/webauthn.js
+++ b/warehouse/static/js/warehouse/utils/webauthn.js
@@ -142,10 +142,13 @@ const postCredential = async (label, credential, token) => {
   return await resp.json();
 };
 
-const postAssertion = async (assertion, token) => {
+const postAssertion = async (assertion, token, rememberDevice) => {
   const formData = new FormData();
   formData.set("credential", JSON.stringify(assertion));
   formData.set("csrf_token", token);
+  if (rememberDevice) {
+    formData.set("remember_device", "true");
+  }
 
   const resp = await fetch(
     "/account/webauthn-authenticate/validate" + window.location.search, {
@@ -225,13 +228,14 @@ export const AuthenticateWebAuthn = () => {
       return;
     }
 
+    const rememberDevice = document.getElementById("remember_device_webauthn").checked;
     const transformedOptions = transformAssertionOptions(assertionOptions);
     await navigator.credentials.get({
       publicKey: transformedOptions,
     }).then(async (assertion) => {
       const transformedAssertion = transformAssertion(assertion);
 
-      const status = await postAssertion(transformedAssertion, csrfToken);
+      const status = await postAssertion(transformedAssertion, csrfToken, rememberDevice);
       if (status.fail) {
         populateWebAuthnErrorList(status.fail.errors);
         return;

--- a/warehouse/templates/accounts/two-factor.html
+++ b/warehouse/templates/accounts/two-factor.html
@@ -57,6 +57,14 @@
               {% endtrans %}
             </li>
           </ul>
+
+          <div class="form-group">
+            <label>
+              <input type="checkbox" id="remember_device_webauthn" name="remember_device" value="true" />
+              {% trans %}Remember this device for 30 days{% endtrans %}
+            </label>
+          </div>
+
           <p class="margin-top--large">{% trans href='/help/#utfkey' %}Lost your device? Not working? <a href="{{ href }}">Get help</a>.{% endtrans %}</p>
         </form>
       </div>
@@ -110,6 +118,13 @@
           </div>
           <div class="form-group">
             <input type="submit" value="{% trans %}Verify{% endtrans %}" class="button button--primary">
+          </div>
+
+          <div class="form-group">
+            <label>
+              <input type="checkbox" name="remember_device" value="true" />
+              {% trans %}Remember this device for 30 days{% endtrans %}
+            </label>
           </div>
 
           {% trans href='/help/#totp' %}


### PR DESCRIPTION
This gives the user the option to not have to provide 2nd factor authentication on a device for 30 days. A new cookie `remember_device` will contain a signed token that allows the user to skip two-factor authentication (assuming the token is valid). To minimize data being sent by the browser, this cookie is only sent for requests with the path `accounts/login`.

This is how the 2FA page looks:
<details>
<summary>With authenticator app and webauthn</summary>

![image](https://user-images.githubusercontent.com/8961650/223918723-d0b2d9dc-d904-4c20-9aec-4171cba86a13.png)
</details>

<details>
<summary>With only webauthn</summary>

![image](https://user-images.githubusercontent.com/8961650/223919131-c7795947-fd91-4a4f-9277-803c3000f96b.png)
</details>

By default "Remember this device for 30 days" will not be checked. 

I originally created a different PR for this issue (https://github.com/pypi/warehouse/pull/13166) but since we decided to take a substantially different approach, I figured this merited a new, clean PR.

This change requires adding a `TOKEN_REMEMBER_DEVICE_SECRET` environment variable to the production configuration. 

Closes https://github.com/pypi/warehouse/issues/5867

I'll create a new issue for how these tokens can be revoked. One approach could be to invalidate the tokens when the user changes their password.