### PR TITLE
docs/packaging: fix the link to correct page

### DIFF
--- a/docs/dev/api-reference/legacy.rst
+++ b/docs/dev/api-reference/legacy.rst
@@ -120,7 +120,7 @@ The API endpoint served at `upload.pypi.org/legacy/
 <https://upload.pypi.org/legacy/>`_ is Warehouse's emulation of the
 legacy PyPI upload API. This is the endpoint that tools such as `twine
 <https://twine.readthedocs.io/>`_ use to `upload distributions to PyPI
-<https://packaging.python.org/tutorials/distributing-packages/>`_.
+<https://packaging.python.org/guides/distributing-packages-using-setuptools/>`_.
 
 The upload api can be used to upload artifacts by sending a multipart/form-data
 POST request with the following fields:

--- a/docs/dev/development/reviewing-patches.rst
+++ b/docs/dev/development/reviewing-patches.rst
@@ -157,4 +157,4 @@ Merge requirements
 
 .. _`twine`: https://github.com/pypa/twine
 
-.. _`Python Packaging User Guide`: https://packaging.python.org/tutorials/distributing-packages/#packaging-your-project
+.. _`Python Packaging User Guide`: https://packaging.python.org/guides/distributing-packages-using-setuptools/#packaging-your-project

--- a/tests/frontend/dismissable_controller_test.js
+++ b/tests/frontend/dismissable_controller_test.js
@@ -24,13 +24,13 @@ describe("Dismissable controller", () => {
     <p>
       To set the 'warehouse' description, author, links,
       classifiers, and other details for your next release, use
-      the <a href="https://packaging.python.org/tutorials/distributing-packages/#setup-args" rel="noopener" target="_blank"><code>setup()</code>
+      the <a href="https://packaging.python.org/guides/distributing-packages-using-setuptools/#setup-args" rel="noopener" target="_blank"><code>setup()</code>
       arguments in your <code>setup.py</code> file</a>. Updating these
       fields will not change the metadata for past
       releases. Additionally, you <strong>must</strong> use
       <a href="https://twine.readthedocs.io/en/latest/" rel="noopener" target="_blank">Twine</a>
       to upload your files in order to get full support for these fields. See
-      <a href="https://packaging.python.org/tutorials/distributing-packages/" rel="noopener" target="_blank">the Python Packaging User Guide</a> for more help.
+      <a href="https://packaging.python.org/guides/distributing-packages-using-setuptools/" rel="noopener" target="_blank">the Python Packaging User Guide</a> for more help.
     </p>
     <button id="dismiss" type="button" title="Dismiss" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
   </div>

--- a/warehouse/templates/manage/project/release.html
+++ b/warehouse/templates/manage/project/release.html
@@ -141,7 +141,7 @@
     <h3>{% trans %}No files found{% endtrans %}</h3>
     {% endif %}
     <button type="button" title="{% trans %}Dismiss{% endtrans %}" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
-    <p>{% trans href='https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi', title=gettext('External link') %}Learn how to upload files on the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging User Guide</a>{% endtrans %}</p>
+    <p>{% trans href='https://packaging.python.org/guides/distributing-packages-using-setuptools/#uploading-your-project-to-pypi', title=gettext('External link') %}Learn how to upload files on the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging User Guide</a>{% endtrans %}</p>
   </div>
 
   <h3>{% trans %}Release settings{% endtrans %}</h3>

--- a/warehouse/templates/manage/project/releases.html
+++ b/warehouse/templates/manage/project/releases.html
@@ -176,6 +176,6 @@
     <h3>{% trans %}No releases found{% endtrans %}</h3>
     {% endif %}
     <button type="button" title="{% trans %}Dismiss{% endtrans %}" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="{% trans %}Close{% endtrans %}"><i class="fa fa-times" aria-hidden="true"></i></button>
-    <p>{% trans href='https://packaging.python.org/tutorials/distributing-packages/', title=gettext('External link') %}Learn how to create a new release on the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging User Guide</a>{% endtrans %}</p>
+    <p>{% trans href='https://packaging.python.org/guides/distributing-packages-using-setuptools/', title=gettext('External link') %}Learn how to create a new release on the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging User Guide</a>{% endtrans %}</p>
   </div>
 {% endblock %}

--- a/warehouse/templates/manage/project/settings.html
+++ b/warehouse/templates/manage/project/settings.html
@@ -59,7 +59,7 @@
   <div class="callout-block" data-controller="dismissable" data-dismissable-identifier="settings">
     <h3>{% trans %}Project description and sidebar{% endtrans %}</h3>
     <p>
-      {% trans project_name=project.name, pyproject_args_href='https://packaging.python.org/en/latest/tutorials/packaging-projects/#creating-pyproject-toml', twine_docs_href='https://twine.readthedocs.io/en/latest/', distribution_href='https://packaging.python.org/tutorials/distributing-packages/' %}
+      {% trans project_name=project.name, pyproject_args_href='https://packaging.python.org/en/latest/tutorials/packaging-projects/#creating-pyproject-toml', twine_docs_href='https://twine.readthedocs.io/en/latest/', distribution_href='https://packaging.python.org/guides/distributing-packages-using-setuptools/' %}
         To set the '{{ project_name }}' description, author, links, classifiers, and other details for your next release, use the <a href="{{ pyproject_args_href }}" rel="noopener" target="_blank"><code>setup()</code> arguments in your <code>setup.py</code> file</a>.
         Updating these fields will not change the metadata for past releases.
         Additionally, you <strong>must</strong> use <a href="{{ twine_docs_href }}" rel="noopener" target="_blank">Twine</a> to upload your files in order to get full support for these fields.

--- a/warehouse/templates/pages/classifiers.html
+++ b/warehouse/templates/pages/classifiers.html
@@ -22,7 +22,7 @@
     <p>{% trans %}Each project's maintainers provide PyPI with a list of "Trove classifiers" to categorize each release, describing who it's for, what systems it can run on, and how mature it is.{% endtrans %}</p>
     <p>{% trans %}These standardized classifiers can then be used by community members to find projects based on their desired criteria.{% endtrans %}</p>
     <p>
-      {% trans ppug_href='https://packaging.python.org/tutorials/distributing-packages/#configuring-metadata', pep301_href='https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification', title=gettext('External link') %}
+      {% trans ppug_href='https://packaging.python.org/guides/distributing-packages-using-setuptools/#configuring-metadata', pep301_href='https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification', title=gettext('External link') %}
       Instructions for how to add Trove classifiers to a project can be found on the <a href="{{ ppug_href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging User Guide</a>.
       To read the original classifier specification, refer to <a href="{{ pep301_href }}" title="{{ title }}" target="_blank" rel="noopener"><abbr title="Python enhancement proposal">PEP</abbr> 301</a>.
       {% endtrans %}

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -616,7 +616,7 @@ print(f"BLAKE2b-256: {blake2b_hash}\nSHA256: {sha256_hash}")</pre>
 
         <h3 id="description-content-type">{{ description_content_type() }}</h3>
         <p>{% trans href='https://docutils.sourceforge.io/rst.html', title=gettext('External link') %}By default, an upload's description will render with <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">reStructuredText</a>. If the description is in an alternate format like Markdown, a package may set the <code>long_description_content_type</code> in <code>setup.py</code> to the alternate format.{% endtrans %}</p>
-        <p>{% trans href='https://packaging.python.org/tutorials/distributing-packages/#description', title=gettext('External link') %}Refer to the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging User Guide</a> for details on the available formats.{% endtrans %}</p>
+        <p>{% trans href='https://packaging.python.org/guides/distributing-packages-using-setuptools/#description', title=gettext('External link') %}Refer to the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging User Guide</a> for details on the available formats.{% endtrans %}</p>
         <p>For how to check a description for validity, see also: <a href="#description-render-failure">{{ description_render_failure() }}</a></p>
 
         <h3 id="file-size-limit">{{ file_size_limit() }}</h3>
@@ -756,7 +756,7 @@ print(f"BLAKE2b-256: {blake2b_hash}\nSHA256: {sha256_hash}")</pre>
 
         <h3 id="uploading">{{ uploading() }}</h3>
         <p>
-          {% trans href='https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi', title=gettext('External link') %}
+          {% trans href='https://packaging.python.org/guides/distributing-packages-using-setuptools/#uploading-your-project-to-pypi', title=gettext('External link') %}
             In a previous version of PyPI, it used to be possible for maintainers
             to upload releases to PyPI using a form in the web browser.
             This feature was deprecated with the new version of PyPI – we instead


### PR DESCRIPTION
https://packaging.python.org/tutorials/distributing-packages/ returns a 404