### PR TITLE
doom transactions for re-uploaded files

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2120,6 +2120,7 @@ class TestFileUpload:
         user = UserFactory.create()
         pyramid_config.testing_securitypolicy(identity=user)
         db_request.user = user
+        db_request.tm = pretend.stub(doom=pretend.call_recorder(lambda: None))
         EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
@@ -2158,6 +2159,7 @@ class TestFileUpload:
 
         resp = legacy.file_upload(db_request)
 
+        assert db_request.tm.doom.calls == [pretend.call()]
         assert resp.status_code == 200
 
     def test_upload_fails_with_existing_filename_diff_content(

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1296,6 +1296,7 @@ def file_upload(request):
         # Check to see if the file that was uploaded exists already or not.
         is_duplicate = _is_duplicate_file(request.db, filename, file_hashes)
         if is_duplicate:
+            request.tm.doom()
             return Response()
         elif is_duplicate is not None:
             raise _exc_with_message(


### PR DESCRIPTION
This stops us from issuing all the purges related to the file/release in question when we no-op.