### PR TITLE
Change wording for API Token

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3167,7 +3167,6 @@ msgid "Active API tokens for this account"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:449
-#: warehouse/templates/manage/account/token.html:17
 msgid "Add API token"
 msgstr ""
 
@@ -4350,6 +4349,10 @@ msgstr ""
 msgid "Ensure that you have securely stored them before continuing."
 msgstr ""
 
+#: warehouse/templates/manage/account/token.html:17
+msgid "Create API token"
+msgstr ""
+
 #: warehouse/templates/manage/account/token.html:38
 #, python-format
 msgid "Token for \"%(macaroon_description)s\""
@@ -4454,7 +4457,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/account/token.html:122
-msgid "Add another token"
+msgid "Create another token"
 msgstr ""
 
 #: warehouse/templates/manage/account/token.html:131
@@ -4462,7 +4465,7 @@ msgid "Token name"
 msgstr ""
 
 #: warehouse/templates/manage/account/token.html:140
-msgid "What is this token for?"
+msgid "What will you use this token for?"
 msgstr ""
 
 #: warehouse/templates/manage/account/token.html:154
@@ -4476,7 +4479,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/account/token.html:170
-msgid "Add token"
+msgid "Create token"
 msgstr ""
 
 #: warehouse/templates/manage/account/totp-provision.html:17

--- a/warehouse/templates/manage/account/token.html
+++ b/warehouse/templates/manage/account/token.html
@@ -14,7 +14,7 @@
 {% extends "manage/manage_base.html" %}
 
 {% set user = request.user %}
-{% set title = gettext("Add API token") %}
+{% set title = gettext("Create API token") %}
 
 {% set active_tab = 'account' %}
 
@@ -119,10 +119,10 @@
     <p>{% trans href='/help#apitoken' %}For further instructions on how to use this token, <a href="{{ href }}">visit the PyPI help page</a>.{% endtrans %}</p>
   </section>
   <hr>
-  <a href="." class="button">{% trans %}Add another token{% endtrans %}</a>
+  <a href="." class="button">{% trans %}Create another token{% endtrans %}</a>
   {% else %}
   {{ form_error_anchor(create_macaroon_form) }}
-  <section id="add-token">
+  <section id="create-token">
     <form method="POST">
       <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
       {{ form_errors(create_macaroon_form) }}
@@ -137,7 +137,7 @@
         <div id="token-name-errors">
           {{ field_errors(create_macaroon_form.description) }}
         </div>
-        <p id="description-help-text" class="form-group__help-text">{% trans %}What is this token for?{% endtrans %}</p>
+        <p id="description-help-text" class="form-group__help-text">{% trans %}What will you use this token for?{% endtrans %}</p>
       </div>
       <div class="form-group">
         <span class="form-group__label">{% trans %}Permissions{% endtrans %}</span>
@@ -167,7 +167,7 @@
         <p>{% trans %}An API token scoped to your entire account will have upload permissions for all of your current and future projects.{% endtrans %}</p>
       </div>
       <div>
-        <input value="{% trans %}Add token{% endtrans %}" class="button button--primary" type="submit">
+        <input value="{% trans %}Create token{% endtrans %}" class="button button--primary" type="submit">
       </div>
     </form>
   </section>


### PR DESCRIPTION
I changed the wording so that it says "Create API Token". I also edited the help message so that it actually helps the user.

Fixes #11874 