### PR TITLE
Genericize OIDC templates, forms and views 

### DIFF
--- a/tests/frontend/horizontal_tabs_controller_test.js
+++ b/tests/frontend/horizontal_tabs_controller_test.js
@@ -1,0 +1,115 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* global expect, beforeEach, describe, it */
+
+import { Application } from "@hotwired/stimulus";
+import HorizontalTabsController from "../../warehouse/static/js/warehouse/controllers/horizontal_tabs_controller";
+
+const tabsHTML = `
+  <div class="horizontal-tabs" data-controller="horizontal-tabs" data-horizontal-tabs-index="0">
+    <div class="horizontal-tabs__tabbar">
+      <button data-horizontal-tabs-target="tab" data-action="horizontal-tabs#change" class="tab is-active">
+        Publisher 1
+      </button>
+      <button data-horizontal-tabs-target="tab" data-action="horizontal-tabs#change" class="tab">
+        Publisher 2
+      </button>
+      <button data-horizontal-tabs-target="tab" data-action="horizontal-tabs#change" class="tab">
+        Publisher 3
+      </button>
+    </div>
+    <div class="horizontal-tabs__tabcontent is-hidden" data-horizontal-tabs-target="tabPanel">
+      <div>Publisher Form 1</div>
+    </div>
+    <div class="horizontal-tabs__tabcontent" data-horizontal-tabs-target="tabPanel">
+      <div>Publisher Form 2</div>
+    </div>
+    <div class="horizontal-tabs__tabcontent" data-horizontal-tabs-target="tabPanel">
+      <div>Publisher Form 3</div>
+    </div>
+  </div>
+`;
+
+describe("Horizontal tabs controller", () => {
+  beforeEach(() => {
+    document.body.innerHTML = tabsHTML;
+    const application = Application.start();
+    application.register("horizontal-tabs", HorizontalTabsController);
+  });
+
+  describe("on initializtion", () => {
+    it("the first tab is shown", () => {
+      const tabs = document.querySelectorAll(".tab");
+      const content = document.querySelectorAll(".horizontal-tabs__tabcontent");
+
+      // First tab is shown
+      expect(tabs[0]).toHaveClass("is-active");
+      expect(content[0]).not.toHaveClass("is-hidden");
+
+      // The other tabs are not shown
+      expect(tabs[1]).not.toHaveClass("is-active");
+      expect(content[1]).toHaveClass("is-hidden");
+      expect(tabs[2]).not.toHaveClass("is-active");
+      expect(content[2]).toHaveClass("is-hidden");
+    });
+  });
+
+  describe("on change", () => {
+    it("updates the active tab and panel when a tab is clicked", () => {
+      const tabs = document.querySelectorAll(".tab");
+      const content = document.querySelectorAll(".horizontal-tabs__tabcontent");
+
+      // Click the second tab
+      tabs[1].click();
+
+      // First tab is not shown
+      expect(tabs[0]).not.toHaveClass("is-active");
+      expect(content[0]).toHaveClass("is-hidden");
+
+      // Second tab is shown
+      expect(tabs[1]).toHaveClass("is-active");
+      expect(content[1]).not.toHaveClass("is-hidden");
+
+      // Third tab is not shown
+      expect(tabs[2]).not.toHaveClass("is-active");
+      expect(content[2]).toHaveClass("is-hidden");
+    });
+  });
+
+  describe("on initializtion with errors", () => {
+    beforeEach(() => {
+      // Add some errors to the second tab
+      const secondTabPanel = document.querySelectorAll(".horizontal-tabs__tabcontent")[1];
+      secondTabPanel.innerHTML = "<div id='errors'></div>" + secondTabPanel.innerHTML;
+      const application = Application.start();
+      application.register("horizontal-tabs", HorizontalTabsController);
+    });
+    it("the tab with errors is shown", () => {
+      const tabs = document.querySelectorAll(".tab");
+      const content = document.querySelectorAll(".horizontal-tabs__tabcontent");
+
+      // First tab is not shown
+      expect(tabs[0]).not.toHaveClass("is-active");
+      expect(content[0]).toHaveClass("is-hidden");
+
+      // Second tab is shown
+      expect(tabs[1]).toHaveClass("is-active");
+      expect(content[1]).not.toHaveClass("is-hidden");
+
+      // Third tab is not shown
+      expect(tabs[2]).not.toHaveClass("is-active");
+      expect(content[2]).toHaveClass("is-hidden");
+    });
+  });
+});

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -3232,6 +3232,12 @@ class TestManageAccountPublishingViews:
     def test_initializes(self, metrics):
         request = pretend.stub(
             find_service=pretend.call_recorder(lambda *a, **kw: metrics),
+            POST=MultiDict(),
+            registry=pretend.stub(
+                settings={
+                    "github.token": "fake-api-token",
+                }
+            ),
         )
         view = views.ManageAccountPublishingViews(request)
 
