### PR TITLE
OIDC: Allow SHA in `job_workflow_ref` claim.

### DIFF
--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -41,13 +41,15 @@ class TestGitHubPublisher:
 
     def test_github_publisher_all_known_claims(self):
         assert github.GitHubPublisher.all_known_claims() == {
-            # verifiable claims
+            # required verifiable claims
             "sub",
-            "ref",
             "repository",
             "repository_owner",
             "repository_owner_id",
             "job_workflow_ref",
+            # required unverifiable claims
+            "ref",
+            "sha",
             # optional verifiable claims
             "environment",
             # preverified claims
@@ -60,7 +62,6 @@ class TestGitHubPublisher:
             "actor",
             "actor_id",
             "jti",
-            "sha",
             "run_id",
             "run_number",
             "run_attempt",

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -113,7 +113,7 @@ class GitHubPublisherMixin:
         "job_workflow_ref": _check_job_workflow_ref,
     }
 
-    __required_unverifiable_claims__: set[str] = {"ref"}
+    __required_unverifiable_claims__: set[str] = {"ref", "sha"}
 
     __optional_verifiable_claims__: dict[str, CheckClaimCallable[Any]] = {
         "environment": _check_environment,
@@ -123,7 +123,6 @@ class GitHubPublisherMixin:
         "actor",
         "actor_id",
         "jti",
-        "sha",
         "run_id",
         "run_number",
         "run_attempt",

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -12,8 +12,6 @@
 
 from typing import Any
 
-import sentry_sdk
-
 from sqlalchemy import ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Query, mapped_column
@@ -39,21 +37,17 @@ def _check_job_workflow_ref(ground_truth, signed_claim, all_signed_claims):
     if not signed_claim:
         raise InvalidPublisherError("The job_workflow_ref claim is empty")
 
+    # We need at least one of these to be non-empty
     ref = all_signed_claims.get("ref")
-    if ref is None:
-        raise InvalidPublisherError("The ref claim is missing")
+    sha = all_signed_claims.get("sha")
+    if not (ref or sha):
+        raise InvalidPublisherError("The ref and sha claims are empty")
 
-    if ref == "":
-        with sentry_sdk.push_scope() as scope:
-            scope.fingerprint = all_signed_claims["sub"]
-            sentry_sdk.capture_message(
-                "GitHub JWT has empty-string ref claim, other claims are: "
-                f"{all_signed_claims}"
-            )
-
-    if not (expected := f"{ground_truth}@{ref}") == signed_claim:
+    expected = {f"{ground_truth}@{_ref}" for _ref in [ref, sha] if _ref}
+    if signed_claim not in expected:
         raise InvalidPublisherError(
-            f"The claim does not match, expecting {expected!r}, got {signed_claim!r}"
+            f"The claim does not match, expecting one of {sorted(expected)!r}, got "
+            f"{signed_claim!r}"
         )
 
     return True


### PR DESCRIPTION
Resolves https://github.com/pypa/gh-action-pypi-publish/issues/173.

Sometimes we receive an OIDC token where the `ref` claim is an empty string and the `job_workflow_ref` claim takes the form `{owner}/{repo}/.github/workflows/{filename}@{sha}` rather than `{owner}/{repo}/.github/workflows/{filename}@{ref}`. It's currently unclear why/when this happens.

Since the `job_workflow_ref` claim can still be considered valid if it contains the SHA, we can expand our validation of it to check for the form containing the SHA.

This PR also makes the `sha` claim a required unverifiable claim, and removes the Sentry message introduced in #14333.