### PR TITLE
OIDC: Allow SHA in `job_workflow_ref` claim, redux.

### DIFF
--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -190,6 +190,7 @@ class TestGitHubPublisher:
             for claim_name in github.GitHubPublisher.__required_verifiable_claims__
         }
         signed_claims["ref"] = "ref"
+        signed_claims["sha"] = "sha"
         signed_claims["job_workflow_ref"] = publisher.job_workflow_ref + "@ref"
         assert publisher.__required_verifiable_claims__
         with pytest.raises(errors.InvalidPublisherError) as e:

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -46,7 +46,7 @@ def _check_job_workflow_ref(ground_truth, signed_claim, all_signed_claims):
     expected = {f"{ground_truth}@{_ref}" for _ref in [ref, sha] if _ref}
     if signed_claim not in expected:
         raise InvalidPublisherError(
-            "The job_workflow_ref claim does not match, expecting one of"
+            "The job_workflow_ref claim does not match, expecting one of "
             f"{sorted(expected)!r}, got {signed_claim!r}"
         )
 


### PR DESCRIPTION
Fixes for #14335 which was unintentionally merged.