### PR TITLE
Improve OIDC error messages

### DIFF
--- a/tests/unit/oidc/models/test_core.py
+++ b/tests/unit/oidc/models/test_core.py
@@ -11,7 +11,9 @@
 # limitations under the License.
 
 import pretend
+import pytest
 
+from warehouse.oidc import errors
 from warehouse.oidc.models import _core
 
 
@@ -40,12 +42,14 @@ def test_check_claim_invariant():
 
 
 class TestOIDCPublisher:
-    def test_lookup_by_claims_default_none(self):
-        assert (
-            _core.OIDCPublisher.lookup_by_claims(pretend.stub(), pretend.stub()) is None
-        )
+    def test_lookup_by_claims_raises(self):
+        with pytest.raises(errors.InvalidPublisherError) as e:
+            _core.OIDCPublisher.lookup_by_claims(pretend.stub(), pretend.stub())
+        assert str(e.value) == "All lookup strategies exhausted"
 
     def test_oidc_publisher_not_default_verifiable(self):
         publisher = _core.OIDCPublisher(projects=[])
 
-        assert not publisher.verify_claims(signed_claims={})
+        with pytest.raises(errors.InvalidPublisherError) as e:
+            publisher.verify_claims(signed_claims={})
+        assert str(e.value) == "No required verifiable claims"

--- a/tests/unit/oidc/test_utils.py
+++ b/tests/unit/oidc/test_utils.py
@@ -18,17 +18,15 @@ import pytest
 from pyramid.authorization import Authenticated
 
 from tests.common.db.oidc import GitHubPublisherFactory, GooglePublisherFactory
-from warehouse.oidc import utils
+from warehouse.oidc import errors, utils
 from warehouse.utils.security_policy import principals_for
 
 
 def test_find_publisher_by_issuer_bad_issuer_url():
-    assert (
+    with pytest.raises(errors.InvalidPublisherError):
         utils.find_publisher_by_issuer(
             pretend.stub(), "https://fake-issuer.url", pretend.stub()
         )
-        is None
-    )
 
 
 @pytest.mark.parametrize(

--- a/warehouse/oidc/errors.py
+++ b/warehouse/oidc/errors.py
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class InvalidPublisherError(Exception):
+    pass

--- a/warehouse/oidc/utils.py
+++ b/warehouse/oidc/utils.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 from pyramid.authorization import Authenticated
 
+from warehouse.oidc.errors import InvalidPublisherError
 from warehouse.oidc.interfaces import SignedClaims
 from warehouse.oidc.models import (
     GitHubPublisher,
@@ -52,7 +53,7 @@ def find_publisher_by_issuer(session, issuer_url, signed_claims, *, pending=Fals
     except KeyError:
         # This indicates a logic error, since we shouldn't have verified
         # claims for an issuer that we don't recognize and support.
-        return None
+        raise InvalidPublisherError(f"Issuer {issuer_url!r} is unsupported")
 
     return publisher_cls.lookup_by_claims(session, signed_claims)
 


### PR DESCRIPTION
This switches our OIDC logic to raising exceptions with specific error messages when publishers are invalid, rather than returning `None` for multiple failure cases, which resulted in one error message covering a large number of possible failures.