### PR TITLE
test: use `metrics` fixture when needed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,9 @@ def _event(
 
 @pytest.fixture
 def metrics():
+    """
+    A good-enough fake metrics fixture.
+    """
     return pretend.stub(
         event=pretend.call_recorder(lambda *args, **kwargs: _event(*args, **kwargs)),
         gauge=pretend.call_recorder(

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import datetime
 import uuid
 
@@ -1288,16 +1287,7 @@ class TestHaveIBeenPwnedPasswordBreachedService:
         assert not svc.check_password("my password")
         assert raiser.calls
 
-    def test_metrics_increments(self):
-        class Metrics:
-            def __init__(self):
-                self.values = collections.Counter()
-
-            def increment(self, metric):
-                self.values[metric] += 1
-
-        metrics = Metrics()
-
+    def test_metrics_increments(self, metrics):
         svc = services.HaveIBeenPwnedPasswordBreachedService(
             session=pretend.stub(), metrics=metrics
         )
@@ -1306,7 +1296,11 @@ class TestHaveIBeenPwnedPasswordBreachedService:
         svc._metrics_increment("another_thing")
         svc._metrics_increment("something")
 
-        assert metrics.values == {"something": 2, "another_thing": 1}
+        assert metrics.increment.calls == [
+            pretend.call("something"),
+            pretend.call("another_thing"),
+            pretend.call("something"),
+        ]
 
     def test_factory(self):
         context = pretend.stub()

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -3146,8 +3146,7 @@ class TestReAuthentication:
 
 
 class TestManageAccountPublishingViews:
-    def test_initializes(self):
-        metrics = pretend.stub()
+    def test_initializes(self, metrics):
         request = pretend.stub(
             find_service=pretend.call_recorder(lambda *a, **kw: metrics),
         )
@@ -3168,8 +3167,7 @@ class TestManageAccountPublishingViews:
             (True, False),
         ],
     )
-    def test_ratelimiting(self, ip_exceeded, user_exceeded):
-        metrics = pretend.stub()
+    def test_ratelimiting(self, metrics, ip_exceeded, user_exceeded):
         user_rate_limiter = pretend.stub(
             hit=pretend.call_recorder(lambda *a, **kw: None),
             test=pretend.call_recorder(lambda uid: not user_exceeded),
@@ -3221,8 +3219,7 @@ class TestManageAccountPublishingViews:
         else:
             view._check_ratelimits()
 
-    def test_manage_publishing(self, monkeypatch):
-        metrics = pretend.stub()
+    def test_manage_publishing(self, metrics, monkeypatch):
         request = pretend.stub(
             user=pretend.stub(),
             registry=pretend.stub(

--- a/tests/unit/integration/github/test_utils.py
+++ b/tests/unit/integration/github/test_utils.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import json
 import time
 import uuid
@@ -92,8 +91,7 @@ def test_token_leak_disclosure_request_from_api_record(source):
 
 
 class TestGitHubTokenScanningPayloadVerifier:
-    def test_init(self):
-        metrics = pretend.stub()
+    def test_init(self, metrics):
         session = pretend.stub()
         token = "api_token"
         url = "http://foo"
@@ -113,7 +111,7 @@ class TestGitHubTokenScanningPayloadVerifier:
         assert github_verifier._api_url == url
         assert github_verifier._public_keys_cache is cache
 
-    def test_verify_cache_miss(self):
+    def test_verify_cache_miss(self, metrics):
         # Example taken from
         # https://gist.github.com/ewjoachim/7dde11c31d9686ed6b4431c3ca166da2
         meta_payload = {
@@ -133,7 +131,6 @@ class TestGitHubTokenScanningPayloadVerifier:
             json=lambda: meta_payload, raise_for_status=lambda: None
         )
         session = pretend.stub(get=lambda *a, **k: response)
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda str: None))
         cache = integrations.PublicKeysCache(cache_time=12)
         github_verifier = utils.GitHubTokenScanningPayloadVerifier(
             api_url="http://foo",
@@ -163,9 +160,8 @@ class TestGitHubTokenScanningPayloadVerifier:
             pretend.call("warehouse.token_leak.github.auth.success"),
         ]
 
-    def test_verify_cache_hit(self):
+    def test_verify_cache_hit(self, metrics):
         session = pretend.stub()
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda str: None))
         cache = integrations.PublicKeysCache(cache_time=12)
         cache.cached_at = time.time()
         cache.cache = [
@@ -207,8 +203,7 @@ class TestGitHubTokenScanningPayloadVerifier:
             pretend.call("warehouse.token_leak.github.auth.success"),
         ]
 
