### PR TITLE
Handle InvalidVersion exception from `parse_wheel_filename`

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3084,6 +3084,10 @@ class TestFileUpload:
                 "foo-1.0-q-py3-none-any.whl",
                 "400 Invalid build number: q in 'foo-1.0-q-py3-none-any'",
             ),
+            (
+                "foo-0.0.4test1-py3-none-any.whl",
+                "400 Invalid filename: Invalid version: '0.0.4test1'",
+            ),
         ],
     )
     def test_upload_fails_with_invalid_filename(

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1349,6 +1349,11 @@ def file_upload(request):
                     HTTPBadRequest,
                     str(e),
                 )
+            except packaging.version.InvalidVersion as e:
+                raise _exc_with_message(
+                    HTTPBadRequest,
+                    f"Invalid filename: {e}",
+                )
 
             for tag in tags:
                 if not _valid_platform_tag(tag.platform):


### PR DESCRIPTION
Fixes https://python-software-foundation.sentry.io/issues/4363701924/.

Fixes WAREHOUSE-STAGING-N1.