### PR TITLE
feat: enable sorted projects on user relationship

### DIFF
--- a/tests/unit/accounts/test_models.py
+++ b/tests/unit/accounts/test_models.py
@@ -25,6 +25,10 @@ from ...common.db.accounts import (
     UserEventFactory as DBUserEventFactory,
     UserFactory as DBUserFactory,
 )
+from ...common.db.packaging import (
+    ProjectFactory as DBProjectFactory,
+    RoleFactory as DBRoleFactory,
+)
 
 
 class TestUserFactory:
@@ -250,3 +254,14 @@ class TestUser:
             )
         db_session.flush()
         assert user.has_single_2fa == expected
+
+    def test_user_projects_is_ordered_by_name(self, db_session):
+        user = DBUserFactory.create()
+        project1 = DBProjectFactory.create(name="foo")
+        DBRoleFactory.create(project=project1, user=user)
+        project2 = DBProjectFactory.create(name="bar")
+        DBRoleFactory.create(project=project2, user=user)
+        project3 = DBProjectFactory.create(name="baz")
+        DBRoleFactory.create(project=project3, user=user)
+
+        assert user.projects == [project2, project3, project1]

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -43,6 +43,7 @@ from warehouse.utils.db.types import TZDateTime, bool_false, datetime_now
 if TYPE_CHECKING:
     from warehouse.macaroons.models import Macaroon
     from warehouse.oidc.models import PendingOIDCPublisher
+    from warehouse.packaging.models import Project
 
 
 class UserFactory:
@@ -119,6 +120,15 @@ class User(SitemapMixin, HasEvents, db.Model):
         backref="added_by",
         cascade="all, delete-orphan",
         lazy=True,
+    )
+
+    projects: Mapped[list[Project]] = orm.relationship(
+        "Project",
+        secondary="roles",
+        back_populates="users",
+        lazy=True,
+        viewonly=True,
+        order_by="Project.normalized_name",
     )
 
     @property

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -190,7 +190,7 @@ class Project(SitemapMixin, TwoFactorRequireable, HasEvents, db.Model):
         passive_deletes=True,
     )
     users: Mapped[list[User]] = orm.relationship(
-        secondary=Role.__table__, backref="projects", viewonly=True
+        secondary=Role.__table__, back_populates="projects", viewonly=True
     )
     releases: Mapped[list[Release]] = orm.relationship(
         backref="project",


### PR DESCRIPTION
In order to obtain an ordered list of project names when calling `User.projects`, refactor the existing relationship to use the more modern `back_populates()` to express the relationship.

This allows us to implement the other side of the relationship as well as express distinct properties for that side calling, specifically `order_by()`.