### PR TITLE
feat: use trusted publishing to adapt UI

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -516,6 +516,60 @@ class TestRelease:
         release = DBReleaseFactory.create(home_page=home_page)
         assert release.github_open_issue_info_url == expected
 
+    def test_trusted_published_none(self, db_session):
+        release = DBReleaseFactory.create()
+
+        assert not release.trusted_published
+
+    def test_trusted_published_all(self, db_session):
+        release = DBReleaseFactory.create()
+        release_file = DBFileFactory.create(
+            release=release,
+            filename=f"{release.project.name}-{release.version}.tar.gz",
+            python_version="source",
+        )
+        DBFileEventFactory.create(
+            source=release_file,
+            tag="fake:event",
+            additional={},
+        )
+
+        # Without the `publisher_url` key, not considered trusted published
+        assert not release.trusted_published
+
+        DBFileEventFactory.create(
+            source=release_file,
+            tag="fake:event",
+            additional={"publisher_url": "https://fake/url"},
+        )
+
+        assert release.trusted_published
+
+    def test_trusted_published_mixed(self, db_session):
+        release = DBReleaseFactory.create()
+        rfile_1 = DBFileFactory.create(
+            release=release,
+            filename=f"{release.project.name}-{release.version}.tar.gz",
+            python_version="source",
+        )
+        rfile_2 = DBFileFactory.create(
+            release=release,
+            filename=f"{release.project.name}-{release.version}.whl",
+            python_version="bdist_wheel",
+        )
+        DBFileEventFactory.create(
+            source=rfile_1,
+            tag="fake:event",
+            additional={},
+        )
+        DBFileEventFactory.create(
+            source=rfile_2,
+            tag="fake:event",
+            additional={"publisher_url": "https://fake/url"},
+        )
+
+        assert not release.trusted_published
+
 
 class TestFile:
     def test_requires_python(self, db_session):

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -52,6 +52,18 @@
           <td><code>{{ release.uploaded_via }}</code></td>
         </tr>
         <tr>
+          <td>Trusted Published?</td>
+          <td>
+            {% if release.trusted_published %}
+              <i class="fa fa-fw fa-check text-green"></i>
+            {% else %}
+              <i class="fa fa-fw fa-times text-red"></i>
+              <span>
+                <i class="fa fa-info-circle" data-bs-toggle="tooltip" title="All Files of a Release must be TP for this to be True"></i>
+              </span>
+            {% endif %}
+        </tr>
+        <tr>
           <td>Yanked</td>
           <td>{{ release.yanked }}</td>
         </tr>
@@ -70,6 +82,7 @@
           <th>Package Type</th>
           <th>Python Version</th>
           <th>Uploaded via</th>
+          <th>Trusted Publisher?</th>
         </tr>
         </thead>
         <tbody>
@@ -79,6 +92,13 @@
           <td>{{ file.packagetype }}</td>
           <td>{{ file.python_version }}</td>
           <td><code>{{ file.uploaded_via }}</code></td>
+          <td>
+            {% if file.uploaded_via_trusted_publisher %}
+              <i class="fa fa-fw fa-check text-green"></i>
+            {% else %}
+              <i class="fa fa-fw fa-times text-red"></i>
+            {% endif %}
+          </td>
         </tr>
         {% endfor %}
         </tbody>

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -603,6 +603,17 @@ class Release(db.Model):
             ]
         )
 
+    @property
+    def trusted_published(self) -> bool:
+        """
+        A Release can be considered published via a trusted publisher if
+        **all** the Files in the release are published via a trusted publisher.
+        """
+        files = self.files.all()  # type: ignore[attr-defined]
+        if not files:
+            return False
+        return all(file.uploaded_via_trusted_publisher for file in files)
+
 
 class PackageType(str, enum.Enum):
     bdist_dmg = "bdist_dmg"

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -670,6 +670,16 @@ class File(HasEvents, db.Model):
         comment="If True, the object has been archived to our archival bucket.",
     )
 
+    @property
+    def uploaded_via_trusted_publisher(self) -> bool:
+        """Return True if the file was uploaded via a trusted publisher."""
+        return (
+            self.events.where(
+                self.Event.additional.has_key("publisher_url")  # type: ignore[attr-defined] # noqa E501
+            ).count()
+            > 0
+        )
+
     @hybrid_property
     def metadata_path(self):
         return self.path + ".metadata"


### PR DESCRIPTION
Projects using Trusted Publishing from GitHub have a strong attestation that the repo is the one they came from.

Using the metadata we have from the upload events, we can determine how the file got there, and bubble that up to the Release to control some aspects of the UI.
We could also display something in the Download Files if we wanted to.

Wrapping the sidebar statistics with the HTML `<details>` accomplishes preserving the sidebar metadata for projects, but making it more prominent for those using a Trusted Publishing workflow.

Refs: [StarJacking](https://capec.mitre.org/data/definitions/693.html)
Addresses #8462 (partially) and probably replaces #10917 