@@ -3275,6 +3281,12 @@ class TestManageAccountPublishingViews:
             find_service=pretend.call_recorder(find_service),
             user=pretend.stub(id=pretend.stub()),
             remote_addr=pretend.stub(),
+            POST=MultiDict(),
+            registry=pretend.stub(
+                settings={
+                    "github.token": "fake-api-token",
+                }
+            ),
         )
 
         view = views.ManageAccountPublishingViews(request)
@@ -3548,10 +3560,6 @@ class TestManageAccountPublishingViews:
                 "environment": "some-environment",
                 "project_name": "some-other-project-name",
             }
-        )
-        default_response = pretend.stub()
-        monkeypatch.setattr(
-            views.ManageAccountPublishingViews, "default_response", default_response
         )
 
         view = views.ManageAccountPublishingViews(db_request)

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1518,23 +1518,29 @@ class ManageAccountPublishingViews:
 
         return self.default_response
 
-    @view_config(
-        request_method="POST",
-        request_param=PendingGitHubPublisherForm.__params__,
-    )
-    def add_pending_github_oidc_publisher(self):
-        if self.request.flags.disallow_oidc(AdminFlagValue.DISALLOW_GITHUB_OIDC):
+    def _add_pending_oidc_publisher(
+        self,
+        publisher_name,
+        publisher_class,
+        admin_flag,
+        form,
+        make_pending_publisher,
+        make_existence_filters,
+    ):
+        if self.request.flags.disallow_oidc(admin_flag):
             self.request.session.flash(
                 self.request._(
-                    "GitHub-based trusted publishing is temporarily disabled. "
-                    "See https://pypi.org/help#admin-intervention for details."
+                    f"{publisher_name}-based trusted publishing is temporarily "
+                    "disabled. See https://pypi.org/help#admin-intervention for "
+                    "details."
                 ),
                 queue="error",
             )
             return self.default_response
 
         self.metrics.increment(
-            "warehouse.oidc.add_pending_publisher.attempt", tags=["publisher:GitHub"]
+            "warehouse.oidc.add_pending_publisher.attempt",
+            tags=[f"publisher:{publisher_name}"],
         )
 
         if not self.request.user.has_primary_verified_email:
