### PR TITLE
blog: fix paginated index page

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.11"
   commands:

--- a/docs/mkdocs-blog.yml
+++ b/docs/mkdocs-blog.yml
@@ -42,6 +42,10 @@ plugins:
   - blog:
       blog_dir: .
       blog_toc: true
+      # Use a custom pagination URL format to avoid ReadTheDocs built-in
+      # redirection, which removes the word `page` from the URL.
+      # Ref: https://docs.readthedocs.io/en/stable/user-defined-redirects.html#page-redirects-at-page
+      pagination_url_format: "pages/{page}"
       post_excerpt: required
       # Preserve backwards compatibility with older URLs.
       # If we ever want to change the format and thus break old URLs,


### PR DESCRIPTION
RTD has a built-in default pagination behavior that takes precedence and
redirects the user to a 404 not found.

By customizing the string used, we avoid this problem.