-    def test_verify_error(self):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda str: None))
+    def test_verify_error(self, metrics):
         cache = integrations.PublicKeysCache(cache_time=12)
         github_verifier = utils.GitHubTokenScanningPayloadVerifier(
             api_url="http://foo",
@@ -248,7 +243,7 @@ class TestGitHubTokenScanningPayloadVerifier:
         )._headers_auth()
         assert headers == {"Authorization": "token api-token"}
 
-    def test_retrieve_public_key_payload(self):
+    def test_retrieve_public_key_payload(self, metrics):
         meta_payload = {
             "public_keys": [
                 {
@@ -266,7 +261,6 @@ class TestGitHubTokenScanningPayloadVerifier:
             json=lambda: meta_payload, raise_for_status=lambda: None
         )
         session = pretend.stub(get=pretend.call_recorder(lambda *a, **k: response))
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda str: None))
 
         github_verifier = utils.GitHubTokenScanningPayloadVerifier(
             api_url="http://foo",
@@ -284,7 +278,6 @@ class TestGitHubTokenScanningPayloadVerifier:
         ]
 
     def test_get_cached_public_key_cache_hit(self):
-        metrics = pretend.stub()
         session = pretend.stub()
         cache = integrations.PublicKeysCache(cache_time=12)
         cache_value = pretend.stub()
@@ -293,21 +286,20 @@ class TestGitHubTokenScanningPayloadVerifier:
         github_verifier = utils.GitHubTokenScanningPayloadVerifier(
             api_url="http://foo",
             session=session,
-            metrics=metrics,
+            metrics=pretend.stub(),
             public_keys_cache=cache,
         )
 
         assert github_verifier._get_cached_public_keys() is cache_value
 
     def test_get_cached_public_key_cache_miss_no_cache(self):
-        metrics = pretend.stub()
         session = pretend.stub()
         cache = integrations.PublicKeysCache(cache_time=12)
 
         github_verifier = utils.GitHubTokenScanningPayloadVerifier(
             api_url="http://foo",
             session=session,
-            metrics=metrics,
+            metrics=pretend.stub(),
             public_keys_cache=cache,
         )
 
@@ -553,12 +545,7 @@ class TestGitHubTokenScanningPayloadVerifier:
         assert exc.value.reason == "invalid_crypto"
 
 
-def test_analyze_disclosure(monkeypatch):
-    metrics = collections.Counter()
-
-    def metrics_increment(key):
-        metrics.update([key])
-
+def test_analyze_disclosure(monkeypatch, metrics):
     user_id = uuid.UUID(bytes=b"0" * 16)
     user = pretend.stub(
         id=user_id,
@@ -574,7 +561,7 @@ def test_analyze_disclosure(monkeypatch):
     find = pretend.call_recorder(lambda *a, **kw: database_macaroon)
     delete = pretend.call_recorder(lambda *a, **kw: None)
     svc = {
-        utils.IMetricsService: pretend.stub(increment=metrics_increment),
+        utils.IMetricsService: metrics,
         utils.IMacaroonService: pretend.stub(
             find_from_raw=find, delete_macaroon=delete
         ),
@@ -596,11 +583,11 @@ def test_analyze_disclosure(monkeypatch):
         },
         origin="github",
     )
-    assert metrics == {
-        "warehouse.token_leak.github.received": 1,
-        "warehouse.token_leak.github.processed": 1,
-        "warehouse.token_leak.github.valid": 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call("warehouse.token_leak.github.received"),
+        pretend.call("warehouse.token_leak.github.valid"),
+        pretend.call("warehouse.token_leak.github.processed"),
+    ]
     assert send_email.calls == [
         pretend.call(request, user, public_url="http://example.com", origin="github")
     ]
@@ -620,14 +607,9 @@ def test_analyze_disclosure(monkeypatch):
     ]
 
 
-def test_analyze_disclosure_wrong_record():
-    metrics = collections.Counter()
-
-    def metrics_increment(key):
-        metrics.update([key])
-
+def test_analyze_disclosure_wrong_record(metrics):
     svc = {
-        utils.IMetricsService: pretend.stub(increment=metrics_increment),
+        utils.IMetricsService: metrics,
         utils.IMacaroonService: pretend.stub(),
     }
 
