### PR TITLE
fix: put null values last

### DIFF
--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -95,7 +95,7 @@ def rss_packages(request):
     newest_projects = (
         request.db.query(Project)
         .options(joinedload(Project.releases, innerjoin=True))
-        .order_by(Project.created.desc())
+        .order_by(Project.created.desc().nulls_last())
         .limit(40)
         .all()
     )


### PR DESCRIPTION
PG puts nulls fist when `ORDER BY DESC`
Refs: https://www.postgresql.org/docs/current/queries-order.html

Fixes WAREHOUSE-PRODUCTION-1KC
https://python-software-foundation.sentry.io/share/issue/b5f7505a29cf42849e43aa86ba067644/