### PR TITLE
Make it easier to see the available wheels per package release

### DIFF
--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -17,7 +17,7 @@ from sqlalchemy.exc import NoResultFound
 
 from warehouse.accounts.models import User
 from warehouse.cache.origin import origin_cache
-from warehouse.packaging.models import File, Project, Release, Role
+from warehouse.packaging.models import File, Project, Release, Role, bdist_filenames_tags
 from warehouse.utils import readme
 
 
@@ -138,6 +138,9 @@ def release_detail(release, request):
         key=lambda f: f.filename,
     )
 
+    # Collect all the available bdist details to enable building filters.
+    bdist_tags = bdist_filenames_tags([bdist.bdist_tags for bdist in bdists])
+
     return {
         "project": project,
         "release": release,
@@ -149,6 +152,7 @@ def release_detail(release, request):
         "all_versions": project.all_versions,
         "maintainers": maintainers,
         "license": license,
+        'bdist_tags': bdist_tags,
     }
 
 

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -394,6 +394,49 @@
               {% endtrans %}
             </h3>
 
+              <form>
+
+                <div class="form-group">
+                  <label for="bdist-filenames-filter">Filter <code>whl</code> filenames</label>
+                  <input type="text" class="form-control" id="bdist-filenames-filter"
+                         placeholder="e.g. 'py3', 'cp311', 'abi3', 'linux'">
+                </div>
+
+                <div class="form-row">
+                  <div class="form-group col-md-4">
+                    <label for="bdist-tags-interpreters">
+                      <abbr title="Interpreter implementation and version">Interpreter</abbr>
+                    </label>
+                    <select id="bdist-tags-interpreters" class="form-control">
+                      <option selected>All interpreters</option>
+                      {% for interpreter in bdist_tags.interpreters %}
+                        <option value="{{ interpreter }}">{{ interpreter }}</option>
+                      {% endfor %}
+                    </select>
+                  </div>
+                  <div class="form-group col-md-4">
+                    <label for="bdist-tags-abis">
+                      <abbr title="Application binary interface">ABI</abbr>
+                    </label>
+                    <select id="bdist-tags-abis" class="form-control">
+                      <option selected>All ABIs</option>
+                      {% for abi in bdist_tags.abis %}
+                        <option value="{{ abi }}">{{ abi }}</option>
+                      {% endfor %}
+                    </select>
+                  </div>
+                  <div class="form-group col-md-4">
+                    <label for="bdist-tags-platforms">Platform</label>
+                    <select id="bdist-tags-platforms" class="form-control">
+                      <option selected>All platforms</option>
+                      {% for platform in bdist_tags.platforms %}
+                        <option value="{{ platform }}">{{ platform }}</option>
+                      {% endfor %}
+                    </select>
+                  </div>
+                </div>
+              </form>
+
             {{ file_table(bdists) }}
             {% endif %}
           </div>


### PR DESCRIPTION
As described in the [issue](https://github.com/pypi/warehouse/issues/14549): "For non pure python, it's often challenging to be able to determine if a wheel is available for a given Python implementation, abi, and platform. Currently, a user has to wade through a long list of wheel file names and decipher their meaning."

This change aims to add these interface elements:
- a text box that allows filtering the list of files by any of the implementations, abis, and platforms that match the typed text
- 3 select elements that show the available options and allow filtering the list of files to only those that match the selected option

I would appreciate feedback on whether this is a reasonable approach or not?
I'm willing to adapt to whatever make sense.

So far I've parsed the filenames and populated the select elements.
My next step will be to create a Stimulus controller that uses the input element and the 3 select elements to filter the list of wheel files.

Closes #14549

![image](https://github.com/pypi/warehouse/assets/441771/2fda8377-8625-47e6-9509-c8a6fe2a00a4)