@@ -1565,7 +1571,7 @@ class ManageAccountPublishingViews:
         except TooManyOIDCRegistrations as exc:
             self.metrics.increment(
                 "warehouse.oidc.add_pending_publisher.ratelimited",
-                tags=["publisher:GitHub"],
+                tags=[f"publisher:{publisher_name}"],
             )
             return HTTPTooManyRequests(
                 self.request._(
@@ -1577,24 +1583,16 @@ class ManageAccountPublishingViews:
 
         self._hit_ratelimits()
 
-        response = self.default_response
-        form = response["pending_github_publisher_form"]
-
         if not form.validate():
             self.request.session.flash(
                 self.request._("The trusted publisher could not be registered"),
                 queue="error",
             )
-            return response
+            return self.default_response
 
         publisher_already_exists = (
-            self.request.db.query(PendingGitHubPublisher)
-            .filter_by(
-                repository_name=form.repository.data,
-                repository_owner=form.normalized_owner,
-                workflow_filename=form.workflow_filename.data,
-                environment=form.normalized_environment,
-            )
+            self.request.db.query(publisher_class)
+            .filter_by(**make_existence_filters(form))
             .first()
             is not None
         )
@@ -1636,10 +1634,39 @@ class ManageAccountPublishingViews:
         )
 
         self.metrics.increment(
-            "warehouse.oidc.add_pending_publisher.ok", tags=["publisher:GitHub"]
+            "warehouse.oidc.add_pending_publisher.ok",
+            tags=[f"publisher:{publisher_name}"],
         )
 
         return HTTPSeeOther(self.request.path)
+
+    @view_config(
+        request_method="POST",
+        request_param=PendingGitHubPublisherForm.__params__,
+    )
+    def add_pending_github_oidc_publisher(self):
+        form = self.default_response["pending_github_publisher_form"]
+        return self._add_pending_oidc_publisher(
+            publisher_name="GitHub",
+            publisher_class=PendingGitHubPublisher,
+            admin_flag=AdminFlagValue.DISALLOW_GITHUB_OIDC,
+            form=form,
+            make_pending_publisher=lambda request, form: PendingGitHubPublisher(
+                project_name=form.project_name.data,
+                added_by=self.request.user,
+                repository_name=form.repository.data,
+                repository_owner=form.normalized_owner,
+                repository_owner_id=form.owner_id,
+                workflow_filename=form.workflow_filename.data,
+                environment=form.normalized_environment,
+            ),
+            make_existence_filters=lambda form: dict(
+                repository_name=form.repository.data,
+                repository_owner=form.normalized_owner,
+                workflow_filename=form.workflow_filename.data,
+                environment=form.normalized_environment,
+            ),
+        )
 
     @view_config(
         request_method="POST",

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -280,55 +280,53 @@ msgstr ""
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1514 warehouse/accounts/views.py:1662
-#: warehouse/manage/views/__init__.py:1183
+#: warehouse/accounts/views.py:1511 warehouse/accounts/views.py:1678
+#: warehouse/manage/views/__init__.py:1180
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1531 warehouse/manage/views/__init__.py:1199
-msgid ""
-"GitHub-based trusted publishing is temporarily disabled. See "
-"https://pypi.org/help#admin-intervention for details."
+#: warehouse/accounts/views.py:1532
+msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1545
+#: warehouse/accounts/views.py:1548
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1558
+#: warehouse/accounts/views.py:1561
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1574 warehouse/manage/views/__init__.py:1218
+#: warehouse/accounts/views.py:1577 warehouse/manage/views/__init__.py:1215
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1588 warehouse/manage/views/__init__.py:1232
+#: warehouse/accounts/views.py:1588 warehouse/manage/views/__init__.py:1229
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1607
+#: warehouse/accounts/views.py:1602
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1642
+#: warehouse/accounts/views.py:1629
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1676 warehouse/accounts/views.py:1689
-#: warehouse/accounts/views.py:1696
+#: warehouse/accounts/views.py:1692 warehouse/accounts/views.py:1705
+#: warehouse/accounts/views.py:1712
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1702
+#: warehouse/accounts/views.py:1718
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -364,7 +362,7 @@ msgstr ""
 msgid "Select project"
 msgstr ""
 
-#: warehouse/manage/forms.py:495 warehouse/oidc/forms/github.py:174
+#: warehouse/manage/forms.py:495 warehouse/oidc/forms/_core.py:23
 msgid "Specify project name"
 msgstr ""
 
@@ -446,78 +444,84 @@ msgstr ""
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1437
-#: warehouse/manage/views/__init__.py:1738
-#: warehouse/manage/views/__init__.py:1846
+#: warehouse/manage/views/__init__.py:1196
+msgid ""
+"GitHub-based trusted publishing is temporarily disabled. See "
+"https://pypi.org/help#admin-intervention for details."
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1434
+#: warehouse/manage/views/__init__.py:1735
+#: warehouse/manage/views/__init__.py:1843
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1569
-#: warehouse/manage/views/__init__.py:1654
-#: warehouse/manage/views/__init__.py:1755
-#: warehouse/manage/views/__init__.py:1855
+#: warehouse/manage/views/__init__.py:1566
+#: warehouse/manage/views/__init__.py:1651
+#: warehouse/manage/views/__init__.py:1752
+#: warehouse/manage/views/__init__.py:1852
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1581
+#: warehouse/manage/views/__init__.py:1578
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1666
+#: warehouse/manage/views/__init__.py:1663
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1767
+#: warehouse/manage/views/__init__.py:1764
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1867
+#: warehouse/manage/views/__init__.py:1864
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1871
+#: warehouse/manage/views/__init__.py:1868
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2021
+#: warehouse/manage/views/__init__.py:2018
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2128
+#: warehouse/manage/views/__init__.py:2125
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2195
+#: warehouse/manage/views/__init__.py:2192
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2227
+#: warehouse/manage/views/__init__.py:2224
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2240
+#: warehouse/manage/views/__init__.py:2237
 #: warehouse/manage/views/organizations.py:878
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2305
+#: warehouse/manage/views/__init__.py:2302
 #: warehouse/manage/views/organizations.py:943
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2338
+#: warehouse/manage/views/__init__.py:2335
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2349
+#: warehouse/manage/views/__init__.py:2346
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2381
+#: warehouse/manage/views/__init__.py:2378
 #: warehouse/manage/views/organizations.py:1130
 msgid "Invitation revoked from '${username}'."
 msgstr ""
@@ -545,11 +549,19 @@ msgstr ""
 msgid "Expired invitation for '${username}' deleted."
 msgstr ""
 
-#: warehouse/oidc/forms/__init__.py:23
+#: warehouse/oidc/forms/_core.py:25
+msgid "Invalid project name"
+msgstr ""
+
+#: warehouse/oidc/forms/_core.py:35
+msgid "This project name is already in use"
+msgstr ""
+
+#: warehouse/oidc/forms/_core.py:44
 msgid "Specify a publisher ID"
 msgstr ""
 
-#: warehouse/oidc/forms/__init__.py:24
+#: warehouse/oidc/forms/_core.py:45
 msgid "Publisher must be specified by ID"
 msgstr ""
 
@@ -599,14 +611,6 @@ msgstr ""
 
 #: warehouse/oidc/forms/github.py:154
 msgid "Workflow filename must be a filename only, without directories"
-msgstr ""
-
-#: warehouse/oidc/forms/github.py:176
-msgid "Invalid project name"
-msgstr ""
-
-#: warehouse/oidc/forms/github.py:190
-msgid "This project name is already in use"
 msgstr ""
 
 #: warehouse/subscriptions/models.py:35
@@ -1268,10 +1272,10 @@ msgstr ""
 #: warehouse/templates/manage/organizations.html:232
 #: warehouse/templates/manage/organizations.html:250
 #: warehouse/templates/manage/organizations.html:269
-#: warehouse/templates/manage/project/publishing.html:79
-#: warehouse/templates/manage/project/publishing.html:94
-#: warehouse/templates/manage/project/publishing.html:109
-#: warehouse/templates/manage/project/publishing.html:124
+#: warehouse/templates/manage/project/publishing.html:38
+#: warehouse/templates/manage/project/publishing.html:53
+#: warehouse/templates/manage/project/publishing.html:68
+#: warehouse/templates/manage/project/publishing.html:83
 #: warehouse/templates/manage/project/roles.html:273
 #: warehouse/templates/manage/project/roles.html:284
 #: warehouse/templates/manage/project/roles.html:296
@@ -2433,8 +2437,6 @@ msgstr ""
 
 #: warehouse/templates/email/trusted-publisher-added/body.html:32
 #: warehouse/templates/email/trusted-publisher-removed/body.html:30
-#: warehouse/templates/manage/account/publishing.html:173
-#: warehouse/templates/manage/project/publishing.html:46
 msgid "Workflow"
 msgstr ""
 
@@ -2445,7 +2447,7 @@ msgstr ""
 #: warehouse/templates/manage/organization/roles.html:53
 #: warehouse/templates/manage/organization/roles.html:172
 #: warehouse/templates/manage/organizations.html:90
-#: warehouse/templates/manage/project/publishing.html:77
+#: warehouse/templates/manage/project/publishing.html:36
 #: warehouse/templates/manage/project/roles.html:50
 #: warehouse/templates/manage/project/roles.html:85
 #: warehouse/templates/manage/project/roles.html:115
@@ -2457,8 +2459,6 @@ msgstr ""
 
 #: warehouse/templates/email/trusted-publisher-added/body.html:34
 #: warehouse/templates/email/trusted-publisher-removed/body.html:32
-#: warehouse/templates/manage/account/publishing.html:172
-#: warehouse/templates/manage/project/publishing.html:45
 msgid "Repository"
 msgstr ""
 
@@ -3711,7 +3711,7 @@ msgstr ""
 #: warehouse/templates/manage/manage_base.html:80
 #: warehouse/templates/manage/manage_base.html:97
 #: warehouse/templates/manage/manage_base.html:100
-#: warehouse/templates/manage/manage_base.html:551
+#: warehouse/templates/manage/manage_base.html:554
 #: warehouse/templates/manage/organization/roles.html:202
 #: warehouse/templates/manage/organization/roles.html:204
 #: warehouse/templates/manage/organization/roles.html:209
@@ -3895,11 +3895,11 @@ msgid ""
 "href=\"%(href)s\">here</a>."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:547
+#: warehouse/templates/manage/manage_base.html:546
 msgid "Any"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:558
+#: warehouse/templates/manage/manage_base.html:561
 #: warehouse/templates/manage/organization/history.html:166
 #: warehouse/templates/manage/project/history.html:43
 #: warehouse/templates/manage/project/history.html:97
@@ -3910,7 +3910,7 @@ msgstr ""
 msgid "Added by:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:560
+#: warehouse/templates/manage/manage_base.html:563
 #: warehouse/templates/manage/organization/history.html:171
 #: warehouse/templates/manage/project/history.html:62
 #: warehouse/templates/manage/project/history.html:128
@@ -3921,24 +3921,24 @@ msgstr ""
 msgid "Removed by:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:562
+#: warehouse/templates/manage/manage_base.html:565
 msgid "Submitted by:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:565
+#: warehouse/templates/manage/manage_base.html:568
 #: warehouse/templates/manage/project/history.html:247
 msgid "Workflow:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:567
+#: warehouse/templates/manage/manage_base.html:570
 msgid "Specifier:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:570
+#: warehouse/templates/manage/manage_base.html:573
 msgid "Publisher:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:572
+#: warehouse/templates/manage/manage_base.html:575
 #: warehouse/templates/manage/project/history.html:52
 #: warehouse/templates/manage/project/history.html:106
 msgid "URL:"
@@ -4217,42 +4217,42 @@ msgid "The project (on PyPI) that will be created when this publisher is used"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:52
-#: warehouse/templates/manage/project/publishing.html:82
+#: warehouse/templates/manage/project/publishing.html:41
 msgid "owner"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:54
-#: warehouse/templates/manage/project/publishing.html:84
+#: warehouse/templates/manage/project/publishing.html:43
 msgid "The GitHub organization name or GitHub username that owns the repository"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:62
-#: warehouse/templates/manage/project/publishing.html:92
+#: warehouse/templates/manage/project/publishing.html:51
 msgid "Repository name"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:67
-#: warehouse/templates/manage/project/publishing.html:97
+#: warehouse/templates/manage/project/publishing.html:56
 msgid "repository"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:69
-#: warehouse/templates/manage/project/publishing.html:99
+#: warehouse/templates/manage/project/publishing.html:58
 msgid "The name of the GitHub repository that contains the publishing workflow"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:77
-#: warehouse/templates/manage/project/publishing.html:107
+#: warehouse/templates/manage/project/publishing.html:66
 msgid "Workflow name"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:82
-#: warehouse/templates/manage/project/publishing.html:112
+#: warehouse/templates/manage/project/publishing.html:71
 msgid "workflow.yml"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:84
-#: warehouse/templates/manage/project/publishing.html:114
+#: warehouse/templates/manage/project/publishing.html:73
 msgid ""
 "The filename of the publishing workflow. This file should exist in the "
 "<code>.github/workflows/</code> directory in the repository configured "
@@ -4260,24 +4260,22 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:92
-#: warehouse/templates/manage/account/publishing.html:174
-#: warehouse/templates/manage/project/publishing.html:47
-#: warehouse/templates/manage/project/publishing.html:122
+#: warehouse/templates/manage/project/publishing.html:81
 msgid "Environment name"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:96
-#: warehouse/templates/manage/project/publishing.html:126
+#: warehouse/templates/manage/project/publishing.html:85
 msgid "(optional)"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:99
-#: warehouse/templates/manage/project/publishing.html:129
+#: warehouse/templates/manage/project/publishing.html:88
 msgid "release"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:101
-#: warehouse/templates/manage/project/publishing.html:131
+#: warehouse/templates/manage/project/publishing.html:90
 #, python-format
 msgid ""
 "The name of the <a href=\"%(href)s\">GitHub Actions environment</a> that "
@@ -4289,7 +4287,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:116
-#: warehouse/templates/manage/project/publishing.html:146
+#: warehouse/templates/manage/project/publishing.html:105
 #: warehouse/templates/manage/project/roles.html:320
 #: warehouse/templates/manage/team/roles.html:123
 msgid "Add"
@@ -4314,25 +4312,30 @@ msgid "Pending project name"
 msgstr ""
 
 #: warehouse/templates/manage/account/publishing.html:171
-#: warehouse/templates/manage/project/publishing.html:44
+#: warehouse/templates/manage/project/publishing.html:131
 msgid "Publisher"
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:186
+#: warehouse/templates/manage/account/publishing.html:172
+#: warehouse/templates/manage/project/publishing.html:132
+msgid "Details"
+msgstr ""
+
+#: warehouse/templates/manage/account/publishing.html:184
 msgid ""
 "No pending publishers are currently configured. Publishers for projects "
 "that don't exist yet can be added below."
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:192
+#: warehouse/templates/manage/account/publishing.html:190
 msgid "Add a new pending publisher"
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:195
+#: warehouse/templates/manage/account/publishing.html:193
 msgid "You can use this page to register \"pending\" trusted publishers."
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:201
+#: warehouse/templates/manage/account/publishing.html:199
 #, python-format
 msgid ""
 "These publishers behave similarly to trusted publishers registered "
@@ -4343,8 +4346,8 @@ msgid ""
 "trusted publishers <a href=\"%(href)s\">here</a>."
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:231
-#: warehouse/templates/manage/project/publishing.html:152
+#: warehouse/templates/manage/account/publishing.html:229
+#: warehouse/templates/manage/project/publishing.html:168
 #, python-format
 msgid ""
 "You must first enable <a href=\"%(href)s\">two-factor authentication</a> "
@@ -5564,28 +5567,28 @@ msgstr ""
 msgid "Back to projects"
 msgstr ""
 
-#: warehouse/templates/manage/project/publishing.html:36
-msgid "Manage current publishers"
-msgstr ""
-
-#: warehouse/templates/manage/project/publishing.html:40
-#, python-format
-msgid "OpenID Connect publishers associated with %(project_name)s"
-msgstr ""
-
-#: warehouse/templates/manage/project/publishing.html:58
-msgid "No publishers are currently configured."
-msgstr ""
-
-#: warehouse/templates/manage/project/publishing.html:61
-msgid "Add a new publisher"
-msgstr ""
-
-#: warehouse/templates/manage/project/publishing.html:66
+#: warehouse/templates/manage/project/publishing.html:25
 #, python-format
 msgid ""
 "Read more about GitHub Actions's OpenID Connect support <a "
 "href=\"%(href)s\">here</a>."
+msgstr ""
+
+#: warehouse/templates/manage/project/publishing.html:123
+msgid "Manage current publishers"
+msgstr ""
+
+#: warehouse/templates/manage/project/publishing.html:127
+#, python-format
+msgid "OpenID Connect publishers associated with %(project_name)s"
+msgstr ""
+
+#: warehouse/templates/manage/project/publishing.html:143
+msgid "No publishers are currently configured."
+msgstr ""
+
+#: warehouse/templates/manage/project/publishing.html:146
+msgid "Add a new publisher"
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:18

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -1131,6 +1131,10 @@ class ManageOIDCPublisherViews:
         self.request = request
         self.project = project
         self.metrics = self.request.find_service(IMetricsService, context=None)
+        self.github_publisher_form = GitHubPublisherForm(
+            self.request.POST,
+            api_token=self.request.registry.settings.get("github.token"),
+        )
 
     @property
     def _ratelimiters(self):
@@ -1161,13 +1165,6 @@ class ManageOIDCPublisherViews:
                     self.request.remote_addr
                 )
             )
