### PR TITLE
refactor: replace release_classifiers with ORM

### DIFF
--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -42,8 +42,8 @@ from warehouse.packaging.models import (
     JournalEntry,
     Project,
     Release,
+    ReleaseClassifiers,
     Role,
-    release_classifiers,
 )
 from warehouse.rate_limiting import IRateLimiter
 
@@ -514,8 +514,8 @@ def browse(request, classifiers: list[StrictStr]):
     )
 
     release_classifiers_q = (
-        select(release_classifiers)
-        .where(release_classifiers.c.trove_id == classifiers_q.c.id)
+        select(ReleaseClassifiers)
+        .where(ReleaseClassifiers.trove_id == classifiers_q.c.id)
         .alias("rc")
     )
 

--- a/warehouse/migrations/versions/a0ae1f9388e4_add_primary_key_to_release_classifiers.py
+++ b/warehouse/migrations/versions/a0ae1f9388e4_add_primary_key_to_release_classifiers.py
@@ -1,0 +1,46 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add Primary Key to release_classifiers
+
+Revision ID: a0ae1f9388e4
+Revises: 7f6bed4f4345
+Create Date: 2023-08-17 12:53:40.995825
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "a0ae1f9388e4"
+down_revision = "7f6bed4f4345"
+
+
+def upgrade():
+    op.execute("SET statement_timeout = 61000")  # 61s
+    op.execute("SET lock_timeout = 60000")  # 60s
+
+    op.alter_column(
+        "release_classifiers", "trove_id", existing_type=sa.INTEGER(), nullable=False
+    )
+    op.create_primary_key(
+        "release_classifiers_pkey", "release_classifiers", ["trove_id", "release_id"]
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "release_classifiers_pkey", "release_classifiers", type_="primary"
+    )
+    op.alter_column(
+        "release_classifiers", "trove_id", existing_type=sa.INTEGER(), nullable=True
+    )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -24,7 +24,6 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     DateTime,
     Enum,
     FetchedValue,
@@ -32,7 +31,6 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
-    Table,
     Text,
     UniqueConstraint,
     func,
@@ -484,7 +482,7 @@ class Release(db.Model):
     _classifiers = orm.relationship(
         Classifier,
         backref="project_releases",
-        secondary=lambda: release_classifiers,  # type: ignore
+        secondary="release_classifiers",
         order_by=Classifier.ordering,
         passive_deletes=True,
     )
@@ -718,19 +716,23 @@ class Filename(db.ModelBase):
     filename = mapped_column(Text, unique=True, nullable=False)
 
 
-# TODO: Convert to Declarative API
-release_classifiers = Table(
-    "release_classifiers",
-    db.metadata,
-    Column(
-        "release_id",
+class ReleaseClassifiers(db.ModelBase):
+    __tablename__ = "release_classifiers"
+    __table_args__ = (
+        Index("rel_class_trove_id_idx", "trove_id"),
+        Index("rel_class_release_id_idx", "release_id"),
+    )
+
+    trove_id = mapped_column(
+        Integer,
+        ForeignKey("trove_classifiers.id"),
+        primary_key=True,
+    )
+    release_id = mapped_column(
+        UUID,
         ForeignKey("releases.id", onupdate="CASCADE", ondelete="CASCADE"),
-        nullable=False,
-    ),
-    Column("trove_id", Integer(), ForeignKey("trove_classifiers.id")),
-    Index("rel_class_trove_id_idx", "trove_id"),
-    Index("rel_class_release_id_idx", "release_id"),
-)
+        primary_key=True,
+    )
 
 
 class JournalEntry(db.ModelBase):

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -31,7 +31,7 @@ from warehouse.packaging.models import (
     Description,
     Project,
     Release,
-    release_classifiers,
+    ReleaseClassifiers,
 )
 from warehouse.packaging.search import Project as ProjectDocument
 from warehouse.search.utils import get_index
@@ -58,9 +58,9 @@ def _project_docs(db, project_name=None):
 
     classifiers = (
         select(func.array_agg(Classifier.classifier))
-        .select_from(release_classifiers)
-        .join(Classifier, Classifier.id == release_classifiers.c.trove_id)
-        .filter(Release.id == release_classifiers.c.release_id)
+        .select_from(ReleaseClassifiers)
+        .join(Classifier, Classifier.id == ReleaseClassifiers.trove_id)
+        .filter(Release.id == ReleaseClassifiers.release_id)
         .correlate(Release)
         .scalar_subquery()
         .label("classifiers")

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -57,7 +57,7 @@ from warehouse.packaging.models import (
     Project,
     ProjectFactory,
     Release,
-    release_classifiers,
+    ReleaseClassifiers,
 )
 from warehouse.search.queries import SEARCH_FILTER_ORDER, get_es_query
 from warehouse.utils.http import is_safe_url
@@ -338,8 +338,8 @@ def search(request):
         request.db.query(Classifier)
         .with_entities(Classifier.classifier)
         .filter(
-            exists(release_classifiers.c.trove_id).where(
-                release_classifiers.c.trove_id == Classifier.id
+            exists(ReleaseClassifiers.trove_id).where(
+                ReleaseClassifiers.trove_id == Classifier.id
             ),
             Classifier.classifier.notin_(deprecated_classifiers.keys()),
         )


### PR DESCRIPTION
Previously table had duplicates and no primary key. We removed the duplicates in #14373 and can now set a primary key.

The migration removes the nullability of `trove_id` (and there are no nulls), and adds the primary key to the table.

Resolves #14264