### PR TITLE
Downgrade pytest from 8.0.0 to 7.4.4

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -228,9 +228,9 @@ psycopg==3.1.18 \
     --hash=sha256:31144d3fb4c17d78094d9e579826f047d4af1da6a10427d91dfcfb6ecdf6f12b \
     --hash=sha256:4d5a0a5a8590906daa58ebd5f3cfc34091377354a1acced269dd10faf55da60e
     # via pytest-postgresql
-pytest==8.0.0 \
-    --hash=sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c \
-    --hash=sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6
+pytest==7.4.4 \
+    --hash=sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280 \
+    --hash=sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8
     # via
     #   -r requirements/tests.in
     #   pytest-icdiff


### PR DESCRIPTION
Attempting to resolve hung runs of our test workflow, e.g.:

https://github.com/pypi/warehouse/actions/runs/7884312889/job/21513166129 https://github.com/pypi/warehouse/actions/runs/7884312873/job/21513149554