### PR TITLE
Require 2FA to join project

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "Confirm Invite"
 msgstr ""
 
-#: warehouse/templates/accounts/invite-confirmation.html:26
+#: warehouse/templates/accounts/invite-confirmation.html:34
 #, python-format
 msgid ""
 "Would you like to accept this invitation to join '<a "
@@ -1344,19 +1344,26 @@ msgid ""
 "%(role_name)s?"
 msgstr ""
 
-#: warehouse/templates/accounts/invite-confirmation.html:32
+#: warehouse/templates/accounts/invite-confirmation.html:40
 #: warehouse/templates/accounts/organization-invite-confirmation.html:40
 #: warehouse/templates/manage/organizations.html:42
 #: warehouse/templates/manage/projects.html:52
 msgid "Accept"
 msgstr ""
 
-#: warehouse/templates/accounts/invite-confirmation.html:33
+#: warehouse/templates/accounts/invite-confirmation.html:41
 #: warehouse/templates/accounts/organization-invite-confirmation.html:41
 #: warehouse/templates/manage/organizations.html:46
 #: warehouse/templates/manage/organizations.html:54
 #: warehouse/templates/manage/projects.html:53
 msgid "Decline"
+msgstr ""
+
+#: warehouse/templates/accounts/invite-confirmation.html:45
+#, python-format
+msgid ""
+"You must first enable <a href=\"%(href)s\">two-factor authentication</a> "
+"on your account before accepting an invitation to join a project."
 msgstr ""
 
 #: warehouse/templates/accounts/login.html:30

--- a/warehouse/templates/accounts/invite-confirmation.html
+++ b/warehouse/templates/accounts/invite-confirmation.html
@@ -17,8 +17,16 @@
     {% trans %}Confirm Invite{% endtrans %}
 {% endblock %}
 
-{% block main %}
+{% block prompt %}
+  {% if request.user.has_two_factor %}
+    {{ super() }}
+  {% else %}
+    <!-- Content hidden -->
+  {% endif %}
+{% endblock %}
 
+{% block main %}
+{% if request.user.has_two_factor %}
 <form method="POST">
   <div class="form-group">
     <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
@@ -33,5 +41,10 @@
     <input name="decline" type="submit" value="{% trans %}Decline{% endtrans %}" class="button">
   </div>
 </form>
+{% else %}{# user has not enabled 2FA #}
+{% trans href=request.route_path('manage.account.two-factor') %}
+You must first enable <a href="{{ href }}">two-factor authentication</a> on your account before accepting an invitation to join a project.
+{% endtrans %}
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This PR will require a user to have 2FA enabled in order to accept an invitation to join a project.

Here's how it looks when they click on the link to join:
![image](https://github.com/pypi/warehouse/assets/8961650/53197802-6dee-481a-a03b-3f1a52ada40d)

I'm not adding a server-side check because I don't see this as a security control but rather as a nudge to enable 2FA. My expectation is that when we globally require 2FA, we will have 1 central location on the server side where we'll enforce this.

Closes https://github.com/pypi/warehouse/issues/13767