### PR TITLE
feat(admin): update UI for macaroon caveats

### DIFF
--- a/tests/unit/integration/github/test_utils.py
+++ b/tests/unit/integration/github/test_utils.py
@@ -555,6 +555,7 @@ def test_analyze_disclosure(monkeypatch, metrics):
         user=user,
         id=12,
         permissions_caveat={"permissions": "user", "version": 1},
+        caveats=[],
         description="foo",
     )
 
@@ -601,6 +602,7 @@ def test_analyze_disclosure(monkeypatch, metrics):
                 "macaroon_id": "12",
                 "public_url": "http://example.com",
                 "permissions": "user",
+                "caveats": [],
                 "description": "foo",
             },
         )

--- a/warehouse/admin/static/js/warehouse.js
+++ b/warehouse/admin/static/js/warehouse.js
@@ -124,6 +124,16 @@ table.columns([".ip_address", ".hashed_ip"]).visible(false);
 new $.fn.dataTable.Buttons(table, {buttons: ["copy", "csv", "colvis"]});
 table.buttons().container().appendTo($(".col-md-6:eq(0)", table.table().container()));
 
+// User API Tokens
+let token_table = $("#api-tokens").DataTable({
+  responsive: true,
+  lengthChange: false,
+});
+token_table.columns([".last_used", ".created"]).order([1, "desc"]).draw();
+token_table.columns([".permissions_caveat"]).visible(false);
+new $.fn.dataTable.Buttons(token_table, {buttons: ["colvis"]});
+token_table.buttons().container().appendTo($(".col-md-6:eq(0)", token_table.table().container()));
+
 // Observations
 let obs_table = $("#observations").DataTable({
   responsive: true,

--- a/warehouse/admin/templates/admin/macaroons/detail.html
+++ b/warehouse/admin/templates/admin/macaroons/detail.html
@@ -50,8 +50,12 @@
         <td>{{ macaroon.oidc_publisher }}</td>
       </tr>
       <tr>
-        <td>Permissions</td>
+        <td>Permissions (deprecated)</td>
         <td>{{ macaroon.permissions_caveat }}</td>
+      </tr>
+      <tr>
+        <td>Caveats (as created)</td>
+        <td>{{ macaroon.caveats }}</td>
       </tr>
       <tr>
         <td>Additional</td>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -430,14 +430,15 @@
         </div>
 
         <div class="card-body">
-          <table class="table table-hover">
+          <table id="api-tokens" class="table table-hover">
             <thead>
               <tr>
-                <th>Token</th>
-                <th>Description</th>
-                <th>Created</th>
-                <th>Last Used</th>
-                <th>Permissions</th>
+                <th scope="col" class="token">Token</th>
+                <th scope="col" class="description">Description</th>
+                <th scope="col" class="created">Created</th>
+                <th scope="col" class="last_used">Last Used</th>
+                <th scope="col" class="caveats">Caveats (as created)</th>
+                <th scope="col" class="permissions_caveat">Permissions (deprecated)</th>
               </tr>
             </thead>
             <tbody>
@@ -451,6 +452,7 @@
                 <td>{{ token.description }}</td>
                 <td>{{ token.created }}</td>
                 <td>{{ token.last_used }}</td>
+                <td>{{ token.caveats }}</td>
                 <td>{{ token.permissions_caveat }}</td>
               </tr>
               {% endfor %}

--- a/warehouse/integrations/github/utils.py
+++ b/warehouse/integrations/github/utils.py
@@ -251,6 +251,7 @@ def _analyze_disclosure(request, disclosure_record, origin):
             "permissions": database_macaroon.permissions_caveat.get(
                 "permissions", "user"
             ),
+            "caveats": database_macaroon.caveats,
             "description": database_macaroon.description,
         },
     )

--- a/warehouse/macaroons/models.py
+++ b/warehouse/macaroons/models.py
@@ -70,6 +70,7 @@ class Macaroon(db.Model):
     created: Mapped[datetime_now]
     last_used: Mapped[datetime | None]
 
+    # FIXME: Deprecated in favor of `Macaroon.caveats()`.
     # Human-readable "permissions" for this macaroon, corresponding to the
     # body of the permissions ("V1") caveat.
     permissions_caveat: Mapped[dict] = mapped_column(


### PR DESCRIPTION
With the newer `Macaroon.caveats()` field containing the caveats provisioned on the macaroon initially, replacing the `permissions_caveat`, start to replace usages where relevant in the admin UI.

Refs: #15242