@@ -638,21 +620,16 @@ def test_analyze_disclosure_wrong_record():
         disclosure_record={},
         origin="github",
     )
-    assert metrics == {
-        "warehouse.token_leak.github.received": 1,
-        "warehouse.token_leak.github.error.format": 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call("warehouse.token_leak.github.received"),
+        pretend.call("warehouse.token_leak.github.error.format"),
+    ]
 
 
-def test_analyze_disclosure_invalid_macaroon():
-    metrics = collections.Counter()
-
-    def metrics_increment(key):
-        metrics.update([key])
-
+def test_analyze_disclosure_invalid_macaroon(metrics):
     find = pretend.raiser(utils.InvalidMacaroonError("Bla", "bla"))
     svc = {
-        utils.IMetricsService: pretend.stub(increment=metrics_increment),
+        utils.IMetricsService: metrics,
         utils.IMacaroonService: pretend.stub(find_from_raw=find),
     }
 
@@ -667,21 +644,14 @@ def test_analyze_disclosure_invalid_macaroon():
         },
         origin="github",
     )
-    assert metrics == {
-        "warehouse.token_leak.github.received": 1,
-        "warehouse.token_leak.github.error.invalid": 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call("warehouse.token_leak.github.received"),
+        pretend.call("warehouse.token_leak.github.error.invalid"),
+    ]
 
 
-def test_analyze_disclosure_unknown_error(monkeypatch):
-    metrics = collections.Counter()
-
-    def metrics_increment(key):
-        metrics.update([key])
-
-    request = pretend.stub(
-        find_service=lambda *a, **k: pretend.stub(increment=metrics_increment)
-    )
+def test_analyze_disclosure_unknown_error(metrics, monkeypatch):
+    request = pretend.stub(find_service=lambda *a, **k: metrics)
     monkeypatch.setattr(utils, "_analyze_disclosure", pretend.raiser(ValueError()))
 
     with pytest.raises(ValueError):
@@ -690,39 +660,25 @@ def test_analyze_disclosure_unknown_error(monkeypatch):
             disclosure_record={},
             origin="github",
         )
-    assert metrics == {
-        "warehouse.token_leak.github.error.unknown": 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call("warehouse.token_leak.github.error.unknown"),
+    ]
 
 
-def test_analyze_disclosures_wrong_type():
-    metrics = collections.Counter()
-
-    def metrics_increment(key):
-        metrics.update([key])
-
-    metrics_service = pretend.stub(increment=metrics_increment)
-
+def test_analyze_disclosures_wrong_type(metrics):
     with pytest.raises(utils.InvalidTokenLeakRequestError) as exc:
         utils.analyze_disclosures(
             request=pretend.stub(),
             disclosure_records={},
             origin="yay",
-            metrics=metrics_service,
+            metrics=metrics,
         )
 
     assert str(exc.value) == "Invalid format: payload is not a list"
     assert exc.value.reason == "format"
 
 
-def test_analyze_disclosures_raise(monkeypatch):
-    metrics = collections.Counter()
-
-    def metrics_increment(key):
-        metrics.update([key])
-
-    metrics_service = pretend.stub(increment=metrics_increment)
-
+def test_analyze_disclosures_raise(metrics, monkeypatch):
     task = pretend.stub(delay=pretend.call_recorder(lambda *a, **k: None))
     request = pretend.stub(task=lambda x: task)
 
@@ -732,7 +688,7 @@ def test_analyze_disclosures_raise(monkeypatch):
         request=request,
         disclosure_records=[1, 2, 3],
         origin="yay",
