### PR TITLE
Trusted Publishing: Google: The _check_sub verifier should check if empty

### DIFF
--- a/tests/unit/oidc/models/test_google.py
+++ b/tests/unit/oidc/models/test_google.py
@@ -159,7 +159,7 @@ class TestGooglePublisher:
             ("fakesubject", "fakesubject", True),
             ("fakesubject", "wrongsubject", False),
             # Publisher configured without subject: any subject is acceptable.
-            (None, "anysubject", True),
+            ("", "anysubject", True),
             # Publisher configured with subject, none provided: must fail.
             ("fakesubject", None, False),
         ],

--- a/warehouse/oidc/models/google.py
+++ b/warehouse/oidc/models/google.py
@@ -31,7 +31,7 @@ def _check_sub(
 ) -> bool:
     # If we haven't set a subject for the publisher, we don't need to check
     # this claim.
-    if ground_truth is None:
+    if ground_truth is "":
         return True
 
     # Defensive: Google should never send us an empty or null subject, but

--- a/warehouse/oidc/models/google.py
+++ b/warehouse/oidc/models/google.py
@@ -31,7 +31,7 @@ def _check_sub(
 ) -> bool:
     # If we haven't set a subject for the publisher, we don't need to check
     # this claim.
-    if ground_truth is "":
+    if ground_truth == "":
         return True
 
     # Defensive: Google should never send us an empty or null subject, but


### PR DESCRIPTION
Follow on to #15202: We should also short-circuit the verification when the ground truth is the empty string, not `None`.