### PR TITLE
chore: strip out whitespace added by jinja blocks

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -402,6 +402,8 @@ def test_configure(monkeypatch, settings, environment):
     assert configurator_obj.add_settings.calls == [
         pretend.call({"jinja2.newstyle": True}),
         pretend.call({"jinja2.i18n.domain": "messages"}),
+        pretend.call({"jinja2.lstrip_blocks": True}),
+        pretend.call({"jinja2.trim_blocks": True}),
         pretend.call({"retry.attempts": 3}),
         pretend.call(
             {
@@ -413,7 +415,7 @@ def test_configure(monkeypatch, settings, environment):
         ),
         pretend.call({"http": {"verify": "/etc/ssl/certs/"}}),
     ]
-    add_settings_dict = configurator_obj.add_settings.calls[3].args[0]
+    add_settings_dict = configurator_obj.add_settings.calls[5].args[0]
     assert add_settings_dict["tm.manager_hook"](pretend.stub()) is transaction_manager
     assert configurator_obj.add_tween.calls == [
         pretend.call("warehouse.config.require_https_tween_factory"),

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -482,6 +482,10 @@ def configure(settings=None):
     # Our translation strings are all in the "messages" domain
     config.add_settings({"jinja2.i18n.domain": "messages"})
 
+    # Trim the Jinja blocks from the output, it's extra whitespace.
+    config.add_settings({"jinja2.lstrip_blocks": True})
+    config.add_settings({"jinja2.trim_blocks": True})
+
     # We also want to use Jinja2 for .html templates as well, because we just
     # assume that all templates will be using Jinja.
     config.add_jinja2_renderer(".html")

--- a/warehouse/templates/robots.txt
+++ b/warehouse/templates/robots.txt
@@ -1,9 +1,9 @@
 Sitemap: {{ request.route_url("index.sitemap.xml") }}
 
 User-agent: *
-{%- if request.registry.settings.get("warehouse.domain") != "pypi.org" %}
+{% if request.registry.settings.get("warehouse.domain") != "pypi.org" %}
 Disallow: /
-{%- else %}
+{% else %}
 Disallow: /simple/
 Disallow: /packages/
 Disallow: /_includes/
@@ -11,5 +11,4 @@ Disallow: /pypi/*/json
 Disallow: /pypi/*/*/json
 Disallow: /pypi*?
 Disallow: /search*
-{%- endif %}
-
+{% endif %}


### PR DESCRIPTION
When looking at source of HTML, we emit whitespace around Jinja blocks.

While individual blocks can opt out of emitting this whitespace with `-` control characters (like `robots.txt` did), it is simpler to apply this as a global setting.

On pages like `/help/`, these settings remove some 500 lines of whitespace from the output.

Refs: https://jinja.palletsprojects.com/en/3.0.x/templates/#whitespace-control