### PR TITLE
chore: revert celery and kombu upgrade

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -5,7 +5,7 @@ b2sdk
 Babel
 bcrypt
 boto3
-celery[sqs]>=5.2.2
+celery[sqs]>=5.2.2,<5.3.2
 celery-redbeat
 certifi
 click
@@ -24,7 +24,7 @@ html5lib
 humanize
 itsdangerous
 Jinja2>=2.8
-kombu[sqs]  # https://github.com/jazzband/pip-tools/issues/1577
+kombu[sqs]<5.3.2  # https://github.com/jazzband/pip-tools/issues/1577
 limits
 linehaul
 lxml

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -157,9 +157,9 @@ cbor2==5.4.6 \
     --hash=sha256:e73ca40dd3c7210ff776acff9869ddc9ff67bae7c425b58e5715dcf55275163f \
     --hash=sha256:ff95b33e5482313a74648ca3620c9328e9f30ecfa034df040b828e476597d352
     # via webauthn
-celery[sqs]==5.3.3 \
-    --hash=sha256:bac90ef99b70b9b5b5d4cfcebf6f1ab5168b86c6120bc7c5814cd8234dfd9381 \
-    --hash=sha256:d65c0be70d0949fcda8893876a071a7cfd9f248f9ad92e1919845e5cbc268db7
+celery[sqs]==5.3.1 \
+    --hash=sha256:27f8f3f3b58de6e0ab4f174791383bbd7445aff0471a43e99cfd77727940753f \
+    --hash=sha256:f84d1c21a1520c116c2b7d26593926581191435a03aa74b77c941b93ca1c6210
     # via
     #   -r requirements/main.in
     #   celery-redbeat
@@ -842,9 +842,9 @@ jmespath==1.0.1 \
     # via
     #   boto3
     #   botocore
-kombu[sqs]==5.3.2 \
-    --hash=sha256:0ba213f630a2cb2772728aef56ac6883dc3a2f13435e10048f6e97d48506dbbd \
-    --hash=sha256:b753c9cfc9b1e976e637a7cbc1a65d446a22e45546cd996ea28f932082b7dc9e
+kombu[sqs]==5.3.1 \
+    --hash=sha256:48ee589e8833126fd01ceaa08f8a2041334e9f5894e5763c8486a550454551e9 \
+    --hash=sha256:fbd7572d92c0bf71c112a6b45163153dea5a7b6a701ec16b568c27d0fd2370f2
     # via
     #   -r requirements/main.in
     #   celery

--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -217,7 +217,6 @@ def includeme(config):
         task_routes={},
         task_serializer="json",
         worker_disable_rate_limits=True,
-        worker_proc_alive_timeout=10.0,
         REDBEAT_REDIS_URL=s["celery.scheduler_url"],
     )
     config.registry["celery.app"].Task = WarehouseTask


### PR DESCRIPTION
We're seeing some slowdowns and startup time alerts with the latest
versions.

Also Revert "chore: increase worker startup timeout (#14474)"