### PR TITLE
blog: update time format to compliant version

### DIFF
--- a/docs/blog/posts/2023-05-26-reducing-stored-ip-data.md
+++ b/docs/blog/posts/2023-05-26-reducing-stored-ip-data.md
@@ -3,7 +3,7 @@ title: Reducing Stored IP Data in PyPI
 description: PyPI has stopped using IP data when possible, and is continuing to reduce the amount of IP data stored overall.
 authors:
   - miketheman
-date: 2023-05-26 15:00:00+00:00
+date: 2023-05-26T15:00:00
 tags:
   - security
   - transparency

--- a/docs/blog/posts/2023-06-22-malware-detection-project.md
+++ b/docs/blog/posts/2023-06-22-malware-detection-project.md
@@ -2,7 +2,7 @@
 title: Announcing the launch of PyPI Malware Reporting and Response project
 authors:
   - s-mm
-date: 2023-06-22 16:00:00+00:00
+date: 2023-06-22T16:00:00
 tags:
   - security
 ---

--- a/docs/blog/posts/2023-11-14-1-pypi-completes-first-security-audit.md
+++ b/docs/blog/posts/2023-11-14-1-pypi-completes-first-security-audit.md
@@ -3,7 +3,7 @@ title: "PyPI has completed its first security audit"
 description: We are proud to announce PyPI's first external security audit.
 authors:
   - di
-date: 2023-11-14 00:00:00+00:00
+date: 2023-11-14T00:00:00
 tags:
   - security
   - transparency

--- a/docs/blog/posts/2023-11-14-2-security-audit-remediation-warehouse.md
+++ b/docs/blog/posts/2023-11-14-2-security-audit-remediation-warehouse.md
@@ -3,7 +3,7 @@ title: "Security Audit Remediation: Warehouse"
 description: A deeper dive into the remediation of the security audit findings for the Warehouse project.
 authors:
   - miketheman
-date: 2023-11-14 00:00:01+00:00
+date: 2023-11-14T00:00:01
 tags:
   - security
   - transparency

--- a/docs/blog/posts/2023-11-14-3-security-audit-remediation-cabotage.md
+++ b/docs/blog/posts/2023-11-14-3-security-audit-remediation-cabotage.md
@@ -3,7 +3,7 @@ title: "Security Audit Remediation: cabotage"
 description: A deeper dive into the remediation of the security audit findings for the cabotage project.
 authors:
   - ewdurbin
-date: 2023-11-14 00:00:02+00:00
+date: 2023-11-14T00:00:02
 tags:
   - security
   - transparency

--- a/requirements/docs-blog.txt
+++ b/requirements/docs-blog.txt
@@ -276,9 +276,9 @@ mkdocs==1.5.3 \
     #   -r requirements/docs-blog.in
     #   mkdocs-material
     #   mkdocs-rss-plugin
-mkdocs-material==9.4.14 \
-    --hash=sha256:a511d3ff48fa8718b033e7e37d17abd9cc1de0fdf0244a625ca2ae2387e2416d \
-    --hash=sha256:dbc78a4fea97b74319a6aa9a2f0be575a6028be6958f813ba367188f7b8428f6
+mkdocs-material==9.5.2 \
+    --hash=sha256:6ed0fbf4682491766f0ec1acc955db6901c2fd424c7ab343964ef51b819741f5 \
+    --hash=sha256:ca8b9cd2b3be53e858e5a1a45ac9668bd78d95d77a30288bb5ebc1a31db6184c
     # via -r requirements/docs-blog.in
 mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \

--- a/requirements/docs-user.txt
+++ b/requirements/docs-user.txt
@@ -203,9 +203,9 @@ mkdocs-macros-plugin==1.0.5 \
     --hash=sha256:f60e26f711f5a830ddf1e7980865bf5c0f1180db56109803cdd280073c1a050a \
     --hash=sha256:fe348d75f01c911f362b6d998c57b3d85b505876dde69db924f2c512c395c328
     # via -r requirements/docs-user.in
-mkdocs-material==9.4.14 \
-    --hash=sha256:a511d3ff48fa8718b033e7e37d17abd9cc1de0fdf0244a625ca2ae2387e2416d \
-    --hash=sha256:dbc78a4fea97b74319a6aa9a2f0be575a6028be6958f813ba367188f7b8428f6
+mkdocs-material==9.5.2 \
+    --hash=sha256:6ed0fbf4682491766f0ec1acc955db6901c2fd424c7ab343964ef51b819741f5 \
+    --hash=sha256:ca8b9cd2b3be53e858e5a1a45ac9668bd78d95d77a30288bb5ebc1a31db6184c
     # via -r requirements/docs-user.in
 mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \


### PR DESCRIPTION
The format used before was unsupported, and a recent fix in
mkdocs-material 9.5.1 breaks the build if using unsupported formats.

Refs: https://squidfunk.github.io/mkdocs-material/plugins/blog/#meta.date
Refs: https://squidfunk.github.io/mkdocs-material/changelog/#9.5.1