### PR TITLE
Add `NullFastlyCache` service, use it in development

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -39,7 +39,7 @@ ARCHIVE_FILES_BACKEND=warehouse.packaging.services.LocalArchiveFileStorage path=
 SIMPLE_BACKEND=warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://localhost:9001/simple/{path}
 DOCS_BACKEND=warehouse.packaging.services.LocalDocsStorage path=/var/opt/warehouse/docs/
 SPONSORLOGOS_BACKEND=warehouse.admin.services.LocalSponsorLogoStorage path=/var/opt/warehouse/sponsorlogos/
-
+ORIGIN_CACHE=warehouse.cache.origin.fastly.NullFastlyCache api_key=some_api_key service_id=some_service_id
 MAIL_BACKEND=warehouse.email.services.ConsoleAndSMTPEmailSender host=maildev port=1025 ssl=false sender=noreply@pypi.org
 
 BREACHED_EMAILS=warehouse.accounts.NullEmailBreachedService

--- a/warehouse/cache/origin/fastly.py
+++ b/warehouse/cache/origin/fastly.py
@@ -143,3 +143,23 @@ class FastlyCache:
                     tags=[f"ip_address:{self.api_connect_via}"],
                 )
                 self._double_purge_key(key)  # Do not connect via on fallback
+
+
+@implementer(IOriginCache)
+class NullFastlyCache(FastlyCache):
+    """Same as FastlyCache, but it doesn't issue any requests"""
+
+    def _purge_key(self, key, connect_via=None):
+        path = "/service/{service_id}/purge/{key}".format(
+            service_id=self.service_id, key=key
+        )
+        url = urllib.parse.urljoin(self.api_endpoint, path)
+        headers = {
+            "Accept": "application/json",
+            "Fastly-Key": self.api_key,
+            "Fastly-Soft-Purge": "1",
+        }
+
+        print("Origin cache purge issued:")
+        print(f"* URL: {url!r}")
+        print(f"* Headers: {headers!r}")


### PR DESCRIPTION
This adds a origin cache service that mimics our Fastly service in local development, and outputs the requests it would issue in production.