### PR TITLE
feat: require 2fa for new users

### DIFF
--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -712,7 +712,7 @@ class TestPermits:
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
                 has_two_factor=False,
-                date_joined=datetime.now(),
+                date_joined=datetime(2023, 8, 9),
             ),
             matched_route=pretend.stub(name="manage.projects"),
         )

--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -502,20 +502,6 @@ class TestSessionSecurityPolicy:
         assert add_vary_cb.calls == [pretend.call("Cookie")]
         assert request.add_response_callback.calls == [pretend.call(vary_cb)]
 
-    def test_permits_with_unverified_email(self, monkeypatch):
-        monkeypatch.setattr(security_policy, "User", pretend.stub)
-
-        request = pretend.stub(
-            identity=pretend.stub(
-                __principals__=lambda: ["user:5"], has_primary_verified_email=False
-            ),
-            matched_route=pretend.stub(name="manage.projects"),
-        )
-        context = pretend.stub(__acl__=[(Allow, "user:5", "myperm")])
-
-        policy = security_policy.SessionSecurityPolicy()
-        assert not policy.permits(request, context, "myperm")
-
 
 @pytest.mark.parametrize(
     "policy_class",
@@ -658,3 +644,17 @@ class TestPermits:
             ]
         else:
             assert request.session.flash.calls == []
+
+    def test_permits_with_unverified_email(self, monkeypatch, policy_class):
+        monkeypatch.setattr(security_policy, "User", pretend.stub)
+
+        request = pretend.stub(
+            identity=pretend.stub(
+                __principals__=lambda: ["user:5"], has_primary_verified_email=False
+            ),
+            matched_route=pretend.stub(name="manage.projects"),
+        )
+        context = pretend.stub(__acl__=[(Allow, "user:5", "myperm")])
+
+        policy = policy_class()
+        assert not policy.permits(request, context, "myperm")

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -309,4 +309,33 @@ def _check_for_mfa(request, context) -> WarehouseDenied | None:
                 queue="warning",
             )
 
+    # Regardless of TwoFactorRequireable, if we're in the manage namespace, we'll
+    # check if the user has 2FA enabled, and if they don't we'll deny them.
+
+    # Management routes that don't require 2FA, mostly to set up 2FA.
+    _exempt_routes = [
+        "manage.account.recovery-codes",
+        "manage.account.totp-provision",
+        "manage.account.two-factor",
+        "manage.account.webauthn-provision",
+    ]
+
+    if (
+        request.matched_route.name.startswith("manage")
+        and request.matched_route.name != "manage.account"
+        and not any(
+            request.matched_route.name.startswith(route) for route in _exempt_routes
+        )
+        and not request.identity.has_two_factor
+    ) and (
+        # Start enforcement from 2023-08-01, but we should remove this check
+        # at the end of 2023.
+        request.identity.date_joined
+        and request.identity.date_joined > datetime.datetime(2023, 8, 1)
+    ):
+        return WarehouseDenied(
+            "You must enable two factor authentication to manage other settings",
+            reason="manage_2fa_required",
+        )
+
     return None

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -328,10 +328,10 @@ def _check_for_mfa(request, context) -> WarehouseDenied | None:
         )
         and not request.identity.has_two_factor
     ) and (
-        # Start enforcement from 2023-08-01, but we should remove this check
+        # Start enforcement from 2023-08-08, but we should remove this check
         # at the end of 2023.
         request.identity.date_joined
-        and request.identity.date_joined > datetime.datetime(2023, 8, 1)
+        and request.identity.date_joined > datetime.datetime(2023, 8, 8)
     ):
         return WarehouseDenied(
             "You must enable two factor authentication to manage other settings",

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4,13 +4,13 @@ msgid ""
 "this action."
 msgstr ""
 
-#: warehouse/views.py:157
+#: warehouse/views.py:161
 msgid ""
 "Two-factor authentication must be enabled on your account to perform this"
 " action."
 msgstr ""
 
-#: warehouse/views.py:282
+#: warehouse/views.py:286
 msgid "Locale updated"
 msgstr ""
 

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -152,7 +152,11 @@ def forbidden(exc, request):
 
         # If the forbidden error is because the user doesn't have 2FA enabled, we'll
         # redirect them to the 2FA page
-        if exc.result.reason in {"owners_require_2fa", "pypi_mandates_2fa"}:
+        if exc.result.reason in {
+            "owners_require_2fa",
+            "pypi_mandates_2fa",
+            "manage_2fa_required",
+        }:
             request.session.flash(
                 request._(
                     "Two-factor authentication must be enabled on your account to "


### PR DESCRIPTION
Hooks into security policy to require all non-account management actions
to have a form of 2FA set up.

Adds a time-based restriction for new users, which we can remove when we
want to enforce for everyone.

Resolves https://github.com/pypi/warehouse/issues/13762

Includes refactor adf056ea5656c20432662d351538cd1de6b22f1b
