### PR TITLE
Add `pytest-icdiff` for better assertion diffing

### DIFF
--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -3,6 +3,7 @@ factory_boy
 freezegun
 pretend
 pytest>=3.0.0
+pytest-icdiff
 pytest-postgresql>=3.1.3,<6.0.0
 pytest-socket
 pytz

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -155,6 +155,9 @@ freezegun==1.2.2 \
     --hash=sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446 \
     --hash=sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f
     # via -r requirements/tests.in
+icdiff==2.0.6 \
+    --hash=sha256:a2673b335d671e64fc73c44e1eaa0aa01fd0e68354e58ee17e863ab29912a79a
+    # via pytest-icdiff
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
@@ -179,6 +182,10 @@ port-for==0.7.1 \
     --hash=sha256:8abdaa1a7810281b0cecf718a6319da5f8538fdae3a5101d1e9afd54da0baf8c \
     --hash=sha256:e0f3b8d7ec8bdc388c14d88bdbab8d6441c8081ed2bdec7847b38ca6d1563f23
     # via pytest-postgresql
+pprintpp==0.4.0 \
+    --hash=sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d \
+    --hash=sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403
+    # via pytest-icdiff
 pretend==1.0.9 \
     --hash=sha256:c90eb810cde8ebb06dafcb8796f9a95228ce796531bc806e794c2f4649aa1b10 \
     --hash=sha256:e389b12b7073604be67845dbe32bf8297360ad9a609b24846fe15d86e0b7dc01
@@ -208,8 +215,12 @@ pytest==7.4.0 \
     --hash=sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a
     # via
     #   -r requirements/tests.in
+    #   pytest-icdiff
     #   pytest-postgresql
     #   pytest-socket
+pytest-icdiff==0.6 \
+    --hash=sha256:e8f1ef4550a893b4f0a0ea7e7a8299b12ded72c086101d7811ddec0d85fd1bad
+    # via -r requirements/tests.in
 pytest-postgresql==5.0.0 \
     --hash=sha256:22edcbafab8995ee85b8d948ddfaad4f70c2c7462303d7477ecd2f77fc9d15bd \
     --hash=sha256:6e8f0773b57c9b8975b6392c241b7b81b7018f32079a533f368f2fbda732ecd3


### PR DESCRIPTION
We have a lot of assertions in our tests that compare two large dictionaries, and `pytest` doesn't natively diff dictionaries in a way that's easy to find the difference. This PR introduces https://pypi.org/project/pytest-icdiff/ as a default pytest plugin, to provide more rich diffs of dicts:

![image](https://github.com/pypi/warehouse/assets/294415/7a4709b8-7d25-4c94-befa-7af4f68ffcb3)
