### PR TITLE
chore: remove md5 hash for comparison

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -775,7 +775,6 @@ def _is_duplicate_file(db_session, filename, hashes):
         return (
             file_.filename == filename
             and file_.sha256_digest == hashes["sha256"]
-            and file_.md5_digest == hashes["md5"]
             and file_.blake2_256_digest == hashes["blake2_256"]
         )
 


### PR DESCRIPTION
None of our database entries are missing sha256 nor blake2_256 entries, which are both stronger than md5.

Solves a low severity data validation issue where collisions could occur in the md5 space, and cause database rollbacks at this stage of the upload cycle.