### PR TITLE
views: don't splat request.POST

### DIFF
--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -422,7 +422,7 @@ def webauthn_authentication_validate(request):
 
     user_service = request.find_service(IUserService, context=None)
     form = WebAuthnAuthenticationForm(
-        **request.POST,
+        request.POST,
         request=request,
         user_id=userid,
         user_service=user_service,


### PR DESCRIPTION
This needs to be a `MultiDict`; by turning it into kwargs, we fail the `InputRequired` validator because it doesn't treat the values as actual user-supplied inputs.

Fixes #14690.