### PR TITLE
refactor: replace backref with back_populates 

### DIFF
--- a/dev/flake8/checkers.py
+++ b/dev/flake8/checkers.py
@@ -23,12 +23,39 @@ from collections.abc import Generator
 from typing import Any
 
 WH001_msg = "WH001 Prefer `urllib3.util.parse_url` over `urllib.parse.urlparse`"
+WH002_msg = (
+    "WH002 Prefer `sqlalchemy.orm.relationship(back_populates=...)` "
+    "over `sqlalchemy.orm.relationship(backref=...)`"
+)
 
 
 class WarehouseVisitor(ast.NodeVisitor):
     def __init__(self, filename: str) -> None:
         self.errors: list[tuple[int, int, str]] = []
         self.filename = filename
+
+    def check_for_backref(self, node) -> None:
+        def _check_keywords(keywords: list[ast.keyword]) -> None:
+            for kw in keywords:
+                if kw.arg == "backref":
+                    self.errors.append((kw.lineno, kw.col_offset, WH002_msg))
+
+        # Nodes can be either Attribute or Name, and depending on the type
+        # of node, the value.func can be either an attr or an id.
+        # TODO: This is aching for a better way to do this.
+        if isinstance(node.value, ast.Call):
+            if (
+                isinstance(node.value.func, ast.Attribute)
+                and node.value.func.attr == "relationship"
+                and isinstance(node.value.keywords, list)
+            ):
+                _check_keywords(node.value.keywords)
+            elif (
+                isinstance(node.value.func, ast.Name)
+                and node.value.func.id == "relationship"
+                and isinstance(node.value.keywords, list)
+            ):
+                _check_keywords(node.value.keywords)
 
     def visit_Name(self, node: ast.Name) -> None:  # noqa: N802
         if node.id == "urlparse":
@@ -44,6 +71,14 @@ class WarehouseVisitor(ast.NodeVisitor):
         ):
             self.errors.append((node.lineno, node.col_offset, WH001_msg))
 
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:  # noqa: N802
+        self.check_for_backref(node)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:  # noqa: N802
+        self.check_for_backref(node)
         self.generic_visit(node)
 
 

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -570,6 +570,16 @@ class TestRelease:
 
         assert not release.trusted_published
 
+    def test_description_relationship(self, db_request):
+        """When a Release is deleted, the Description is also deleted."""
+        release = DBReleaseFactory.create()  # also creates a Description
+        description = release.description
+
+        db_request.db.delete(release)
+
+        assert release in db_request.db.deleted
+        assert description in db_request.db.deleted
+
 
 class TestFile:
     def test_requires_python(self, db_session):

--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -389,13 +389,12 @@ def test_update_description_html(monkeypatch, db_request):
 
 
 def test_update_release_description(db_request):
-    release = ReleaseFactory.create()
     description = DescriptionFactory.create(
-        release=release,
         raw="rst\n===\n\nbody text",
         html="",
         rendered_by="0.0",
     )
+    release = ReleaseFactory.create(description=description)
 
     task = pretend.stub()
     update_release_description(task, db_request, release.id)

--- a/warehouse/email/ses/models.py
+++ b/warehouse/email/ses/models.py
@@ -248,9 +248,8 @@ class EmailMessage(db.Model):
     missing: Mapped[bool_false]
 
     # Relationships!
-    events = orm.relationship(
-        "Event",
-        backref="email",
+    events: Mapped[list["Event"]] = orm.relationship(
+        back_populates="email",
         cascade="all, delete-orphan",
         lazy=False,
         order_by=lambda: Event.created,
@@ -274,6 +273,10 @@ class Event(db.Model):
             "ses_emails.id", deferrable=True, initially="DEFERRED", ondelete="CASCADE"
         ),
         index=True,
+    )
+    email: Mapped[EmailMessage] = orm.relationship(
+        back_populates="events",
+        lazy=False,
     )
 
     event_id: Mapped[str] = mapped_column(unique=True, index=True)

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -467,23 +467,13 @@ class Release(db.Model):
         ForeignKey("release_descriptions.id", onupdate="CASCADE", ondelete="CASCADE"),
         index=True,
     )
-    description: Mapped[Description] = orm.relationship(
-        backref=orm.backref(
-            "release",
-            cascade="all, delete-orphan",
-            passive_deletes=True,
-            passive_updates=True,
-            single_parent=True,
-            uselist=False,
-        ),
-    )
+    description: Mapped[Description] = orm.relationship()
 
     yanked: Mapped[bool_false]
 
     yanked_reason: Mapped[str] = mapped_column(server_default="")
 
     _classifiers: Mapped[list[Classifier]] = orm.relationship(
-        backref="project_releases",
         secondary="release_classifiers",
         order_by=Classifier.ordering,
         passive_deletes=True,

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -403,6 +403,8 @@ class Description(db.Model):
     html: Mapped[str]
     rendered_by: Mapped[str]
 
+    release: Mapped[Release] = orm.relationship(back_populates="description")
+
 
 class ReleaseURL(db.Model):
     __tablename__ = "release_urls"
@@ -467,7 +469,11 @@ class Release(db.Model):
         ForeignKey("release_descriptions.id", onupdate="CASCADE", ondelete="CASCADE"),
         index=True,
     )
-    description: Mapped[Description] = orm.relationship()
+    description: Mapped[Description] = orm.relationship(
+        back_populates="release",
+        cascade="all, delete-orphan",
+        single_parent=True,
+    )
 
     yanked: Mapped[bool_false]
 


### PR DESCRIPTION
Add both sides of the relationship equation where needed.

Add a linter checker to find them, and remove unnecessary usage.

Resolves #6320 

Now also includes bugfix to correctly delete orphan Descriptions when their Release is removed.