### PR TITLE
feat: add email for 2fa not yet enabled on upload

### DIFF
--- a/tests/common/db/accounts.py
+++ b/tests/common/db/accounts.py
@@ -38,6 +38,7 @@ class UserFactory(WarehouseFactory):
     last_login = factory.Faker(
         "date_time_between_dates", datetime_start=datetime.datetime(2011, 1, 1)
     )
+    totp_secret = factory.Faker("binary", length=20)
 
 
 class UserEventFactory(WarehouseFactory):

--- a/tests/unit/accounts/test_models.py
+++ b/tests/unit/accounts/test_models.py
@@ -235,7 +235,7 @@ class TestUser:
         ],
     )
     def test_has_single_2fa(self, db_session, has_totp, count_webauthn, expected):
-        user = DBUserFactory.create()
+        user = DBUserFactory.create(totp_secret=None)
         if has_totp:
             user.totp_secret = b"secret"
         for i in range(count_webauthn):

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -536,14 +536,14 @@ class TestDatabaseUserService:
         assert user_service.is_disabled(user.id) == (False, None)
 
     def test_has_two_factor(self, user_service):
-        user = UserFactory.create()
+        user = UserFactory.create(totp_secret=None)
         assert not user_service.has_two_factor(user.id)
 
         user_service.update_user(user.id, totp_secret=b"foobar")
         assert user_service.has_two_factor(user.id)
 
     def test_has_totp(self, user_service):
-        user = UserFactory.create()
+        user = UserFactory.create(totp_secret=None)
         assert not user_service.has_totp(user.id)
         user_service.update_user(user.id, totp_secret=b"foobar")
         assert user_service.has_totp(user.id)
@@ -642,7 +642,7 @@ class TestDatabaseUserService:
         ]
 
     def test_check_totp_value_invalid_secret(self, user_service):
-        user = UserFactory.create()
+        user = UserFactory.create(totp_secret=None)
         limiter = pretend.stub(
             hit=pretend.call_recorder(lambda *a, **kw: None), test=lambda *a, **kw: True
         )

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -2141,7 +2141,7 @@ class TestVerifyEmail:
     def test_verify_email(
         self, db_request, user_service, token_service, is_primary, confirm_message
     ):
-        user = UserFactory(is_active=False)
+        user = UserFactory(is_active=False, totp_secret=None)
         email = EmailFactory(user=user, verified=False, primary=is_primary)
         db_request.user = user
         db_request.GET.update({"token": "RANDOM_KEY"})

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -1537,6 +1537,79 @@ class TestGPGSignatureUploadedEmail:
         ]
 
 
