### PR TITLE
Typeguard be gone

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -67,7 +67,6 @@ stripe
 structlog
 transaction
 trove-classifiers
-typeguard
 ua-parser
 webauthn>=1.0.0,<2.0.0
 whitenoise

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1512,10 +1512,6 @@ trove-classifiers==2023.7.6 \
     --hash=sha256:8a8e168b51d20fed607043831d37632bb50919d1c80a64e0f1393744691a8b22 \
     --hash=sha256:b420d5aa048ee7c456233a49203f7d58d1736af4a6cde637657d78c13ab7969b
     # via -r requirements/main.in
-typeguard==2.13.3 \
-    --hash=sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4 \
-    --hash=sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1
-    # via -r requirements/main.in
 typing-extensions==4.7.1 \
     --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \
     --hash=sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2

--- a/tests/functional/legacy_api/test_xmlrpc.py
+++ b/tests/functional/legacy_api/test_xmlrpc.py
@@ -34,7 +34,7 @@ def test_xmlrpc_succeeds(app_config, webtest, metrics):
 def test_invalid_arguments(app_config, webtest):
     with pytest.raises(
         xmlrpc.client.Fault,
-        match="client error; missing a required argument: 'package_name'",
+        match=r"client error; \('package_name',\): field required",
     ):
         webtest.xmlrpc("/pypi", "package_releases")
 
@@ -42,7 +42,7 @@ def test_invalid_arguments(app_config, webtest):
 def test_arguments_with_wrong_type(app_config, webtest):
     with pytest.raises(
         xmlrpc.client.Fault,
-        match='client error; type of argument "serial" must be int; got str instead',
+        match=r"client error; \('serial',\): value is not a valid integer",
     ):
         webtest.xmlrpc("/pypi", "changelog_since_serial", "wrong!")
 
@@ -50,6 +50,9 @@ def test_arguments_with_wrong_type(app_config, webtest):
 def test_multiple_garbage_types(app_config, webtest):
     with pytest.raises(
         xmlrpc.client.Fault,
-        match='client error; type of argument "serial" must be int; got str instead',
+        match=(
+            r"client error; \('since',\): value is not a valid integer; "
+            r"\('with_ids',\): value could not be parsed to a boolean"
+        ),
     ):
         webtest.xmlrpc("/pypi", "changelog", "wrong!", "also wrong!")

--- a/tests/functional/legacy_api/test_xmlrpc.py
+++ b/tests/functional/legacy_api/test_xmlrpc.py
@@ -45,3 +45,11 @@ def test_arguments_with_wrong_type(app_config, webtest):
         match='client error; type of argument "serial" must be int; got str instead',
     ):
         webtest.xmlrpc("/pypi", "changelog_since_serial", "wrong!")
+
+
+def test_multiple_garbage_types(app_config, webtest):
+    with pytest.raises(
+        xmlrpc.client.Fault,
+        match='client error; type of argument "serial" must be int; got str instead',
+    ):
+        webtest.xmlrpc("/pypi", "changelog", "wrong!", "also wrong!")

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -215,7 +215,7 @@ class TypedMapplyViewMapper(MapplyViewMapper):
         try:
             validated = ValidatedFunction(fn, None)
             values = validated.build_values(args, kwargs)
-            model = validated.model(**values)
+            validated.model(**values)
         except ValidationError as exc:
             raise XMLRPCInvalidParamTypes(
                 "; ".join([f"{e['loc']}: {e['msg']}" for e in exc.errors()])


### PR DESCRIPTION
Replaces use of typeguard for xmlrpc validation with pydantic, closes #13960 closes #13274