### PR TITLE
feat: emit metrics on email schedule

### DIFF
--- a/docs/dev/development/email.rst
+++ b/docs/dev/development/email.rst
@@ -40,6 +40,8 @@ Calling a function with the ``_email`` decorator does the following:
   response
 - A security log is added to the user's account
 - The email is sent using Amazon SES (on production environment)
+- A metric is sent to Datadog named `warehouse.emails.scheduled` with the tags
+  ``template_name``, ``allow_unverified``, and ``repeat_window``.
 
 Testing e-mails
 ---------------

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -808,6 +808,7 @@ class TestSendPasswordResetEmail:
         pyramid_request,
         pyramid_config,
         token_service,
+        metrics,
         monkeypatch,
     ):
         stub_user = pretend.stub(
@@ -903,6 +904,16 @@ class TestSendPasswordResetEmail:
                         "redact_ip": False,
                     },
                 },
+            )
+        ]
+        assert metrics.increment.calls == [
+            pretend.call(
+                "warehouse.emails.scheduled",
+                tags=[
+                    "template_name:password-reset",
+                    "allow_unverified:True",
+                    "repeat_window:none",
+                ],
             )
         ]
 
@@ -1376,7 +1387,7 @@ class TestPasswordCompromisedEmail:
 class TestBasicAuthWith2FAEmail:
     @pytest.mark.parametrize("verified", [True, False])
     def test_basic_auth_with_2fa_email(
-        self, pyramid_request, pyramid_config, monkeypatch, verified
+        self, pyramid_request, pyramid_config, monkeypatch, verified, metrics
     ):
         stub_user = pretend.stub(
             id="id",
@@ -1441,6 +1452,16 @@ class TestBasicAuthWith2FAEmail:
                         "redact_ip": False,
                     },
                 },
+            )
+        ]
+        assert metrics.increment.calls == [
+            pretend.call(
+                "warehouse.emails.scheduled",
+                tags=[
+                    "template_name:basic-auth-with-2fa",
+                    "allow_unverified:True",
+                    "repeat_window:86400.0",
+                ],
             )
         ]
 
@@ -1517,7 +1538,9 @@ class TestGPGSignatureUploadedEmail:
 
 
 class TestAccountDeletionEmail:
-    def test_account_deletion_email(self, pyramid_request, pyramid_config, monkeypatch):
+    def test_account_deletion_email(
+        self, pyramid_request, pyramid_config, metrics, monkeypatch
+    ):
         stub_user = pretend.stub(
             id="id",
             username="username",
@@ -1582,6 +1605,17 @@ class TestAccountDeletionEmail:
                         "redact_ip": False,
                     },
                 },
+            )
+        ]
+
+        assert metrics.increment.calls == [
+            pretend.call(
+                "warehouse.emails.scheduled",
+                tags=[
+                    "template_name:account-deleted",
+                    "allow_unverified:False",
+                    "repeat_window:none",
+                ],
             )
         ]
 

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -197,7 +197,9 @@ def _email(
                     tags=[
                         f"template_name:{name}",
                         f"allow_unverified:{allow_unverified}",
-                        f"repeat_window:{repeat_window}",
+                        f"repeat_window:{repeat_window.total_seconds()}"
+                        if repeat_window
+                        else "repeat_window:none",
                     ],
                 )
 

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -30,6 +30,7 @@ from warehouse.email.interfaces import IEmailSender
 from warehouse.email.services import EmailMessage
 from warehouse.email.ses.tasks import cleanup as ses_cleanup
 from warehouse.events.tags import EventTag
+from warehouse.metrics.interfaces import IMetricsService
 
 
 def _compute_recipient(user, email):
@@ -189,6 +190,15 @@ def _email(
                     email=email,
                     allow_unverified=allow_unverified,
                     repeat_window=repeat_window,
+                )
+                metrics = request.find_service(IMetricsService, context=None)
+                metrics.increment(
+                    "warehouse.emails.scheduled",
+                    tags=[
+                        f"template_name:{name}",
+                        f"allow_unverified:{allow_unverified}",
+                        f"repeat_window:{repeat_window}",
+                    ],
                 )
 
             return context


### PR DESCRIPTION
As a way for us to gain more visibility into which email templates are being sent and when, add a metrics emitter at the last place we know about the template name.