### PR TITLE
Fix dev docs instructions on how to build docs

### DIFF
--- a/docs/dev/development/getting-started.rst
+++ b/docs/dev/development/getting-started.rst
@@ -568,10 +568,11 @@ Use :command:`make` to build the documentation. For example:
 
 .. code-block:: console
 
-    make docs
+    make user-docs dev-docs
 
-The HTML documentation index can now be found at
-:file:`docs/_build/html/index.html`.
+The HTML index for the user documentation can now be found at
+:file:`docs/user-site/index.html`, and the index for the developer
+documentation at :file:`docs/dev/_build/html/index.html`.
 
 Building the docs requires Python 3.8. If it is not installed, the
 :command:`make` command will give the following error message:

--- a/docs/dev/development/submitting-patches.rst
+++ b/docs/dev/development/submitting-patches.rst
@@ -62,7 +62,7 @@ Documentation
 
 Important information should be documented with prose in the ``docs`` section.
 To ensure it builds and passes `doc8`_ style checks you can run
-``make docs`` and ``make lint`` respectively.
+``make dev-docs user-docs`` and ``make lint`` respectively.
 
 
 Translations


### PR DESCRIPTION
Since https://github.com/pypi/warehouse/commit/1db4b00729138b80f9d008f8622bf28e79c587bc, the `make` target for building the docs changed from `make docs` to `make user-docs` and `make dev-docs`. This fixes the dev documentation to account for that change.