### PR TITLE
fix: restore values_callable on enum

### DIFF
--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -673,7 +673,9 @@ class File(HasEvents, db.Model):
     )
     python_version = mapped_column(Text, nullable=False)
     requires_python = mapped_column(Text)
-    packagetype: Mapped[PackageType] = mapped_column()
+    packagetype: Mapped[PackageType] = mapped_column(
+        Enum(PackageType, values_callable=lambda x: [e.value for e in x]),
+    )
     comment_text = mapped_column(Text)
     filename = mapped_column(Text, unique=True, nullable=False)
     path = mapped_column(Text, unique=True, nullable=False)


### PR DESCRIPTION
Since this isn't the default for our enums yet, we still have to provide a function to retrieve the .value, instead of the .name

Refs: #14515
Fixes WAREHOUSE-PRODUCTION-1MC
https://python-software-foundation.sentry.io/share/issue/7d2bd0fbb8334d32b71639e22fc8d0cc/