### PR TITLE
Document additional Trusted Publishers

### DIFF
--- a/docs/user/trusted-publishers/adding-a-publisher.md
+++ b/docs/user/trusted-publishers/adding-a-publisher.md
@@ -43,6 +43,17 @@ each.
         your trusted workflow, such as requiring manual approval on each run
         by a trusted subset of repository maintainers.
 
+=== "Google Cloud"
+
+    TODO
+
+=== "ActiveState"
+
+    TODO
+
+=== "GitLab CI/CD"
+
+    TODO
 
 Once you click "Add", your publisher will be registered and will appear
 at the top of the page:

--- a/docs/user/trusted-publishers/creating-a-project-through-oidc.md
+++ b/docs/user/trusted-publishers/creating-a-project-through-oidc.md
@@ -39,6 +39,18 @@ provide the name of the PyPI project that will be created.
         Like with "normal" trusted publishers, configuring a GitHub Actions
         environment is **optional but strongly recommended**.
 
+=== "Google Cloud"
+
+    TODO
+
+
+=== "ActiveState"
+
+    TODO
+
+=== "GitLab CI/CD"
+
+    TODO
 
 Clicking "Add" will register the "pending" publisher, and show it to you:
 

--- a/docs/user/trusted-publishers/security-model.md
+++ b/docs/user/trusted-publishers/security-model.md
@@ -131,6 +131,18 @@ own security model and considerations.
       access the OIDC token to a bare minimum. This prevents both accidental
       and malicious disclosure.
 
+=== "Google Cloud"
+
+    TODO
+
+=== "ActiveState"
+
+    TODO
+
+=== "GitLab CI/CD"
+
+    TODO
+
 [fundamentally dangerous]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 
 [Use a dedicated environment]: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment


### PR DESCRIPTION
These sections are all empty for now; I'll fill them out as we complete each Trusted Publisher's provider implementation.

Trackers:

- [ ] Google Cloud: https://github.com/pypi/warehouse/issues/13551
- [ ] ActiveState: https://github.com/pypi/warehouse/pull/13980
- [ ] GitLab CI/CD: https://github.com/pypi/warehouse/issues/13575

With each of these, the following is needed for their documentation:

* Each needs to be merged with a per-provider admin flag disabled, so that users can't yet access it
* Each needs to be enabled on TestPyPI so we can experiment + write their specific docs
