### PR TITLE
fix: handle invalid URLs

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -463,6 +463,7 @@ class TestRelease:
                 "https://www.github.com/pypi/warehouse.git/",
                 "https://api.github.com/repos/pypi/warehouse",
             ),
+            ("git@bitbucket.org:definex/dsgnutils.git", None),
         ],
     )
     def test_github_repo_info_url(self, db_session, home_page, expected):

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -41,6 +41,7 @@ from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import attribute_keyed_dict, declared_attr, mapped_column, validates
+from urllib3.exceptions import LocationParseError
 from urllib3.util import parse_url
 
 from warehouse import db
@@ -582,7 +583,10 @@ class Release(db.Model):
     @staticmethod
     def get_user_name_and_repo_name(urls):
         for url in urls:
-            parsed = parse_url(url)
+            try:
+                parsed = parse_url(url)
+            except LocationParseError:
+                continue
             segments = parsed.path.strip("/").split("/") if parsed.path else []
             if parsed.netloc in {"github.com", "www.github.com"} and len(segments) >= 2:
                 user_name, repo_name = segments[:2]


### PR DESCRIPTION
If we already have invalid URLs in the database due to historical metadata, don't crash when we can't parse them.

Fixes WAREHOUSE-PRODUCTION-1MA
Refs https://python-software-foundation.sentry.io/share/issue/f366cafde47946c199d2b0f599de17a4/