### PR TITLE
Prevent removing the last 2FA method associated with an account

### DIFF
--- a/tests/unit/accounts/test_models.py
+++ b/tests/unit/accounts/test_models.py
@@ -227,14 +227,14 @@ class TestUser:
         ("has_totp", "count_webauthn", "expected"),
         [
             (False, 0, False),
-            (False, 1, False),
-            (False, 2, True),
-            (True, 0, False),
-            (True, 1, True),
-            (True, 2, True),
+            (False, 1, True),
+            (False, 2, False),
+            (True, 0, True),
+            (True, 1, False),
+            (True, 2, False),
         ],
     )
-    def test_has_multiple_2fa(self, db_session, has_totp, count_webauthn, expected):
+    def test_has_single_2fa(self, db_session, has_totp, count_webauthn, expected):
         user = DBUserFactory.create()
         if has_totp:
             user.totp_secret = b"secret"
@@ -249,4 +249,4 @@ class TestUser:
                 )
             )
         db_session.flush()
-        assert user.has_multiple_2fa == expected
+        assert user.has_single_2fa == expected

--- a/tests/unit/accounts/test_models.py
+++ b/tests/unit/accounts/test_models.py
@@ -17,7 +17,7 @@ import pytest
 
 from pyramid.authorization import Authenticated
 
-from warehouse.accounts.models import Email, RecoveryCode, User, UserFactory
+from warehouse.accounts.models import Email, RecoveryCode, User, UserFactory, WebAuthn
 from warehouse.utils.security_policy import principals_for
 
 from ...common.db.accounts import (
@@ -222,3 +222,31 @@ class TestUser:
         expected = expected[:] + [f"user:{user.id}", Authenticated]
 
         assert set(principals_for(user)) == set(expected)
+
+    @pytest.mark.parametrize(
+        ("has_totp", "count_webauthn", "expected"),
+        [
+            (False, 0, False),
+            (False, 1, False),
+            (False, 2, True),
+            (True, 0, False),
+            (True, 1, True),
+            (True, 2, True),
+        ],
+    )
+    def test_has_multiple_2fa(self, db_session, has_totp, count_webauthn, expected):
+        user = DBUserFactory.create()
+        if has_totp:
+            user.totp_secret = b"secret"
+        for i in range(count_webauthn):
+            user.webauthn.append(
+                WebAuthn(
+                    user_id=user.id,
+                    label=f"label{i}",
+                    credential_id=f"foo{i}",
+                    public_key=f"bar{i}",
+                    sign_count=i,
+                )
+            )
+        db_session.flush()
+        assert user.has_multiple_2fa == expected

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -1284,6 +1284,7 @@ class TestProvisionTOTP:
                 totp_secret=b"secret",
                 has_primary_verified_email=True,
                 record_event=pretend.call_recorder(lambda *a, **kw: None),
+                has_multiple_2fa=True,
             ),
             route_path=lambda *a, **kw: "/foo/bar/",
             remote_addr="0.0.0.0",
@@ -1337,6 +1338,7 @@ class TestProvisionTOTP:
                 email=pretend.stub(),
                 name=pretend.stub(),
                 has_primary_verified_email=True,
+                has_multiple_2fa=True,
             ),
             route_path=lambda *a, **kw: "/foo/bar/",
         )
@@ -1412,6 +1414,36 @@ class TestProvisionTOTP:
                 "Verify your email to modify two factor authentication", queue="error"
             )
         ]
+
+    def test_delete_totp_last_2fa(self, monkeypatch, db_request):
+        user_service = pretend.stub(
+            get_totp_secret=lambda id: b"secret",
+            update_user=pretend.call_recorder(lambda *a, **kw: None),
+        )
+        request = pretend.stub(
+            POST={"confirm_password": pretend.stub()},
+            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+            find_service=lambda *a, **kw: user_service,
+            user=pretend.stub(
+                id=pretend.stub(),
+                username=pretend.stub(),
+                email=pretend.stub(),
+                name=pretend.stub(),
+                has_primary_verified_email=True,
+                has_multiple_2fa=False,
+            ),
+            route_path=lambda *a, **kw: "/foo/bar/",
+        )
+
+        view = views.ProvisionTOTPViews(request)
+        result = view.delete_totp()
+
+        assert user_service.update_user.calls == []
+        assert request.session.flash.calls == [
+            pretend.call("Cannot remove last 2FA method", queue="error")
+        ]
+        assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Location"] == "/foo/bar/"
 
 
 class TestProvisionWebAuthn:
