### PR TITLE
refactor: make captcha a real service

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -70,3 +70,6 @@ OIDC_AUDIENCE=pypi
 # Default to the reCAPTCHA testing keys from https://developers.google.com/recaptcha/docs/faq
 RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+
+# Example of Captcha backend configuration
+# CAPTCHA_BACKEND=warehouse.captcha.recaptcha.Service

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -21,7 +21,6 @@ from webob.multidict import MultiDict
 
 import warehouse.utils.otp as otp
 
-from warehouse import recaptcha
 from warehouse.accounts import forms
 from warehouse.accounts.interfaces import (
     BurnedRecoveryCode,
@@ -30,6 +29,7 @@ from warehouse.accounts.interfaces import (
     TooManyFailedLogins,
 )
 from warehouse.accounts.models import DisableReason
+from warehouse.captcha import recaptcha
 from warehouse.events.tags import EventTag
 from warehouse.utils.webauthn import AuthenticationRejectedError
 

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -374,7 +374,7 @@ class TestLoginForm:
 
 class TestRegistrationForm:
     def test_validate(self):
-        recaptcha_service = pretend.stub(
+        captcha_service = pretend.stub(
             enabled=False,
             verify_response=pretend.call_recorder(lambda _: None),
         )
@@ -400,12 +400,12 @@ class TestRegistrationForm:
                 }
             ),
             user_service=user_service,
-            recaptcha_service=recaptcha_service,
+            captcha_service=captcha_service,
             breach_service=breach_service,
         )
 
         assert form.user_service is user_service
-        assert form.recaptcha_service is recaptcha_service
+        assert form.captcha_service is captcha_service
         assert form.validate(), str(form.errors)
 
     def test_password_confirm_required_error(self):
@@ -414,7 +414,7 @@ class TestRegistrationForm:
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub())
             ),
-            recaptcha_service=pretend.stub(enabled=True),
+            captcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw: False),
         )
 
@@ -430,7 +430,7 @@ class TestRegistrationForm:
                 {"new_password": "password", "password_confirm": "mismatch"}
             ),
             user_service=user_service,
-            recaptcha_service=pretend.stub(enabled=True),
+            captcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -452,7 +452,7 @@ class TestRegistrationForm:
                 }
             ),
             user_service=user_service,
-            recaptcha_service=pretend.stub(enabled=True),
+            captcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -466,7 +466,7 @@ class TestRegistrationForm:
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub())
             ),
-            recaptcha_service=pretend.stub(enabled=True),
+            captcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -480,7 +480,7 @@ class TestRegistrationForm:
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: None)
             ),
-            recaptcha_service=pretend.stub(enabled=True),
+            captcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -495,7 +495,7 @@ class TestRegistrationForm:
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: None)
             ),
-            recaptcha_service=pretend.stub(enabled=True),
+            captcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -508,7 +508,7 @@ class TestRegistrationForm:
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub())
             ),
-            recaptcha_service=pretend.stub(enabled=True),
+            captcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -525,7 +525,7 @@ class TestRegistrationForm:
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: None)
             ),
-            recaptcha_service=pretend.stub(enabled=True),
+            captcha_service=pretend.stub(enabled=True),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
 
@@ -540,7 +540,7 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             formdata=MultiDict({"g_recpatcha_response": ""}),
             user_service=pretend.stub(),
