### PR TITLE
Deprecate 'changelog' XML-RPC endpoint

### DIFF
--- a/docs/dev/api-reference/feeds.rst
+++ b/docs/dev/api-reference/feeds.rst
@@ -48,33 +48,19 @@ then.
 
 Example usage::
 
+  >>> import time
   >>> import xmlrpc.client
-  >>> import arrow
-  >>> client = xmlrpc.client.ServerProxy('https://test.pypi.org/pypi')
-  >>> latefeb = arrow.get('2018-02-20 10:00:00')
-  >>> latefeb.timestamp
-  1519120800
-  >>> latefebstamp = latefeb.timestamp
-  >>> recentchanges = client.changelog(latefebstamp)
-  >>> len(recentchanges)
-  7322
+  >>> client = xmlrpc.client.ServerProxy("https://test.pypi.org/pypi")
+  >>> serial = client.changelog_last_serial()
+  >>> serial
+  4601224
+  >>> while serial == client.changelog_last_serial():
+  ...     time.sleep(5)
+  >>> recentchanges = client.changelog_since_serial(serial)
   >>> for entry in recentchanges:
-  ...     if entry[0] == 'twine':
-  ...         print(entry[1], " ", entry[3], " ", entry[2])
-  ...
-  ...
-  ...
-  None   add Owner brainwane   1519952529
-  1.10.0   add py2.py3 file twine-1.10.0-py2.py3-none-any.whl   1520023899
-  1.10.0   new release   1520023899
-  1.10.0rc1   add py2.py3 file twine-1.10.0rc1-py2.py3-none-any.whl   1520023900
-  1.10.0rc1   new release   1520023900
-  1.10.0rc1   add source file twine-1.10.0rc1.tar.gz   1520023902
-  1.10.0   add source file twine-1.10.0.tar.gz   1520023903
-  1.10.0   remove file twine-1.10.0.tar.gz   1520024758
-  1.10.0   remove file twine-1.10.0-py2.py3-none-any.whl   1520024797
-  1.10.0   remove   1520025270
-
+  ...     print(entry)
+  ['openllm', '0.4.33.dev3', 1701280908, 'new release', 4601225]
+  ['openllm', '0.4.33.dev3', 1701280908, 'add py3 file openllm-0.4.33.dev3-py3-none-any.whl', 4601226]
 
 You could also request ``GET /simple/``, and record the ``ETag``, and
 then periodically do a conditional HTTP GET to ``/simple/`` with that

--- a/docs/dev/api-reference/xml-rpc.rst
+++ b/docs/dev/api-reference/xml-rpc.rst
@@ -73,15 +73,6 @@ Mirroring Support
   pypi-announce_ mailing list to ensure they are aware of changes or
   deprecations related to these methods.
 
-``changelog(since, with_ids=False)``
-++++++++++++++++++++++++++++++++++++
-
-Retrieve a list of `[name, version, timestamp, action]`, or `[name,
-version, timestamp, action, id]` if `with_ids=True`, since the given
-`since`. All `since` timestamps are UTC values. The argument is a
-UTC integer seconds since the epoch (e.g., the ``timestamp`` method
-to a ``datetime.datetime`` object).
-
 ``changelog_last_serial()``
 +++++++++++++++++++++++++++
 
@@ -229,6 +220,11 @@ Deprecated Methods
 .. warning::
   The following methods are permanently deprecated and will return a
   `RuntimeError`
+
+``changelog(since, with_ids=False)``
+++++++++++++++++++++++++++++++++++++
+
+Deprecated in favor of ``changelog_since_serial``.
 
 ``package_data(package_name, version)``
 +++++++++++++++++++++++++++++++++++++++

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -481,29 +481,12 @@ def changelog_since_serial(request, serial: StrictInt):
 
 @xmlrpc_method(method="changelog")
 def changelog(request, since: StrictInt, with_ids: StrictBool = False):
-    since_dt = datetime.datetime.utcfromtimestamp(since)
-    entries = (
-        request.db.query(JournalEntry)
-        .filter(JournalEntry.submitted_date > since_dt)
-        .order_by(JournalEntry.id)
-        .limit(50000)
-    )
-
-    results = (
-        (
-            e.name,
-            e.version,
-            int(e.submitted_date.replace(tzinfo=datetime.UTC).timestamp()),
-            e.action,
-            e.id,
+    raise XMLRPCWrappedError(
+        ValueError(
+            "The changelog method has been deprecated, use changelog_since_serial "
+            "instead."
         )
-        for e in entries
     )
-
-    if with_ids:
-        return list(results)
-    else:
-        return [r[:-1] for r in results]
 
 
 @xmlrpc_method(method="browse")


### PR DESCRIPTION
This endpoint is being deprecated due to low usage and high resource consumption.