### PR TITLE
refactor: update url parsing

### DIFF
--- a/dev/flake8/checkers.py
+++ b/dev/flake8/checkers.py
@@ -1,0 +1,60 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Warehouse Flake8 Local Checkers
+
+This module contains custom Flake8 checkers that are used to enforce
+Warehouse-specific style rules.
+"""
+
+import ast
+
+from collections.abc import Generator
+from typing import Any
+
+WH001_msg = "WH001 Prefer `urllib3.util.parse_url` over `urllib.parse.urlparse`"
+
+
+class WarehouseVisitor(ast.NodeVisitor):
+    def __init__(self, filename: str) -> None:
+        self.errors: list[tuple[int, int, str]] = []
+        self.filename = filename
+
+    def visit_Name(self, node: ast.Name) -> None:  # noqa: N802
+        if node.id == "urlparse":
+            self.errors.append((node.lineno, node.col_offset, WH001_msg))
+
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:  # noqa: N802
+        if (
+            node.attr == "urlparse"
+            and isinstance(node.value, ast.Attribute)
+            and node.value.value.id == "urllib"
+        ):
+            self.errors.append((node.lineno, node.col_offset, WH001_msg))
+
+        self.generic_visit(node)
+
+
+class WarehouseCheck:
+    def __init__(self, tree: ast.AST, filename: str) -> None:
+        self.tree = tree
+        self.filename = filename
+
+    def run(self) -> Generator[tuple[int, int, str, type[Any]], None, None]:
+        visitor = WarehouseVisitor(self.filename)
+        visitor.visit(self.tree)
+
+        for e in visitor.errors:
+            yield *e, type(self)

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -68,6 +68,7 @@ structlog
 transaction
 trove-classifiers
 ua-parser
+urllib3
 webauthn>=1.0.0,<2.0.0
 whitenoise
 WTForms[email]>=2.0.0

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1630,6 +1630,7 @@ urllib3==1.26.16 \
     --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \
     --hash=sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
     # via
+    #   -r requirements/main.in
     #   botocore
     #   celery
     #   elasticsearch

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ max-line-length = 88
 exclude = *.egg,*/interfaces.py,node_modules,.state
 ignore = W503,E203
 select = E,W,F,N
+
+[flake8:local-plugins]
+extension =
+    WH = dev.flake8.checkers:WarehouseCheck

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 import datetime
-import urllib.parse
 
 from functools import partial
 
@@ -19,6 +18,8 @@ import packaging.version
 import packaging_legacy.version
 import pretend
 import pytest
+
+from urllib3.util import parse_url
 
 from warehouse import filters
 
@@ -113,7 +114,7 @@ def test_tojson(inp, expected):
 
 def test_urlparse():
     inp = "https://google.com/foo/bar?a=b"
-    expected = urllib.parse.urlparse(inp)
+    expected = parse_url(inp)
     assert filters.urlparse(inp) == expected
 
 

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -43,6 +43,7 @@ class TestIsSafeUrl:
             "\njavascript:alert(x)",
             "\x08//example.com",
             "\n",
+            "view/?param=//example.com",
         ],
     )
     def test_rejects_bad_url(self, url):
@@ -54,7 +55,6 @@ class TestIsSafeUrl:
             "/view/?param=http://example.com",
             "/view/?param=https://example.com",
             "/view?param=ftp://exampel.com",
-            "view/?param=//example.com",
             "https://testserver/",
             "HTTPS://testserver/",
             "//testserver/",

--- a/tests/unit/utils/test_otp.py
+++ b/tests/unit/utils/test_otp.py
@@ -13,13 +13,14 @@
 import time
 
 from base64 import b32encode
-from urllib.parse import parse_qsl, urlparse
+from urllib.parse import parse_qsl
 
 import pytest
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.hashes import SHA1
 from cryptography.hazmat.primitives.twofactor.totp import TOTP
+from urllib3.util import parse_url
 
 from warehouse.utils.otp import (
     TOTP_INTERVAL,
@@ -46,7 +47,7 @@ def test_generate_totp_provisioning_uri():
     issuer_name = "pypi.org"
     uri = generate_totp_provisioning_uri(secret, username, issuer_name=issuer_name)
 
-    parsed = urlparse(uri)
+    parsed = parse_url(uri)
 
     assert parsed.scheme == "otpauth"
     assert parsed.netloc == "totp"

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -12,7 +12,8 @@
 
 import collections
 import copy
-import urllib.parse
+
+from urllib3.util import parse_url
 
 from warehouse.config import Environment
 
@@ -100,17 +101,16 @@ def _connect_src_settings(config) -> list:
 
     if config.registry.settings.get("warehouse.env") == Environment.development:
         livereload_url = config.registry.settings.get("livereload.url")
-        parsed_url = urllib.parse.urlparse(livereload_url)
+        parsed_url = parse_url(livereload_url)
 
         # Incoming scheme could be http or https.
         scheme_replacement = "wss" if parsed_url.scheme == "https" else "ws"
 
         replaced = parsed_url._replace(scheme=scheme_replacement)  # noqa
-        fixed = urllib.parse.urlunparse(replaced)
 
         settings.extend(
             [
-                f"{fixed}/livereload",
+                f"{replaced.url}/livereload",
             ]
         )
 

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -30,6 +30,7 @@ import pytz
 
 from natsort import natsorted
 from pyramid.threadlocal import get_current_request
+from urllib3.util import parse_url
 
 from warehouse.utils.http import is_valid_uri
 
@@ -106,7 +107,7 @@ def tojson(value):
 
 
 def urlparse(value):
-    return urllib.parse.urlparse(value)
+    return parse_url(value)
 
 
 def format_tags(tags):

--- a/warehouse/legacy/api/xmlrpc/cache/__init__.py
+++ b/warehouse/legacy/api/xmlrpc/cache/__init__.py
@@ -12,11 +12,10 @@
 
 import collections
 
-from urllib.parse import urlparse
-
 from pyramid.exceptions import ConfigurationError
 from sqlalchemy.orm.base import NO_VALUE
 from sqlalchemy.orm.session import Session
+from urllib3.util import parse_url
 
 from warehouse import db
 from warehouse.accounts.models import Email, User
@@ -95,7 +94,7 @@ def includeme(config):
             "Cannot configure xlmrpc_cache without warehouse.xmlrpc.cache.url"
         )
 
-    xmlrpc_cache_url_scheme = urlparse(xmlrpc_cache_url).scheme
+    xmlrpc_cache_url_scheme = parse_url(xmlrpc_cache_url).scheme
     if xmlrpc_cache_url_scheme in ("redis", "rediss"):
         xmlrpc_cache_class = RedisXMLRPCCache
     elif xmlrpc_cache_url_scheme in ("null"):

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -13,7 +13,6 @@
 import enum
 
 from collections import OrderedDict
-from urllib.parse import urlparse
 
 import packaging.utils
 
@@ -42,6 +41,7 @@ from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import attribute_keyed_dict, declared_attr, mapped_column, validates
+from urllib3.util import parse_url
 
 from warehouse import db
 from warehouse.accounts.models import User
@@ -582,8 +582,8 @@ class Release(db.Model):
     @staticmethod
     def get_user_name_and_repo_name(urls):
         for url in urls:
-            parsed = urlparse(url)
-            segments = parsed.path.strip("/").split("/")
+            parsed = parse_url(url)
+            segments = parsed.path.strip("/").split("/") if parsed.path else []
             if parsed.netloc in {"github.com", "www.github.com"} and len(segments) >= 2:
                 user_name, repo_name = segments[:2]
                 if user_name in GITHUB_RESERVED_NAMES:

--- a/warehouse/search/__init__.py
+++ b/warehouse/search/__init__.py
@@ -18,6 +18,7 @@ import requests_aws4auth
 
 from celery.schedules import crontab
 from elasticsearch_dsl import serializer
+from urllib3.util import parse_url
 
 from warehouse import db
 from warehouse.packaging.models import Project, Release
@@ -79,10 +80,10 @@ def es(request):
 
 
 def includeme(config):
-    p = urllib.parse.urlparse(config.registry.settings["elasticsearch.url"])
+    p = parse_url(config.registry.settings["elasticsearch.url"])
     qs = urllib.parse.parse_qs(p.query)
     kwargs = {
-        "hosts": [urllib.parse.urlunparse(p[:2] + ("",) * 4)],
+        "hosts": [urllib.parse.urlunparse((p.scheme, p.netloc) + ("",) * 4)],
         "verify_certs": True,
         "ca_certs": certifi.where(),
         "timeout": 2,

--- a/warehouse/utils/http.py
+++ b/warehouse/utils/http.py
@@ -12,9 +12,8 @@
 
 import unicodedata
 
-from urllib.parse import urlparse
-
 from rfc3986 import exceptions, uri_reference, validators
+from urllib3.util import parse_url
 
 
 # FROM https://github.com/django/django/blob/
@@ -35,7 +34,7 @@ def is_safe_url(url, host=None):
     # urlparse is not so flexible. Treat any url with three slashes as unsafe.
     if url.startswith("///"):
         return False
-    url_info = urlparse(url)
+    url_info = parse_url(url)
     # Forbid URLs like http:///example.com - with a scheme, but without a
     # hostname.
     # In that URL, example.com is not the hostname but, a path component.

--- a/warehouse/utils/sns.py
+++ b/warehouse/utils/sns.py
@@ -13,7 +13,6 @@
 import base64
 import datetime
 import re
-import urllib.parse
 
 import requests
 
@@ -22,6 +21,7 @@ from cryptography.exceptions import InvalidSignature as _InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.hashes import SHA256
+from urllib3.util import parse_url
 
 _signing_url_host_re = re.compile(r"^sns\.[a-zA-Z0-9\-]{3,}\.amazonaws\.com(\.cn)?$")
 
@@ -75,7 +75,7 @@ class MessageVerifier:
     def _get_pubkey(self, cert_url):
         # Before we do anything, we need to verify that the URL for the
         # signature matches what we expect.
-        cert_url_p = urllib.parse.urlparse(cert_url)
+        cert_url_p = parse_url(cert_url)
         cert_scheme = cert_url_p.scheme
         cert_host = cert_url_p.netloc
         if cert_scheme != "https":


### PR DESCRIPTION
- Make urllib3 a direct dependency
  We're already installing it as part of requests, boto, and more.
  Make it explicit as we'll be importing it directly now for parsing.
- Add a local flake8 plugin to detect usage of `urllib.parse.urlparse`
- Refactor usages