### PR TITLE
Allow GitHub OIDC subject claim to be case insensitive

### DIFF
--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -417,6 +417,8 @@ class TestGitHubPublisher:
         [
             ("repo:foo/bar", "repo:foo/bar:someotherstuff", True),
             ("repo:foo/bar", "repo:foo/bar:", True),
+            ("repo:fOo/BaR", "repo:foo/bar", True),
+            ("repo:foo/bar", "repo:fOo/BaR:", True),
             ("repo:foo/bar:someotherstuff", "repo:foo/bar", False),
             ("repo:foo/bar-baz", "repo:foo/bar", False),
             ("repo:foo/bar", "repo:foo/bar-baz", False),

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -91,7 +91,12 @@ def _check_sub(ground_truth, signed_claim, _all_signed_claims):
     if len(components) < 2:
         return False
 
-    return f"{components[0]}:{components[1]}" == ground_truth
+    org, repo, *_ = components
+    if not org or not repo:
+        return False
+
+    # The sub claim is case-insensitive
+    return f"{org}:{repo}".lower() == ground_truth.lower()
 
 
 class GitHubPublisherMixin:


### PR DESCRIPTION
Fixes #14622.

This also fixes a minor bug where a claim like "org:" was making it to the last check rather than short-circuiting early as intended. Instead, we require that some non-empty string for the repository exists before comparing the claim to the ground truth.