### PR TITLE
chore: cache calls to signing key

### DIFF
--- a/warehouse/utils/sns.py
+++ b/warehouse/utils/sns.py
@@ -12,6 +12,7 @@
 
 import base64
 import datetime
+import functools
 import re
 
 import requests
@@ -72,6 +73,7 @@ class MessageVerifier:
         except _InvalidSignature:
             raise InvalidMessageError("Invalid Signature") from None
 
+    @functools.lru_cache(maxsize=1)
     def _get_pubkey(self, cert_url):
         # Before we do anything, we need to verify that the URL for the
         # signature matches what we expect.


### PR DESCRIPTION
With this simple caching mechanism, each running instance should only have to make a single call at their first instantiation, and cache the result for the lifetime of the process.

This call rarely fails, and adds ~200ms of each inbound hook, so caching across requests should cut down the time it takes to complete the processing.

Instead of using a Redis cache and worrying about cache expiration strategies, if this ever fails a restart should evict the in-memory cache and trigger a new HTTP call for the key.

Resolves #4463