### PR TITLE
feat: admin flag to require 2fa

### DIFF
--- a/docs/blog/posts/2023-12-06-2fa-enforcement-on-testpypi.md
+++ b/docs/blog/posts/2023-12-06-2fa-enforcement-on-testpypi.md
@@ -1,0 +1,44 @@
+---
+title: 2FA Enforcement for TestPyPI
+description: PyPI requires 2FA for all management actions on TestPyPI.
+author: Mike Fiedler
+publish_date: 2023-12-06
+date: "2023-12-06 00:00"
+tags:
+  - 2fa
+  - security
+---
+
+## What's changing?
+
+Starting today, **all users must enable 2FA**
+before they can perform any management actions on [TestPyPI](https://test.pypi.org/).
+
+This change is in preparation for the
+[scheduled enforcement of 2FA on PyPI](2023-05-25-securing-pypi-with-2fa.md)
+at the end of 2023.
+
+Previously the PyPI team has announced
+[2FA requirement for uploads](2023-06-01-2fa-enforcement-for-upload.md),
+[2FA requirement for new user registrations on PyPI](2023-08-08-2fa-enforcement-for-new-users.md),
+and now the requirement extends that **all users** on TestPyPI.
+
+## How does this affect me?
+
+If you only need to browse, download, and install packages from TestPyPI
+then a PyPI account isn't needed so this change does not affect you.
+
+If you've already enabled 2FA on your PyPI account,
+this change will not affect you.
+
+If you recently registered a new PyPI account,
+you are required to enable 2FA before you can perform any management actions.
+When attempting to perform a management action,
+you may see a red banner flash at the top of the page,
+and be redirected to the 2FA setup page for your account.
+You will still be able to log in, browse, and download packages without 2FA.
+But to perform any management actions, you'll need to enable 2FA.
+
+Visit [the 2FA FAQ](https://pypi.org/help/#twofa) for more details.
+
+_Mike Fiedler is the PyPI Safety & Security Engineer since 2023._

--- a/docs/blog/posts/2023-12-06-2fa-enforcement-on-testpypi.md
+++ b/docs/blog/posts/2023-12-06-2fa-enforcement-on-testpypi.md
@@ -26,12 +26,12 @@ and now the requirement extends that **all users** on TestPyPI.
 ## How does this affect me?
 
 If you only need to browse, download, and install packages from TestPyPI
-then a PyPI account isn't needed so this change does not affect you.
+then a TestPyPI account isn't needed so this change does not affect you.
 
-If you've already enabled 2FA on your PyPI account,
+If you've already enabled 2FA on your TestPyPI account,
 this change will not affect you.
 
-If you recently registered a new PyPI account,
+If you recently registered a new TestPyPI account,
 you are required to enable 2FA before you can perform any management actions.
 When attempting to perform a management action,
 you may see a red banner flash at the top of the page,

--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -21,6 +21,7 @@ from zope.interface.verify import verifyClass
 
 from warehouse.accounts import security_policy
 from warehouse.accounts.interfaces import IUserService
+from warehouse.admin.flags import AdminFlagValue
 from warehouse.utils.security_policy import AuthenticationMethod
 
 
@@ -571,6 +572,7 @@ class TestPermits:
         monkeypatch.setattr(security_policy, "User", pretend.stub)
 
         request = pretend.stub(
+            flags=pretend.stub(enabled=lambda flag: False),
             identity=pretend.stub(
                 __principals__=lambda: principals,
                 has_primary_verified_email=True,
@@ -600,6 +602,7 @@ class TestPermits:
         monkeypatch.setattr(security_policy, "TwoFactorRequireable", pretend.stub)
 
         request = pretend.stub(
+            flags=pretend.stub(enabled=lambda flag: False),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -638,6 +641,7 @@ class TestPermits:
         monkeypatch.setattr(security_policy, "TwoFactorRequireable", pretend.stub)
 
         request = pretend.stub(
+            flags=pretend.stub(enabled=lambda flag: False),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -676,6 +680,7 @@ class TestPermits:
         monkeypatch.setattr(security_policy, "TwoFactorRequireable", pretend.stub)
 
         request = pretend.stub(
+            flags=pretend.stub(enabled=lambda flag: False),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -734,6 +739,7 @@ class TestPermits:
         monkeypatch.setattr(security_policy, "User", pretend.stub)
 
         request = pretend.stub(
+            flags=pretend.stub(enabled=lambda flag: False),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -751,6 +757,7 @@ class TestPermits:
         monkeypatch.setattr(security_policy, "User", pretend.stub)
 
         request = pretend.stub(
+            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: True)),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -763,11 +770,15 @@ class TestPermits:
 
         policy = policy_class()
         assert policy.permits(request, context, "myperm")
+        assert request.flags.enabled.calls == [
+            pretend.call(AdminFlagValue.TWOFA_REQUIRED_EVERYWHERE)
+        ]
 
     def test_deny_manage_projects_without_2fa(self, monkeypatch, policy_class):
         monkeypatch.setattr(security_policy, "User", pretend.stub)
 
         request = pretend.stub(
+            flags=pretend.stub(enabled=lambda flag: False),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -785,6 +796,7 @@ class TestPermits:
         monkeypatch.setattr(security_policy, "User", pretend.stub)
 
         request = pretend.stub(
+            flags=pretend.stub(enabled=lambda flag: False),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -815,6 +827,7 @@ class TestPermits:
         monkeypatch.setattr(security_policy, "User", pretend.stub)
 
         request = pretend.stub(
+            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -828,3 +841,6 @@ class TestPermits:
 
         policy = policy_class()
         assert policy.permits(request, context, "myperm")
+        assert request.flags.enabled.calls == [
+            pretend.call(AdminFlagValue.TWOFA_REQUIRED_EVERYWHERE)
+        ]

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -24,6 +24,7 @@ from zope.interface import implementer
 
 from warehouse.accounts.interfaces import IPasswordBreachedService, IUserService
 from warehouse.accounts.models import DisableReason, User
+from warehouse.admin.flags import AdminFlagValue
 from warehouse.cache.http import add_vary_callback
 from warehouse.email import send_password_compromised_email_hibp
 from warehouse.errors import (
@@ -332,9 +333,10 @@ def _check_for_mfa(request, context) -> WarehouseDenied | None:
         "manage.account.webauthn-provision",
     ]
 
-    # Start enforcement from 2023-08-08, but we should remove this check
-    # at the end of 2023.
-    if (
+    # If flag is active, require 2FA for management and upload.
+    if request.flags.enabled(AdminFlagValue.TWOFA_REQUIRED_EVERYWHERE) or (
+        # Start enforcement from 2023-08-08, but we should remove this check
+        # at the end of 2023.
         request.identity.date_joined
         and request.identity.date_joined > datetime.datetime(2023, 8, 8)
     ):

--- a/warehouse/admin/flags.py
+++ b/warehouse/admin/flags.py
@@ -28,6 +28,7 @@ class AdminFlagValue(enum.Enum):
     DISALLOW_GITHUB_OIDC = "disallow-github-oidc"
     DISALLOW_GOOGLE_OIDC = "disallow-google-oidc"
     READ_ONLY = "read-only"
+    TWOFA_REQUIRED_EVERYWHERE = "2fa-required"
 
 
 class AdminFlag(db.ModelBase):

--- a/warehouse/migrations/versions/0940ed80e40a_admin_flag_2fa_required.py
+++ b/warehouse/migrations/versions/0940ed80e40a_admin_flag_2fa_required.py
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Admin Flag: 2fa-required
+
+Revision ID: 0940ed80e40a
+Revises: 4297620f7b41
+Create Date: 2023-12-05 23:44:58.113194
+"""
+
+from alembic import op
+
+revision = "0940ed80e40a"
+down_revision = "4297620f7b41"
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO admin_flags(id, description, enabled, notify)
+        VALUES (
+            '2fa-required',
+            'Require 2FA for all users',
+            FALSE,
+            FALSE
+        )
+    """
+    )
+
+
+def downgrade():
+    op.execute("DELETE FROM admin_flags WHERE id = '2fa-required'")


### PR DESCRIPTION
To ease our deployment of 2FA overall, add an admin flag that overrides any date-based logic.

The flag, and any date-based logic can be removed once we're happy with everything.

Refs: #14010