### PR TITLE
Don't inadvertently normalize the METADATA filename

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -80,7 +80,6 @@ def _get_tar_testdata(compression_type=""):
 
 def _get_whl_testdata(name="fake_package", version="1.0"):
     temp_f = io.BytesIO()
-    name = name.lower().replace(".", "_").replace("-", "_")
     with zipfile.ZipFile(file=temp_f, mode="w") as zfp:
         zfp.writestr(f"{name}-{version}.dist-info/METADATA", "Fake metadata")
     return temp_f.getvalue()

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1348,7 +1348,7 @@ def file_upload(request):
             # should use packaging.utils.parse_wheel_filename(filename), but until then
             # we can't use this as it adds additional normailzation to the project name
             # and version.
-            name, version, _ = filename.split('-', 2)
+            name, version, _ = filename.split("-", 2)
             metadata_filename = f"{name}-{version}.dist-info/METADATA"
             try:
                 with zipfile.ZipFile(temporary_filename) as zfp:

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1344,8 +1344,12 @@ def file_upload(request):
             See https://peps.python.org/pep-0491/#file-contents
             """
             filename = os.path.basename(temporary_filename)
-            name, version, _, __ = packaging.utils.parse_wheel_filename(filename)
-            metadata_filename = f"{name.replace('-', '_')}-{version}.dist-info/METADATA"
+            # Get the name and version from the original filename. Eventually this
+            # should use packaging.utils.parse_wheel_filename(filename), but until then
+            # we can't use this as it adds additional normailzation to the project name
+            # and version.
+            name, version, _ = filename.split('-', 2)
+            metadata_filename = f"{name}-{version}.dist-info/METADATA"
             try:
                 with zipfile.ZipFile(temporary_filename) as zfp:
                     wheel_metadata_contents = zfp.read(metadata_filename)


### PR DESCRIPTION
In #14193, the use of `packaging.utils.parse_wheel_filename` to get the filename for the `.dist-info/METADATA` file inadvertently introduced additional normalization to the path. This is overly restrictive given #14156.

This PR updates the creation of the path for this file based on the original filename of the distribution file instead.

Fixes #14202.