@@ -1590,6 +1622,7 @@ class TestProvisionWebAuthn:
                     remove=pretend.call_recorder(lambda *a: pretend.stub()),
                 ),
                 record_event=pretend.call_recorder(lambda *a, **kw: None),
+                has_multiple_2fa=True,
             ),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=pretend.call_recorder(lambda x: "/foo/bar"),
@@ -1655,7 +1688,10 @@ class TestProvisionWebAuthn:
         request = pretend.stub(
             POST={},
             user=pretend.stub(
-                id=1234, username=pretend.stub(), webauthn=[pretend.stub()]
+                id=1234,
+                username=pretend.stub(),
+                webauthn=[pretend.stub()],
+                has_multiple_2fa=True,
             ),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=pretend.call_recorder(lambda x: "/foo/bar"),
@@ -1673,6 +1709,26 @@ class TestProvisionWebAuthn:
 
         assert request.session.flash.calls == [
             pretend.call("Invalid credentials", queue="error")
+        ]
+        assert request.route_path.calls == [pretend.call("manage.account")]
+        assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Location"] == "/foo/bar"
+
+    def test_delete_webauthn_last_2fa(self):
+        request = pretend.stub(
+            user=pretend.stub(
+                id=1234, webauthn=[pretend.stub()], has_multiple_2fa=False
+            ),
+            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
+            route_path=pretend.call_recorder(lambda x: "/foo/bar"),
+            find_service=lambda *a, **kw: pretend.stub(),
+        )
+
+        view = views.ProvisionWebAuthnViews(request)
+        result = view.delete_webauthn()
+
+        assert request.session.flash.calls == [
+            pretend.call("Cannot remove last 2FA method", queue="error")
         ]
         assert request.route_path.calls == [pretend.call("manage.account")]
         assert isinstance(result, HTTPSeeOther)

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -1284,7 +1284,7 @@ class TestProvisionTOTP:
                 totp_secret=b"secret",
                 has_primary_verified_email=True,
                 record_event=pretend.call_recorder(lambda *a, **kw: None),
-                has_multiple_2fa=True,
+                has_single_2fa=False,
             ),
             route_path=lambda *a, **kw: "/foo/bar/",
             remote_addr="0.0.0.0",
@@ -1338,7 +1338,7 @@ class TestProvisionTOTP:
                 email=pretend.stub(),
                 name=pretend.stub(),
                 has_primary_verified_email=True,
-                has_multiple_2fa=True,
+                has_single_2fa=False,
             ),
             route_path=lambda *a, **kw: "/foo/bar/",
         )
@@ -1430,7 +1430,7 @@ class TestProvisionTOTP:
                 email=pretend.stub(),
                 name=pretend.stub(),
                 has_primary_verified_email=True,
-                has_multiple_2fa=False,
+                has_single_2fa=True,
             ),
             route_path=lambda *a, **kw: "/foo/bar/",
         )
@@ -1622,7 +1622,7 @@ class TestProvisionWebAuthn:
                     remove=pretend.call_recorder(lambda *a: pretend.stub()),
                 ),
                 record_event=pretend.call_recorder(lambda *a, **kw: None),
-                has_multiple_2fa=True,
+                has_single_2fa=False,
             ),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=pretend.call_recorder(lambda x: "/foo/bar"),
@@ -1691,7 +1691,7 @@ class TestProvisionWebAuthn:
                 id=1234,
                 username=pretend.stub(),
                 webauthn=[pretend.stub()],
-                has_multiple_2fa=True,
+                has_single_2fa=False,
             ),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=pretend.call_recorder(lambda x: "/foo/bar"),
