### PR TITLE
test: randomize test order every run

### DIFF
--- a/docs/dev/development/getting-started.rst
+++ b/docs/dev/development/getting-started.rst
@@ -543,6 +543,21 @@ If you want to run a specific test, you can use the ``T`` variable:
 
     T=tests/unit/i18n/test_filters.py make tests
 
+You can add arguments to the test runner by using the ``TESTARGS`` variable:
+
+.. code-block:: console
+
+    TESTARGS="-vvv -x" make tests
+
+This will pass the arguments ``-vvv`` and ``-x`` down to ``pytest``.
+
+This is useful in scenarios like passing a
+`random seed <https://pypi.org/project/pytest-randomly/>`_ to the test runner:
+
+.. code-block:: console
+
+    TESTARGS="--randomly-seed=1234" make tests
+
 You can run linters, programs that check the code, with:
 
 .. code-block:: console

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -5,6 +5,7 @@ pretend
 pytest>=3.0.0
 pytest-icdiff
 pytest-postgresql>=3.1.3,<6.0.0
+pytest-randomly
 pytest-socket
 pytz
 responses>=0.5.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -235,6 +235,7 @@ pytest==8.0.0 \
     #   -r requirements/tests.in
     #   pytest-icdiff
     #   pytest-postgresql
+    #   pytest-randomly
     #   pytest-socket
 pytest-icdiff==0.9 \
     --hash=sha256:13aede616202e57fcc882568b64589002ef85438046f012ac30a8d959dac8b75 \
@@ -243,6 +244,10 @@ pytest-icdiff==0.9 \
 pytest-postgresql==5.1.0 \
     --hash=sha256:8747199f33d2db0199ee6ec4dbd3955e14b53d702894c038639c591a405271bd \
     --hash=sha256:9d575796dad2c0bbbf87a3af150ed273911b10dc2a47360a90e1a92f7fcb74d4
+    # via -r requirements/tests.in
+pytest-randomly==3.15.0 \
+    --hash=sha256:0516f4344b29f4e9cdae8bce31c4aeebf59d0b9ef05927c33354ff3859eeeca6 \
+    --hash=sha256:b908529648667ba5e54723088edd6f82252f540cc340d748d1fa985539687047
     # via -r requirements/tests.in
 pytest-socket==0.7.0 \
     --hash=sha256:71ab048cbbcb085c15a4423b73b619a8b35d6a307f46f78ea46be51b1b7e11b3 \

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -615,11 +615,13 @@ class TestRelease:
             release=release,
             filename=f"{release.project.name}-{release.version}.tar.gz",
             python_version="source",
+            packagetype="sdist",
         )
         rfile_2 = DBFileFactory.create(
             release=release,
             filename=f"{release.project.name}-{release.version}.whl",
             python_version="bdist_wheel",
+            packagetype="bdist_wheel",
         )
         DBFileEventFactory.create(
             source=rfile_1,

--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -98,8 +98,8 @@ def test_compute_packaging_metrics(db_request, metrics):
     release3 = ReleaseFactory(project=project2)
     FileFactory(release=release1)
     FileFactory(release=release2)
-    FileFactory(release=release3)
-    FileFactory(release=release3)
+    FileFactory(release=release3, packagetype="sdist")
+    FileFactory(release=release3, packagetype="bdist_wheel")
 
     compute_packaging_metrics(db_request)
 


### PR DESCRIPTION
As surfaced in #12227 

[`pytest-randomly`](https://pypi.org/p/pytest-randomly/) plays nicely with `factory_boy` and `faker`, so passing the `--randomly-seed=NNNN` value to pytest can help recreate the conditions from a previous test run (found in the `test session starts` section).



