### PR TITLE
More helpful example text for twine upload command

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4578,8 +4578,8 @@ msgstr ""
 #: warehouse/templates/manage/account/token.html:113
 #, python-format
 msgid ""
-"You can then use <code>%(command)s</code> to switch to the correct token "
-"when uploading to PyPI."
+"You can then use <code>%(command)s</code> to use the correct token when "
+"uploading to PyPI."
 msgstr ""
 
 #: warehouse/templates/manage/account/token.html:119

--- a/warehouse/templates/manage/account/token.html
+++ b/warehouse/templates/manage/account/token.html
@@ -110,8 +110,8 @@
   username = __token__
   password = # {% trans %}a project token{% endtrans %} </pre>
     <p>
-      {% trans command='twine --repository PROJECT_NAME' %}
-        You can then use <code>{{ command }}</code> to switch to the correct token when uploading to PyPI.
+      {% trans command='twine upload --repository PROJECT_NAME' %}
+        You can then use <code>{{ command }}</code> to use the correct token when uploading to PyPI.
       {% endtrans %}
     </p>
     {% endif %}


### PR DESCRIPTION
When [adding a new token](https://pypi.org/manage/account/token/), the current message describing how to use it with twine renders like:

__"You can then use `twine --repository PROJECT_NAME` to switch to the correct token when uploading to PyPI."__

It's confusing, because the repository option only applies on a _subcommand_ of `twine`. If you use it as written you get an error message:

```
$ twine --repository myproj upload dist/*
usage: twine [-h] [--version] [--no-color] {register,check,upload}
twine: error: argument command: invalid choice: 'myproj' (choose from 'register', 'check', 'upload')
```

Then you think, ok, maybe it's literally saying that using `twine --repository PROJECT_NAME` is like a "switch" command which sets some state in the rc file, but that's not right either:

```
$ twine --repository myproj                
usage: twine [-h] [--version] [--no-color] {check,upload,register}
twine: error: argument command: invalid choice: 'myproj' (choose from 'check', 'upload', 'register')
```

I change the message to be more in-line with actual usage:

__"You can then use `twine upload --repository PROJECT_NAME` to use the correct token when uploading to PyPI."__