### PR TITLE
wip feat: add ratelimit view deriver

### DIFF
--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -236,6 +236,7 @@ def opensearchxml(request):
     has_translations=True,
     # FIXME: Remove from here and add to other views. Testing only!
     ratelimit="2 per second",
+    ratelimit_by="remote_addr_hashed",
 )
 def index(request):
     counts = dict(

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -234,6 +234,8 @@ def opensearchxml(request):
         )
     ],
     has_translations=True,
+    # FIXME: Remove from here and add to other views. Testing only!
+    ratelimit="2 per second",
 )
 def index(request):
     counts = dict(


### PR DESCRIPTION
To support a more generic use case of rate limiting views by IP.