### PR TITLE
chore: move more caches to dev/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-              .mypy_cache
+              dev/.mypy_cache
           key: ${{ runner.os }}-mypy-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
       - name: Restore built Python environment from deps
         uses: actions/cache/restore@v4

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ node_modules/
 dev/example.sql
 dev/prod.sql
 dev/prod.sql.xz
-dev/.coverage
+dev/.coverage*
+dev/.mypy_cache/
+dev/.pytest_cache/
 ./data/
 
 warehouse/.commit

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ clean:
 	rm -rf dev/*.sql
 
 purge: stop clean
-	rm -rf .state
+	rm -rf .state dev/.coverage* dev/.pytest_cache dev/.mypy_cache
 	docker compose down -v
 	docker compose rm --force
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,6 @@ services:
       - ./bin:/opt/warehouse/src/bin:z
       - ./requirements:/opt/warehouse/src/requirements:z
       - caches:/root/.cache
-      - caches:/opt/warehouse/src/.mypy_cache
-      - caches:/opt/warehouse/src/.pytest_cache
       # Included to support linters during development
       - ./gunicorn-prod.conf.py:/opt/warehouse/src/gunicorn-prod.conf.py:z
       - ./gunicorn-uploads.conf.py:/opt/warehouse/src/gunicorn-uploads.conf.py:z

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ warn_unused_configs = true
 warn_unused_ignores = true
 plugins = ["mypy_zope:plugin"]
 exclude = ["warehouse/locale/.*", "warehouse/migrations/versions.*"]
+cache_dir = "dev/.mypy_cache"
 
 [[tool.mypy.overrides]]
 # These modules do not yet have types available.
@@ -85,6 +86,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--disable-socket --allow-hosts='localhost,::1,stripe' --durations=20"
+cache_dir = "dev/.pytest_cache"
 norecursedirs = ['build', 'dist', 'node_modules', '*.egg-info', '.state requirements']
 markers = [
     'unit: Quick running unit tests which test small units of functionality.',


### PR DESCRIPTION
With the change to have the main container run as `nobody`, move some more application-root directories to `dev/`.

Refs: #15365