### PR TITLE
refactor: extract package type to enum

### DIFF
--- a/warehouse/migrations/versions/b985bb544962_text.py
+++ b/warehouse/migrations/versions/b985bb544962_text.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Rename package_type enum to packagetype
+
+Revision ID: b985bb544962
+Revises: 757731924605
+Create Date: 2023-09-08 18:06:56.085062
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "b985bb544962"
+down_revision = "757731924605"
+
+
+def upgrade():
+    op.execute("ALTER TYPE package_type RENAME TO packagetype")
+
+
+def downgrade():
+    op.execute("ALTER TYPE packagetype RENAME TO package_type ")

--- a/warehouse/migrations/versions/b985bb544962_text.py
+++ b/warehouse/migrations/versions/b985bb544962_text.py
@@ -17,10 +17,7 @@ Revises: 757731924605
 Create Date: 2023-09-08 18:06:56.085062
 """
 
-import sqlalchemy as sa
-
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 revision = "b985bb544962"
 down_revision = "757731924605"

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -40,7 +40,13 @@ from sqlalchemy.dialects.postgresql import CITEXT, UUID
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import attribute_keyed_dict, declared_attr, mapped_column, validates
+from sqlalchemy.orm import (
+    Mapped,
+    attribute_keyed_dict,
+    declared_attr,
+    mapped_column,
+    validates,
+)
 from urllib3.exceptions import LocationParseError
 from urllib3.util import parse_url
 
@@ -627,6 +633,17 @@ class Release(db.Model):
         )
 
 
+class PackageType(str, enum.Enum):
+    bdist_dmg = "bdist_dmg"
+    bdist_dumb = "bdist_dumb"
+    bdist_egg = "bdist_egg"
+    bdist_msi = "bdist_msi"
+    bdist_rpm = "bdist_rpm"
+    bdist_wheel = "bdist_wheel"
+    bdist_wininst = "bdist_wininst"
+    sdist = "sdist"
+
+
 class File(HasEvents, db.Model):
     __tablename__ = "release_files"
 
@@ -656,19 +673,7 @@ class File(HasEvents, db.Model):
     )
     python_version = mapped_column(Text, nullable=False)
     requires_python = mapped_column(Text)
-    packagetype = mapped_column(
-        Enum(
-            "bdist_dmg",
-            "bdist_dumb",
-            "bdist_egg",
-            "bdist_msi",
-            "bdist_rpm",
-            "bdist_wheel",
-            "bdist_wininst",
-            "sdist",
-        ),
-        nullable=False,
-    )
+    packagetype: Mapped[PackageType] = mapped_column()
     comment_text = mapped_column(Text)
     filename = mapped_column(Text, unique=True, nullable=False)
     path = mapped_column(Text, unique=True, nullable=False)


### PR DESCRIPTION
An update to alembic's autogenerate detection started to barf on the unnamed enum.

The ALTER TYPE migration is to make the custom-built type conform to the alembic autogenerated name, since it's used in a custom index (which really ought to be a Check Constraint, but that's a problem for another time).