### PR TITLE
chore: enable tcp keepalive for celery/kombu/sqs

### DIFF
--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -454,49 +454,85 @@ def test_make_celery_app():
             "amqp://guest@rabbitmq:5672//",
             {},
         ),
-        (Environment.development, False, "sqs://", "sqs://", {}),
-        (Environment.production, True, "sqs://", "sqs://", {}),
+        (
+            Environment.development,
+            False,
+            "sqs://",
+            "sqs://",
+            {
+                "client-config": {"tcp_keepalive": True},
+            },
+        ),
+        (
+            Environment.production,
+            True,
+            "sqs://",
+            "sqs://",
+            {
+                "client-config": {"tcp_keepalive": True},
+            },
+        ),
         (
             Environment.development,
             False,
             "sqs://?queue_name_prefix=warehouse",
             "sqs://",
-            {"queue_name_prefix": "warehouse-"},
+            {
+                "queue_name_prefix": "warehouse-",
+                "client-config": {"tcp_keepalive": True},
+            },
         ),
         (
             Environment.production,
             True,
             "sqs://?queue_name_prefix=warehouse",
             "sqs://",
-            {"queue_name_prefix": "warehouse-"},
+            {
+                "queue_name_prefix": "warehouse-",
+                "client-config": {"tcp_keepalive": True},
+            },
         ),
         (
             Environment.development,
             False,
             "sqs://?region=us-east-2",
             "sqs://",
-            {"region": "us-east-2"},
+            {
+                "region": "us-east-2",
+                "client-config": {"tcp_keepalive": True},
+            },
         ),
         (
             Environment.production,
             True,
             "sqs://?region=us-east-2",
             "sqs://",
-            {"region": "us-east-2"},
+            {
+                "region": "us-east-2",
+                "client-config": {"tcp_keepalive": True},
+            },
         ),
         (
             Environment.development,
             False,
             "sqs:///?region=us-east-2&queue_name_prefix=warehouse",
             "sqs://",
-            {"region": "us-east-2", "queue_name_prefix": "warehouse-"},
+            {
+                "region": "us-east-2",
+                "queue_name_prefix": "warehouse-",
+                "client-config": {"tcp_keepalive": True},
+            },
         ),
         (
             Environment.production,
             True,
             "sqs:///?region=us-east-2&queue_name_prefix=warehouse",
             "sqs://",
-            {"region": "us-east-2", "queue_name_prefix": "warehouse-"},
+            {
+                "region": "us-east-2",
+                "queue_name_prefix": "warehouse-",
+                "client-config": {"tcp_keepalive": True},
+            },
         ),
     ],
 )

--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -202,6 +202,11 @@ def includeme(config):
         if "region" in parsed_query:
             broker_transport_options["region"] = parsed_query["region"][0]
 
+        # Add TCP keepalive options to the SQS connection
+        broker_transport_options["client-config"] = {
+            "tcp_keepalive": True,
+        }
+
     config.registry["celery.app"] = celery.Celery(
         "warehouse", autofinalize=False, set_as_current=False
     )


### PR DESCRIPTION
We perform a number of calls to SQS as part of normal operations - sometimes on the order of 10 calls during an upload request.

Using TCP Keep-Alives is one way to speed up subsequent connections, and the default is `False`.
Refs: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#:~:text=respective%20regional%20endpoint.-,tcp_keepalive,-Toggles%20the%20TCP

Passing this config to Celery, which in turn sends it to Kombu, which in turn sends it to boto3, which sends to botocore, which sends to urllib3, enables it.

That's quite a few turtles :turtle: