### PR TITLE
chore: add datadog tracing to tasks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: bin/release
 web: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-prod.conf.py warehouse.wsgi:application
 web-uploads: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
-worker: bin/start-worker celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
-worker-beat: bin/start-worker celery -A warehouse beat -S redbeat.RedBeatScheduler -l info
+worker: bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
+worker-beat: bin/start-worker ddtrace-run celery -A warehouse beat -S redbeat.RedBeatScheduler -l info

--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ release: bin/release
 web: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-prod.conf.py warehouse.wsgi:application
 web-uploads: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
 worker: env DD_SERVICE=warehouse-worker bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
-worker-beat: bin/start-worker ddtrace-run celery -A warehouse beat -S redbeat.RedBeatScheduler -l info
+worker-beat: env DD_SERVICE=warehouse-worker-beat bin/start-worker ddtrace-run celery -A warehouse beat -S redbeat.RedBeatScheduler -l info

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: bin/release
 web: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-prod.conf.py warehouse.wsgi:application
 web-uploads: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
-worker: bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
+worker: DD_SERVICE=warehouse-worker bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
 worker-beat: bin/start-worker ddtrace-run celery -A warehouse beat -S redbeat.RedBeatScheduler -l info

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: bin/release
 web: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-prod.conf.py warehouse.wsgi:application
 web-uploads: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
-worker: DD_SERVICE=warehouse-worker bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
+worker: env DD_SERVICE=warehouse-worker bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
 worker-beat: bin/start-worker ddtrace-run celery -A warehouse beat -S redbeat.RedBeatScheduler -l info

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -6,5 +6,8 @@ set -eo pipefail
 # Setup our Redis settings
 source bin/redis-tls
 
+# Override the project-wide
+export DD_SERVICE=warehouse-worker
+
 # Finally, go ahead and execute the given command.
 exec "$@"

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -6,8 +6,5 @@ set -eo pipefail
 # Setup our Redis settings
 source bin/redis-tls
 
-# Override the project-wide
-export DD_SERVICE=warehouse-worker
-
 # Finally, go ahead and execute the given command.
 exec "$@"


### PR DESCRIPTION
Previously attempted in #12981 and reverted in #13003

ddtrace shipped a fix recently after in 1.9.0
Refs: https://github.com/DataDog/dd-trace-py/pull/4969

This time we also add a distinct name for the worker class (thanks, Karl) as Cabotage doesn't provide a facility yet to set environment variables per-Procfile process.