### PR TITLE
fix: Unsupported platform tag macosx_14_0_arm64 (#14700) 

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3140,7 +3140,7 @@ class TestFileUpload:
             "linux_x86_64",
             "linux_x86_64.win32",
             "macosx_9_2_x86_64",
-            "macosx_14_2_arm64",
+            "macosx_15_2_arm64",
             "macosx_10_15_amd64",
         ],
     )

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -146,6 +146,7 @@ _macosx_major_versions = {
     "11",
     "12",
     "13",
+    "14",
 }
 
 # manylinux pep600 and musllinux pep656 are a little more complicated:


### PR DESCRIPTION
fix: Unsupported platform tag macosx_14_0_arm64 (#14700) 