### PR TITLE
fix: Hash-checking mode link updated

### DIFF
--- a/warehouse/templates/includes/hash-modal.html
+++ b/warehouse/templates/includes/hash-modal.html
@@ -20,7 +20,7 @@
     </a>
     <div class="modal__body">
       <h3 class="modal__title">
-        {% trans href='https://pip.pypa.io/en/stable/cli/pip_install/#hash-checking-mode', title=gettext('External link'), filename=file.filename %}
+        {% trans href='https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode', title=gettext('External link'), filename=file.filename %}
         <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Hashes</a> for {{ filename }}
         {% endtrans %}
       </h3>


### PR DESCRIPTION
This updates the "Hashes" link seen when viewing the hashes of package files.

fixes #14651 