### PR TITLE
fix: return a naive UTC object

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -22,6 +22,15 @@ import pytest
 from urllib3.util import parse_url
 
 from warehouse import filters
+from warehouse.utils import now
+
+
+def test_now():
+    assert isinstance(now(), datetime.datetime)
+    assert now().tzinfo is None
+    with pytest.raises(TypeError) as excinfo:
+        _ = now() < datetime.datetime.now(datetime.UTC)
+    assert "can't compare offset-naive and offset-aware datetimes" in str(excinfo.value)
 
 
 def test_camo_url():

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -31,6 +31,7 @@ def test_now():
     with pytest.raises(TypeError) as excinfo:
         _ = now() < datetime.datetime.now(datetime.UTC)
     assert "can't compare offset-naive and offset-aware datetimes" in str(excinfo.value)
+    assert now() <= datetime.datetime.now()
 
 
 def test_camo_url():

--- a/warehouse/utils/__init__.py
+++ b/warehouse/utils/__init__.py
@@ -14,7 +14,8 @@ import datetime
 
 
 def now() -> datetime.datetime:
-    return datetime.datetime.now(datetime.UTC)
+    """Return the current datetime in UTC without a timezone."""
+    return datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
 
 
 def dotted_navigator(path):


### PR DESCRIPTION
When used in Jinja filters, we compare against other naive time-like objects.

Introduced in #14860
Fixes https://python-software-foundation.sentry.io/share/issue/6f07733076404820b4e87c3fad7cb896/

Add docstring and test for explicit behavior.