@@ -1716,9 +1716,7 @@ class TestProvisionWebAuthn:
 
     def test_delete_webauthn_last_2fa(self):
         request = pretend.stub(
-            user=pretend.stub(
-                id=1234, webauthn=[pretend.stub()], has_multiple_2fa=False
-            ),
+            user=pretend.stub(id=1234, webauthn=[pretend.stub()], has_single_2fa=True),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             route_path=pretend.call_recorder(lambda x: "/foo/bar"),
             find_service=lambda *a, **kw: pretend.stub(),

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -157,8 +157,10 @@ class User(SitemapMixin, HasEvents, db.Model):
         return len(self.webauthn) > 0
 
     @property
-    def has_multiple_2fa(self):
-        return len(self.webauthn) >= 2 or (self.has_totp and len(self.webauthn) == 1)
+    def has_single_2fa(self):
+        if self.has_totp:
+            return not self.webauthn
+        return len(self.webauthn) == 1
 
     @property
     def has_recovery_codes(self):

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -157,6 +157,10 @@ class User(SitemapMixin, HasEvents, db.Model):
         return len(self.webauthn) > 0
 
     @property
+    def has_multiple_2fa(self):
+        return len(self.webauthn) >= 2 or (self.has_totp and len(self.webauthn) == 1)
+
+    @property
     def has_recovery_codes(self):
         return any(not code.burned for code in self.recovery_codes)
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:499 warehouse/manage/views/__init__.py:825
+#: warehouse/accounts/views.py:499 warehouse/manage/views/__init__.py:833
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -277,13 +277,13 @@ msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
 #: warehouse/accounts/views.py:1437 warehouse/accounts/views.py:1585
-#: warehouse/manage/views/__init__.py:1231
+#: warehouse/manage/views/__init__.py:1239
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1454 warehouse/manage/views/__init__.py:1247
+#: warehouse/accounts/views.py:1454 warehouse/manage/views/__init__.py:1255
 msgid ""
 "GitHub-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
@@ -299,13 +299,13 @@ msgstr ""
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1497 warehouse/manage/views/__init__.py:1266
+#: warehouse/accounts/views.py:1497 warehouse/manage/views/__init__.py:1274
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1511 warehouse/manage/views/__init__.py:1280
+#: warehouse/accounts/views.py:1511 warehouse/manage/views/__init__.py:1288
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
@@ -422,98 +422,98 @@ msgstr ""
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:773
+#: warehouse/manage/views/__init__.py:781
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:774
+#: warehouse/manage/views/__init__.py:782
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:883
+#: warehouse/manage/views/__init__.py:891
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1008
+#: warehouse/manage/views/__init__.py:1016
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1130
+#: warehouse/manage/views/__init__.py:1138
 msgid "2FA requirement cannot be disabled for critical projects"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1485
-#: warehouse/manage/views/__init__.py:1786
-#: warehouse/manage/views/__init__.py:1894
+#: warehouse/manage/views/__init__.py:1493
+#: warehouse/manage/views/__init__.py:1794
+#: warehouse/manage/views/__init__.py:1902
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1617
-#: warehouse/manage/views/__init__.py:1702
-#: warehouse/manage/views/__init__.py:1803
-#: warehouse/manage/views/__init__.py:1903
+#: warehouse/manage/views/__init__.py:1625
+#: warehouse/manage/views/__init__.py:1710
+#: warehouse/manage/views/__init__.py:1811
+#: warehouse/manage/views/__init__.py:1911
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1629
+#: warehouse/manage/views/__init__.py:1637
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1714
+#: warehouse/manage/views/__init__.py:1722
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1815
+#: warehouse/manage/views/__init__.py:1823
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1915
+#: warehouse/manage/views/__init__.py:1923
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1919
+#: warehouse/manage/views/__init__.py:1927
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2069
+#: warehouse/manage/views/__init__.py:2077
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2176
+#: warehouse/manage/views/__init__.py:2184
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2243
+#: warehouse/manage/views/__init__.py:2251
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2275
+#: warehouse/manage/views/__init__.py:2283
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2288
+#: warehouse/manage/views/__init__.py:2296
 #: warehouse/manage/views/organizations.py:882
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2353
+#: warehouse/manage/views/__init__.py:2361
 #: warehouse/manage/views/organizations.py:947
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2386
+#: warehouse/manage/views/__init__.py:2394
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2397
+#: warehouse/manage/views/__init__.py:2405
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2429
+#: warehouse/manage/views/__init__.py:2437
 #: warehouse/manage/views/organizations.py:1134
 msgid "Invitation revoked from '${username}'."
 msgstr ""
@@ -681,7 +681,7 @@ msgstr ""
 #: warehouse/templates/manage/account/webauthn-provision.html:28
 #: warehouse/templates/manage/account/webauthn-provision.html:53
 #: warehouse/templates/manage/account/webauthn-provision.html:74
-#: warehouse/templates/manage/manage_base.html:185
+#: warehouse/templates/manage/manage_base.html:197
 #: warehouse/templates/manage/project/release.html:144
 #: warehouse/templates/manage/project/release.html:200
 #: warehouse/templates/manage/project/releases.html:140
@@ -917,8 +917,8 @@ msgstr ""
 #: warehouse/templates/includes/flash-messages.html:30
 #: warehouse/templates/includes/session-notifications.html:20
 #: warehouse/templates/manage/account.html:744
-#: warehouse/templates/manage/manage_base.html:317
-#: warehouse/templates/manage/manage_base.html:376
+#: warehouse/templates/manage/manage_base.html:329
+#: warehouse/templates/manage/manage_base.html:388
 #: warehouse/templates/manage/organization/settings.html:194
 #: warehouse/templates/manage/organization/settings.html:250
 #: warehouse/templates/manage/organization/settings.html:256
@@ -1217,7 +1217,7 @@ msgstr ""
 #: warehouse/templates/accounts/login.html:69
 #: warehouse/templates/accounts/register.html:112
 #: warehouse/templates/accounts/reset-password.html:38
-#: warehouse/templates/manage/manage_base.html:385
+#: warehouse/templates/manage/manage_base.html:397
 #: warehouse/templates/re-auth.html:50
 msgid "Password"
 msgstr ""
@@ -1286,7 +1286,7 @@ msgid "Your password"
 msgstr ""
 
 #: warehouse/templates/accounts/login.html:92
-#: warehouse/templates/manage/manage_base.html:388
+#: warehouse/templates/manage/manage_base.html:400
 #: warehouse/templates/re-auth.html:73
 msgid "Show password"
 msgstr ""
@@ -2576,16 +2576,16 @@ msgid "Admin"
 msgstr ""
 
 #: warehouse/templates/includes/current-user-indicator.html:37
-#: warehouse/templates/manage/manage_base.html:216
-#: warehouse/templates/manage/manage_base.html:250
+#: warehouse/templates/manage/manage_base.html:228
+#: warehouse/templates/manage/manage_base.html:262
 #: warehouse/templates/manage/projects.html:18
 #: warehouse/templates/manage/projects.html:62
 msgid "Your projects"
 msgstr ""
 
 #: warehouse/templates/includes/current-user-indicator.html:44
-#: warehouse/templates/manage/manage_base.html:223
-#: warehouse/templates/manage/manage_base.html:257
+#: warehouse/templates/manage/manage_base.html:235
+#: warehouse/templates/manage/manage_base.html:269
 #: warehouse/templates/manage/organizations.html:18
 #: warehouse/templates/manage/organizations.html:63
 msgid "Your organizations"
@@ -2594,8 +2594,8 @@ msgstr ""
 #: warehouse/templates/includes/current-user-indicator.html:51
 #: warehouse/templates/manage/account.html:17
 #: warehouse/templates/manage/account/two-factor.html:17
-#: warehouse/templates/manage/manage_base.html:230
-#: warehouse/templates/manage/manage_base.html:264
+#: warehouse/templates/manage/manage_base.html:242
+#: warehouse/templates/manage/manage_base.html:276
 msgid "Account settings"
 msgstr ""
 
@@ -2625,8 +2625,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:199
 #: warehouse/templates/manage/account.html:201
 #: warehouse/templates/manage/account.html:211
-#: warehouse/templates/manage/manage_base.html:306
-#: warehouse/templates/manage/manage_base.html:308
+#: warehouse/templates/manage/manage_base.html:318
+#: warehouse/templates/manage/manage_base.html:320
 #: warehouse/templates/manage/project/release.html:143
 #: warehouse/templates/manage/project/releases.html:178
 #: warehouse/templates/manage/project/settings.html:111
@@ -2816,8 +2816,8 @@ msgid "Documentation"
 msgstr ""
 
 #: warehouse/templates/includes/manage/manage-project-menu.html:51
-#: warehouse/templates/manage/manage_base.html:236
-#: warehouse/templates/manage/manage_base.html:270
+#: warehouse/templates/manage/manage_base.html:248
+#: warehouse/templates/manage/manage_base.html:282
 msgid "Publishing"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgid "None"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:487
-#: warehouse/templates/manage/manage_base.html:75
+#: warehouse/templates/manage/manage_base.html:81
 msgid "Security device (<abbr title=\"web authentication\">WebAuthn</abbr>)"
 msgstr ""
 
@@ -3587,9 +3587,11 @@ msgstr ""
 msgid "Two factor method"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:64
-#: warehouse/templates/manage/manage_base.html:78
-#: warehouse/templates/manage/manage_base.html:528
+#: warehouse/templates/manage/manage_base.html:65
+#: warehouse/templates/manage/manage_base.html:72
+#: warehouse/templates/manage/manage_base.html:85
+#: warehouse/templates/manage/manage_base.html:96
+#: warehouse/templates/manage/manage_base.html:540
 #: warehouse/templates/manage/organization/roles.html:202
 #: warehouse/templates/manage/organization/roles.html:204
 #: warehouse/templates/manage/organization/roles.html:209
@@ -3603,98 +3605,103 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:65
+#: warehouse/templates/manage/manage_base.html:66
 msgid "Remove authentication application"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:66
+#: warehouse/templates/manage/manage_base.html:67
 msgid "Remove application"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:79
-msgid "Remove two factor security device"
-msgstr ""
-
-#: warehouse/templates/manage/manage_base.html:80
-msgid "Remove device"
+#: warehouse/templates/manage/manage_base.html:71
+#: warehouse/templates/manage/manage_base.html:95
+msgid "Cannot remove last 2FA method"
 msgstr ""
 
 #: warehouse/templates/manage/manage_base.html:86
+msgid "Remove two factor security device"
+msgstr ""
+
+#: warehouse/templates/manage/manage_base.html:87
+msgid "Remove device"
+msgstr ""
+
+#: warehouse/templates/manage/manage_base.html:93
 msgid "Device name"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:99
+#: warehouse/templates/manage/manage_base.html:111
 #, python-format
 msgid ""
 "<a href=\"%(href)s\">Verify your primary email address</a> before adding "
 "additional two factor authentication methods to your account."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:104
+#: warehouse/templates/manage/manage_base.html:116
 #, python-format
 msgid ""
 "<a href=\"%(href)s\">Verify your primary email address</a> before "
 "enabling two factor authentication on your account."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:115
+#: warehouse/templates/manage/manage_base.html:127
 msgid ""
 "You must generate and safely store recovery codes before adding "
 "additional two factor authentication methods to your account."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:120
+#: warehouse/templates/manage/manage_base.html:132
 msgid ""
 "You must generate and safely store recovery codes before enabling two "
 "factor authentication on your account."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:126
+#: warehouse/templates/manage/manage_base.html:138
 msgid "Generate recovery codes"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:135
+#: warehouse/templates/manage/manage_base.html:147
 msgid ""
 "Use a recovery code before adding additional two factor authentication "
 "methods to your account."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:140
+#: warehouse/templates/manage/manage_base.html:152
 msgid ""
 "Use a recovery code before enabling two factor authentication on your "
 "account."
 msgstr ""
 
 #: warehouse/templates/manage/account/recovery_codes-burn.html:17
-#: warehouse/templates/manage/manage_base.html:149
+#: warehouse/templates/manage/manage_base.html:161
 msgid "Use a recovery code"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:160
+#: warehouse/templates/manage/manage_base.html:172
 msgid "You have not enabled two factor authentication on your account."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:168
+#: warehouse/templates/manage/manage_base.html:180
 msgid ""
 "Add <abbr title=\"two factor authentication\">2FA</abbr> with "
 "authentication application"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:173
+#: warehouse/templates/manage/manage_base.html:185
 msgid ""
 "Add <abbr title=\"two factor authentication\">2FA</abbr> with security "
 "device (e.g. USB key)"
 msgstr ""
 
 #: warehouse/templates/manage/account/webauthn-provision.html:37
-#: warehouse/templates/manage/manage_base.html:180
+#: warehouse/templates/manage/manage_base.html:192
 msgid ""
 "Enable JavaScript to set up two factor authentication with a security "
 "device (e.g. USB key)"
 msgstr ""
 
 #: warehouse/templates/manage/account/webauthn-provision.html:53
-#: warehouse/templates/manage/manage_base.html:185
+#: warehouse/templates/manage/manage_base.html:197
 #, python-format
 msgid ""
 "<a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -3702,82 +3709,82 @@ msgid ""
 "authentication with a security device (e.g. USB key)"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:196
+#: warehouse/templates/manage/manage_base.html:208
 #: warehouse/templates/manage/organization/manage_organization_base.html:28
 #: warehouse/templates/manage/project/manage_project_base.html:28
 #: warehouse/templates/manage/team/manage_team_base.html:28
 msgid "Breadcrumbs"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:201
+#: warehouse/templates/manage/manage_base.html:213
 #: warehouse/templates/manage/organization/manage_organization_base.html:32
 #: warehouse/templates/manage/project/manage_project_base.html:32
 #: warehouse/templates/manage/team/manage_team_base.html:32
 msgid "Your account"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:211
-#: warehouse/templates/manage/manage_base.html:245
+#: warehouse/templates/manage/manage_base.html:223
+#: warehouse/templates/manage/manage_base.html:257
 msgid "Account navigation"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:318
-#: warehouse/templates/manage/manage_base.html:377
+#: warehouse/templates/manage/manage_base.html:330
+#: warehouse/templates/manage/manage_base.html:389
 msgid "This action cannot be undone!"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:330
+#: warehouse/templates/manage/manage_base.html:342
 msgid "Confirm your username to continue."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:332
+#: warehouse/templates/manage/manage_base.html:344
 #, python-format
 msgid "Confirm the %(item)s to continue."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:343
-#: warehouse/templates/manage/manage_base.html:395
+#: warehouse/templates/manage/manage_base.html:355
+#: warehouse/templates/manage/manage_base.html:407
 #: warehouse/templates/manage/organization/activate_subscription.html:32
 msgid "Cancel"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:366
+#: warehouse/templates/manage/manage_base.html:378
 msgid "close"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:382
+#: warehouse/templates/manage/manage_base.html:394
 msgid "Enter your password to continue."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:465
+#: warehouse/templates/manage/manage_base.html:477
 msgid "Trusted Publisher Management"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:470
+#: warehouse/templates/manage/manage_base.html:482
 msgid ""
 "OpenID Connect (OIDC) provides a flexible, credential-free mechanism for "
 "delegating publishing authority for a PyPI package to a trusted third "
 "party service, like GitHub Actions."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:478
+#: warehouse/templates/manage/manage_base.html:490
 msgid ""
 "PyPI users and projects can use trusted publishers to automate their "
 "release processes, without needing to use API tokens or passwords."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:485
+#: warehouse/templates/manage/manage_base.html:497
 #, python-format
 msgid ""
 "You can read more about trusted publishers and how to use them <a "
 "href=\"%(href)s\">here</a>."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:524
+#: warehouse/templates/manage/manage_base.html:536
 msgid "Any"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:535
+#: warehouse/templates/manage/manage_base.html:547
 #: warehouse/templates/manage/organization/history.html:166
 #: warehouse/templates/manage/project/history.html:43
 #: warehouse/templates/manage/project/history.html:97
@@ -3788,7 +3795,7 @@ msgstr ""
 msgid "Added by:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:537
+#: warehouse/templates/manage/manage_base.html:549
 #: warehouse/templates/manage/organization/history.html:171
 #: warehouse/templates/manage/project/history.html:62
 #: warehouse/templates/manage/project/history.html:128
@@ -3799,24 +3806,24 @@ msgstr ""
 msgid "Removed by:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:539
+#: warehouse/templates/manage/manage_base.html:551
 msgid "Submitted by:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:542
+#: warehouse/templates/manage/manage_base.html:554
 #: warehouse/templates/manage/project/history.html:247
 msgid "Workflow:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:544
+#: warehouse/templates/manage/manage_base.html:556
 msgid "Specifier:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:547
+#: warehouse/templates/manage/manage_base.html:559
 msgid "Publisher:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:549
+#: warehouse/templates/manage/manage_base.html:561
 #: warehouse/templates/manage/project/history.html:52
 #: warehouse/templates/manage/project/history.html:106
 msgid "URL:"

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3588,9 +3588,14 @@ msgid "Two factor method"
 msgstr ""
 
 #: warehouse/templates/manage/manage_base.html:65
-#: warehouse/templates/manage/manage_base.html:72
 #: warehouse/templates/manage/manage_base.html:85
-#: warehouse/templates/manage/manage_base.html:96
+msgid "Cannot remove last 2FA method"
+msgstr ""
+
+#: warehouse/templates/manage/manage_base.html:66
+#: warehouse/templates/manage/manage_base.html:69
+#: warehouse/templates/manage/manage_base.html:86
+#: warehouse/templates/manage/manage_base.html:89
 #: warehouse/templates/manage/manage_base.html:540
 #: warehouse/templates/manage/organization/roles.html:202
 #: warehouse/templates/manage/organization/roles.html:204
@@ -3605,28 +3610,23 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:66
+#: warehouse/templates/manage/manage_base.html:70
 msgid "Remove authentication application"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:67
+#: warehouse/templates/manage/manage_base.html:71
 msgid "Remove application"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:71
-#: warehouse/templates/manage/manage_base.html:95
-msgid "Cannot remove last 2FA method"
-msgstr ""
-
-#: warehouse/templates/manage/manage_base.html:86
+#: warehouse/templates/manage/manage_base.html:90
 msgid "Remove two factor security device"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:87
+#: warehouse/templates/manage/manage_base.html:91
 msgid "Remove device"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:93
+#: warehouse/templates/manage/manage_base.html:97
 msgid "Device name"
 msgstr ""
 

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -592,6 +592,10 @@ class ProvisionTOTPViews:
             )
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
+        if not self.request.user.has_multiple_2fa:
+            self.request.session.flash("Cannot remove last 2FA method", queue="error")
+            return HTTPSeeOther(self.request.route_path("manage.account"))
+
         form = DeleteTOTPForm(
             formdata=MultiDict(
                 {
@@ -721,6 +725,10 @@ class ProvisionWebAuthnViews:
             self.request.session.flash(
                 "There is no security device to delete", queue="error"
             )
+            return HTTPSeeOther(self.request.route_path("manage.account"))
+
+        if not self.request.user.has_multiple_2fa:
+            self.request.session.flash("Cannot remove last 2FA method", queue="error")
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
         form = DeleteWebAuthnForm(

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -592,7 +592,7 @@ class ProvisionTOTPViews:
             )
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
-        if not self.request.user.has_multiple_2fa:
+        if self.request.user.has_single_2fa:
             self.request.session.flash("Cannot remove last 2FA method", queue="error")
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
@@ -727,7 +727,7 @@ class ProvisionWebAuthnViews:
             )
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
-        if not self.request.user.has_multiple_2fa:
+        if self.request.user.has_single_2fa:
             self.request.session.flash("Cannot remove last 2FA method", queue="error")
             return HTTPSeeOther(self.request.route_path("manage.account"))
 

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -61,16 +61,16 @@
         <tr>
           <th scope="row">{% trans %}Authentication application (<abbr title="time-based one-time password">TOTP</abbr>){% endtrans %}</th>
           <td class="table__align-right">
-            {% if user.has_multiple_2fa %}
+            {% if user.has_single_2fa %}
+            <button class="button" disabled title="{% trans %}Cannot remove last 2FA method{% endtrans %}" >
+            {% trans %}Remove{% endtrans %}
+            </button>
+            {% else %}
             <a href="#disable-totp" class="button button--secondary">{% trans %}Remove{% endtrans %}</a>
             {% set title=gettext("Remove authentication application") %}
             {% set confirm_button_label=gettext("Remove application") %}
             {% set action=request.route_path('manage.account.totp-provision') %}
             {{ confirm_password_modal(title=title, action=action, slug="disable-totp", warning=False, confirm_button_label=confirm_button_label) }}
-            {% else %}
-            <button class="button" disabled title="{% trans %}Cannot remove last 2FA method{% endtrans %}" >
-            {% trans %}Remove{% endtrans %}
-            </button>
             {% endif %}
           </td>
         </tr>
@@ -81,20 +81,20 @@
             <strong>"{{ credential.label }}"</strong> - {% trans %}Security device (<abbr title="web authentication">WebAuthn</abbr>){% endtrans %}
           </th>
           <td class="table__align-right">
-            {% if user.has_multiple_2fa %}
+            {% if user.has_single_2fa %}
+            <button class="button" disabled title="{% trans %}Cannot remove last 2FA method{% endtrans %}" >
+            {% trans %}Remove{% endtrans %}
+            </button>
+            {% else %}
             <a href="#disable-webauthn-{{ credential.id }}" class="button button--secondary">{% trans %}Remove{% endtrans %}</a>
             {% set title=gettext("Remove two factor security device") + " - " + credential.label %}
             {% set confirm_button_label=gettext("Remove device") %}
             {% set action=request.route_path('manage.account.webauthn-provision.delete') %}
             {% set slug="disable-webauthn-" + credential.id | string %}
             {% set extra_fields %}
-              <input type="hidden" name="label" value="{{ credential.label }}" autocomplete="off">
+            <input type="hidden" name="label" value="{{ credential.label }}" autocomplete="off">
             {% endset %}
             {{ confirm_modal(title=title, label=gettext("Device name"), confirm_name="device_name", confirm_string=credential.label, confirm_button_label=confirm_button_label, slug=slug, extra_fields=extra_fields, action=action, warning=False, confirm_string_in_title=False) }}
-            {% else %}
-            <button class="button" disabled title="{% trans %}Cannot remove last 2FA method{% endtrans %}" >
-            {% trans %}Remove{% endtrans %}
-            </button>
             {% endif %}
           </td>
         </tr>

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -61,11 +61,17 @@
         <tr>
           <th scope="row">{% trans %}Authentication application (<abbr title="time-based one-time password">TOTP</abbr>){% endtrans %}</th>
           <td class="table__align-right">
+            {% if user.has_multiple_2fa %}
             <a href="#disable-totp" class="button button--secondary">{% trans %}Remove{% endtrans %}</a>
             {% set title=gettext("Remove authentication application") %}
             {% set confirm_button_label=gettext("Remove application") %}
             {% set action=request.route_path('manage.account.totp-provision') %}
             {{ confirm_password_modal(title=title, action=action, slug="disable-totp", warning=False, confirm_button_label=confirm_button_label) }}
+            {% else %}
+            <button class="button" disabled title="{% trans %}Cannot remove last 2FA method{% endtrans %}" >
+            {% trans %}Remove{% endtrans %}
+            </button>
+            {% endif %}
           </td>
         </tr>
         {% endif %}
@@ -75,6 +81,7 @@
             <strong>"{{ credential.label }}"</strong> - {% trans %}Security device (<abbr title="web authentication">WebAuthn</abbr>){% endtrans %}
           </th>
           <td class="table__align-right">
+            {% if user.has_multiple_2fa %}
             <a href="#disable-webauthn-{{ credential.id }}" class="button button--secondary">{% trans %}Remove{% endtrans %}</a>
             {% set title=gettext("Remove two factor security device") + " - " + credential.label %}
             {% set confirm_button_label=gettext("Remove device") %}
@@ -84,6 +91,11 @@
               <input type="hidden" name="label" value="{{ credential.label }}" autocomplete="off">
             {% endset %}
             {{ confirm_modal(title=title, label=gettext("Device name"), confirm_name="device_name", confirm_string=credential.label, confirm_button_label=confirm_button_label, slug=slug, extra_fields=extra_fields, action=action, warning=False, confirm_string_in_title=False) }}
+            {% else %}
+            <button class="button" disabled title="{% trans %}Cannot remove last 2FA method{% endtrans %}" >
+            {% trans %}Remove{% endtrans %}
+            </button>
+            {% endif %}
           </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
With this change, a user will only be allowed to remove a 2FA method if there are 2 or more 2FA methods on the account. When there is only 1, the "Remove" button will be disabled. The backend also checks if there are 2 or more 2FA methods when trying to remove.

I noticed that when the "Remove" button is disabled, the cursor doesn't change to "not-allowed" when hovering, nor does the title appear in a tooltip. That's because https://github.com/pypi/warehouse/pull/13110, added `pointer-events: none` to [disabled buttons](https://github.com/pypi/warehouse/blob/fe6455c0a946e81f61d72edc1049f536d8bba903/warehouse/static/sass/blocks/_button.scss#L121). On the "Your Projects" page, disabled buttons show the title and the "not-allowed" cursor because [_snippet.scss](https://github.com/pypi/warehouse/blob/fe6455c0a946e81f61d72edc1049f536d8bba903/warehouse/static/sass/blocks/_snippet.scss#L92) sets `pointer-events: auto`. I wasn't sure the reason behind setting `pointer-events: none` in `_button.scss`, but if this behavior change is unintended, we could address this in another PR.

Closes https://github.com/pypi/warehouse/issues/13771