-            recaptcha_service=pretend.stub(
+            captcha_service=pretend.stub(
                 enabled=False,
                 verify_response=pretend.call_recorder(lambda _: None),
             ),
@@ -555,7 +555,7 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             formdata=MultiDict({"g_recaptcha_response": ""}),
             user_service=pretend.stub(),
-            recaptcha_service=pretend.stub(
+            captcha_service=pretend.stub(
                 enabled=True,
                 verify_response=pretend.call_recorder(lambda _: None),
             ),
@@ -568,7 +568,7 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             formdata=MultiDict({"g_recaptcha_response": "asd"}),
             user_service=pretend.stub(),
-            recaptcha_service=pretend.stub(
+            captcha_service=pretend.stub(
                 verify_response=pretend.raiser(recaptcha.RecaptchaError),
                 enabled=True,
             ),
@@ -584,7 +584,7 @@ class TestRegistrationForm:
                 find_userid=pretend.call_recorder(lambda name: 1),
                 username_is_prohibited=lambda a: False,
             ),
-            recaptcha_service=pretend.stub(
+            captcha_service=pretend.stub(
                 enabled=False,
                 verify_response=pretend.call_recorder(lambda _: None),
             ),
@@ -603,7 +603,7 @@ class TestRegistrationForm:
             user_service=pretend.stub(
                 username_is_prohibited=lambda a: True,
             ),
-            recaptcha_service=pretend.stub(
+            captcha_service=pretend.stub(
                 enabled=False,
                 verify_response=pretend.call_recorder(lambda _: None),
             ),
@@ -624,7 +624,7 @@ class TestRegistrationForm:
                 find_userid=pretend.call_recorder(lambda _: None),
                 username_is_prohibited=lambda a: False,
             ),
-            recaptcha_service=pretend.stub(
+            captcha_service=pretend.stub(
                 enabled=False,
                 verify_response=pretend.call_recorder(lambda _: None),
             ),
@@ -649,7 +649,7 @@ class TestRegistrationForm:
             form = forms.RegistrationForm(
                 formdata=MultiDict({"new_password": pwd, "password_confirm": pwd}),
                 user_service=pretend.stub(),
-                recaptcha_service=pretend.stub(
+                captcha_service=pretend.stub(
                     enabled=False,
                     verify_response=pretend.call_recorder(lambda _: None),
                 ),
@@ -664,7 +664,7 @@ class TestRegistrationForm:
             user_service=pretend.stub(
                 find_userid=pretend.call_recorder(lambda _: None)
             ),
-            recaptcha_service=pretend.stub(
+            captcha_service=pretend.stub(
                 enabled=False,
                 verify_response=pretend.call_recorder(lambda _: None),
             ),
@@ -688,7 +688,7 @@ class TestRegistrationForm:
             user_service=pretend.stub(
                 find_userid=pretend.call_recorder(lambda _: None)
             ),
-            recaptcha_service=pretend.stub(
+            captcha_service=pretend.stub(
                 enabled=False,
                 verify_response=pretend.call_recorder(lambda _: None),
             ),

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -53,6 +53,7 @@ from warehouse.accounts.views import (
     two_factor_and_totp_validate,
 )
 from warehouse.admin.flags import AdminFlag, AdminFlagValue
+from warehouse.captcha.interfaces import ICaptchaService
 from warehouse.events.tags import EventTag
 from warehouse.metrics.interfaces import IMetricsService
 from warehouse.oidc.interfaces import TooManyOIDCRegistrations
@@ -1570,7 +1571,7 @@ class TestRegister:
                 ),
                 IRateLimiter: pretend.stub(hit=lambda user_id: None),
                 "csp": pretend.stub(merge=lambda *a, **kw: {}),
-                "recaptcha": pretend.stub(
+                ICaptchaService: pretend.stub(
                     csp_policy={}, enabled=True, verify_response=lambda a: True
                 ),
             }[key]

--- a/tests/unit/captcha/__init__.py
+++ b/tests/unit/captcha/__init__.py
@@ -9,20 +9,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .interfaces import ICaptchaService
-from .recaptcha import Service
-
-
-def includeme(config):
-    # Register our Captcha service
-    captcha_class = config.maybe_dotted(
-        config.registry.settings.get("captcha.backend", Service)
-    )
-    config.register_service_factory(
-        captcha_class.create_service,
-        ICaptchaService,
-        # Service requires a name for lookup in Jinja2 template,
-        # where the Interface object is not available.
-        name="recaptcha",
-    )

--- a/tests/unit/captcha/test_init.py
+++ b/tests/unit/captcha/test_init.py
@@ -29,6 +29,6 @@ def test_includeme_defaults_to_recaptcha():
         pretend.call(
             recaptcha.Service.create_service,
             interfaces.ICaptchaService,
-            name="recaptcha",
+            name="captcha",
         ),
     ]

--- a/tests/unit/captcha/test_init.py
+++ b/tests/unit/captcha/test_init.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pretend
+
+from warehouse.captcha import includeme, interfaces, recaptcha
+
+
+def test_includeme_defaults_to_recaptcha():
+    config = pretend.stub(
+        registry=pretend.stub(settings={}),
+        maybe_dotted=lambda i: i,
+        register_service_factory=pretend.call_recorder(
+            lambda factory, iface, name: None
+        ),
+    )
+    includeme(config)
+
+    assert config.register_service_factory.calls == [
+        pretend.call(
+            recaptcha.Service.create_service,
+            interfaces.ICaptchaService,
+            name="recaptcha",
+        ),
+    ]

--- a/tests/unit/captcha/test_init.py
+++ b/tests/unit/captcha/test_init.py
@@ -32,3 +32,24 @@ def test_includeme_defaults_to_recaptcha():
             name="captcha",
         ),
     ]
+
+
+def test_include_with_custom_backend():
+    cache_class = pretend.stub(create_service=pretend.stub())
+    config = pretend.stub(
+        registry=pretend.stub(settings={"captcha.backend": "tests.CustomBackend"}),
+        maybe_dotted=pretend.call_recorder(lambda n: cache_class),
+        register_service_factory=pretend.call_recorder(
+            lambda factory, iface, name: None
+        ),
+    )
+    includeme(config)
+
+    assert config.maybe_dotted.calls == [pretend.call("tests.CustomBackend")]
+    assert config.register_service_factory.calls == [
+        pretend.call(
+            cache_class.create_service,
+            interfaces.ICaptchaService,
+            name="captcha",
+        )
+    ]

--- a/tests/unit/captcha/test_recaptcha.py
+++ b/tests/unit/captcha/test_recaptcha.py
@@ -42,8 +42,8 @@ class TestVerifyResponse:
             recaptcha.VERIFY_URL,
             body="",
         )
-        serv = recaptcha.Service(
-            request=pretend.stub(registry=pretend.stub(settings={}))
+        serv = recaptcha.Service.create_service(
+            context=None, request=pretend.stub(registry=pretend.stub(settings={}))
         )
         assert serv.verify_response("") is None
         assert not responses.calls
@@ -55,7 +55,8 @@ class TestVerifyResponse:
             recaptcha.VERIFY_URL,
             body="",
         )
-        serv = recaptcha.Service(
+        serv = recaptcha.Service.create_service(
+            context=None,
             request=pretend.stub(
                 registry=pretend.stub(
                     settings={
@@ -75,7 +76,7 @@ class TestVerifyResponse:
             recaptcha.VERIFY_URL,
             json={"success": True},
         )
-        serv = recaptcha.Service(request=_REQUEST)
+        serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
         serv.verify_response("meaningless", remote_ip="ip")
 
         payload = dict(urllib.parse.parse_qsl(responses.calls[0].request.body))
@@ -88,7 +89,7 @@ class TestVerifyResponse:
             recaptcha.VERIFY_URL,
             body="something awful",
         )
-        serv = recaptcha.Service(request=_REQUEST)
+        serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
 
         with pytest.raises(recaptcha.UnexpectedError) as err:
             serv.verify_response("meaningless")
@@ -103,7 +104,7 @@ class TestVerifyResponse:
             recaptcha.VERIFY_URL,
             json={"foo": "bar"},
         )
-        serv = recaptcha.Service(request=_REQUEST)
+        serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
 
         with pytest.raises(recaptcha.UnexpectedError) as err:
             serv.verify_response("meaningless")
@@ -118,7 +119,7 @@ class TestVerifyResponse:
             recaptcha.VERIFY_URL,
             json={"success": False},
         )
-        serv = recaptcha.Service(request=_REQUEST)
+        serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
 
         with pytest.raises(recaptcha.UnexpectedError) as err:
             serv.verify_response("meaningless")
@@ -140,7 +141,7 @@ class TestVerifyResponse:
                 },
             )
 
-            serv = recaptcha.Service(request=_REQUEST)
+            serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
             with pytest.raises(exc_tp):
                 serv.verify_response("meaningless")
 
@@ -159,7 +160,7 @@ class TestVerifyResponse:
             },
         )
 