-
-    @property
-    def github_publisher_form(self):
-        return GitHubPublisherForm(
-            self.request.POST,
-            api_token=self.request.registry.settings.get("github.token"),
-        )
 
     @property
     def default_response(self):

--- a/warehouse/oidc/forms/__init__.py
+++ b/warehouse/oidc/forms/__init__.py
@@ -9,18 +9,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import wtforms
 
-from warehouse import forms
-from warehouse.i18n import localize as _
+from warehouse.oidc.forms._core import DeletePublisherForm
+from warehouse.oidc.forms.github import GitHubPublisherForm, PendingGitHubPublisherForm
 
-
-class DeletePublisherForm(forms.Form):
-    __params__ = ["publisher_id"]
-
-    publisher_id = wtforms.StringField(
-        validators=[
-            wtforms.validators.InputRequired(message=_("Specify a publisher ID")),
-            wtforms.validators.UUID(message=_("Publisher must be specified by ID")),
-        ]
-    )
+__all__ = [
+    "DeletePublisherForm",
+    "GitHubPublisherForm",
+    "PendingGitHubPublisherForm",
+]

--- a/warehouse/oidc/forms/_core.py
+++ b/warehouse/oidc/forms/_core.py
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import wtforms
+
+from warehouse import forms
+from warehouse.i18n import localize as _
+from warehouse.utils.project import PROJECT_NAME_RE
+
+
+class PendingPublisherMixin:
+    project_name = wtforms.StringField(
+        validators=[
+            wtforms.validators.InputRequired(message=_("Specify project name")),
+            wtforms.validators.Regexp(
+                PROJECT_NAME_RE, message=_("Invalid project name")
+            ),
+        ]
+    )
+
+    def validate_project_name(self, field):
+        project_name = field.data
+
+        if project_name in self._project_factory:
+            raise wtforms.validators.ValidationError(
+                _("This project name is already in use")
+            )
+
+
+class DeletePublisherForm(forms.Form):
+    __params__ = ["publisher_id"]
+
+    publisher_id = wtforms.StringField(
+        validators=[
+            wtforms.validators.InputRequired(message=_("Specify a publisher ID")),
+            wtforms.validators.UUID(message=_("Publisher must be specified by ID")),
+        ]
+    )