+class Test2FAonUploadEmail:
+    def test_send_two_factor_not_yet_enabled_email(
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
+        stub_user = pretend.stub(
+            id="id",
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+            has_2fa=False,
+        )
+        subject_renderer = pyramid_config.testing_add_renderer(
+            "email/two-factor-not-yet-enabled/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            "email/two-factor-not-yet-enabled/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            "email/two-factor-not-yet-enabled/body.html"
+        )
+        html_renderer.string_response = "Email HTML Body"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        pyramid_request.db = pretend.stub(
+            query=lambda a: pretend.stub(
+                filter=lambda *a: pretend.stub(
+                    one=lambda: pretend.stub(user_id=stub_user.id)
+                )
+            ),
+        )
+        pyramid_request.user = stub_user
+        pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
+
+        result = email.send_two_factor_not_yet_enabled_email(
+            pyramid_request,
+            stub_user,
+        )
+
+        assert result == {"username": stub_user.username}
+        assert pyramid_request.task.calls == [pretend.call(send_email)]
+        assert send_email.delay.calls == [
+            pretend.call(
+                f"{stub_user.username} <{stub_user.email}>",
+                {
+                    "subject": "Email Subject",
+                    "body_text": "Email Body",
+                    "body_html": (
+                        "<html>\n<head></head>\n"
+                        "<body><p>Email HTML Body</p></body>\n</html>\n"
+                    ),
+                },
+                {
+                    "tag": "account:email:sent",
+                    "user_id": stub_user.id,
+                    "additional": {
+                        "from_": "noreply@example.com",
+                        "to": stub_user.email,
+                        "subject": "Email Subject",
+                        "redact_ip": False,
+                    },
+                },
+            )
+        ]
+
+
 class TestAccountDeletionEmail:
     def test_account_deletion_email(
         self, pyramid_request, pyramid_config, metrics, monkeypatch

--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -941,7 +941,7 @@ def test_compute_2fa_metrics(db_request, monkeypatch):
     )
 
     # A critical maintainer with two WebAuthn methods enabled
-    third_critical_project_maintainer = UserFactory.create()
+    third_critical_project_maintainer = UserFactory.create(totp_secret=None)
     RoleFactory.create(user=third_critical_project_maintainer, project=critical_project)
     webauthn = WebAuthn(
         user_id=third_critical_project_maintainer.id,

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -345,8 +345,7 @@ def send_basic_auth_with_two_factor_email(request, user, *, project_name):
 @_email(
     "two-factor-not-yet-enabled",
     allow_unverified=True,
-    # may repeat at 15 days due to table cleanup.
-    repeat_window=datetime.timedelta(days=90),
+    repeat_window=datetime.timedelta(days=14),
 )
 def send_two_factor_not_yet_enabled_email(request, user):
     return {"username": user.username}

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -342,6 +342,16 @@ def send_basic_auth_with_two_factor_email(request, user, *, project_name):
     return {"project_name": project_name}
 
 
+@_email(
+    "two-factor-not-yet-enabled",
+    allow_unverified=True,
+    # may repeat at 15 days due to table cleanup.
+    repeat_window=datetime.timedelta(days=90),
+)
+def send_two_factor_not_yet_enabled_email(request, user):
+    return {"username": user.username}
+
+
 @_email("gpg-signature-uploaded", repeat_window=datetime.timedelta(days=1))
 def send_gpg_signature_uploaded_email(request, user, *, project_name):
     return {"project_name": project_name}

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -50,6 +50,7 @@ from warehouse.classifiers.models import Classifier
 from warehouse.email import (
     send_basic_auth_with_two_factor_email,
     send_gpg_signature_uploaded_email,
+    send_two_factor_not_yet_enabled_email,
 )
 from warehouse.errors import BasicAuthTwoFactorEnabled
 from warehouse.events.tags import EventTag
@@ -1492,6 +1493,11 @@ def file_upload(request):
                     "python-version": file_.python_version,
                 },
             )
+
+    # Check if the user has any 2FA methods enabled, and if not, email them.
+    if request.user and not request.user.has_two_factor:
+        warnings.append("Two factor authentication is not enabled for your account.")
+        send_two_factor_not_yet_enabled_email(request, request.user)
 
     request.db.flush()  # flush db now so server default values are populated for celery
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2496,6 +2496,128 @@ msgid ""
 "method to your PyPI account <strong>%(username)s</strong>."
 msgstr ""
 
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:17
+#, python-format
+msgid "Hi %(username)s!"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:19
+#, python-format
+msgid ""
+"Earlier this year, <a href=\"%(blogpost)s\">we announced</a> that PyPI "
+"would require all users to enable a form of two-factor authentication on "
+"their accounts by the end of 2023."
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:26
+msgid ""
+"Keeping your PyPI account secure is important to all of us. We encourage "
+"you to enable two-factor authentication on your PyPI account as soon as "
+"possible."
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:34
+msgid "What forms of 2FA can I use?"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:37
+msgid "We currently offer two main forms of 2FA for your account:"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:42
+#, python-format
+msgid ""
+"<a href=\"%(utfkey)s\">Security device</a> including modern browsers "
+"(preferred) (e.g. Yubikey, Google Titan)"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:48
+#, python-format
+msgid "<a href=\"%(totp)s\">Authentication app</a> (e.g. Google Authenticator)"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:54
+#, python-format
+msgid ""
+"Once one of these secure forms is enabled on your account, you will also "
+"need to use either <a href=\"%(trusted_publishers)s\">Trusted "
+"Publishers</a> (preferred) or <a href=\"%(api_token)s\">API tokens</a> to"
+" upload to PyPI."
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:63
+msgid "What do I do if I lose my 2FA device?"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:66
+msgid ""
+"As part of 2FA enrollment, you will receive one-time use recovery codes. "
+"One of them must be used to confirm receipt before 2FA is fully active. "
+"<strong>Keep these recovery codes safe</strong> - they are equivalent to "
+"your 2FA device. Should you lose access to your 2FA device, use a "
+"recovery code to log in and swap your 2FA to a new device."
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:77
+#, python-format
+msgid "Read more about<a href=\"%(recovery_codes)s\">recovery codes</a>."
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:83
+msgid "Why is PyPI requiring 2FA?"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:86
+msgid ""
+"Keeping all users of PyPI is a shared responsibility we take seriously. "
+"Strong passwords combined with 2FA is a recognized secure practice for "
+"over a decade."
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:93
+msgid ""
+"We are requiring 2FA to protect your account and the packages you upload,"
+" and to protect PyPI itself from malicious actors. The most damaging "
+"attacks are account takeover and malicious package upload."
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:101
+#, python-format
+msgid ""
+"To see this and other security events for your account, visit your <a "
+"href=\"%(account_events)s\">account security history</a>."
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:107
+#, python-format
+msgid "Read more on <a href=\"%(blog_post)s\">this blog post.</a>"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:112
+#, python-format
+msgid ""
+"If you run into problems, read the <a href=\"%(help_page)s\">FAQ "
+"page</a>. If the solutions there are unable to resolve the issue, contact"
+" us via <a href=\"%(support_email)s\">support@pypi.org</a>."
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:119
+msgid "Thanks,"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:121
+msgid "The PyPI Admins (aka Mike, Ee, Dustin, Donald)"
+msgstr ""
+
+#: warehouse/templates/email/two-factor-not-yet-enabled/body.html:127
+#, python-format
+msgid ""
+"You're receiving this email because you have not yet enabled two-factor "
+"authentication on your PyPI account. If you have enabled 2FA and believe "
+"this message is an error, please let us know via <a "
+"href=\"%(support_mail)s\">support@pypi.org</a>."
+msgstr ""
+
 #: warehouse/templates/email/two-factor-removed/body.html:18
 #, python-format
 msgid ""

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2614,7 +2614,7 @@ msgid "Thanks,"
 msgstr ""
 
 #: warehouse/templates/email/two-factor-not-yet-enabled/body.html:121
