### PR TITLE
test: make order explicit

### DIFF
--- a/tests/unit/organizations/test_services.py
+++ b/tests/unit/organizations/test_services.py
@@ -136,10 +136,10 @@ class TestDatabaseOrganizationService:
 
         assert organization_service.get_organization_applications_by_name(
             organization_application.name
-        ) == [organization_application, competing_organization_application]
+        ) == sorted([organization_application, competing_organization_application])
         assert organization_service.get_organization_applications_by_name(
             organization_application.name, undecided=True
-        ) == [organization_application, competing_organization_application]
+        ) == sorted([organization_application, competing_organization_application])
 
         assert (
             organization_service.get_organization_by_name(organization_application.name)

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -486,6 +486,9 @@ class OrganizationApplication(OrganizationMixin, db.Model):
         back_populates="application", viewonly=True
     )
 
+    def __lt__(self, other: OrganizationApplication) -> bool:
+        return self.name < other.name
+
 
 class OrganizationNameCatalog(db.Model):
     __tablename__ = "organization_name_catalog"


### PR DESCRIPTION
As the names for the orgs are generated by Faker, we should sort them during comparison.

Fixes #14645