### PR TITLE
chore: remove 2fa conditionals

### DIFF
--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -21,7 +21,6 @@ from zope.interface.verify import verifyClass
 
 from warehouse.accounts import security_policy
 from warehouse.accounts.interfaces import IUserService
-from warehouse.admin.flags import AdminFlagValue
 from warehouse.utils.security_policy import AuthenticationMethod
 
 
@@ -601,7 +600,6 @@ class TestPermits:
 
         policy = policy_class()
         assert not policy.permits(request, context, "myperm")
-
 
     def test_permits_manage_projects_with_2fa(self, monkeypatch, policy_class):
         monkeypatch.setattr(security_policy, "User", pretend.stub)

--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -602,32 +602,11 @@ class TestPermits:
         policy = policy_class()
         assert not policy.permits(request, context, "myperm")
 
-    # TODO: remove this test when we remove the conditional
-    def test_permits_manage_projects_without_2fa_for_older_users(
-        self, monkeypatch, policy_class
-    ):
-        monkeypatch.setattr(security_policy, "User", pretend.stub)
-
-        request = pretend.stub(
-            flags=pretend.stub(enabled=lambda flag: False),
-            identity=pretend.stub(
-                __principals__=lambda: ["user:5"],
-                has_primary_verified_email=True,
-                has_two_factor=False,
-                date_joined=datetime(2019, 1, 1),
-            ),
-            matched_route=pretend.stub(name="manage.projects"),
-        )
-        context = pretend.stub(__acl__=[(Allow, "user:5", "myperm")])
-
-        policy = policy_class()
-        assert policy.permits(request, context, "myperm")
 
     def test_permits_manage_projects_with_2fa(self, monkeypatch, policy_class):
         monkeypatch.setattr(security_policy, "User", pretend.stub)
 
         request = pretend.stub(
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: True)),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -640,9 +619,6 @@ class TestPermits:
 
         policy = policy_class()
         assert policy.permits(request, context, "myperm")
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.TWOFA_REQUIRED_EVERYWHERE)
-        ]
 
     def test_deny_manage_projects_without_2fa(self, monkeypatch, policy_class):
         monkeypatch.setattr(security_policy, "User", pretend.stub)
@@ -697,7 +673,6 @@ class TestPermits:
         monkeypatch.setattr(security_policy, "User", pretend.stub)
 
         request = pretend.stub(
-            flags=pretend.stub(enabled=pretend.call_recorder(lambda *a: False)),
             identity=pretend.stub(
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
@@ -711,6 +686,3 @@ class TestPermits:
 
         policy = policy_class()
         assert policy.permits(request, context, "myperm")
-        assert request.flags.enabled.calls == [
-            pretend.call(AdminFlagValue.TWOFA_REQUIRED_EVERYWHERE)
-        ]

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -24,7 +24,6 @@ from zope.interface import implementer
 
 from warehouse.accounts.interfaces import IPasswordBreachedService, IUserService
 from warehouse.accounts.models import DisableReason, User
-from warehouse.admin.flags import AdminFlagValue
 from warehouse.cache.http import add_vary_callback
 from warehouse.email import send_password_compromised_email_hibp
 from warehouse.errors import (

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -293,33 +293,26 @@ def _check_for_mfa(request, context) -> WarehouseDenied | None:
         "manage.account.webauthn-provision",
     ]
 
-    # If flag is active, require 2FA for management and upload.
-    if request.flags.enabled(AdminFlagValue.TWOFA_REQUIRED_EVERYWHERE) or (
-        # Start enforcement from 2023-08-08, but we should remove this check
-        # at the end of 2023.
-        request.identity.date_joined
-        and request.identity.date_joined > datetime.datetime(2023, 8, 8)
+    if (
+        request.matched_route.name.startswith("manage")
+        and request.matched_route.name != "manage.account"
+        and not any(
+            request.matched_route.name.startswith(route) for route in _exempt_routes
+        )
+        and not request.identity.has_two_factor
     ):
-        if (
-            request.matched_route.name.startswith("manage")
-            and request.matched_route.name != "manage.account"
-            and not any(
-                request.matched_route.name.startswith(route) for route in _exempt_routes
-            )
-            and not request.identity.has_two_factor
-        ):
-            return WarehouseDenied(
-                "You must enable two factor authentication to manage other settings",
-                reason="manage_2fa_required",
-            )
+        return WarehouseDenied(
+            "You must enable two factor authentication to manage other settings",
+            reason="manage_2fa_required",
+        )
 
-        if (
-            request.matched_route.name == "forklift.legacy.file_upload"
-            and not request.identity.has_two_factor
-        ):
-            return WarehouseDenied(
-                "You must enable two factor authentication to upload",
-                reason="upload_2fa_required",
-            )
+    if (
+        request.matched_route.name == "forklift.legacy.file_upload"
+        and not request.identity.has_two_factor
+    ):
+        return WarehouseDenied(
+            "You must enable two factor authentication to upload",
+            reason="upload_2fa_required",
+        )
 
     return None

--- a/warehouse/admin/flags.py
+++ b/warehouse/admin/flags.py
@@ -28,7 +28,6 @@ class AdminFlagValue(enum.Enum):
     DISALLOW_GITHUB_OIDC = "disallow-github-oidc"
     DISALLOW_GOOGLE_OIDC = "disallow-google-oidc"
     READ_ONLY = "read-only"
-    TWOFA_REQUIRED_EVERYWHERE = "2fa-required"
 
 
 class AdminFlag(db.ModelBase):


### PR DESCRIPTION
Now that's it's the rule, remove conditional.

Intentionally omitting a data migration to remove the flag from the DB, may come later.