### PR TITLE
OIDC: explicitly require that `ref` claim is present

### DIFF
--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -43,6 +43,7 @@ class TestGitHubPublisher:
         assert github.GitHubPublisher.all_known_claims() == {
             # verifiable claims
             "sub",
+            "ref",
             "repository",
             "repository_owner",
             "repository_owner_id",
@@ -59,7 +60,6 @@ class TestGitHubPublisher:
             "actor",
             "actor_id",
             "jti",
-            "ref",
             "sha",
             "run_id",
             "run_number",

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -177,7 +177,8 @@ class OIDCPublisherMixin:
                     f"{unaccounted_claims}"
                 )
 
-        # Finally, perform the actual claim verification.
+        # Finally, perform the actual claim verification. First, verify that
+        # all requred claims are present.
         for claim_name, check in self.__required_verifiable_claims__.items():
             # All required claims are mandatory. The absence of a missing
             # claim *is* an error with the JWT, since it indicates a breaking
@@ -192,6 +193,9 @@ class OIDCPublisherMixin:
                     )
                 raise InvalidPublisherError(f"Missing claim {claim_name!r}")
 
+        # Now that we've verified all claims are present, verify each claim is correct
+        for claim_name, check in self.__required_verifiable_claims__.items():
+            signed_claim = signed_claims.get(claim_name)
             if not check(getattr(self, claim_name), signed_claim, signed_claims):
                 raise InvalidPublisherError(
                     f"Check failed for required claim {claim_name!r}"

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -88,10 +88,10 @@ class OIDCPublisherMixin:
 
     # A map of claim names to "check" functions, each of which
     # has the signature `check(ground-truth, signed-claim, all-signed-claims) -> bool`.
-    __required_verifiable_claims__: dict[str, CheckClaimCallable[Any]] = dict()
+    __required_verifiable_claims__: dict[str, CheckClaimCallable[Any] | None] = dict()
 
     # Simlar to __verificable_claims__, but these claims are optional
-    __optional_verifiable_claims__: dict[str, CheckClaimCallable[Any]] = dict()
+    __optional_verifiable_claims__: dict[str, CheckClaimCallable[Any] | None] = dict()
 
     # Claims that have already been verified during the JWT signature
     # verification phase.

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -196,7 +196,9 @@ class OIDCPublisherMixin:
         # Now that we've verified all claims are present, verify each claim is correct
         for claim_name, check in self.__required_verifiable_claims__.items():
             signed_claim = signed_claims.get(claim_name)
-            if not check(getattr(self, claim_name), signed_claim, signed_claims):
+            if check and not check(
+                getattr(self, claim_name), signed_claim, signed_claims
+            ):
                 raise InvalidPublisherError(
                     f"Check failed for required claim {claim_name!r}"
                 )
@@ -209,7 +211,9 @@ class OIDCPublisherMixin:
             # required for a given publisher.
             signed_claim = signed_claims.get(claim_name)
 
-            if not check(getattr(self, claim_name), signed_claim, signed_claims):
+            if check and not check(
+                getattr(self, claim_name), signed_claim, signed_claims
+            ):
                 raise InvalidPublisherError(
                     f"Check failed for optional claim {claim_name!r}"
                 )

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 from sqlalchemy import ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Query, mapped_column
@@ -18,6 +20,7 @@ from sqlalchemy.sql.expression import func, literal
 from warehouse.oidc.errors import InvalidPublisherError
 from warehouse.oidc.interfaces import SignedClaims
 from warehouse.oidc.models._core import (
+    CheckClaimCallable,
     OIDCPublisher,
     PendingOIDCPublisher,
     check_claim_binary,
@@ -100,7 +103,7 @@ class GitHubPublisherMixin:
     workflow_filename = mapped_column(String, nullable=False)
     environment = mapped_column(String, nullable=True)
 
-    __required_verifiable_claims__ = {
+    __required_verifiable_claims__: dict[str, CheckClaimCallable[Any] | None] = {
         "sub": _check_sub,
         "ref": None,  # We only want to ensure it is present
         "repository": check_claim_binary(str.__eq__),
@@ -109,7 +112,7 @@ class GitHubPublisherMixin:
         "job_workflow_ref": _check_job_workflow_ref,
     }
 
-    __optional_verifiable_claims__ = {
+    __optional_verifiable_claims__: dict[str, CheckClaimCallable[Any] | None] = {
         "environment": _check_environment,
     }
 

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -23,6 +23,8 @@ from warehouse.oidc.models._core import (
     check_claim_binary,
 )
 
+unpredictable = object()
+
 
 def _check_job_workflow_ref(ground_truth, signed_claim, all_signed_claims):
     # We expect a string formatted as follows:
@@ -100,6 +102,7 @@ class GitHubPublisherMixin:
 
     __required_verifiable_claims__ = {
         "sub": _check_sub,
+        "ref": None,  # We only want to ensure it is present
         "repository": check_claim_binary(str.__eq__),
         "repository_owner": check_claim_binary(str.__eq__),
         "repository_owner_id": check_claim_binary(str.__eq__),
@@ -114,7 +117,6 @@ class GitHubPublisherMixin:
         "actor",
         "actor_id",
         "jti",
-        "ref",
         "sha",
         "run_id",
         "run_number",
@@ -204,6 +206,10 @@ class GitHubPublisherMixin:
     @property
     def sub(self):
         return f"repo:{self.repository}"
+
+    @property
+    def ref(self):
+        return unpredictable
 
     def publisher_url(self, claims=None):
         base = f"https://github.com/{self.repository}"

--- a/warehouse/oidc/models/google.py
+++ b/warehouse/oidc/models/google.py
@@ -51,12 +51,12 @@ class GooglePublisherMixin:
     email = mapped_column(String, nullable=False)
     sub = mapped_column(String, nullable=True)
 
-    __required_verifiable_claims__: dict[str, CheckClaimCallable[Any]] = {
+    __required_verifiable_claims__: dict[str, CheckClaimCallable[Any] | None] = {
         "email": check_claim_binary(str.__eq__),
         "email_verified": check_claim_invariant(True),
     }
 
-    __optional_verifiable_claims__: dict[str, CheckClaimCallable[Any]] = {
+    __optional_verifiable_claims__: dict[str, CheckClaimCallable[Any] | None] = {
         "sub": _check_sub
     }
 


### PR DESCRIPTION
We implicitly require this via the `_job_workflow_ref` claim check, but this PR makes it explicit that this claim is required.

Since we can't predict what the value of this will be, and thus can't verify the value against anything we know, this PR modifies the mechanics a bit to permit specifying required claims that have no check function.

This PR also changes the OIDC token validation flow a bit, to first check for the presence of all required claims, and then check for the validity of all required claims, rather than checking both back to back, per claim.

Tokens missing this claim will error with now error with "Missing claim 'ref'" and we'll get a Sentry notification as well.