### PR TITLE
chore: update dependabot config for groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,25 @@ updates:
   ignore:
   # Always ignore elasticsearch, future versions are always incompatible with our provider
   - dependency-name: "elasticsearch"
-  # These update basically every day, and 99.9% of the time we don't care
-  - dependency-name: "boto3"
-  - dependency-name: "boto3-stubs"
-  - dependency-name: "botocore"
-  - dependency-name: "botocore-stubs"
+  groups:
+    # Items in these groups are combined in a single PR
+    psycopg:
+      patterns:
+        # Combine both `psycopg` and `psycopg[c]`
+        - "psycopg*"
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: monthly
+  groups:
+    # Items in these groups are combined in a single PR
+    boto3:
+      patterns:
+        - "boto3*"
+    botocore:
+      patterns:
+        - "botocore*"
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,11 +25,9 @@ updates:
     interval: monthly
   groups:
     # Items in these groups are combined in a single PR
-    boto3:
+    boto-deps:
       patterns:
         - "boto3*"
-    botocore:
-      patterns:
         - "botocore*"
 
 - package-ecosystem: github-actions


### PR DESCRIPTION
Inform Dependabot that some deps should move together.
See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

Bring back updates to `boto*` on a less frequent cadence.