--- a/warehouse/oidc/forms/github.py
+++ b/warehouse/oidc/forms/github.py
@@ -18,7 +18,7 @@ import wtforms
 
 from warehouse import forms
 from warehouse.i18n import localize as _
-from warehouse.utils.project import PROJECT_NAME_RE
+from warehouse.oidc.forms._core import PendingPublisherMixin
 
 _VALID_GITHUB_REPO = re.compile(r"^[a-zA-Z0-9-_.]+$")
 _VALID_GITHUB_OWNER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$")
@@ -166,29 +166,12 @@ class GitHubPublisherBase(forms.Form):
         )
 
 
-class PendingGitHubPublisherForm(GitHubPublisherBase):
+class PendingGitHubPublisherForm(GitHubPublisherBase, PendingPublisherMixin):
     __params__ = GitHubPublisherBase.__params__ + ["project_name"]
-
-    project_name = wtforms.StringField(
-        validators=[
-            wtforms.validators.InputRequired(message=_("Specify project name")),
-            wtforms.validators.Regexp(
-                PROJECT_NAME_RE, message=_("Invalid project name")
-            ),
-        ]
-    )
 
     def __init__(self, *args, project_factory, **kwargs):
         super().__init__(*args, **kwargs)
         self._project_factory = project_factory
