### PR TITLE
Resolve issue with sqlalchemy mapper

### DIFF
--- a/warehouse/integrations/vulnerabilities/models.py
+++ b/warehouse/integrations/vulnerabilities/models.py
@@ -10,14 +10,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
+
+from typing import TYPE_CHECKING
 
 from sqlalchemy import ForeignKey, ForeignKeyConstraint, String, orm
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import Mapped, mapped_column
 
 from warehouse import db
-from warehouse.packaging.models import Release
+
+if TYPE_CHECKING:
+    from warehouse.packaging.models import Release
 
 
 class ReleaseVulnerability(db.ModelBase):

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -49,6 +49,7 @@ from warehouse import db
 from warehouse.accounts.models import User
 from warehouse.classifiers.models import Classifier
 from warehouse.events.models import HasEvents
+from warehouse.integrations.vulnerabilities.models import VulnerabilityRecord
 from warehouse.organizations.models import (
     Organization,
     OrganizationProject,
@@ -520,7 +521,7 @@ class Release(db.Model):
     )
 
     vulnerabilities = orm.relationship(
-        "VulnerabilityRecord",
+        VulnerabilityRecord,
         back_populates="releases",
         secondary="release_vulnerabilities",
         passive_deletes=True,


### PR DESCRIPTION
This resolves an issue with running a subset of our test suite, introduced with the new sqlalchemy declarative API, where the `Release` model was being imported but `ReleaseVulnerability` and `VulnerabilityRecord` were not, causing the sqlalchemy mapper to fail:

```
sqlalchemy.exc.InvalidRequestError: One or more mappers failed to initialize -
can't proceed with initialization of other mappers. Triggering mapper:
'Mapper[Release(releases)]'. Original exception was: When initializing mapper
Mapper[Release(releases)], expression 'release_vulnerabilities' failed to
locate a name ("name 'release_vulnerabilities' is not defined"). If this is a
class name, consider adding this relationship() to the <class
'warehouse.packaging.models.Release'> class after both dependent classes have
been defined
```

As a workaround, we ensure that the vulnerability models are always imported when `Release` is imported, and do some typing magic to work around the circular dependency that would otherwise exist.