### PR TITLE
fix: call for the enum's value in xmlrpc

### DIFF
--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -418,7 +418,7 @@ def release_urls(request, package_name: StrictStr, version: StrictStr):
     return [
         {
             "filename": f.filename,
-            "packagetype": f.packagetype,
+            "packagetype": f.packagetype.value,
             "python_version": f.python_version,
             "size": f.size,
             "md5_digest": f.md5_digest,


### PR DESCRIPTION
`xmlrpc.client.dumps()` cannot marshall a `str, Enum` to the string value like `json.dumps()` can.

Refs: #14515 #14517