### PR TITLE
feat: allow bearer type for macaroons

### DIFF
--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -34,6 +34,7 @@ from warehouse.oidc.utils import OIDCContext
         ("notarealtoken", None),
         ("maybeafuturemethod foobar", None),
         ("token foobar", "foobar"),
+        ("bearer foobar", "foobar"),
         ("basic X190b2tlbl9fOmZvb2Jhcg==", "foobar"),  # "__token__:foobar"
     ],
 )

--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -38,9 +38,10 @@ from warehouse.oidc.utils import OIDCContext
         ("basic X190b2tlbl9fOmZvb2Jhcg==", "foobar"),  # "__token__:foobar"
     ],
 )
-def test_extract_http_macaroon(auth, result):
+def test_extract_http_macaroon(auth, result, metrics):
     request = pretend.stub(
-        headers=pretend.stub(get=pretend.call_recorder(lambda k: auth))
+        find_service=pretend.call_recorder(lambda *a, **kw: metrics),
+        headers=pretend.stub(get=pretend.call_recorder(lambda k: auth)),
     )
 
     assert security_policy._extract_http_macaroon(request) == result

--- a/warehouse/macaroons/security_policy.py
+++ b/warehouse/macaroons/security_policy.py
@@ -66,7 +66,7 @@ def _extract_http_macaroon(request):
 
     if auth_method.lower() == "basic":
         return _extract_basic_macaroon(auth)
-    elif auth_method.lower() == "token":
+    elif auth_method.lower() in ["token", "bearer"]:
         return auth
 
     return None

--- a/warehouse/macaroons/security_policy.py
+++ b/warehouse/macaroons/security_policy.py
@@ -21,6 +21,7 @@ from warehouse.cache.http import add_vary_callback
 from warehouse.errors import WarehouseDenied
 from warehouse.macaroons import InvalidMacaroonError
 from warehouse.macaroons.interfaces import IMacaroonService
+from warehouse.metrics.interfaces import IMetricsService
 from warehouse.oidc.utils import OIDCContext
 from warehouse.utils.security_policy import AuthenticationMethod, principals_for
 
@@ -64,9 +65,16 @@ def _extract_http_macaroon(request):
     except ValueError:
         return None
 
-    if auth_method.lower() == "basic":
+    auth_method = auth_method.lower()
+
+    metrics = request.find_service(IMetricsService, context=None)
+    # TODO: As this is called in both `identity` and `permits`, we're going to
+    #       end up double counting the metrics.
+    metrics.increment("warehouse.macaroon.auth_method", tags=[f"method:{auth_method}"])
+
+    if auth_method == "basic":
         return _extract_basic_macaroon(auth)
-    elif auth_method.lower() in ["token", "bearer"]:
+    elif auth_method in ["token", "bearer"]:
         return auth
 
     return None


### PR DESCRIPTION
Since Macaroons are often considered bearer tokens, allow them to be used in the authorization header scheme.