-        metrics=metrics_service,
+        metrics=metrics,
     )
 
     assert task.delay.calls == [

--- a/tests/unit/integration/test_package.py
+++ b/tests/unit/integration/test_package.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pretend
 import pytest
 
 from warehouse import integrations
@@ -45,8 +44,7 @@ class TestCache:
 
 
 class TestPayloadVerifier:
-    def test_unimplemented(self):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda str: None))
+    def test_unimplemented(self, metrics):
         cache = integrations.PublicKeysCache(cache_time=10)
         payload_verifier = integrations.PayloadVerifier(
             metrics=metrics, public_keys_cache=cache

--- a/tests/unit/integration/vulnerabilities/osv/test_package.py
+++ b/tests/unit/integration/vulnerabilities/osv/test_package.py
@@ -22,8 +22,7 @@ from warehouse.integrations.vulnerabilities import osv
 
 
 class TestVulnerabilityReportVerifier:
-    def test_init(self):
-        metrics = pretend.stub()
+    def test_init(self, metrics):
         session = pretend.stub()
         cache = integrations.PublicKeysCache(cache_time=12)
 
@@ -37,7 +36,7 @@ class TestVulnerabilityReportVerifier:
         assert vuln_report_verifier._metrics is metrics
         assert vuln_report_verifier._public_keys_cache is cache
 
-    def test_verify_cache_miss(self):
+    def test_verify_cache_miss(self, metrics):
         # Example taken from
         # https://gist.github.com/ewjoachim/7dde11c31d9686ed6b4431c3ca166da2
         meta_payload = {
@@ -57,7 +56,6 @@ class TestVulnerabilityReportVerifier:
             json=lambda: meta_payload, raise_for_status=lambda: None
         )
         session = pretend.stub(get=lambda *a, **k: response)
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda str: None))
         cache = integrations.PublicKeysCache(cache_time=12)
         vuln_report_verifier = osv.VulnerabilityReportVerifier(
             public_keys_api_url="http://foo",
@@ -90,9 +88,8 @@ class TestVulnerabilityReportVerifier:
             pretend.call("warehouse.vulnerabilities.osv.auth.success"),
         ]
 
-    def test_verify_cache_hit(self):
+    def test_verify_cache_hit(self, metrics):
         session = pretend.stub()
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda str: None))
         cache = integrations.PublicKeysCache(cache_time=12)
         cache.cached_at = time.time()
         cache.cache = [
@@ -137,8 +134,7 @@ class TestVulnerabilityReportVerifier:
             pretend.call("warehouse.vulnerabilities.osv.auth.success"),
         ]
 
-    def test_verify_error(self):
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda str: None))
+    def test_verify_error(self, metrics):
         cache = integrations.PublicKeysCache(cache_time=12)
         vuln_report_verifier = osv.VulnerabilityReportVerifier(
             public_keys_api_url="http://foo",
@@ -177,12 +173,11 @@ class TestVulnerabilityReportVerifier:
             json=lambda: meta_payload, raise_for_status=lambda: None
         )
         session = pretend.stub(get=pretend.call_recorder(lambda *a, **k: response))
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda str: None))
 
         vuln_report_verifier = osv.VulnerabilityReportVerifier(
             public_keys_api_url="http://foo",
             session=session,
-            metrics=metrics,
+            metrics=pretend.stub(),
             public_keys_cache=pretend.stub(),
         )
         assert vuln_report_verifier.retrieve_public_key_payload() == meta_payload
@@ -193,7 +188,6 @@ class TestVulnerabilityReportVerifier:
         ]
 
     def test_get_cached_public_key_cache_hit(self):
-        metrics = pretend.stub()
         session = pretend.stub()
         cache = integrations.PublicKeysCache(cache_time=12)
         cache_value = pretend.stub()
@@ -202,21 +196,20 @@ class TestVulnerabilityReportVerifier:
         vuln_report_verifier = osv.VulnerabilityReportVerifier(
             public_keys_api_url="http://foo",
             session=session,
-            metrics=metrics,
+            metrics=pretend.stub(),
             public_keys_cache=cache,
         )
 
         assert vuln_report_verifier._get_cached_public_keys() is cache_value
 
     def test_get_cached_public_key_cache_miss_no_cache(self):
-        metrics = pretend.stub()
         session = pretend.stub()
         cache = integrations.PublicKeysCache(cache_time=12)
 
         vuln_report_verifier = osv.VulnerabilityReportVerifier(
             public_keys_api_url="http://foo",
             session=session,
-            metrics=metrics,
+            metrics=pretend.stub(),
             public_keys_cache=cache,
         )
 

--- a/tests/unit/integration/vulnerabilities/test_tasks.py
+++ b/tests/unit/integration/vulnerabilities/test_tasks.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import datetime
 
 import faker
@@ -26,12 +25,6 @@ def test_analyze_vulnerability(db_request, metrics):
     release2 = ReleaseFactory.create(project=project, version="2.0")
     release3 = ReleaseFactory.create(project=project, version="3.0")
 
