### PR TITLE
OIDC: Handle empty string `ref`

### DIFF
--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -264,18 +264,11 @@ class TestGitHubPublisher:
                 True,
                 None,
             ),
-            # bad: workflow name, empty or missing ref
-            (
-                "foo/bar/.github/workflows/baz.yml@emptyref",
-                "",
-                False,
-                "The ref claim is empty",
-            ),
             (
                 "foo/bar/.github/workflows/baz.yml@missingref",
                 None,
                 False,
-                "The ref claim is empty",
+                "The ref claim is missing",
             ),
             # bad: workflow name with various attempted impersonations
             (

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -38,8 +38,8 @@ def _check_job_workflow_ref(ground_truth, signed_claim, all_signed_claims):
         raise InvalidPublisherError("The job_workflow_ref claim is empty")
 
     ref = all_signed_claims.get("ref")
-    if not ref:
-        raise InvalidPublisherError("The ref claim is empty")
+    if ref is None:
+        raise InvalidPublisherError("The ref claim is missing")
 
     if not (expected := f"{ground_truth}@{ref}") == signed_claim:
         raise InvalidPublisherError(


### PR DESCRIPTION
Looks like the cause of the issues we're seeing are due to the `ref` claim being an empty string, which is unexpected and undocumented AFAICT.

To help determine the cause, and how we should validate tokens that have empty `ref` claims, we'll let the empty string validate and log the full claim set to Sentry when the `ref` claim is an empty string. This check will likely still fail when we try to validate the value of `job_workflow_ref` claim, but will give us some additional details for this edge case.