### PR TITLE
Catch `InvalidWheelFilename` exceptions

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3057,10 +3057,19 @@ class TestFileUpload:
             )
         ]
 
-    @pytest.mark.parametrize("filename, expected", [
-        ("foo-1.0.whl", "400 Invalid wheel filename (wrong number of parts): foo-1.0"),
-        ("foo-1.0-q-py3-none-any.whl", "400 Invalid build number: q in 'foo-1.0-q-py3-none-any'"),
-    ])
+    @pytest.mark.parametrize(
+        "filename, expected",
+        [
+            (
+                "foo-1.0.whl",
+                "400 Invalid wheel filename (wrong number of parts): foo-1.0",
+            ),
+            (
+                "foo-1.0-q-py3-none-any.whl",
+                "400 Invalid build number: q in 'foo-1.0-q-py3-none-any'",
+            ),
+        ],
+    )
     def test_upload_fails_with_invalid_filename(
         self, monkeypatch, pyramid_config, db_request, filename, expected
     ):
@@ -3102,7 +3111,6 @@ class TestFileUpload:
 
         assert resp.status_code == 400
         assert resp.status == expected
-
 
     @pytest.mark.parametrize(
         "plat",

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3057,6 +3057,53 @@ class TestFileUpload:
             )
         ]
 
+    @pytest.mark.parametrize("filename, expected", [
+        ("foo-1.0.whl", "400 Invalid wheel filename (wrong number of parts): foo-1.0"),
+        ("foo-1.0-q-py3-none-any.whl", "400 Invalid build number: q in 'foo-1.0-q-py3-none-any'"),
+    ])
+    def test_upload_fails_with_invalid_filename(
+        self, monkeypatch, pyramid_config, db_request, filename, expected
+    ):
+        user = UserFactory.create()
+        pyramid_config.testing_securitypolicy(identity=user)
+        db_request.user = user
+        EmailFactory.create(user=user)
+        project = ProjectFactory.create(name="foo")
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
+
+        filebody = _get_whl_testdata(name=project.name, version=release.version)
+
+        pyramid_config.testing_securitypolicy(identity=user)
+        db_request.user = user
+        db_request.user_agent = "warehouse-tests/6.6.6"
+        db_request.POST = MultiDict(
+            {
+                "metadata_version": "1.2",
+                "name": project.name,
+                "version": release.version,
+                "filetype": "bdist_wheel",
+                "pyversion": "cp34",
+                "md5_digest": hashlib.md5(filebody).hexdigest(),
+                "content": pretend.stub(
+                    filename=filename,
+                    file=io.BytesIO(filebody),
+                    type="application/zip",
+                ),
+            }
+        )
+
+        monkeypatch.setattr(legacy, "_is_valid_dist_file", lambda *a, **kw: True)
+
+        with pytest.raises(HTTPBadRequest) as excinfo:
+            legacy.file_upload(db_request)
+
+        resp = excinfo.value
+
+        assert resp.status_code == 400
+        assert resp.status == expected
+
+
     @pytest.mark.parametrize(
         "plat",
         [

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1329,7 +1329,14 @@ def file_upload(request):
 
         # Check that if it's a binary wheel, it's on a supported platform
         if filename.endswith(".whl"):
-            _, __, ___, tags = packaging.utils.parse_wheel_filename(filename)
+            try:
+                _, __, ___, tags = packaging.utils.parse_wheel_filename(filename)
+            except packaging.utils.InvalidWheelFilename as e:
+                raise _exc_with_message(
+                    HTTPBadRequest,
+                    str(e),
+                )
+
             for tag in tags:
                 if not _valid_platform_tag(tag.platform):
                     raise _exc_with_message(


### PR DESCRIPTION
Using `packaging.utils.parse_wheel_filename` might throw some exceptions: https://github.com/pypa/packaging/blob/1277904652c497ec84560a830a2e01d434358818/src/packaging/utils.py#L86

This makes an update to catch all of them, although realistically there's only two that could be thrown due to prior evaluation of the filename.

Fixes https://python-software-foundation.sentry.io/issues/4342235543/