-    metrics_counter = collections.Counter()
-
-    def metrics_increment(key, tags):
-        metrics_counter.update([(key, tuple(tags))])
-
-    metrics = pretend.stub(increment=metrics_increment, timed=metrics.timed)
     db_request.find_service = lambda *a, **kw: metrics
 
     tasks.analyze_vulnerability_task(
@@ -61,23 +54,23 @@ def test_analyze_vulnerability(db_request, metrics):
     assert "vuln_alias1" in vuln_record.aliases
     assert "vuln_alias2" in vuln_record.aliases
 
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]
 
 
 def test_analyze_vulnerability_update_metadata(db_request, metrics):
     project = ProjectFactory.create()
     release = ReleaseFactory.create(project=project, version="1.0")
 
-    metrics_counter = collections.Counter()
-
-    def metrics_increment(key, tags):
-        metrics_counter.update([(key, tuple(tags))])
-
-    metrics = pretend.stub(increment=metrics_increment, timed=metrics.timed)
     db_request.find_service = lambda *a, **kw: metrics
 
     tasks.analyze_vulnerability_task(
@@ -103,13 +96,19 @@ def test_analyze_vulnerability_update_metadata(db_request, metrics):
     assert release.vulnerabilities[0].fixed_in == []
     assert release.vulnerabilities[0].withdrawn is None
 
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]
 
-    metrics_counter.clear()
+    metrics.increment.calls = []  # reset
 
     withdrawn_date = datetime.datetime.utcnow()
 
@@ -137,11 +136,17 @@ def test_analyze_vulnerability_update_metadata(db_request, metrics):
     assert release.vulnerabilities[0].fixed_in == ["2.0"]
     assert release.vulnerabilities[0].withdrawn is withdrawn_date
 
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]
 
 
 def test_analyze_vulnerability_add_release(db_request, metrics):
@@ -149,12 +154,6 @@ def test_analyze_vulnerability_add_release(db_request, metrics):
     release1 = ReleaseFactory.create(project=project, version="1.0")
     release2 = ReleaseFactory.create(project=project, version="2.0")
 
-    metrics_counter = collections.Counter()
-
-    def metrics_increment(key, tags):
-        metrics_counter.update([(key, tuple(tags))])
-
-    metrics = pretend.stub(increment=metrics_increment, timed=metrics.timed)
     db_request.find_service = lambda *a, **kw: metrics
 
     tasks.analyze_vulnerability_task(
@@ -171,13 +170,19 @@ def test_analyze_vulnerability_add_release(db_request, metrics):
 
     assert len(release1.vulnerabilities) == 1
     assert len(release2.vulnerabilities) == 0
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]
 
-    metrics_counter.clear()
+    metrics.increment.calls = []  # reset
 
     tasks.analyze_vulnerability_task(
         request=db_request,
@@ -195,11 +200,17 @@ def test_analyze_vulnerability_add_release(db_request, metrics):
     assert len(release2.vulnerabilities) == 1
     assert release1.vulnerabilities[0] == release2.vulnerabilities[0]
 
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]
 
 
 def test_analyze_vulnerability_delete_releases(db_request, metrics):
@@ -207,12 +218,6 @@ def test_analyze_vulnerability_delete_releases(db_request, metrics):
     release1 = ReleaseFactory.create(project=project, version="1.0")
     release2 = ReleaseFactory.create(project=project, version="2.0")
 
-    metrics_counter = collections.Counter()
-
-    def metrics_increment(key, tags):
-        metrics_counter.update([(key, tuple(tags))])
-
-    metrics = pretend.stub(increment=metrics_increment, timed=metrics.timed)
     db_request.find_service = lambda *a, **kw: metrics
 
     tasks.analyze_vulnerability_task(
@@ -231,13 +236,19 @@ def test_analyze_vulnerability_delete_releases(db_request, metrics):
     assert len(release2.vulnerabilities) == 1
     assert release1.vulnerabilities[0] == release2.vulnerabilities[0]
 
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]
 
-    metrics_counter.clear()
+    metrics.increment.calls = []  # reset
 
     tasks.analyze_vulnerability_task(
         request=db_request,
@@ -253,13 +264,19 @@ def test_analyze_vulnerability_delete_releases(db_request, metrics):
 
     assert len(release1.vulnerabilities) == 1
     assert len(release2.vulnerabilities) == 0
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]
 
