### PR TITLE
refactor: convert `manage:project` to Permissions

### DIFF
--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -317,7 +317,7 @@ class TestMacaroonSecurityPolicy:
 
     @pytest.mark.parametrize(
         "invalid_permission",
-        [Permissions.AccountManage, "manage:project", "nonexistent"],
+        [Permissions.AccountManage, Permissions.ProjectsWrite, "nonexistent"],
     )
     def test_denies_valid_macaroon_for_incorrect_permission(
         self, monkeypatch, invalid_permission

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -200,22 +200,22 @@ class TestProject:
                 (
                     Allow,
                     f"user:{owner1.user.id}",
-                    ["manage:project", "upload"],
+                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
                 ),
                 (
                     Allow,
                     f"user:{owner2.user.id}",
-                    ["manage:project", "upload"],
+                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
                 ),
                 (
                     Allow,
                     f"user:{owner3.user.id}",
-                    ["manage:project", "upload"],
+                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
                 ),
                 (
                     Allow,
                     f"user:{owner4.user.id}",
-                    ["manage:project", "upload"],
+                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
                 ),
             ],
             key=lambda x: x[1],
@@ -484,8 +484,16 @@ class TestRelease:
             ),
         ] + sorted(
             [
-                (Allow, f"user:{owner1.user.id}", ["manage:project", "upload"]),
-                (Allow, f"user:{owner2.user.id}", ["manage:project", "upload"]),
+                (
+                    Allow,
+                    f"user:{owner1.user.id}",
+                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
+                ),
+                (
+                    Allow,
+                    f"user:{owner2.user.id}",
+                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
+                ),
             ],
             key=lambda x: x[1],
         ) + sorted(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -541,7 +541,7 @@ def test_root_factory_access_control_list():
                 Permissions.AccountVerifyOrgRole,
                 Permissions.AccountVerifyProjectRole,
                 Permissions.OrganizationsManage,
-                Permissions.ProjectsView,
+                Permissions.ProjectsRead,
             ),
         ),
     ]

--- a/warehouse/authnz/_permissions.py
+++ b/warehouse/authnz/_permissions.py
@@ -91,7 +91,8 @@ class Permissions(StrEnum):
     AccountVerifyProjectRole = "account:verify-project-role"
 
     # Projects Permissions
-    ProjectsView = "projects:view"
+    ProjectsRead = "projects:read"
+    ProjectsWrite = "projects:write"  # TODO: Worth splitting out ProjectDelete?
 
     # Organization Permissions
     OrganizationsManage = "organizations:manage"

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -147,7 +147,7 @@ class RootFactory:
                 Permissions.AccountVerifyOrgRole,
                 Permissions.AccountVerifyProjectRole,
                 Permissions.OrganizationsManage,
-                Permissions.ProjectsView,
+                Permissions.ProjectsRead,
             ),
         ),
     ]

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -1033,7 +1033,7 @@ class ProvisionMacaroonViews:
     route_name="manage.projects",
     renderer="manage/projects.html",
     uses_session=True,
-    permission=Permissions.ProjectsView,
+    permission=Permissions.ProjectsRead,
     has_translations=True,
 )
 def manage_projects(request):
@@ -1076,7 +1076,7 @@ def manage_projects(request):
     context=Project,
     renderer="manage/project/settings.html",
     uses_session=True,
-    permission="manage:project",
+    permission=Permissions.ProjectsRead,
     has_translations=True,
     require_reauth=True,
     require_methods=False,
@@ -1131,7 +1131,7 @@ class ManageProjectSettingsViews:
     uses_session=True,
     require_csrf=True,
     require_methods=False,
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
     http_cache=0,
@@ -1668,7 +1668,7 @@ def get_user_role_in_organization_project(project, user, request):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )
@@ -1715,7 +1715,7 @@ def delete_project(project, request):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )
@@ -1735,7 +1735,7 @@ def destroy_project_docs(project, request):
     context=Project,
     renderer="manage/project/releases.html",
     uses_session=True,
-    permission="manage:project",
+    permission=Permissions.ProjectsRead,
     has_translations=True,
     require_reauth=True,
 )
@@ -1779,7 +1779,7 @@ def manage_project_releases(project, request):
     uses_session=True,
     require_csrf=True,
     require_methods=False,
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )
@@ -2175,7 +2175,7 @@ class ManageProjectRelease:
     renderer="manage/project/roles.html",
     uses_session=True,
     require_methods=False,
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )
@@ -2559,7 +2559,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
 )
 def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm):
@@ -2636,7 +2636,7 @@ def revoke_project_role_invitation(project, request, _form_class=ChangeRoleForm)
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )
@@ -2719,7 +2719,7 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )
@@ -2790,7 +2790,7 @@ def delete_project_role(project, request):
     context=Project,
     renderer="manage/project/history.html",
     uses_session=True,
-    permission="manage:project",
+    permission=Permissions.ProjectsRead,
     has_translations=True,
 )
 def manage_project_history(project, request):
@@ -2839,7 +2839,7 @@ def manage_project_history(project, request):
     context=Project,
     renderer="manage/project/documentation.html",
     uses_session=True,
-    permission="manage:project",
+    permission=Permissions.ProjectsRead,
     has_translations=True,
 )
 def manage_project_documentation(project, request):

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -1353,7 +1353,7 @@ def manage_organization_history(organization, request):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )
@@ -1447,7 +1447,7 @@ def remove_organization_project(project, request):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import NoResultFound
 from webob.multidict import MultiDict
 
 from warehouse.accounts import IUserService
+from warehouse.authnz import Permissions
 from warehouse.email import (
     send_added_as_team_member_email,
     send_removed_as_team_collaborator_email,
@@ -490,7 +491,7 @@ def manage_team_history(team, request):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )
@@ -600,7 +601,7 @@ def change_team_project_role(project, request, _form_class=ChangeTeamProjectRole
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage:project",
+    permission=Permissions.ProjectsWrite,
     has_translations=True,
     require_reauth=True,
 )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -327,7 +327,17 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
 
         for user_id, permission_name in sorted(permissions, key=lambda x: (x[1], x[0])):
             if permission_name == "Administer":
-                acls.append((Allow, f"user:{user_id}", ["manage:project", "upload"]))
+                acls.append(
+                    (
+                        Allow,
+                        f"user:{user_id}",
+                        [
+                            Permissions.ProjectsRead,
+                            Permissions.ProjectsWrite,
+                            "upload",
+                        ],
+                    )
+                )
             else:
                 acls.append((Allow, f"user:{user_id}", ["upload"]))
         return acls

--- a/warehouse/templates/includes/manage-project-button.html
+++ b/warehouse/templates/includes/manage-project-button.html
@@ -12,6 +12,6 @@
  # limitations under the License.
 -#}
 
-{% if request.has_permission("manage:project") %}
+{% if request.has_permission(Permissions.ProjectsWrite) %}
   <a href="{{ request.route_path('manage.project.releases', project_name=project.name) }}" class="button button--primary package-description__edit-button">{% trans %}Manage project{% endtrans %}</a>
 {% endif %}


### PR DESCRIPTION
Follows #15385

Converted `ProjectsView` to `ProjectRead` to follow consistency, basically anything with a GET == Read, and POST == Write.