### PR TITLE
Dockerignore `.venv`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ dev/*
 **/*.pyc
 htmlcov
 warehouse/static/dist
+.venv


### PR DESCRIPTION
I like to have a venv in the project folder so i can run tools without having to go through launching a container. I'd like to add `.venv` to `.dockerignore` to avoid this venv being picked up by linters and formatters.

See https://github.com/pypi/warehouse/pull/13606#issuecomment-1759942618