### PR TITLE
Handle invalid wheels (Part 1): Add `File.unbackfillable` column

### DIFF
--- a/warehouse/migrations/versions/4d1b4fcc4076_add_a_flag_for_un_backfillable_files.py
+++ b/warehouse/migrations/versions/4d1b4fcc4076_add_a_flag_for_un_backfillable_files.py
@@ -1,0 +1,42 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add a flag for un-backfillable files
+
+Revision ID: 4d1b4fcc4076
+Revises: be62a4cd76e3
+Create Date: 2024-02-13 23:15:18.105618
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "4d1b4fcc4076"
+down_revision = "be62a4cd76e3"
+
+
+def upgrade():
+    op.add_column(
+        "release_files",
+        sa.Column(
+            "unbackfillable",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+            comment="If True, the metadata for the file cannot be backfilled.",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("release_files", "unbackfillable")

--- a/warehouse/migrations/versions/4d1b4fcc4076_add_a_flag_for_un_backfillable_files.py
+++ b/warehouse/migrations/versions/4d1b4fcc4076_add_a_flag_for_un_backfillable_files.py
@@ -32,7 +32,7 @@ def upgrade():
             "unbackfillable",
             sa.Boolean(),
             server_default=sa.text("false"),
-            nullable=False,
+            nullable=True,
             comment="If True, the metadata for the file cannot be backfilled.",
         ),
     )

--- a/warehouse/migrations/versions/4d1b4fcc4076_add_a_flag_for_un_backfillable_files.py
+++ b/warehouse/migrations/versions/4d1b4fcc4076_add_a_flag_for_un_backfillable_files.py
@@ -29,7 +29,7 @@ def upgrade():
     op.add_column(
         "release_files",
         sa.Column(
-            "unbackfillable",
+            "metadata_file_unbackfillable",
             sa.Boolean(),
             server_default=sa.text("false"),
             nullable=True,
@@ -39,4 +39,4 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_column("release_files", "unbackfillable")
+    op.drop_column("release_files", "metadata_file_unbackfillable")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -719,6 +719,9 @@ class File(HasEvents, db.Model):
     archived: Mapped[bool_false] = mapped_column(
         comment="If True, the object has been archived to our archival bucket.",
     )
+    unbackfillable: Mapped[bool_false] = mapped_column(
+        comment="If True, the metadata for the file cannot be backfilled.",
+    )
 
     @property
     def uploaded_via_trusted_publisher(self) -> bool:

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -719,7 +719,7 @@ class File(HasEvents, db.Model):
     archived: Mapped[bool_false] = mapped_column(
         comment="If True, the object has been archived to our archival bucket.",
     )
-    unbackfillable: Mapped[bool_false] = mapped_column(
+    metadata_file_unbackfillable: Mapped[bool_false] = mapped_column(
         comment="If True, the metadata for the file cannot be backfilled.",
     )
 


### PR DESCRIPTION
This adds a temporary column `File.unbackfillable` which will be set when we determine we can't backfill metadata for a wheel.