-msgid "The PyPI Admins (aka Mike, Ee, Dustin, Donald)"
+msgid "The PyPI Admins"
 msgstr ""
 
 #: warehouse/templates/email/two-factor-not-yet-enabled/body.html:127

--- a/warehouse/templates/email/two-factor-not-yet-enabled/body.html
+++ b/warehouse/templates/email/two-factor-not-yet-enabled/body.html
@@ -118,7 +118,7 @@
   <p>
     {% trans %}Thanks,{% endtrans %}
     <br/>
-    {% trans %}The PyPI Admins (aka Mike, Ee, Dustin, Donald){% endtrans %}
+    {% trans %}The PyPI Admins{% endtrans %}
   </p>
 {% endblock %}
 

--- a/warehouse/templates/email/two-factor-not-yet-enabled/body.html
+++ b/warehouse/templates/email/two-factor-not-yet-enabled/body.html
@@ -1,0 +1,135 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+{% block content %}
+  <h1>{% trans username=username %}Hi {{ username }}!{% endtrans %}</h1>
+  <p>
+    {% trans blogpost="https://blog.pypi.org/posts/2023-05-25-securing-pypi-with-2fa/" %}
+      Earlier this year, <a href="{{ blogpost }}">we announced</a>
+      that PyPI would require all users to enable a form of two-factor
+      authentication on their accounts by the end of 2023.
+    {% endtrans %}
+  </p>
+  <p>
+    {% trans %}
+      Keeping your PyPI account secure is important to all of us.
+      We encourage you to enable two-factor authentication
+      on your PyPI account as soon as possible.
+    {% endtrans %}
+  </p>
+
+  <h3>
+    {% trans %}What forms of 2FA can I use?{% endtrans %}
+  </h3>
+  <p>
+    {% trans %}We currently offer two main forms of 2FA for your
+      account:{% endtrans %}
+  </p>
+  <ul>
+    <li>
+      {% trans utfkey="https://pypi.org/help/#utfkey" %}
+        <a href="{{ utfkey }}">Security device</a> including
+        modern browsers (preferred) (e.g. Yubikey, Google Titan)
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans totp="https://pypi.org/help/#totp" %}
+        <a href="{{ totp }}">Authentication app</a> (e.g. Google Authenticator)
+      {% endtrans %}
+    </li>
+  </ul>
+  <p>
+    {% trans trusted_publishers="https://docs.pypi.org/trusted-publishers/", api_token="https://pypi.org/help/#apitoken" %}
+      Once one of these secure forms is enabled on your account,
+      you will also need to use either
+      <a href="{{ trusted_publishers }}">Trusted Publishers</a> (preferred) or
+      <a href="{{ api_token }}">API tokens</a> to upload to PyPI.
+    {% endtrans %}
+  </p>
+
+  <h3>
+    {% trans %}What do I do if I lose my 2FA device?{% endtrans %}
+  </h3>
+  <p>
+    {% trans %}
+      As part of 2FA enrollment, you will receive one-time use recovery codes.
+      One of them must be used to confirm receipt before 2FA is fully active.
+      <strong>Keep these recovery codes safe</strong> - they are equivalent to
+      your 2FA device.
+      Should you lose access to your 2FA device, use a recovery code to log in
+      and
+      swap your 2FA to a new device.
+    {% endtrans %}
+  </p>
+  <p>
+    {% trans recovery_codes="https://pypi.org/help/#recoverycodes" %}
+      Read more about<a href="{{ recovery_codes }}">recovery codes</a>.
+    {% endtrans %}
+  </p>
+
+  <h3>
+    {% trans %}Why is PyPI requiring 2FA?{% endtrans %}
+  </h3>
+  <p>
+    {% trans %}
+      Keeping all users of PyPI is a shared responsibility we take seriously.
+      Strong passwords combined with 2FA is a recognized secure practice for
+      over a decade.
+    {% endtrans %}
+  </p>
+  <p>
+    {% trans %}
+      We are requiring 2FA to protect your account and the packages you upload,
+      and to protect PyPI itself from malicious actors.
+      The most damaging attacks are account takeover and malicious package
+      upload.
+    {% endtrans %}
+  </p>
+  <p>
+    {% trans account_events="https://pypi.org/manage/account/#account-events" %}
+      To see this and other security events for your account,
+      visit your <a href="{{ account_events }}">account security history</a>.
+    {% endtrans %}
+  </p>
+  <p>
+    {% trans blog_post="https://blog.pypi.org/posts/2023-05-25-securing-pypi-with-2fa/#why-now" %}
+      Read more on <a href="{{ blog_post }}">this blog post.</a>
+    {% endtrans %}
+  </p>
+  <p>
+    {% trans help_page="https://pypi.org/help/", support_email="mailto:support@pypi.org" %}
+      If you run into problems, read the <a href="{{ help_page }}">FAQ page</a>.
+      If the solutions there are unable to resolve the issue, contact us via
+      <a href="{{ support_email }}">support@pypi.org</a>.
+    {% endtrans %}
+  </p>
+  <p>
+    {% trans %}Thanks,{% endtrans %}
+    <br/>
+    {% trans %}The PyPI Admins (aka Mike, Ee, Dustin, Donald){% endtrans %}
+  </p>
+{% endblock %}
+
+{% block reason %}
+  <p>
+    {% trans support_mail="mailto:support@pypi.org" %}
+      You're receiving this email because you have not yet enabled two-factor
+      authentication on your PyPI account.
+      If you have enabled 2FA and believe this message is an error,
+      please let us know via
+      <a href="{{ support_mail }}">support@pypi.org</a>.
+    {% endtrans %}
+  </p>
+{% endblock %}

