### PR TITLE
Order `.events` by time

### DIFF
--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -184,7 +184,11 @@ class HasEvents:
                     ),
                     nullable=False,
                 ),
-                source=orm.relationship(cls, back_populates="events"),
+                source=orm.relationship(
+                    cls,
+                    back_populates="events",
+                    order_by=f"desc({cls.__name__}Event.time)",
+                ),
             ),
         )
         return orm.relationship(


### PR DESCRIPTION
For every model using `HasEvents`, the `.events` value ends up being unsorted. This results in the projects events in the admin being difficult to use.

Instead, order these by time by default.