### PR TITLE
forklift/legacy: fallback on all project users for GPG email

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1142,7 +1142,9 @@ def file_upload(request):
                 "provided signature has been discarded."
             )
             send_gpg_signature_uploaded_email(
-                request, request.user, project_name=project.name
+                request,
+                request.user if request.user else project.users,
+                project_name=project.name,
             )
 
         # TODO: This should be handled by some sort of database trigger or


### PR DESCRIPTION
If a distribution is uploaded via Trusted Publishing and is accompanied by a PGP signature, send the GPG deprecation email to all project members, rather than exploding due to `request.user` not being present.

Fixes #14928.