--- a/warehouse/templates/email/two-factor-not-yet-enabled/body.txt
+++ b/warehouse/templates/email/two-factor-not-yet-enabled/body.txt
@@ -100,7 +100,7 @@ If the solutions there are unable to resolve the issue, contact us via support@p
 {% endtrans %}
 
 {% trans %}Thanks,{% endtrans %}
-{% trans %}The PyPI Admins (aka Mike, Ee, Dustin, Donald){% endtrans %}
+{% trans %}The PyPI Admins{% endtrans %}
 {% endblock %}
 
 {% block reason %}

--- a/warehouse/templates/email/two-factor-not-yet-enabled/body.txt
+++ b/warehouse/templates/email/two-factor-not-yet-enabled/body.txt
@@ -1,0 +1,113 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+{% trans username=username %}Hi {{ username }}!{% endtrans %}
+
+{% trans %}
+Earlier this year, we announced
+that PyPI would require all users to enable a form of two-factor
+authentication on their accounts by the end of 2023.
+{% endtrans %}
+{% trans blogpost="https://blog.pypi.org/posts/2023-05-25-securing-pypi-with-2fa/" %}
+Read more: {{ blogpost }}
+{% endtrans %}
+
+
+{% trans %}
+Keeping your PyPI account secure is important to all of us.
+We encourage you to enable two-factor authentication
+on your PyPI account as soon as possible.
+{% endtrans %}
+
+* {% trans %}What forms of 2FA can I use?{% endtrans %}
+
+{% trans %}We currently offer two main forms of 2FA for your account:{% endtrans %}
+{% trans utfkey="https://pypi.org/help/#utfkey" %}
+- Security device including modern browsers (preferred) (e.g. Yubikey, Google Titan) {{ utfkey }}
+{% endtrans %}
+{% trans totp="https://pypi.org/help/#totp" %}
+- Authentication app (e.g. Google Authenticator) {{ totp }}
+{% endtrans %}
+
+{% trans %}
+Once one of these secure forms is enabled on your account,
+to upload to PyPI you will also need to use either:
+{% endtrans %}
+{% trans trusted_publishers="https://docs.pypi.org/trusted-publishers/" %}
+- Trusted Publishers (preferred) {{ trusted_publishers }}
+{% endtrans %}
+{% trans api_token="https://pypi.org/help/#apitoken" %}
+- API tokens {{ api_token }}
+{% endtrans %}
+
+* {% trans %}What do I do if I lose my 2FA device?{% endtrans %}
+
+{% trans %}
+As part of 2FA enrollment, you will receive one-time use recovery codes.
+One of them must be used to confirm receipt before 2FA is fully active.
+
+Keep these recovery codes safe - they are equivalent to
+your 2FA device.
+
+Should you lose access to your 2FA device, use a recovery code to log in
+and swap your 2FA to a new device.
+{% endtrans %}
+{% trans recovery_codes="https://pypi.org/help/#recoverycodes" %}
+Read more about recovery codes: {{ recovery_codes }}
+{% endtrans %}
+
+* {% trans %}Why is PyPI requiring 2FA?{% endtrans %}
+
+{% trans %}
+Keeping all users of PyPI is a shared responsibility we take seriously.
+Strong passwords combined with 2FA is a recognized secure practice for
+over a decade.
+{% endtrans %}
+
+{% trans %}
+We are requiring 2FA to protect your account and the packages you upload,
+and to protect PyPI itself from malicious actors.
+The most damaging attacks are account takeover and malicious package
+upload.
+{% endtrans %}
+
+{% trans account_events="https://pypi.org/manage/account/#account-events" %}
+To see this and other security events for your account,
+visit your account security history at: {{ account_events }}
+{% endtrans %}
+{% trans blog_post="https://blog.pypi.org/posts/2023-05-25-securing-pypi-with-2fa/#why-now" %}
+Read more on this blog post: {{ blog_post }}
+{% endtrans %}
+
+{% trans help_page="https://pypi.org/help/" %}
+If you run into problems, read the FAQ page: {{ help_page }}
+{% endtrans %}
+{% trans %}
+If the solutions there are unable to resolve the issue, contact us via support@pypi.org
+{% endtrans %}
+
+{% trans %}Thanks,{% endtrans %}
+{% trans %}The PyPI Admins (aka Mike, Ee, Dustin, Donald){% endtrans %}
+{% endblock %}
+
+{% block reason %}
+{% trans %}
+You're receiving this email because you have not yet enabled two-factor
+authentication on your PyPI account.
+If you have enabled 2FA and believe this message is an error,
+please let us know via support@pypi.org .
+{% endtrans %}
+{% endblock %}

--- a/warehouse/templates/email/two-factor-not-yet-enabled/subject.txt
+++ b/warehouse/templates/email/two-factor-not-yet-enabled/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}{% trans %}Your PyPI account will soon require 2FA{% endtrans %}{% endblock %}


### PR DESCRIPTION
As a way to create an activity-based campaign, enable the email on file upload.
Use the `repeat_window` to only send the email again within the 14 (or 90 in the event of failure) day window.

Resolves #13761

Includes a test commit refactor to supply `totp_secret` by default.