### PR TITLE
chore(dev): update maildev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,7 @@ services:
       - caches:/opt/warehouse/src/.stylelintcache
 
   maildev:
-    image: maildev/maildev:2.0.2
+    image: maildev/maildev:2.1.0
     ports:
       - "1080:1080"
       - "1025:1025"


### PR DESCRIPTION
A number of releases since, found when trying to test an email template at different screen sizes.

Releases:
- https://github.com/maildev/maildev/releases/tag/v2.0.4
- https://github.com/maildev/maildev/releases/tag/v2.0.5
- https://github.com/maildev/maildev/releases/tag/v2.1.0