### PR TITLE
refactor: use specific classes for responses

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -21,10 +21,10 @@ from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
 from pyramid.httpexceptions import (
     HTTPBadRequest,
     HTTPNotFound,
+    HTTPOk,
     HTTPSeeOther,
     HTTPTooManyRequests,
 )
-from pyramid.response import Response
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import joinedload
 from webauthn.helpers import bytes_to_base64url
@@ -943,7 +943,7 @@ class TestProvisionTOTP:
         view = views.ProvisionTOTPViews(request)
         result = view.generate_totp_qr()
 
-        assert isinstance(result, Response)
+        assert isinstance(result, HTTPOk)
         assert result.content_type == "image/svg+xml"
 
     def test_generate_totp_qr_two_factor_not_allowed(self):

--- a/tests/unit/test_sanity.py
+++ b/tests/unit/test_sanity.py
@@ -15,9 +15,8 @@ import io
 import pretend
 import pytest
 
-from pyramid.httpexceptions import HTTPBadRequest, HTTPMovedPermanently
+from pyramid.httpexceptions import HTTPBadRequest, HTTPMovedPermanently, HTTPOk
 from pyramid.request import Request
-from pyramid.response import Response
 
 from warehouse import sanity
 
@@ -89,7 +88,7 @@ def test_unicode_redirects(original_location, expected_location):
     if original_location:
         resp_in = HTTPMovedPermanently(original_location)
     else:
-        resp_in = Response()
+        resp_in = HTTPOk()
 
     resp_out = sanity.unicode_redirects(resp_in)
 

--- a/tests/unit/utils/test_compression.py
+++ b/tests/unit/utils/test_compression.py
@@ -13,7 +13,7 @@
 import pretend
 import pytest
 
-from pyramid.response import Response
+from pyramid.httpexceptions import HTTPOk
 from webob.acceptparse import AcceptEncodingNoHeader, AcceptEncodingValidHeader
 from webob.response import gzip_app_iter
 
@@ -48,7 +48,7 @@ class TestCompressor:
     )
     def test_sets_vary(self, vary, expected):
         request = pretend.stub(accept_encoding=AcceptEncodingNoHeader())
-        response = Response(body=b"foo")
+        response = HTTPOk(body=b"foo")
         response.vary = vary
 
         compressor(request, response)
@@ -60,7 +60,7 @@ class TestCompressor:
         compressed_body = b"".join(list(gzip_app_iter([decompressed_body])))
 
         request = pretend.stub(accept_encoding=AcceptEncodingValidHeader("gzip"))
-        response = Response(body=decompressed_body)
+        response = HTTPOk(body=decompressed_body)
         response.md5_etag()
 
         original_etag = response.etag
@@ -77,7 +77,7 @@ class TestCompressor:
         compressed_body = b"".join(list(gzip_app_iter([decompressed_body])))
 
         request = pretend.stub(accept_encoding=AcceptEncodingValidHeader("gzip"))
-        response = Response(app_iter=iter([decompressed_body]))
+        response = HTTPOk(app_iter=iter([decompressed_body]))
 
         compressor(request, response)
 
@@ -90,7 +90,7 @@ class TestCompressor:
         compressed_body = b"".join(list(gzip_app_iter([decompressed_body])))
 
         request = pretend.stub(accept_encoding=AcceptEncodingValidHeader("gzip"))
-        response = Response(app_iter=iter([decompressed_body]))
+        response = HTTPOk(app_iter=iter([decompressed_body]))
         response.etag = "foo"
 
         compressor(request, response)
@@ -105,7 +105,7 @@ class TestCompressor:
         compressed_body = b"".join(list(gzip_app_iter([decompressed_body])))
 
         request = pretend.stub(accept_encoding=AcceptEncodingValidHeader("gzip"))
-        response = Response(
+        response = HTTPOk(
             app_iter=iter([decompressed_body]), content_length=len(decompressed_body)
         )
 
@@ -117,7 +117,7 @@ class TestCompressor:
 
     def test_doesnt_compress_too_small(self):
         request = pretend.stub(accept_encoding=AcceptEncodingValidHeader("gzip"))
-        response = Response(body=b"foo")
+        response = HTTPOk(body=b"foo")
 
         compressor(request, response)
 

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -25,7 +25,7 @@ import transaction
 from pyramid import renderers
 from pyramid.authorization import Allow, Authenticated
 from pyramid.config import Configurator as _Configurator
-from pyramid.response import Response
+from pyramid.exceptions import HTTPForbidden
 from pyramid.tweens import EXCVIEW
 from pyramid_rpc.xmlrpc import XMLRPCRenderer
 
@@ -140,7 +140,7 @@ def require_https_tween_factory(handler, registry):
         # If we have an :action URL and we're not using HTTPS, then we want to
         # return a 403 error.
         if request.params.get(":action", None) and request.scheme != "https":
-            resp = Response("SSL is required.", status=403, content_type="text/plain")
+            resp = HTTPForbidden(body="SSL is required.", content_type="text/plain")
             resp.status = "403 SSL is required"
             resp.headers["X-Fastly-Error"] = "803"
             return resp

--- a/warehouse/email/ses/views.py
+++ b/warehouse/email/ses/views.py
@@ -14,8 +14,7 @@ import json
 
 import requests
 
-from pyramid.httpexceptions import HTTPBadRequest, HTTPServiceUnavailable
-from pyramid.response import Response
+from pyramid.httpexceptions import HTTPBadRequest, HTTPOk, HTTPServiceUnavailable
 from pyramid.view import view_config
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.sql import exists
@@ -60,7 +59,7 @@ def confirm_subscription(request):
         TopicArn=data["TopicArn"], Token=data["Token"], AuthenticateOnUnsubscribe="true"
     )
 
