### PR TITLE
fix: evaluate Trusted Publisher events correctly

### DIFF
--- a/tests/common/db/packaging.py
+++ b/tests/common/db/packaging.py
@@ -128,6 +128,7 @@ class FileEventFactory(WarehouseFactory):
         model = File.Event
 
     source = factory.SubFactory(FileFactory)
+    additional = {"publisher_url": None}
 
 
 class RoleFactory(WarehouseFactory):

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -531,10 +531,9 @@ class TestRelease:
         DBFileEventFactory.create(
             source=release_file,
             tag="fake:event",
-            additional={},
         )
 
-        # Without the `publisher_url` key, not considered trusted published
+        # Without a `publisher_url` value, not considered trusted published
         assert not release.trusted_published
 
         DBFileEventFactory.create(
@@ -560,7 +559,6 @@ class TestRelease:
         DBFileEventFactory.create(
             source=rfile_1,
             tag="fake:event",
-            additional={"publisher_url": None},
         )
         DBFileEventFactory.create(
             source=rfile_2,
@@ -656,7 +654,6 @@ class TestFile:
         DBFileEventFactory.create(
             source=rfile,
             tag="fake:event",
-            additional={"publisher_url": None},
         )
 
         # Without the `publisher_url` key, not considered trusted published

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -560,7 +560,7 @@ class TestRelease:
         DBFileEventFactory.create(
             source=rfile_1,
             tag="fake:event",
-            additional={},
+            additional={"publisher_url": None},
         )
         DBFileEventFactory.create(
             source=rfile_2,
@@ -656,7 +656,7 @@ class TestFile:
         DBFileEventFactory.create(
             source=rfile,
             tag="fake:event",
-            additional={},
+            additional={"publisher_url": None},
         )
 
         # Without the `publisher_url` key, not considered trusted published

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -697,7 +697,7 @@ class File(HasEvents, db.Model):
         """Return True if the file was uploaded via a trusted publisher."""
         return (
             self.events.where(
-                self.Event.additional.has_key("publisher_url")  # type: ignore[attr-defined] # noqa E501
+                self.Event.additional.op("->>")("publisher_url").is_not(None)  # type: ignore[attr-defined] # noqa E501
             ).count()
             > 0
         )


### PR DESCRIPTION
The code that adds the Events we're looking at adds the `publisher_url` key regardless of whether or not there's a Trusted Publisher used.

Refs: https://github.com/pypi/warehouse/blob/19e6fed8e39230520aa8dd7e7cde955ba4919894/warehouse/forklift/legacy.py#L1442-L1446

Instead of checking for the key, let's check the value.

Tests updated to behave similarly, and fail without this fix.