### PR TITLE
tests, warehouse: fix WebAuthnCredentialMixin validator

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -950,8 +950,8 @@ class TestWebAuthnAuthenticationForm:
         origin = (pretend.stub(),)
         rp_id = (pretend.stub(),)
         form = forms.WebAuthnAuthenticationForm(
+            formdata=MultiDict({"credential": json.dumps({})}),
             request=request,
-            credential=json.dumps({}),
             user_id=pretend.stub(),
             user_service=pretend.stub(
                 verify_webauthn_assertion=pretend.call_recorder(
@@ -972,8 +972,8 @@ class TestWebAuthnAuthenticationForm:
     def test_credential_bad_payload(self, pyramid_config):
         request = pretend.stub()
         form = forms.WebAuthnAuthenticationForm(
+            formdata=MultiDict({"credential": "not valid json"}),
             request=request,
-            credential="not valid json",
             user_id=pretend.stub(),
             user_service=pretend.stub(),
             challenge=pretend.stub(),
@@ -998,8 +998,8 @@ class TestWebAuthnAuthenticationForm:
             ),
         )
         form = forms.WebAuthnAuthenticationForm(
+            formdata=MultiDict({"credential": json.dumps({})}),
             request=request,
-            credential=json.dumps({}),
             user_id=1,
             user_service=user_service,
             challenge=pretend.stub(),

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -105,7 +105,7 @@ class TOTPValueMixin:
 
 
 class WebAuthnCredentialMixin:
-    credential = wtforms.StringField(wtforms.validators.InputRequired())
+    credential = wtforms.StringField(validators=[wtforms.validators.InputRequired()])
 
 
 class RecoveryCodeValueMixin:


### PR DESCRIPTION
This was passing, but for surprising reasons: the `InputRequired` validator wasn't actually firing.

Fixes #14673.