### PR TITLE
Revert "chore: add datadog tracing to tasks (#14553)"

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: bin/release
 web: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-prod.conf.py warehouse.wsgi:application
 web-uploads: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
-worker: env DD_SERVICE=warehouse-worker bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
-worker-beat: env DD_SERVICE=warehouse-worker-beat bin/start-worker ddtrace-run celery -A warehouse beat -S redbeat.RedBeatScheduler -l info
+worker: bin/start-worker celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
+worker-beat: bin/start-worker celery -A warehouse beat -S redbeat.RedBeatScheduler -l info


### PR DESCRIPTION
This reverts commit a8a83bba2397a47a1c326dd437910be0259fe886.

Workers have been stalling out like the last time we tried to enable this.