### PR TITLE
feat: 2fa code input validation

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4655,7 +4655,9 @@ msgid "QR code for setting up an authentication application"
 msgstr ""
 
 #: warehouse/templates/manage/account/totp-provision.html:55
-msgid "<strong>No QR scanner?</strong> Manually enter the code instead:"
+msgid ""
+"<strong>No QR scanner?</strong> Enter this code in your TOTP application "
+"instead:"
 msgstr ""
 
 #: warehouse/templates/manage/account/totp-provision.html:67
@@ -4668,8 +4670,8 @@ msgstr ""
 
 #: warehouse/templates/manage/account/totp-provision.html:73
 msgid ""
-"To finalize the set up process, enter the authentication code provided by"
-" your application."
+"To finalize the set-up process, enter the 6-digit code provided by your "
+"TOTP application."
 msgstr ""
 
 #: warehouse/templates/manage/account/totp-provision.html:85

--- a/warehouse/static/sass/blocks/_form-group.scss
+++ b/warehouse/static/sass/blocks/_form-group.scss
@@ -96,4 +96,16 @@
       }
     }
   }
+
+  // Specific cases for input validation using `pattern` attribute
+
+  /* stylelint-disable-next-line selector-id-pattern -- Form sets name */
+  input#totp_value:valid {
+    background-color: lighten($success-color, 40%);
+  }
+
+  /* stylelint-disable-next-line selector-id-pattern -- Form sets name */
+  input#totp_value:invalid {
+    background-color: lighten($danger-color, 40%);
+  }
 }

--- a/warehouse/templates/accounts/two-factor.html
+++ b/warehouse/templates/accounts/two-factor.html
@@ -105,7 +105,7 @@
               autocapitalize="off",
               autocomplete="one-time-code",
               inputmode="numeric",
-              pattern="[0-9]*",
+              pattern="\d{6}",
               required="required",
               spellcheck="false",
               class_="form-group__field",

--- a/warehouse/templates/manage/account/totp-provision.html
+++ b/warehouse/templates/manage/account/totp-provision.html
@@ -52,7 +52,7 @@
         <img src="{{ request.route_path('manage.account.totp-provision.image') }}" alt="{% trans %}QR code for setting up an authentication application{% endtrans %}" aria-label="{{ provision_totp_uri }}">
       </div>
       <div class="totp-form__manual-code" data-controller="clipboard">
-        <p>{% trans %}<strong>No QR scanner?</strong> Manually enter the code instead:{% endtrans %}
+        <p>{% trans %}<strong>No QR scanner?</strong> Enter this code in your TOTP application instead:{% endtrans %}
           <code data-clipboard-target="source">{{ provision_totp_secret }}</code>
           <button type="button" class="button button--small copy-tooltip copy-tooltip-w" data-action="clipboard#copy" data-clipboard-target="tooltip" data-clipboard-tooltip-value="{% trans %}Copy to clipboard{% endtrans %}">
             {% trans %}Copy{% endtrans %}
@@ -69,8 +69,8 @@
           <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
           {% endif %}
         </label>
-        {{ provision_totp_form.totp_value(placeholder=gettext("Authentication code"), autocapitalize="off", autocomplete="off", inputmode="numeric", pattern="[0-9]*", required="required", spellcheck="false", class_="form-group__field", **{"aria-describedby":"totp-help totp-errors"}) }}
-        <p id="totp-help" class="form-group__help-text">{% trans %}To finalize the set up process, enter the authentication code provided by your application.{% endtrans %}</p>
+        {{ provision_totp_form.totp_value(placeholder=gettext("Authentication code"), autocapitalize="off", autocomplete="off", inputmode="numeric", pattern="\d{6}", required="required", spellcheck="false", class_="form-group__field", **{"aria-describedby":"totp-help totp-errors"}) }}
+        <p id="totp-help" class="form-group__help-text">{% trans %}To finalize the set-up process, enter the 6-digit code provided by your TOTP application.{% endtrans %}</p>
         <div id="totp-errors">
           {% if provision_totp_form.totp_value.errors %}
           <ul class="form-errors" role="alert">


### PR DESCRIPTION
After multiple reports of users copying the TOTP enrollment key into the verification field and not being able to proceed, make the form a little clearer.

- Expand help text
- Update input pattern to be explicit about 6 digits (set via `warehouse.utils.otp.TOTP_LENGTH` = 6)
- Add CSS to highlight invalid vs valid input