### PR TITLE
Revert "chore: update dependabot config for groups (#14292)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,23 +13,11 @@ updates:
   ignore:
   # Always ignore elasticsearch, future versions are always incompatible with our provider
   - dependency-name: "elasticsearch"
-  groups:
-    # Items in these groups are combined in a single PR
-    psycopg:
-      patterns:
-        # Combine both `psycopg` and `psycopg[c]`
-        - "psycopg*"
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: monthly
-  groups:
-    # Items in these groups are combined in a single PR
-    boto-deps:
-      patterns:
-        - "boto3*"
-        - "botocore*"
-
+  # These update basically every day, and 99.9% of the time we don't care
+  - dependency-name: "boto3"
+  - dependency-name: "boto3-stubs"
+  - dependency-name: "botocore"
+  - dependency-name: "botocore-stubs"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
This reverts commit 67f51e14174fd16712aab20921820011d4ea994b.

Borked:

> The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'

Probably need to a slightly different structure to accomplish this.