### PR TITLE
improve stop time for docker compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
     image: vault:1.12.3
     restart: on-failure
     entrypoint: /bin/sh
-    command: ["/etc/vault/entry.sh"]
+    command: /etc/vault/entry.sh
+    stop_signal: SIGINT
     environment:
       VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
       VAULT_DEV_ROOT_TOKEN_ID: "an insecure vault access token"
@@ -49,6 +50,7 @@ services:
 
   localstack:
     image: localstack/localstack:1.4
+    stop_signal: SIGKILL
     environment:
       SERVICES: "sqs"
       HOSTNAME: "localstack"
@@ -134,6 +136,7 @@ services:
     pull_policy: never
     working_dir: /var/opt/warehouse
     command: python -m http.server 9001
+    stop_signal: SIGINT
     volumes:
       - packages:/var/opt/warehouse/packages
       - packages-archive:/var/opt/warehouse/packages-archive
@@ -166,7 +169,8 @@ services:
       - "35729:35729" # LiveReload
     environment:
       NODE_ENV: "development"
-    command: bash -c "npm run watch"
+    command: ["npm", "run", "watch"]
+    stop_signal: SIGKILL
     volumes:
       - ./warehouse:/opt/warehouse/src/warehouse:z
       - ./webpack.config.js:/opt/warehouse/src/webpack.config.js:z
@@ -186,6 +190,7 @@ services:
     image: warehouse:docker-compose
     pull_policy: never
     command: python /opt/warehouse/dev/notdatadog.py 0.0.0.0:8125
+    stop_signal: SIGINT
     environment:
       METRICS_OUTPUT: "false"
     ports:
@@ -213,6 +218,7 @@ services:
     image: warehouse:docker-compose-docs
     pull_policy: never
     command: mkdocs serve -a 0.0.0.0:8000 -f docs/mkdocs-user-docs.yml
+    stop_signal: SIGINT
     volumes:
       - ./bin:/opt/warehouse/src/bin:z
       - ./docs/mkdocs-user-docs.yml:/opt/warehouse/src/docs/mkdocs-user-docs.yml:z
@@ -224,6 +230,7 @@ services:
     image: warehouse:docker-compose-docs
     pull_policy: never
     command: mkdocs serve -a 0.0.0.0:8000 -f docs/mkdocs-blog.yml
+    stop_signal: SIGINT
     volumes:
       # we mount git because rss, thanks feed nerds
       - ./.git:/opt/warehouse/src/.git:ro


### PR DESCRIPTION
signal handling is mixed bag, for most of the Python processes setting SIGINT is good enough

for localstack and static, just use SIGKILL since its all that seems to work and that is effectively what we have been doing forever... just without waiting 10s