### PR TITLE
feat: nudge users to 2fa after email verification

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -2168,7 +2168,9 @@ class TestVerifyEmail:
         assert user.is_active
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/"
-        assert db_request.route_path.calls == [pretend.call("manage.account")]
+        assert db_request.route_path.calls == [
+            pretend.call("manage.account.two-factor")
+        ]
         assert token_service.loads.calls == [pretend.call("RANDOM_KEY")]
         assert email_limiter.clear.calls == [pretend.call(db_request.remote_addr)]
         assert verify_limiter.clear.calls == [pretend.call(user.id)]

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -874,6 +874,11 @@ def verify_email(request):
         ),
         queue="success",
     )
+
+    # If they've already set up a 2FA app, send them to their account page.
+    if request.user.has_two_factor:
+        return HTTPSeeOther(request.route_path("manage.account"))
+    # Otherwise, send them to the two-factor setup page.
     return HTTPSeeOther(request.route_path("manage.account.two-factor"))
 
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -874,7 +874,7 @@ def verify_email(request):
         ),
         queue="success",
     )
-    return HTTPSeeOther(request.route_path("manage.account"))
+    return HTTPSeeOther(request.route_path("manage.account.two-factor"))
 
 
 def _get_two_factor_data(request, _redirect_to="/"):

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -166,7 +166,7 @@ msgid "Invalid token: request a new password reset link"
 msgstr ""
 
 #: warehouse/accounts/views.py:727 warehouse/accounts/views.py:829
-#: warehouse/accounts/views.py:928 warehouse/accounts/views.py:1097
+#: warehouse/accounts/views.py:933 warehouse/accounts/views.py:1102
 msgid "Invalid token: no token supplied"
 msgstr ""
 
@@ -224,111 +224,111 @@ msgstr ""
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:924
+#: warehouse/accounts/views.py:929
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:926
+#: warehouse/accounts/views.py:931
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:932
+#: warehouse/accounts/views.py:937
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:936
+#: warehouse/accounts/views.py:941
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:945
+#: warehouse/accounts/views.py:950
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:996
+#: warehouse/accounts/views.py:1001
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1059
+#: warehouse/accounts/views.py:1064
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1093
+#: warehouse/accounts/views.py:1098
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1095
+#: warehouse/accounts/views.py:1100
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1101
+#: warehouse/accounts/views.py:1106
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1105
+#: warehouse/accounts/views.py:1110
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1120
+#: warehouse/accounts/views.py:1125
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1151
+#: warehouse/accounts/views.py:1156
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1217
+#: warehouse/accounts/views.py:1222
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1438 warehouse/accounts/views.py:1586
+#: warehouse/accounts/views.py:1443 warehouse/accounts/views.py:1591
 #: warehouse/manage/views/__init__.py:1230
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1455 warehouse/manage/views/__init__.py:1246
+#: warehouse/accounts/views.py:1460 warehouse/manage/views/__init__.py:1246
 msgid ""
 "GitHub-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1469
+#: warehouse/accounts/views.py:1474
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1482
+#: warehouse/accounts/views.py:1487
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1498 warehouse/manage/views/__init__.py:1265
+#: warehouse/accounts/views.py:1503 warehouse/manage/views/__init__.py:1265
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1512 warehouse/manage/views/__init__.py:1279
+#: warehouse/accounts/views.py:1517 warehouse/manage/views/__init__.py:1279
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1531
+#: warehouse/accounts/views.py:1536
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1566
+#: warehouse/accounts/views.py:1571
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1600 warehouse/accounts/views.py:1613
-#: warehouse/accounts/views.py:1620
+#: warehouse/accounts/views.py:1605 warehouse/accounts/views.py:1618
+#: warehouse/accounts/views.py:1625
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1626
+#: warehouse/accounts/views.py:1631
 msgid "Removed trusted publisher for project "
 msgstr ""
 

--- a/warehouse/templates/includes/session-notifications.html
+++ b/warehouse/templates/includes/session-notifications.html
@@ -30,7 +30,7 @@
       </a>
     </span>
   </div>
-  {% elif not request.user.has_two_factor %}
+  {% elif not request.referrer.endswith('/account/two-factor/') and not request.user.has_two_factor %}
   <div class="notification-bar notification-bar--dismissable" data-controller="notification" data-notification-target="notification">
     <span class="notification-bar__message">
       {% trans href=request.route_path('manage.account.two-factor') %}

--- a/warehouse/templates/includes/session-notifications.html
+++ b/warehouse/templates/includes/session-notifications.html
@@ -30,7 +30,7 @@
       </a>
     </span>
   </div>
-  {% elif not request.referrer.endswith('/account/two-factor/') and not request.user.has_two_factor %}
+  {% elif not request.referrer.endswith(request.route_path('manage.account.two-factor')) and not request.user.has_two_factor %}
   <div class="notification-bar notification-bar--dismissable" data-controller="notification" data-notification-target="notification">
     <span class="notification-bar__message">
       {% trans href=request.route_path('manage.account.two-factor') %}
@@ -39,7 +39,7 @@
     </span>
     <button type="button" title="Dismiss this notification" data-notification-target="dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
   </div>
-  {% elif not request.user.has_recovery_codes %}
+  {% elif not request.referrer.endswith(request.route_path('manage.account.two-factor')) and not request.user.has_recovery_codes %}
   <div class="notification-bar notification-bar--warning">
     <span class="notification-bar__message">
       {% trans href=request.route_path('manage.account.two-factor') %}


### PR DESCRIPTION
Prior to this change, after a user has registered, and verified their email address, they end up on their own account management page. If they try to take any non-account actions, they get a red bar telling them to set up 2FA.

Since we will already show users a blue notice that they _can_ set up 2FA, why not send them there immediately after confirming their email to complete the task.

The template change is to prevent adding the blue bar at the top of the session, since they are already on the right page. We can deduce that from the `Referrer` header.

Follows #14294