### PR TITLE
More OIDC metrics

### DIFF
--- a/tests/unit/oidc/test_tasks.py
+++ b/tests/unit/oidc/test_tasks.py
@@ -109,5 +109,5 @@ def test_compute_oidc_metrics(db_request, metrics):
             "warehouse.oidc.total_critical_projects_published_with_oidc_publishers", 1
         ),
         pretend.call("warehouse.oidc.total_files_published_with_oidc_publishers", 2),
-        pretend.call("warehouse.oidc.github_oidc_publishers.publishers", 4),
+        pretend.call("warehouse.oidc.publishers", 4, tag="github_oidc_publishers"),
     ]

--- a/tests/unit/oidc/test_tasks.py
+++ b/tests/unit/oidc/test_tasks.py
@@ -108,4 +108,6 @@ def test_compute_oidc_metrics(db_request, metrics):
         pretend.call(
             "warehouse.oidc.total_critical_projects_published_with_oidc_publishers", 1
         ),
+        pretend.call("warehouse.oidc.total_files_published_with_oidc_publishers", 2),
+        pretend.call("warehouse.oidc.github_oidc_publishers.publishers", 4),
     ]

--- a/warehouse/oidc/tasks.py
+++ b/warehouse/oidc/tasks.py
@@ -71,8 +71,9 @@ def compute_oidc_metrics(request):
     for t in request.db.query(OIDCPublisher.discriminator).distinct().all():
         discriminator = t[0]
         metrics.gauge(
-            f"warehouse.oidc.{discriminator}.publishers",
+            "warehouse.oidc.publishers",
             request.db.query(OIDCPublisher)
             .where(OIDCPublisher.discriminator == discriminator)
             .count(),
+            tag=discriminator,
         )

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -57,6 +57,21 @@ def sync_file_to_cache(request, file_id):
 
 
 @tasks.task(ignore_result=True, acks_late=True)
+def compute_packaging_metrics(request):
+    metrics = request.find_service(IMetricsService, context=None)
+
+    metrics.gauge(
+        "warehouse.packaging.total_projects", request.db.query(Project).count()
+    )
+
+    metrics.gauge(
+        "warehouse.packaging.total_releases", request.db.query(Release).count()
+    )
+
+    metrics.gauge("warehouse.packaging.total_files", request.db.query(File).count())
+
+
+@tasks.task(ignore_result=True, acks_late=True)
 def check_file_cache_tasks_outstanding(request):
     metrics = request.find_service(IMetricsService, context=None)
 

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -21,6 +21,7 @@ import pip_api
 
 from google.cloud.bigquery import LoadJobConfig
 from packaging.utils import canonicalize_name
+from sqlalchemy import func
 from sqlalchemy.orm import joinedload
 
 from warehouse import tasks
@@ -61,14 +62,18 @@ def compute_packaging_metrics(request):
     metrics = request.find_service(IMetricsService, context=None)
 
     metrics.gauge(
-        "warehouse.packaging.total_projects", request.db.query(Project).count()
+        "warehouse.packaging.total_projects",
+        request.db.query(func.count(Project.id)).scalar(),
     )
 
     metrics.gauge(
-        "warehouse.packaging.total_releases", request.db.query(Release).count()
+        "warehouse.packaging.total_releases",
+        request.db.query(func.count(Release.id)).scalar(),
     )
 
-    metrics.gauge("warehouse.packaging.total_files", request.db.query(File).count())
+    metrics.gauge(
+        "warehouse.packaging.total_files", request.db.query(func.count(File)).scalar()
+    )
 
 
 @tasks.task(ignore_result=True, acks_late=True)


### PR DESCRIPTION
This adds some additional OIDC metrics: total # of files published via OIDC, and number of publishers per publisher type.

This also adds some basic stats on the total number of projects, releases and files so we can calculate percentages easily.