### PR TITLE
Handle `BadZipFile` in metadata backfill

### DIFF
--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -16,6 +16,7 @@ import tempfile
 from contextlib import contextmanager
 from itertools import product
 from pathlib import Path
+from zipfile import BadZipFile
 
 import pretend
 import pytest
@@ -1028,7 +1029,10 @@ def test_metadata_backfill_individual(db_request, monkeypatch, metrics):
     ]
 
 
-def test_metadata_backfill_file_invalid_wheel(db_request, monkeypatch, metrics):
+@pytest.mark.parametrize("exception", [UnsupportedWheel, BadZipFile])
+def test_metadata_backfill_file_invalid_wheel(
+    db_request, monkeypatch, metrics, exception
+):
     project = ProjectFactory()
     release = ReleaseFactory(project=project)
     backfillable_file = FileFactory(
@@ -1037,7 +1041,7 @@ def test_metadata_backfill_file_invalid_wheel(db_request, monkeypatch, metrics):
 
     stub_session = pretend.stub()
     monkeypatch.setattr(warehouse.packaging.tasks, "PipSession", lambda: stub_session)
-    dist_from_wheel_url = pretend.raiser(UnsupportedWheel)
+    dist_from_wheel_url = pretend.raiser(exception)
     monkeypatch.setattr(
         warehouse.packaging.tasks, "dist_from_wheel_url", dist_from_wheel_url
     )

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -19,6 +19,7 @@ import tempfile
 from collections import namedtuple
 from itertools import product
 from pathlib import Path
+from zipfile import BadZipFile
 
 from google.cloud.bigquery import LoadJobConfig
 from pip._internal.exceptions import UnsupportedWheel
@@ -106,7 +107,7 @@ def metadata_backfill_individual(request, file_id):
             file_.release.project.normalized_name, file_url, session
         )
         wheel_metadata_contents = lazy_dist._dist._files[Path("METADATA")]
-    except UnsupportedWheel:
+    except (UnsupportedWheel, BadZipFile):
         file_.metadata_file_unbackfillable = True
         return
 


### PR DESCRIPTION
Fixes https://python-software-foundation.sentry.io/issues/5002343865/