### PR TITLE
chore: replace deprecated custom_predicates

### DIFF
--- a/tests/unit/forklift/test_action_routing.py
+++ b/tests/unit/forklift/test_action_routing.py
@@ -15,23 +15,20 @@ import pretend
 from warehouse.forklift import action_routing
 
 
-def test_add_legacy_action_route(monkeypatch):
-    pred = pretend.stub()
-    pypi_action = pretend.call_recorder(lambda name: pred)
-    monkeypatch.setattr(action_routing, "pypi_action", pypi_action)
-
+def test_add_legacy_action_route():
     config = pretend.stub(add_route=pretend.call_recorder(lambda *a, **k: None))
 
     action_routing.add_legacy_action_route(config, "the name", "the action")
 
     assert config.add_route.calls == [
-        pretend.call("the name", "/legacy/", custom_predicates=[pred])
+        pretend.call("the name", "/legacy/", pypi_action="the action")
     ]
 
 
 def test_includeme():
     config = pretend.stub(
-        add_directive=pretend.call_recorder(lambda name, f, action_wrap: None)
+        add_route_predicate=pretend.call_recorder(lambda name, pred: None),
+        add_directive=pretend.call_recorder(lambda name, f, action_wrap: None),
     )
 
     action_routing.includeme(config)

--- a/warehouse/forklift/action_routing.py
+++ b/warehouse/forklift/action_routing.py
@@ -10,14 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from warehouse.legacy.action_routing import pypi_action
-
 
 def add_legacy_action_route(config, name, action, **kwargs):
-    custom_predicates = kwargs.pop("custom_predicates", [])
-    custom_predicates += [pypi_action(action)]
-
-    config.add_route(name, "/legacy/", custom_predicates=custom_predicates, **kwargs)
+    config.add_route(name, "/legacy/", pypi_action=action, **kwargs)
 
 
 def includeme(config):

--- a/warehouse/legacy/action_routing.py
+++ b/warehouse/legacy/action_routing.py
@@ -11,28 +11,29 @@
 # limitations under the License.
 
 
-def pypi_action(action):
-    def predicate(info, request):
-        return action == request.params.get(":action", None)
+class PyPIActionPredicate:
+    def __init__(self, action: str, info):
+        self.action_name = action
 
-    return predicate
+    def text(self) -> str:
+        return f"pypi_action = {self.action_name}"
+
+    phash = text
+
+    def __call__(self, context, request) -> bool:
+        return self.action_name == request.params.get(":action", None)
 
 
 def add_pypi_action_route(config, name, action, **kwargs):
-    custom_predicates = kwargs.pop("custom_predicates", [])
-    custom_predicates += [pypi_action(action)]
-
-    config.add_route(name, "/pypi", custom_predicates=custom_predicates, **kwargs)
+    config.add_route(name, "/pypi", pypi_action=action, **kwargs)
 
 
 def add_pypi_action_redirect(config, action, target, **kwargs):
-    custom_predicates = kwargs.pop("custom_predicates", [])
-    custom_predicates += [pypi_action(action)]
-
-    config.add_redirect("/pypi", target, custom_predicates=custom_predicates, **kwargs)
+    config.add_redirect("/pypi", target, pypi_action=action, **kwargs)
 
 
 def includeme(config):
+    config.add_route_predicate("pypi_action", PyPIActionPredicate)
     config.add_directive(
         "add_pypi_action_route", add_pypi_action_route, action_wrap=False
     )


### PR DESCRIPTION
`custom_predicates` was deprecated in Pyramid 1.5 10 years ago. We don't actively use the ability we have to pass along more `custom_predicates` and add them.

    DeprecationWarning: The "custom_predicates" argument to
    Configurator.add_route is deprecated as of Pyramid 1.5. Use
    "config.add_route_predicate" and use the registered route predicate as a
    predicate argument to add_route instead. See "Adding A Custom View,
    Route, or Subscriber Predicate" in the "Hooks" chapter of the
    documentation for more information.

Instead, construct a predicate factory that is then added to the route, similar to `warehouse.predicates.DomainPredicate`.

I opted to keep this one close to its primary usage, instead of relocating it to `warehouse.predicates`.

Refs: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#view-and-route-predicates
Refs: https://github.com/Pylons/pyramid/pull/1118