### PR TITLE
Emit unique error when TOTP is skewed

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -899,11 +899,7 @@ class TestTOTPAuthenticationForm:
         "exception, expected_error, reason",
         [
             (otp.InvalidTOTPError, "Invalid TOTP code.", "invalid_totp"),
-            (
-                otp.OutOfSyncTOTPError,
-                "Invalid TOTP code. Your device time may be out of sync.",
-                "out_of_sync_totp",
-            ),
+            (otp.OutOfSyncTOTPError, "Invalid TOTP code.", "invalid_totp"),
         ],
     )
     def test_totp_secret_raises(

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -592,7 +592,8 @@ class TestDatabaseUserService:
 
     def test_check_totp_value_no_secret(self, user_service):
         user = UserFactory.create()
-        assert not user_service.check_totp_value(user.id, b"123456")
+        with pytest.raises(otp.InvalidTOTPError):
+            user_service.check_totp_value(user.id, b"123456")
 
     def test_check_totp_global_rate_limited(self, user_service, metrics):
         resets = pretend.stub()

--- a/tests/unit/utils/test_otp.py
+++ b/tests/unit/utils/test_otp.py
@@ -22,17 +22,11 @@ from cryptography.hazmat.primitives.hashes import SHA1
 from cryptography.hazmat.primitives.twofactor.totp import TOTP
 from urllib3.util import parse_url
 
-from warehouse.utils.otp import (
-    TOTP_INTERVAL,
-    TOTP_LENGTH,
-    generate_totp_provisioning_uri,
-    generate_totp_secret,
-    verify_totp,
-)
+import warehouse.utils.otp as otp
 
 
 def test_generate_totp_secret():
-    secret = generate_totp_secret()
+    secret = otp.generate_totp_secret()
 
     # secret should be bytes
     assert type(secret) is bytes
@@ -45,7 +39,7 @@ def test_generate_totp_provisioning_uri():
     secret = b"F" * 32
     username = "pony"
     issuer_name = "pypi.org"
-    uri = generate_totp_provisioning_uri(secret, username, issuer_name=issuer_name)
+    uri = otp.generate_totp_provisioning_uri(secret, username, issuer_name=issuer_name)
 
     parsed = parse_url(uri)
 
@@ -64,15 +58,20 @@ def test_generate_totp_provisioning_uri():
 
 @pytest.mark.parametrize("skew", [0, -20, 20])
 def test_verify_totp_success(skew):
-    secret = generate_totp_secret()
-    totp = TOTP(secret, TOTP_LENGTH, SHA1(), TOTP_INTERVAL, backend=default_backend())
+    secret = otp.generate_totp_secret()
+    totp = TOTP(
+        secret, otp.TOTP_LENGTH, SHA1(), otp.TOTP_INTERVAL, backend=default_backend()
+    )
     value = totp.generate(time.time() + skew)
-    assert verify_totp(secret, value)
+    assert otp.verify_totp(secret, value)
 
 
 @pytest.mark.parametrize("skew", [-60, 60])
 def test_verify_totp_failure(skew):
-    secret = generate_totp_secret()
-    totp = TOTP(secret, TOTP_LENGTH, SHA1(), TOTP_INTERVAL, backend=default_backend())
+    secret = otp.generate_totp_secret()
+    totp = TOTP(
+        secret, otp.TOTP_LENGTH, SHA1(), otp.TOTP_INTERVAL, backend=default_backend()
+    )
     value = totp.generate(time.time() + skew)
-    assert not verify_totp(secret, value)
+    with pytest.raises(otp.OutOfSyncTOTPError):
+        otp.verify_totp(secret, value)

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -417,17 +417,7 @@ class TOTPAuthenticationForm(TOTPValueMixin, _TwoFactorAuthenticationForm):
 
         try:
             self.user_service.check_totp_value(self.user_id, totp_value)
-        except otp.OutOfSyncTOTPError:
-            user = self.user_service.get_user(self.user_id)
-            user.record_event(
-                tag=EventTag.Account.LoginFailure,
-                request=self.request,
-                additional={"reason": "out_of_sync_totp"},
-            )
-            raise wtforms.validators.ValidationError(
-                _("Invalid TOTP code. Your device time may be out of sync.")
-            )
-        except otp.InvalidTOTPError:
+        except (otp.InvalidTOTPError, otp.OutOfSyncTOTPError):
             user = self.user_service.get_user(self.user_id)
             user.record_event(
                 tag=EventTag.Account.LoginFailure,

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -94,27 +94,23 @@ msgstr ""
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:428
-msgid "Invalid TOTP code. Your device time may be out of sync."
-msgstr ""
-
-#: warehouse/accounts/forms.py:437
+#: warehouse/accounts/forms.py:427
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:454
+#: warehouse/accounts/forms.py:444
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:523
+#: warehouse/accounts/forms.py:513
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:532
+#: warehouse/accounts/forms.py:522
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:551
+#: warehouse/accounts/forms.py:541
 msgid "No user found with that username or email"
 msgstr ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -94,23 +94,27 @@ msgstr ""
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:425
+#: warehouse/accounts/forms.py:428
+msgid "Invalid TOTP code. Your device time may be out of sync."
+msgstr ""
+
+#: warehouse/accounts/forms.py:437
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:442
+#: warehouse/accounts/forms.py:454
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:511
+#: warehouse/accounts/forms.py:523
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:520
+#: warehouse/accounts/forms.py:532
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:539
+#: warehouse/accounts/forms.py:551
 msgid "No user found with that username or email"
 msgstr ""
 
@@ -336,11 +340,11 @@ msgstr ""
 msgid "Banner Preview"
 msgstr ""
 
-#: warehouse/manage/forms.py:408
+#: warehouse/manage/forms.py:414
 msgid "Choose an organization account name with 50 characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:416
+#: warehouse/manage/forms.py:422
 msgid ""
 "The organization account name is invalid. Organization account names must"
 " be composed of letters, numbers, dots, hyphens and underscores. And must"
@@ -348,73 +352,73 @@ msgid ""
 "organization account name."
 msgstr ""
 
-#: warehouse/manage/forms.py:439
+#: warehouse/manage/forms.py:445
 msgid ""
 "This organization account name has already been used. Choose a different "
 "organization account name."
 msgstr ""
 
-#: warehouse/manage/forms.py:454
+#: warehouse/manage/forms.py:460
 msgid ""
 "You have already submitted an application for that name. Choose a "
 "different organization account name."
 msgstr ""
 
-#: warehouse/manage/forms.py:490
+#: warehouse/manage/forms.py:496
 msgid "Select project"
 msgstr ""
 
-#: warehouse/manage/forms.py:495 warehouse/oidc/forms/github.py:174
+#: warehouse/manage/forms.py:501 warehouse/oidc/forms/github.py:174
 msgid "Specify project name"
 msgstr ""
 
-#: warehouse/manage/forms.py:498
+#: warehouse/manage/forms.py:504
 msgid ""
 "Start and end with a letter or numeral containing only ASCII numeric and "
 "'.', '_' and '-'."
 msgstr ""
 
-#: warehouse/manage/forms.py:505
+#: warehouse/manage/forms.py:511
 msgid "This project name has already been used. Choose a different project name."
 msgstr ""
 
-#: warehouse/manage/forms.py:576
+#: warehouse/manage/forms.py:582
 msgid ""
 "The organization name is too long. Choose a organization name with 100 "
 "characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:588
+#: warehouse/manage/forms.py:594
 msgid ""
 "The organization URL is too long. Choose a organization URL with 400 "
 "characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:595
+#: warehouse/manage/forms.py:601
 msgid "The organization URL must start with http:// or https://"
 msgstr ""
 
-#: warehouse/manage/forms.py:606
+#: warehouse/manage/forms.py:612
 msgid ""
 "The organization description is too long. Choose a organization "
 "description with 400 characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:641
+#: warehouse/manage/forms.py:647
 msgid "You have already submitted the maximum number of "
 msgstr ""
 
-#: warehouse/manage/forms.py:671
+#: warehouse/manage/forms.py:677
 msgid "Choose a team name with 50 characters or less."
 msgstr ""
 
-#: warehouse/manage/forms.py:677
+#: warehouse/manage/forms.py:683
 msgid ""
 "The team name is invalid. Team names cannot start or end with a space, "
 "period, underscore, hyphen, or slash. Choose a different team name."
 msgstr ""
 
-#: warehouse/manage/forms.py:705
+#: warehouse/manage/forms.py:711
 msgid "This team name has already been used. Choose a different team name."
 msgstr ""
 

--- a/warehouse/manage/forms.py
+++ b/warehouse/manage/forms.py
@@ -203,7 +203,13 @@ class ProvisionTOTPForm(TOTPValueMixin, forms.Form):
 
     def validate_totp_value(self, field):
         totp_value = field.data.encode("utf8")
-        if not otp.verify_totp(self.totp_secret, totp_value):
+        try:
+            otp.verify_totp(self.totp_secret, totp_value)
+        except otp.OutOfSyncTOTPError:
+            raise wtforms.validators.ValidationError(
+                "Invalid TOTP code. Your device time may be out of sync."
+            )
+        except otp.InvalidTOTPError:
             raise wtforms.validators.ValidationError("Invalid TOTP code. Try again?")
 
 


### PR DESCRIPTION
This PR adds a unique error message when a TOTP is valid, but outside the time range of what we consider valid. This should help identify issues to add TOTP devices due to clock skew. 

Related to #14710.