-    metrics_counter.clear()
+    metrics.increment.calls = []  # reset
 
     tasks.analyze_vulnerability_task(
         request=db_request,
@@ -277,22 +294,22 @@ def test_analyze_vulnerability_delete_releases(db_request, metrics):
     # https://docs.sqlalchemy.org/en/14/orm/cascades.html#notes-on-delete-deleting-objects-referenced-from-collections-and-scalar-relationships
     # assert len(release1.vulnerabilities) == 0
     assert len(release2.vulnerabilities) == 0
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]
 
 
 def test_analyze_vulnerability_invalid_request(db_request, metrics):
     project = ProjectFactory.create()
 
-    metrics_counter = collections.Counter()
-
-    def metrics_increment(key, tags):
-        metrics_counter.update([(key, tuple(tags))])
-
-    metrics = pretend.stub(increment=metrics_increment, timed=metrics.timed)
     db_request.find_service = lambda *a, **kw: metrics
 
     tasks.analyze_vulnerability_task(
@@ -307,19 +324,17 @@ def test_analyze_vulnerability_invalid_request(db_request, metrics):
         origin="test_report_source",
     )
 
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.error.format", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.error.format", tags=["origin:test_report_source"]
+        ),
+    ]
 
 
 def test_analyze_vulnerability_project_not_found(db_request, metrics):
-    metrics_counter = collections.Counter()
-
-    def metrics_increment(key, tags):
-        metrics_counter.update([(key, tuple(tags))])
-
-    metrics = pretend.stub(increment=metrics_increment, timed=metrics.timed)
     db_request.find_service = lambda *a, **kw: metrics
 
     tasks.analyze_vulnerability_task(
@@ -334,26 +349,24 @@ def test_analyze_vulnerability_project_not_found(db_request, metrics):
         origin="test_report_source",
     )
 
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-        (
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
             "warehouse.vulnerabilities.error.project_not_found",
-            ("origin:test_report_source",),
-        ): 1,
-    }
+            tags=["origin:test_report_source"],
+        ),
+    ]
 
 
 def test_analyze_vulnerability_release_not_found(db_request, metrics):
     project = ProjectFactory.create()
     ReleaseFactory.create(project=project, version="1.0")
 
-    metrics_counter = collections.Counter()
-
-    def metrics_increment(key, tags):
-        metrics_counter.update([(key, tuple(tags))])
-
-    metrics = pretend.stub(increment=metrics_increment, timed=metrics.timed)
     db_request.find_service = lambda *a, **kw: metrics
 
     tasks.analyze_vulnerability_task(
@@ -368,30 +381,34 @@ def test_analyze_vulnerability_release_not_found(db_request, metrics):
         origin="test_report_source",
     )
 
-    assert metrics_counter == {
-        (
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
             "warehouse.vulnerabilities.error.release_not_found",
-            ("origin:test_report_source",),
-        ): 2,
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-        (
+            tags=["origin:test_report_source"],
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.error.release_not_found",
+            tags=["origin:test_report_source"],
+        ),
+        pretend.call(
             "warehouse.vulnerabilities.error.no_releases_found",
-            ("origin:test_report_source",),
-        ): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-    }
+            tags=["origin:test_report_source"],
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]
 
 
 def test_analyze_vulnerability_no_versions(db_request, metrics):
     project = ProjectFactory.create()
 
-    metrics_counter = collections.Counter()
-
-    def metrics_increment(key, tags):
-        metrics_counter.update([(key, tuple(tags))])
-
-    metrics = pretend.stub(increment=metrics_increment, timed=metrics.timed)
     db_request.find_service = lambda *a, **kw: metrics
 
     tasks.analyze_vulnerability_task(
@@ -406,8 +423,14 @@ def test_analyze_vulnerability_no_versions(db_request, metrics):
         origin="test_report_source",
     )
 
-    assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.processed", ("origin:test_report_source",)): 1,
-    }
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.vulnerabilities.received", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.valid", tags=["origin:test_report_source"]
+        ),
+        pretend.call(
+            "warehouse.vulnerabilities.processed", tags=["origin:test_report_source"]
+        ),
+    ]

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -5913,8 +5913,7 @@ class TestManageProjectHistory:
 
 
 class TestManageOIDCPublisherViews:
