### PR TITLE
chore: update base debian image to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # First things first, we build an image which is where we're going to compile
 # our static assets with. We use this stage in development.
-FROM node:20.5.1-bullseye as static-deps
+FROM node:20.5.1-bookworm as static-deps
 
 WORKDIR /opt/warehouse/src/
 
@@ -36,7 +36,7 @@ RUN NODE_ENV=production npm run build
 
 
 # We'll build a light-weight layer along the way with just docs stuff
-FROM python:3.11.5-slim-bullseye as docs
+FROM python:3.11.5-slim-bookworm as docs
 
 # By default, Docker has special steps to avoid keeping APT caches in the layers, which
 # is good, but in our case, we're going to mount a special cache volume (kept between
@@ -105,7 +105,7 @@ USER docs
 
 # Now we're going to build our actual application, but not the actual production
 # image that it gets deployed into.
-FROM python:3.11.5-slim-bullseye as build
+FROM python:3.11.5-slim-bookworm as build
 
 # Define whether we're building a production or a development image. This will
 # generally be used to control whether or not we install our development and
@@ -184,7 +184,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Now we're going to build our actual application image, which will eventually
 # pull in the static files that were built above.
-FROM python:3.11.5-slim-bullseye
+FROM python:3.11.5-slim-bookworm
 
 # Setup some basic environment variables that are ~never going to change.
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
Debian 12 released in June. Updates any of our base-level deps, since Python is already selected via Docker image tag.

Refs: https://www.debian.org/News/2023/20230610