-
-    def validate_project_name(self, field):
-        project_name = field.data
-
-        if project_name in self._project_factory:
-            raise wtforms.validators.ValidationError(
-                _("This project name is already in use")
-            )
 
 
 class GitHubPublisherForm(GitHubPublisherBase):

--- a/warehouse/static/js/warehouse/controllers/horizontal_tabs_controller.js
+++ b/warehouse/static/js/warehouse/controllers/horizontal_tabs_controller.js
@@ -19,6 +19,14 @@ export default class extends Controller {
 
 
   initialize() {
+    // Select the tab with errors if there are any
+    this.tabPanelTargets.forEach((target, index) => {
+      const aElement = target.querySelector("div#errors");
+      if (aElement) {
+        this.index = index;
+      }
+    });
+
     this.showTab();
   }
 

--- a/warehouse/templates/manage/account/publishing.html
+++ b/warehouse/templates/manage/account/publishing.html
@@ -22,7 +22,7 @@
   {{ oidc_title() }}
 {% endblock %}
 
-{% macro github_form(request, pending_github_pubisher_form) %}
+{% macro github_form(request, pending_github_publisher_form) %}
   {{ form_error_anchor(pending_github_publisher_form) }}
   <form method="POST" action="{{ request.route_path('manage.account.publishing') }}#errors">
     <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
@@ -169,9 +169,7 @@
       <tr>
         <th scope="col">{% trans %}Pending project name{% endtrans %}</th>
         <th scope="col">{% trans %}Publisher{% endtrans %}</th>
-        <th scope="col">{% trans %}Repository{% endtrans %}</th>
-        <th scope="col">{% trans %}Workflow{% endtrans %}</th>
-        <th scope="col">{% trans %}Environment name{% endtrans %}</th>
+        <th scope="col">{% trans %}Details{% endtrans %}</th>
         <th></th>
       </tr>
     </thead>

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -535,17 +535,20 @@
     {{ publisher.publisher_name }}
   </td>
   <td scope="row">
-    <a href="{{ publisher.publisher_url() }}">{{ publisher.repository }}</a>
-  </td>
-  <td scope="row">
-    {{ publisher.workflow_filename }}
-  </td>
-  <td scope="row">
-    {% if publisher.environment %}
-      {{ publisher.environment }}
+    <small>
+    {% if publisher.publisher_name == "GitHub" %}
+      <b>Repository:</b> <a href="{{ publisher.publisher_url() }}">{{ publisher.repository }}</a><br>
+      <b>Workflow:</b> {{ publisher.workflow_filename }}<br>
+      <b>Environment name:</b>
+      {% if publisher.environment %}
+        {{ publisher.environment }}
+      {% else %}
+        <i>({% trans %}Any{% endtrans %})</i>
+      {% endif %}
     {% else %}
-      <i>({% trans %}Any{% endtrans %})</i>
+      -
     {% endif %}
+    </small>
   </td>
   <td scope="row">
     <input form="delete-publisher-{{ publisher.id }}" type="submit" value="{% trans %}Remove{% endtrans %}" class="button button--danger">

--- a/warehouse/templates/manage/project/publishing.html
+++ b/warehouse/templates/manage/project/publishing.html
@@ -20,48 +20,7 @@
   {{ oidc_title() }}
 {% endblock %}
 
-{% block main %}
-{% if testPyPI %}
-{% set title = "TestPyPI" %}
-{% else %}
-{% set title = "PyPI" %}
-{% endif %}
-
-<div class="horizontal-section">
-  <div class="site-container">
-    <h1 class="page-title">{{ oidc_title() }}</h1>
-
-    {{ oidc_desc() }}
-
-    <h2>{% trans %}Manage current publishers{% endtrans %}</h2>
-    {% if project.oidc_publishers %}
-    <table class="table table--publisher-list">
-      <caption class="sr-only">
-        {% trans project_name=project.name %}OpenID Connect publishers associated with {{ project_name }}{% endtrans %}
-      </caption>
-      <thead>
-        <tr>
-          <th scope="col">{% trans %}Publisher{% endtrans %}</th>
-          <th scope="col">{% trans %}Repository{% endtrans %}</th>
-          <th scope="col">{% trans %}Workflow{% endtrans %}</th>
-          <th scope="col">{% trans %}Environment name{% endtrans %}</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for publisher in project.oidc_publishers %}
-        {{ oidc_publisher_row(publisher) }}
-        {% endfor %}
-      </tbody>
-    </table>
-    {% else %}
-    <p class="no-bottom-padding">{% trans %}No publishers are currently configured.{% endtrans %}</p>
-    {% endif %}
-
-    <h2 class="no-bottom-padding">{% trans %}Add a new publisher{% endtrans %}</h2>
-    {% if request.user.has_two_factor %}
-    <h3>GitHub</h3>
-
+{% macro github_form(request, github_publisher_form) %}
     <p>
       {% trans href="https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect" %}
       Read more about GitHub Actions's OpenID Connect support <a href="{{ href }}">here</a>.
