### PR TITLE
Fix unbackfillable migration

### DIFF
--- a/warehouse/migrations/versions/4d1b4fcc4076_add_a_flag_for_un_backfillable_files.py
+++ b/warehouse/migrations/versions/4d1b4fcc4076_add_a_flag_for_un_backfillable_files.py
@@ -26,6 +26,9 @@ down_revision = "be62a4cd76e3"
 
 
 def upgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text("SET statement_timeout = 120000"))
+
     op.add_column(
         "release_files",
         sa.Column(

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -720,6 +720,7 @@ class File(HasEvents, db.Model):
         comment="If True, the object has been archived to our archival bucket.",
     )
     metadata_file_unbackfillable: Mapped[bool_false] = mapped_column(
+        nullable=True,
         comment="If True, the metadata for the file cannot be backfilled.",
     )
 


### PR DESCRIPTION
Extends the statement timeout and fixes the field on the model.