-        serv = recaptcha.Service(request=_REQUEST)
+        serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
         with pytest.raises(recaptcha.UnexpectedError) as err:
             serv.verify_response("meaningless")
         assert str(err.value) == "Unexpected error code: slartibartfast"
@@ -175,7 +176,7 @@ class TestVerifyResponse:
             },
         )
 
-        serv = recaptcha.Service(request=_REQUEST)
+        serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
         res = serv.verify_response("meaningless")
 
         assert isinstance(res, recaptcha.ChallengeResponse)
@@ -193,7 +194,7 @@ class TestVerifyResponse:
             },
         )
 
-        serv = recaptcha.Service(request=_REQUEST)
+        serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
         res = serv.verify_response("meaningless")
 
         assert isinstance(res, recaptcha.ChallengeResponse)
@@ -212,7 +213,7 @@ class TestVerifyResponse:
             },
         )
 
-        serv = recaptcha.Service(request=_REQUEST)
+        serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
         res = serv.verify_response("meaningless")
 
         assert isinstance(res, recaptcha.ChallengeResponse)
@@ -221,7 +222,7 @@ class TestVerifyResponse:
 
     @responses.activate
     def test_unexpected_error(self):
-        serv = recaptcha.Service(request=_REQUEST)
+        serv = recaptcha.Service.create_service(context=None, request=_REQUEST)
         serv.request.http.post = pretend.raiser(socket.error)
 
         with pytest.raises(recaptcha.UnexpectedError):
