### PR TITLE
fix: sort applications by name

### DIFF
--- a/warehouse/organizations/services.py
+++ b/warehouse/organizations/services.py
@@ -88,7 +88,7 @@ class DatabaseOrganizationService:
             query = query.filter(OrganizationApplication.submitted_by == submitted_by)
         if undecided is True:
             query = query.filter(OrganizationApplication.is_approved.is_(None))
-        return query.all()
+        return query.order_by(OrganizationApplication.normalized_name).all()
 
     def find_organizationid(self, name):
         """


### PR DESCRIPTION
Remove a bit of test flakiness previously attempted. We sorted on one side (python), so sort the query-side as well.

Refs: #14645
Refs: #14883