### PR TITLE
chore: increase worker startup timeout

### DIFF
--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -217,6 +217,7 @@ def includeme(config):
         task_routes={},
         task_serializer="json",
         worker_disable_rate_limits=True,
+        worker_proc_alive_timeout=10.0,
         REDBEAT_REDIS_URL=s["celery.scheduler_url"],
     )
     config.registry["celery.app"].Task = WarehouseTask


### PR DESCRIPTION
With the latest Celery release 5.3.2, the default startup time of 4.0 seconds is no longer fast enough for some of our worker bootups.

This is not a full solution, rather a stopgap to allow workers to thrash less.

Refs: https://python-software-foundation.sentry.io/share/issue/fc01ee336e3045199ea9918e41c0a05e/
Fixes WAREHOUSE-PRODUCTION-1FX
Fixes WAREHOUSE-PRODUCTION-1M4
Fixes WAREHOUSE-PRODUCTION-1M5
Fixes WAREHOUSE-STAGING-MK
Fixes WAREHOUSE-STAGING-MM
Fixes WAREHOUSE-STAGING-N8