### PR TITLE
Fix sub filter for Google OIDC Publisher lookup

### DIFF
--- a/tests/unit/oidc/test_utils.py
+++ b/tests/unit/oidc/test_utils.py
@@ -89,7 +89,7 @@ def test_find_publisher_by_issuer_google(db_request, sub, expected_id):
     GooglePublisherFactory(
         id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
         email="fake@example.com",
-        sub=None,  # No subject
+        sub="",  # No subject
     )
     GooglePublisherFactory(
         id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",

--- a/warehouse/oidc/models/google.py
+++ b/warehouse/oidc/models/google.py
@@ -70,7 +70,7 @@ class GooglePublisherMixin:
 
     @staticmethod
     def __lookup_no_sub__(klass, signed_claims: SignedClaims) -> Query | None:
-        return Query(klass).filter_by(email=signed_claims["email"], sub=None)
+        return Query(klass).filter_by(email=signed_claims["email"], sub="")
 
     __lookup_strategies__ = [
         __lookup_all__,


### PR DESCRIPTION
This fixes a bug in the `sub` filter in the `__lookup_no_sub__` strategy to correctly match an Google publisher which has not had a `sub` configured, similar to the same thing for GitHub's `environment` claim: https://github.com/pypi/warehouse/blob/e62049b47483464239fc35df01854274da16c091/warehouse/oidc/models/github.py#L188