### PR TITLE
Handle InvalidWheel for metadata backfill

### DIFF
--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -22,7 +22,7 @@ import pretend
 import pytest
 
 from google.cloud.bigquery import SchemaField
-from pip._internal.exceptions import UnsupportedWheel
+from pip._internal.exceptions import InvalidWheel, UnsupportedWheel
 from wtforms import Field, Form, StringField
 
 import warehouse.packaging.tasks
@@ -1029,7 +1029,9 @@ def test_metadata_backfill_individual(db_request, monkeypatch, metrics):
     ]
 
 
-@pytest.mark.parametrize("exception", [UnsupportedWheel, BadZipFile])
+@pytest.mark.parametrize(
+    "exception", [InvalidWheel("foo", "bar"), UnsupportedWheel, BadZipFile]
+)
 def test_metadata_backfill_file_invalid_wheel(
     db_request, monkeypatch, metrics, exception
 ):

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from zipfile import BadZipFile
 
 from google.cloud.bigquery import LoadJobConfig
-from pip._internal.exceptions import UnsupportedWheel
+from pip._internal.exceptions import InvalidWheel, UnsupportedWheel
 from pip._internal.network.lazy_wheel import dist_from_wheel_url
 from pip._internal.network.session import PipSession
 from sqlalchemy import desc
@@ -107,7 +107,7 @@ def metadata_backfill_individual(request, file_id):
             file_.release.project.normalized_name, file_url, session
         )
         wheel_metadata_contents = lazy_dist._dist._files[Path("METADATA")]
-    except (UnsupportedWheel, BadZipFile):
+    except (InvalidWheel, UnsupportedWheel, BadZipFile):
         file_.metadata_file_unbackfillable = True
         return
 


### PR DESCRIPTION
Fixes https://python-software-foundation.sentry.io/issues/5002343865/.