-    return Response()
+    return HTTPOk()
 
 
 @view_config(
@@ -87,7 +86,7 @@ def notification(request):
         exists().where(Event.event_id == data["MessageId"])
     ).scalar()
     if event_exists:
-        return Response()
+        return HTTPOk()
 
     message = json.loads(data["Message"])
     message_id = message["mail"]["messageId"]
@@ -129,4 +128,4 @@ def notification(request):
         )
     )
 
-    return Response()
+    return HTTPOk()

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -35,10 +35,10 @@ from pyramid.httpexceptions import (
     HTTPException,
     HTTPForbidden,
     HTTPGone,
+    HTTPOk,
     HTTPPermanentRedirect,
     HTTPTooManyRequests,
 )
-from pyramid.response import Response
 from pyramid.view import view_config
 from sqlalchemy import func, orm
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
@@ -1278,7 +1278,7 @@ def file_upload(request):
         is_duplicate = _is_duplicate_file(request.db, filename, file_hashes)
         if is_duplicate:
             request.tm.doom()
-            return Response()
+            return HTTPOk()
         elif is_duplicate is not None:
             raise _exc_with_message(
                 HTTPBadRequest,
@@ -1532,7 +1532,7 @@ def file_upload(request):
     request.task(sync_file_to_cache).delay(file_.id)
 
     # Return any warnings that we've accumulated as the response body.
-    return Response("\n".join(warnings))
+    return HTTPOk(body="\n".join(warnings))
 
 
 @view_config(

--- a/warehouse/legacy/api/pypi.py
+++ b/warehouse/legacy/api/pypi.py
@@ -10,8 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyramid.httpexceptions import HTTPGone, HTTPMovedPermanently, HTTPNotFound
-from pyramid.response import Response
+from pyramid.httpexceptions import HTTPGone, HTTPMovedPermanently, HTTPNotFound, HTTPOk
 from pyramid.view import forbidden_view_config, view_config
 from trove_classifiers import sorted_classifiers
 
@@ -75,7 +74,7 @@ def forbidden_legacy(exc, request):
 
 @view_config(route_name="legacy.api.pypi.list_classifiers")
 def list_classifiers(request):
-    return Response(
+    return HTTPOk(
         text="\n".join(sorted_classifiers), content_type="text/plain; charset=utf-8"
     )
 

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -19,10 +19,10 @@ from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
 from pyramid.httpexceptions import (
     HTTPBadRequest,
     HTTPNotFound,
+    HTTPOk,
     HTTPSeeOther,
     HTTPTooManyRequests,
 )
-from pyramid.response import Response
 from pyramid.view import view_config, view_defaults
 from sqlalchemy import func
 from sqlalchemy.exc import NoResultFound
@@ -509,7 +509,7 @@ class ProvisionTOTPViews:
         qr_buffer = io.BytesIO()
         totp_qr.svg(qr_buffer, scale=5)
 
-        return Response(content_type="image/svg+xml", body=qr_buffer.getvalue())
+        return HTTPOk(content_type="image/svg+xml", body=qr_buffer.getvalue())
 
     @view_config(request_method="GET")
     def totp_provision(self):

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -19,8 +19,8 @@ import jwt
 import sentry_sdk
 
 from pydantic import BaseModel, StrictStr, ValidationError
+from pyramid.httpexceptions import HTTPForbidden
 from pyramid.request import Request
-from pyramid.response import Response
 from pyramid.view import view_config
 
 from warehouse.events.tags import EventTag
@@ -83,8 +83,8 @@ def _invalid(errors: list[Error], request: Request) -> JsonResponse:
 )
 def oidc_audience(request: Request):
     if request.flags.disallow_oidc():
-        return Response(
-            status=403, json={"message": "Trusted publishing functionality not enabled"}
+        return HTTPForbidden(
+            json={"message": "Trusted publishing functionality not enabled"}
         )
 
     audience: str = request.registry.settings["warehouse.oidc.audience"]

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -20,6 +20,7 @@ from pyramid.exceptions import PredicateMismatch
 from pyramid.httpexceptions import (
     HTTPBadRequest,
     HTTPException,
+    HTTPForbidden,
     HTTPMovedPermanently,
     HTTPNotFound,
     HTTPRequestEntityTooLarge,
@@ -30,7 +31,6 @@ from pyramid.httpexceptions import (
 from pyramid.i18n import make_localizer
 from pyramid.interfaces import ITranslationDirectories
 from pyramid.renderers import render_to_response
-from pyramid.response import Response
 from pyramid.view import (
     exception_view_config,
     forbidden_view_config,
@@ -94,9 +94,9 @@ def httpexception_view(exc, request):
     try:
         # Lightweight version of 404 page for `/simple/`
         if isinstance(exc, HTTPNotFound) and request.path.startswith("/simple/"):
-            response = Response(body="404 Not Found", content_type="text/plain")
+            response = HTTPNotFound(body="404 Not Found", content_type="text/plain")
         elif isinstance(exc, HTTPNotFound) and json_path.match(request.path):
-            response = Response(
+            response = HTTPNotFound(
                 body='{"message": "Not Found"}',
                 charset="utf-8",
                 content_type="application/json",
@@ -177,7 +177,7 @@ def forbidden(exc, request):
 def forbidden_include(exc, request):
     # If the forbidden error is for a client-side-include, just return an empty
     # response instead of redirecting
-    return Response(status=403)
+    return HTTPForbidden()
 
 
 @view_config(context=DatabaseNotAvailableError)


### PR DESCRIPTION
Instead of using a generic `Response` class that passes through to `webob.Response`, use a more specific response class from the (misnamed) `pyramid.httpexceptions` module.

Now when looking at a response, it's clearer what the intent is.