### PR TITLE
chore(dev): couple of dev env improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,8 @@ insert_final_newline = true
 
 [*.py]
 indent_size = 4
+# handled by black config
+max_line_length = off
 
 [Makefile]
 indent_style = tab

--- a/bin/reformat
+++ b/bin/reformat
@@ -1,14 +1,6 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -ex
 
-# Click requires us to ensure we have a well configured environment to run
-# our click commands. So we'll set our environment to ensure our locale is
-# correct.
-export LC_ALL="${ENCODING:-en_US.UTF-8}"
-export LANG="${ENCODING:-en_US.UTF-8}"
-
-# Print all the following commands
-set -x
-
+find . -name '*.py' -exec python -m pyupgrade --py311-plus {} +
 python -m isort *.py warehouse/ tests/
 python -m black *.py warehouse/ tests/


### PR DESCRIPTION
Instead of only tripping us up in `lint` step, perform the same action
in `reformat` so that we don't have to do it ourselves.

Tell editorconfig it's not responsible for Python line length.