### PR TITLE
xmlrpc: return client error when excess args are sent

### DIFF
--- a/tests/functional/legacy_api/test_xmlrpc.py
+++ b/tests/functional/legacy_api/test_xmlrpc.py
@@ -39,6 +39,14 @@ def test_invalid_arguments(app_config, webtest):
         webtest.xmlrpc("/pypi", "package_releases")
 
 
+def test_excess_arguments(app_config, webtest):
+    with pytest.raises(
+        xmlrpc.client.Fault,
+        match=r"client error; 1: Unexpected positional argument",
+    ):
+        webtest.xmlrpc("/pypi", "changelog_last_serial", 1)
+
+
 def test_arguments_with_wrong_type(app_config, webtest):
     with pytest.raises(
         xmlrpc.client.Fault,

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -222,7 +222,8 @@ class TypedMapplyViewMapper(MapplyViewMapper):
                         (
                             list(signature(fn).parameters.keys())[e["loc"][0]]
                             if isinstance(e["loc"][0], int)
-                            else e["loc"][0]
+                            and e["loc"][0] < len(signature(fn).parameters.keys())
+                            else str(e["loc"][0])
                         )
                         + ": "
                         + e["msg"]


### PR DESCRIPTION
Fixes [WAREHOUSE-PRODUCTION-1M3](https://python-software-foundation.sentry.io/share/issue/e1c7d5ebac5d4bcab63f1cf224c0a082/)