### PR TITLE
fix: account for user.last_login being null

### DIFF
--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -796,7 +796,7 @@ def reset_password(request, _form_class=ResetPasswordForm):
     # now it's localized to UTC
     if not last_login.tzinfo:
         last_login = pytz.UTC.localize(last_login)
-    if user.last_login > last_login:
+    if user.last_login and user.last_login > last_login:
         sentry_sdk.set_context(
             "user",
             {


### PR DESCRIPTION
Already fixed the token-side from being a "None" string in #14756

The change here accounts for the model-side being null in the database, along with a test that expresses that behavior as well.

Introduced by #10846
Fixes https://python-software-foundation.sentry.io/share/issue/aeef04ecbb5148af86122dcc2876cc64/