### PR TITLE
refactor: extract observation kind map

### DIFF
--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import joinedload
 from warehouse.accounts.models import User
 from warehouse.authnz import Permissions
 from warehouse.forklift.legacy import MAX_FILESIZE, MAX_PROJECT_SIZE
-from warehouse.observations.models import ObservationKind
+from warehouse.observations.models import OBSERVATION_KIND_MAP, ObservationKind
 from warehouse.packaging.models import JournalEntry, Project, Release, Role
 from warehouse.packaging.tasks import update_release_description
 from warehouse.search.tasks import reindex_project as _reindex_project
@@ -32,8 +32,6 @@ from warehouse.utils.project import confirm_project, remove_project
 ONE_MB = 1024 * 1024  # bytes
 ONE_GB = 1024 * 1024 * 1024  # bytes
 UPLOAD_LIMIT_CAP = 1073741824  # 1 GiB
-
-KIND_MAP = {kind.value[0]: kind for kind in ObservationKind}
 
 
 @view_config(
@@ -202,7 +200,7 @@ def add_project_observation(project, request):
         )
 
     try:
-        kind = KIND_MAP[kind]
+        kind = OBSERVATION_KIND_MAP[kind]
     except KeyError as e:
         request.session.flash("Invalid kind", queue="error")
         raise HTTPSeeOther(
@@ -340,7 +338,7 @@ def add_release_observation(release, request):
         )
 
     try:
-        kind = KIND_MAP[kind]
+        kind = OBSERVATION_KIND_MAP[kind]
     except KeyError as e:
         request.session.flash("Invalid kind", queue="error")
         raise HTTPSeeOther(

--- a/warehouse/observations/models.py
+++ b/warehouse/observations/models.py
@@ -111,11 +111,19 @@ class ObservationKind(enum.Enum):
     The kinds of observations we can make. Format:
 
     key_used_in_python = ("key_used_in_postgres", "Human Readable Name")
+
+    Explicitly not a ForeignKey to a table, since we want to be able to add new
+    kinds of observations without having to update the database schema.
     """
 
-    IsMalicious = ("is_malicious", "Is Malicious")
+    IsDependencyConfusion = ("is_dependency_confusion", "Is Dependency Confusion")
+    IsMalware = ("is_malware", "Is Malware")
     IsSpam = ("is_spam", "Is Spam")
     SomethingElse = ("something_else", "Something Else")
+
+
+# A reverse-lookup map by the string value stored in the database
+OBSERVATION_KIND_MAP = {kind.value[0]: kind for kind in ObservationKind}
 
 
 class Observation(AbstractConcreteBase, db.Model):


### PR DESCRIPTION
As a useful map, move to a more common place so it can be called generally, instead of importing an admin view.