### PR TITLE
Bring back disabled cursor and tooltip for disabled buttons

### DIFF
--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -118,7 +118,7 @@
     border-color: darken($background-color, 5%);
     color: darken($background-color, 12%);
     text-decoration: line-through;
-    pointer-events: none;
+    pointer-events: auto;
 
     &:focus,
     &:hover,


### PR DESCRIPTION
I noticed that when most buttons are disabled, the cursor doesn't change to "not-allowed" when hovering, nor does the title appear in a tooltip. This change happened in https://github.com/pypi/warehouse/pull/13110 from adding `pointer-events: none` to [disabled buttons](https://github.com/pypi/warehouse/blob/fe6455c0a946e81f61d72edc1049f536d8bba903/warehouse/static/sass/blocks/_button.scss#L121). In https://github.com/pypi/warehouse/pull/14195#issuecomment-1648501825, Dustin commented saying that it probably makes sense to have `pointer-events: auto`.