-    def test_initializes(self):
-        metrics = pretend.stub()
+    def test_initializes(self, metrics):
         project = pretend.stub()
         request = pretend.stub(
             find_service=pretend.call_recorder(lambda *a, **kw: metrics),
@@ -5937,10 +5936,8 @@ class TestManageOIDCPublisherViews:
             (True, False),
         ],
     )
-    def test_ratelimiting(self, ip_exceeded, user_exceeded):
+    def test_ratelimiting(self, metrics, ip_exceeded, user_exceeded):
         project = pretend.stub()
-
-        metrics = pretend.stub()
         user_rate_limiter = pretend.stub(
             hit=pretend.call_recorder(lambda *a, **kw: None),
             test=pretend.call_recorder(lambda uid: not user_exceeded),
@@ -6071,7 +6068,7 @@ class TestManageOIDCPublisherViews:
             pretend.call(pyramid_request.POST, api_token="fake-api-token")
         ]
 
-    def test_add_github_oidc_publisher_preexisting(self, monkeypatch):
+    def test_add_github_oidc_publisher_preexisting(self, metrics, monkeypatch):
         publisher = pretend.stub(
             id="fakeid",
             publisher_name="GitHub",
@@ -6091,8 +6088,6 @@ class TestManageOIDCPublisherViews:
             record_event=pretend.call_recorder(lambda *a, **kw: None),
             users=[],
         )
-
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
 
         request = pretend.stub(
             user=pretend.stub(
@@ -6174,7 +6169,7 @@ class TestManageOIDCPublisherViews:
         assert view._check_ratelimits.calls == [pretend.call()]
         assert project.oidc_publishers == [publisher]
 
-    def test_add_github_oidc_publisher_created(self, monkeypatch):
+    def test_add_github_oidc_publisher_created(self, metrics, monkeypatch):
         fakeuser = pretend.stub()
         project = pretend.stub(
             name="fakeproject",
@@ -6182,8 +6177,6 @@ class TestManageOIDCPublisherViews:
             record_event=pretend.call_recorder(lambda *a, **kw: None),
             users=[fakeuser],
         )
-
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
 
         request = pretend.stub(
             user=pretend.stub(
@@ -6355,10 +6348,8 @@ class TestManageOIDCPublisherViews:
             )
         ]
 
-    def test_add_github_oidc_publisher_ratelimited(self, monkeypatch):
+    def test_add_github_oidc_publisher_ratelimited(self, metrics, monkeypatch):
         project = pretend.stub()
-
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
 
         request = pretend.stub(
             user=pretend.stub(),
@@ -6422,9 +6413,8 @@ class TestManageOIDCPublisherViews:
             )
         ]
 
-    def test_add_github_oidc_publisher_invalid_form(self, monkeypatch):
+    def test_add_github_oidc_publisher_invalid_form(self, metrics, monkeypatch):
         project = pretend.stub()
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
         request = pretend.stub(
             user=pretend.stub(),
             find_service=lambda *a, **kw: metrics,
@@ -6644,10 +6634,9 @@ class TestManageOIDCPublisherViews:
             )
         ]
 
-    def test_delete_oidc_publisher_invalid_form(self, monkeypatch):
+    def test_delete_oidc_publisher_invalid_form(self, metrics, monkeypatch):
         publisher = pretend.stub()
         project = pretend.stub(oidc_publishers=[publisher])
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
         request = pretend.stub(
             user=pretend.stub(),
             find_service=lambda *a, **kw: metrics,
@@ -6686,7 +6675,9 @@ class TestManageOIDCPublisherViews:
     @pytest.mark.parametrize(
         "other_publisher", [None, pretend.stub(id="different-fakeid")]
     )
-    def test_delete_oidc_publisher_not_found(self, monkeypatch, other_publisher):
+    def test_delete_oidc_publisher_not_found(
+        self, metrics, monkeypatch, other_publisher
+    ):
         publisher = pretend.stub(
             publisher_name="fakepublisher",
             id="fakeid",
@@ -6699,7 +6690,6 @@ class TestManageOIDCPublisherViews:
             name="fakeproject",
             record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
-        metrics = pretend.stub(increment=pretend.call_recorder(lambda *a, **kw: None))
         request = pretend.stub(
             user=pretend.stub(),
             find_service=lambda *a, **kw: metrics,


### PR DESCRIPTION
Instead of creating a new `metrics` object for call recording, use our perfectly good fixture whenever needed.