### PR TITLE
chore(deps): pin isort to prior to 5.13

### DIFF
--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -3,7 +3,7 @@ flake8
 curlylint
 pep8-naming
 black==23.11.0
-isort>=5
+isort>=5,<5.13  # Waiting for fix from https://github.com/PyCQA/isort/pull/2207
 pyupgrade
 mypy
 celery-types


### PR DESCRIPTION
5.13 mistakenly included more extra dependencies by default.

Pin until a fix is released.