@@ -240,7 +241,7 @@ class TestCSPPolicy:
                 }
             ),
         )
-        serv = recaptcha.Service(request=request)
+        serv = recaptcha.Service.create_service(context=None, request=request)
         assert serv.csp_policy == {
             "script-src": [
                 "{request.scheme}://www.recaptcha.net/recaptcha/",
@@ -253,7 +254,6 @@ class TestCSPPolicy:
 
 
 def test_create_service():
-    request = pretend.stub()
-    svc = recaptcha.Service.create_service(None, request)
+    svc = recaptcha.Service.create_service(context=None, request=_REQUEST)
     assert isinstance(svc, recaptcha.Service)
-    assert svc.request is request
+    assert svc.request is _REQUEST

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -379,7 +379,7 @@ def test_configure(monkeypatch, settings, environment):
             pretend.call(".sentry"),
             pretend.call(".csp"),
             pretend.call(".referrer_policy"),
-            pretend.call(".recaptcha"),
+            pretend.call(".captcha"),
             pretend.call(".http"),
         ]
         + [pretend.call(x) for x in [configurator_settings.get("warehouse.theme")] if x]

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -18,7 +18,7 @@ import pytest
 import requests
 import responses
 
-from warehouse import recaptcha
+from warehouse.captcha import includeme, recaptcha, service_factory
 
 _SETTINGS = {
     "recaptcha.site_key": "site_key_value",
@@ -251,7 +251,7 @@ class TestCSPPolicy:
 
 
 def test_service_factory():
-    serv = recaptcha.service_factory(None, _REQUEST)
+    serv = service_factory(None, _REQUEST)
     assert serv.request is _REQUEST
 
 
@@ -259,8 +259,8 @@ def test_includeme():
     config = pretend.stub(
         register_service_factory=pretend.call_recorder(lambda fact, name: None),
     )
-    recaptcha.includeme(config)
+    includeme(config)
 
     assert config.register_service_factory.calls == [
-        pretend.call(recaptcha.service_factory, name="recaptcha"),
+        pretend.call(service_factory, name="recaptcha"),
     ]

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -343,18 +343,18 @@ class RegistrationForm(  # type: ignore[misc]
     )
     g_recaptcha_response = wtforms.StringField()
 
-    def __init__(self, *args, recaptcha_service, user_service, **kwargs):
+    def __init__(self, *args, captcha_service, user_service, **kwargs):
         super().__init__(*args, **kwargs)
         self.user_service = user_service
         self.user_id = None
-        self.recaptcha_service = recaptcha_service
+        self.captcha_service = captcha_service
 
     def validate_g_recaptcha_response(self, field):
         # do required data validation here due to enabled flag being required
-        if self.recaptcha_service.enabled and not field.data:
+        if self.captcha_service.enabled and not field.data:
             raise wtforms.validators.ValidationError("Recaptcha error.")
         try:
-            self.recaptcha_service.verify_response(field.data)
+            self.captcha_service.verify_response(field.data)
         except recaptcha.RecaptchaError:
             # TODO: log error
             # don't want to provide the user with any detail

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -24,7 +24,7 @@ import wtforms.fields
 import warehouse.utils.otp as otp
 import warehouse.utils.webauthn as webauthn
 
-from warehouse import forms, recaptcha
+from warehouse import forms
 from warehouse.accounts.interfaces import (
     BurnedRecoveryCode,
     InvalidRecoveryCode,
@@ -33,6 +33,7 @@ from warehouse.accounts.interfaces import (
 )
 from warehouse.accounts.models import DisableReason
 from warehouse.accounts.services import RECOVERY_CODE_BYTES
+from warehouse.captcha import recaptcha
 from warehouse.email import (
     send_password_compromised_email_hibp,
     send_recovery_code_used_email,

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -62,6 +62,7 @@ from warehouse.accounts.interfaces import (
 from warehouse.accounts.models import Email, User
 from warehouse.admin.flags import AdminFlagValue
 from warehouse.cache.origin import origin_cache
+from warehouse.captcha.interfaces import ICaptchaService
 from warehouse.email import (
     send_added_as_collaborator_email,
     send_added_as_organization_member_email,
@@ -658,7 +659,7 @@ def register(request, _form_class=RegistrationForm):
 
     user_service = request.find_service(IUserService, context=None)
     breach_service = request.find_service(IPasswordBreachedService, context=None)
-    recaptcha_service = request.find_service(name="recaptcha")
+    recaptcha_service = request.find_service(ICaptchaService, name="recaptcha")
     request.find_service(name="csp").merge(recaptcha_service.csp_policy)
 
     # the form contains an auto-generated field from recaptcha with

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -659,8 +659,8 @@ def register(request, _form_class=RegistrationForm):
 
     user_service = request.find_service(IUserService, context=None)
     breach_service = request.find_service(IPasswordBreachedService, context=None)
-    recaptcha_service = request.find_service(ICaptchaService, name="recaptcha")
-    request.find_service(name="csp").merge(recaptcha_service.csp_policy)
+    captcha_service = request.find_service(ICaptchaService, name="captcha")
+    request.find_service(name="csp").merge(captcha_service.csp_policy)
 
     # the form contains an auto-generated field from recaptcha with
     # hyphens in it. make it play nice with wtforms.
@@ -671,7 +671,7 @@ def register(request, _form_class=RegistrationForm):
     form = _form_class(
         formdata=post_body,
         user_service=user_service,
-        recaptcha_service=recaptcha_service,
+        captcha_service=captcha_service,
         breach_service=breach_service,
     )
 

--- a/warehouse/captcha/__init__.py
+++ b/warehouse/captcha/__init__.py
@@ -24,5 +24,5 @@ def includeme(config):
         ICaptchaService,
         # Service requires a name for lookup in Jinja2 template,
         # where the Interface object is not available.
-        name="recaptcha",
+        name="captcha",
     )

--- a/warehouse/captcha/__init__.py
+++ b/warehouse/captcha/__init__.py
@@ -1,0 +1,24 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .recaptcha import Service
+
+
+def service_factory(handler, request):
+    return Service(request)
+
+
+def includeme(config):
+    # yeah yeah, binding to a concrete implementation rather than an
+    # interface. in a perfect world, this will never be offloaded to another
+    # service. however, if it is, then we'll deal with the refactor then
+    config.register_service_factory(service_factory, name="recaptcha")

--- a/warehouse/captcha/interfaces.py
+++ b/warehouse/captcha/interfaces.py
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from zope.interface import Interface
+
+
+class ICaptchaService(Interface):
+    def create_service(context, request):
+        """
+        Create the service, given the context and request for which it is being
+        created for, passing a name for settings.
+        """
+
+    def enabled() -> bool:
+        """
+        Return whether the Captcha service is enabled.
+        """
+
+    def csp_policy() -> str:
+        """
+        Return the CSP policy appropriate for the Captcha service.
+        """
+
+    def verify_response(response) -> bool:
+        """
+        Verify the response from the Captcha service.
+        """

--- a/warehouse/captcha/recaptcha.py
+++ b/warehouse/captcha/recaptcha.py
@@ -143,14 +143,3 @@ class Service:
             data.get("challenge_ts"),
             data.get("hostname"),
         )
-
-
-def service_factory(handler, request):
-    return Service(request)
-
-
-def includeme(config):
-    # yeah yeah, binding to a concrete implementation rather than an
-    # interface. in a perfect world, this will never be offloaded to another
-    # service. however, if it is, then we'll deal with the refactor then
-    config.register_service_factory(service_factory, name="recaptcha")

--- a/warehouse/captcha/recaptcha.py
+++ b/warehouse/captcha/recaptcha.py
@@ -15,6 +15,10 @@ import http
 
 from urllib.parse import urlencode
 
+from zope.interface import implementer
+
+from .interfaces import ICaptchaService
+
 VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify"
 
 
@@ -54,9 +58,14 @@ ChallengeResponse = collections.namedtuple(
 )
 
 
+@implementer(ICaptchaService)
 class Service:
-    def __init__(self, request):
+    def __init__(self, *, request):
         self.request = request
+
+    @classmethod
+    def create_service(cls, context, request):
+        return cls(request=request)
 
     @property
     def csp_policy(self):

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -713,8 +713,8 @@ def configure(settings=None):
     # Register Referrer-Policy service
     config.include(".referrer_policy")
 
-    # Register recaptcha service
-    config.include(".recaptcha")
+    # Register Captcha service
+    config.include(".captcha")
 
     config.add_settings({"http": {"verify": "/etc/ssl/certs/"}})
     config.include(".http")

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -203,6 +203,7 @@ def configure(settings=None):
     maybe_set(settings, "sentry.transport", "SENTRY_TRANSPORT")
     maybe_set(settings, "sessions.url", "REDIS_URL")
     maybe_set(settings, "ratelimit.url", "REDIS_URL")
+    maybe_set(settings, "captcha.backend", "CAPTCHA_BACKEND")
     maybe_set(settings, "recaptcha.site_key", "RECAPTCHA_SITE_KEY")
     maybe_set(settings, "recaptcha.secret_key", "RECAPTCHA_SECRET_KEY")
     maybe_set(settings, "sessions.secret", "SESSION_SECRET")

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -14,321 +14,321 @@ msgstr ""
 msgid "Locale updated"
 msgstr ""
 
-#: warehouse/accounts/forms.py:47
+#: warehouse/accounts/forms.py:48
 msgid "The password is invalid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:48
+#: warehouse/accounts/forms.py:49
 msgid ""
 "The username is invalid. Usernames must be composed of letters, numbers, "
 "dots, hyphens and underscores. And must also start and finish with a "
 "letter or number. Choose a different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:66
+#: warehouse/accounts/forms.py:67
 msgid "Null bytes are not allowed."
 msgstr ""
 
-#: warehouse/accounts/forms.py:87
+#: warehouse/accounts/forms.py:88
 msgid "No user found with that username"
 msgstr ""
 
-#: warehouse/accounts/forms.py:98
+#: warehouse/accounts/forms.py:99
 msgid "TOTP code must be ${totp_length} digits."
 msgstr ""
 
-#: warehouse/accounts/forms.py:118
+#: warehouse/accounts/forms.py:119
 msgid "Recovery Codes must be ${recovery_code_length} characters."
 msgstr ""
 
-#: warehouse/accounts/forms.py:133
+#: warehouse/accounts/forms.py:134
 msgid "Choose a username with 50 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:150
+#: warehouse/accounts/forms.py:151
 msgid ""
 "This username is already being used by another account. Choose a "
 "different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:164 warehouse/accounts/forms.py:213
-#: warehouse/accounts/forms.py:226
+#: warehouse/accounts/forms.py:165 warehouse/accounts/forms.py:214
+#: warehouse/accounts/forms.py:227
 msgid "Password too long."
 msgstr ""
 
-#: warehouse/accounts/forms.py:200
+#: warehouse/accounts/forms.py:201
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for ${time}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/forms.py:229
+#: warehouse/accounts/forms.py:230
 msgid "Your passwords don't match. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:262 warehouse/accounts/forms.py:276
+#: warehouse/accounts/forms.py:263 warehouse/accounts/forms.py:277
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:265
+#: warehouse/accounts/forms.py:266
 msgid "The email address is too long. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:284
+#: warehouse/accounts/forms.py:285
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:295
+#: warehouse/accounts/forms.py:296
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:302
+#: warehouse/accounts/forms.py:303
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:336 warehouse/manage/forms.py:139
+#: warehouse/accounts/forms.py:337 warehouse/manage/forms.py:139
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:427
+#: warehouse/accounts/forms.py:428
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:444
+#: warehouse/accounts/forms.py:445
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:513
+#: warehouse/accounts/forms.py:514
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:522
+#: warehouse/accounts/forms.py:523
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:541
+#: warehouse/accounts/forms.py:542
 msgid "No user found with that username or email"
 msgstr ""
 
-#: warehouse/accounts/views.py:107
+#: warehouse/accounts/views.py:108
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for {}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:124
+#: warehouse/accounts/views.py:125
 msgid ""
 "Too many emails have been added to this account without verifying them. "
 "Check your inbox and follow the verification links. (IP: ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:136
+#: warehouse/accounts/views.py:137
 msgid ""
 "Too many password resets have been requested for this account without "
 "completing them. Check your inbox and follow the verification links. (IP:"
 " ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:320 warehouse/accounts/views.py:389
-#: warehouse/accounts/views.py:391 warehouse/accounts/views.py:420
-#: warehouse/accounts/views.py:422 warehouse/accounts/views.py:528
+#: warehouse/accounts/views.py:321 warehouse/accounts/views.py:390
+#: warehouse/accounts/views.py:392 warehouse/accounts/views.py:421
+#: warehouse/accounts/views.py:423 warehouse/accounts/views.py:529
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:383
+#: warehouse/accounts/views.py:384
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:463
+#: warehouse/accounts/views.py:464
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:559 warehouse/manage/views/__init__.py:823
+#: warehouse/accounts/views.py:560 warehouse/manage/views/__init__.py:823
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:651
+#: warehouse/accounts/views.py:652
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:782
+#: warehouse/accounts/views.py:783
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:784
+#: warehouse/accounts/views.py:785
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:786 warehouse/accounts/views.py:899
-#: warehouse/accounts/views.py:1003 warehouse/accounts/views.py:1172
+#: warehouse/accounts/views.py:787 warehouse/accounts/views.py:900
+#: warehouse/accounts/views.py:1004 warehouse/accounts/views.py:1173
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:790
+#: warehouse/accounts/views.py:791
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:795
+#: warehouse/accounts/views.py:796
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:817
+#: warehouse/accounts/views.py:818
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:835
+#: warehouse/accounts/views.py:836
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:867
+#: warehouse/accounts/views.py:868
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:895
+#: warehouse/accounts/views.py:896
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:897
+#: warehouse/accounts/views.py:898
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:903
+#: warehouse/accounts/views.py:904
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:912
+#: warehouse/accounts/views.py:913
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:915
+#: warehouse/accounts/views.py:916
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:932
+#: warehouse/accounts/views.py:933
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:936
+#: warehouse/accounts/views.py:937
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:941
+#: warehouse/accounts/views.py:942
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:999
+#: warehouse/accounts/views.py:1000
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1001
+#: warehouse/accounts/views.py:1002
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1007
+#: warehouse/accounts/views.py:1008
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1011
+#: warehouse/accounts/views.py:1012
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1020
+#: warehouse/accounts/views.py:1021
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1071
+#: warehouse/accounts/views.py:1072
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1134
+#: warehouse/accounts/views.py:1135
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1168
+#: warehouse/accounts/views.py:1169
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1170
+#: warehouse/accounts/views.py:1171
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1176
+#: warehouse/accounts/views.py:1177
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1180
+#: warehouse/accounts/views.py:1181
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1195
+#: warehouse/accounts/views.py:1196
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1226
+#: warehouse/accounts/views.py:1227
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1292
+#: warehouse/accounts/views.py:1293
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1513 warehouse/accounts/views.py:1661
+#: warehouse/accounts/views.py:1514 warehouse/accounts/views.py:1662
 #: warehouse/manage/views/__init__.py:1183
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1530 warehouse/manage/views/__init__.py:1199
+#: warehouse/accounts/views.py:1531 warehouse/manage/views/__init__.py:1199
 msgid ""
 "GitHub-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1544
+#: warehouse/accounts/views.py:1545
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1557
+#: warehouse/accounts/views.py:1558
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1573 warehouse/manage/views/__init__.py:1218
+#: warehouse/accounts/views.py:1574 warehouse/manage/views/__init__.py:1218
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1587 warehouse/manage/views/__init__.py:1232
+#: warehouse/accounts/views.py:1588 warehouse/manage/views/__init__.py:1232
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1606
+#: warehouse/accounts/views.py:1607
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1641
+#: warehouse/accounts/views.py:1642
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1675 warehouse/accounts/views.py:1688
-#: warehouse/accounts/views.py:1695
+#: warehouse/accounts/views.py:1676 warehouse/accounts/views.py:1689
+#: warehouse/accounts/views.py:1696
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1701
+#: warehouse/accounts/views.py:1702
 msgid "Removed trusted publisher for project "
 msgstr ""
 

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -18,7 +18,7 @@
   {% trans %}Create an account{% endtrans %}
 {% endblock %}
 
-{%- from "warehouse:templates/includes/input-recaptcha.html" import recaptcha_html, recaptcha_src %}
+{%- from "warehouse:templates/includes/input-captcha.html" import captcha_html, captcha_src %}
 
 {% block content %}
   {% if testPyPI %}
@@ -162,7 +162,7 @@
         </div>
 
         <div class="form-group">
-          {{ recaptcha_html(request, form) }}
+          {{ captcha_html(request, form) }}
         </div>
 
         <input type="submit" value="{% trans %}Create account{% endtrans %}" class="button button--primary" data-password-match-target="submit">
@@ -172,7 +172,7 @@
 {% endblock %}
 
 {% block extra_js %}
-  {{ recaptcha_src(request) }}
+  {{ captcha_src(request) }}
   <script async
   src="{{ request.static_path('warehouse:static/dist/js/vendor/zxcvbn.js') }}">
 </script>

--- a/warehouse/templates/includes/input-captcha.html
+++ b/warehouse/templates/includes/input-captcha.html
@@ -13,7 +13,7 @@
 -#}
 {% macro captcha_html(request, form) -%}
   {% if request.find_service(name="captcha").enabled %}
-  <div class="g-recaptcha" data-sitekey="{{ request.registry.settings['recaptcha.site_key'] }}"></div>
+  <div class="g-recaptcha" data-sitekey="{{ request.find_service(name="captcha").site_key }}"></div>
     {% if form.g_recaptcha_response.errors %}
     <ul class="form-errors">
       {% for error in form.g_recaptcha_response.errors %}
@@ -26,6 +26,6 @@
 
 {% macro captcha_src(request) -%}
   {% if request.find_service(name="captcha").enabled %}
-    <script src="//www.recaptcha.net/recaptcha/api.js" async defer></script>
+    <script src="{{ request.find_service(name="captcha").script_src_url }}" async defer></script>
   {% endif %}
 {%- endmacro %}

--- a/warehouse/templates/includes/input-captcha.html
+++ b/warehouse/templates/includes/input-captcha.html
@@ -11,8 +11,8 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 -#}
-{% macro recaptcha_html(request, form) -%}
-  {% if request.find_service(name="recaptcha").enabled %}
+{% macro captcha_html(request, form) -%}
+  {% if request.find_service(name="captcha").enabled %}
   <div class="g-recaptcha" data-sitekey="{{ request.registry.settings['recaptcha.site_key'] }}"></div>
     {% if form.g_recaptcha_response.errors %}
     <ul class="form-errors">
@@ -24,8 +24,8 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro recaptcha_src(request) -%}
-  {% if request.find_service(name="recaptcha").enabled %}
+{% macro captcha_src(request) -%}
+  {% if request.find_service(name="captcha").enabled %}
     <script src="//www.recaptcha.net/recaptcha/api.js" async defer></script>
   {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
Best reviewed commit by commit, since there's some that are not too interesting (example: mass rename).

Paves the way for a future captcha service via interface.