@@ -146,7 +105,64 @@
         <input type="submit" value="{% trans %}Add{% endtrans %}" class="button button--primary">
       </div>
     </form>
+{% endmacro %}
 
+{% block main %}
+{% if testPyPI %}
+{% set title = "TestPyPI" %}
+{% else %}
+{% set title = "PyPI" %}
+{% endif %}
+
+<div class="horizontal-section">
+  <div class="site-container">
+    <h1 class="page-title">{{ oidc_title() }}</h1>
+
+    {{ oidc_desc() }}
+
+    <h2>{% trans %}Manage current publishers{% endtrans %}</h2>
+    {% if project.oidc_publishers %}
+    <table class="table table--publisher-list">
+      <caption class="sr-only">
+        {% trans project_name=project.name %}OpenID Connect publishers associated with {{ project_name }}{% endtrans %}
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">{% trans %}Publisher{% endtrans %}</th>
+          <th scope="col">{% trans %}Details{% endtrans %}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for publisher in project.oidc_publishers %}
+        {{ oidc_publisher_row(publisher) }}
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p class="no-bottom-padding">{% trans %}No publishers are currently configured.{% endtrans %}</p>
+    {% endif %}
+
+    <h2 class="no-bottom-padding">{% trans %}Add a new publisher{% endtrans %}</h2>
+
+    {% if request.user.has_two_factor %}
+
+    {% set publishers = [("GitHub", github_form(request, github_publisher_form))] %}
+
+    <div class="horizontal-tabs" data-controller="horizontal-tabs" data-horizontal-tabs-index="0">
+      <div class="horizontal-tabs__tabbar">
+        {% for publisher_name, _ in publishers %}
+        <button data-horizontal-tabs-target="tab" data-action="horizontal-tabs#change" class="tab {{ "is-active" if loop.first else "" }}">
+          {{ publisher_name }}
+        </button>
+        {% endfor %}
+      </div>
+      {% for _, publisher_form in publishers %}
+      <div class="horizontal-tabs__tabcontent {{ "is-hidden" if loop.first else "" }}" data-horizontal-tabs-target="tabPanel">
+        {{ publisher_form }}
+      </div>
+      {% endfor %}
+    </div>
     {% else %}{# user has not enabled 2FA #}
     <div class="callout-block callout-block--warning">
       {% trans href=request.route_path('manage.account.two-factor') %}


### PR DESCRIPTION
This PR makes the OIDC templates, forms and views more "generic" and less GitHub-specific. This is a precursor to the fix for #13551 (which I have drafted). This PR doesn't introduce any functional changes.

After this, we should get https://github.com/pypi/warehouse/pull/14063 merged as well, and then we can begin adding other trusted publishers.

(cc @woodruffw)