### PR TITLE
Check for disabled/frozen users when authorizing via macaroons

### DIFF
--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -131,7 +131,7 @@ class TestMacaroonSecurityPolicy:
         assert add_vary_cb.calls == [pretend.call("Authorization")]
         assert request.add_response_callback.calls == [pretend.call(vary_cb)]
 
-    def test_identity_frozen_user(self, monkeypatch):
+    def test_identity_disabled_user(self, monkeypatch):
         policy = security_policy.MacaroonSecurityPolicy()
 
         vary_cb = pretend.stub()


### PR DESCRIPTION
I noticed some frozen malware uploaders were still able to get things shipped via API tokens (Macaroons) minted before being frozen.

Tracked it down to not checking is_frozen via is_disabled in the MacroonSecurityPolicy.

I'm not _that_ happy we have to duplicate this check across files... so I'm not that committed to this as a fix.