### PR TITLE
Warn users when API token is used in Trusted Publishing project

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -5850,3 +5850,123 @@ class TestTrustedPublisherEmails:
                 },
             )
         ]
+
+    def test_api_token_warning_with_trusted_publisher_emails(
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
+        template_name = "api-token-used-in-trusted-publisher-project"
+        # We set up two users to receive the email. The owner of the API token
+        # will be stub_user, their username should be the one mentioned in the
+        # email body.
+        stub_user = pretend.stub(
+            id="id",
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+        )
+        stub_user_maintainer = pretend.stub(
+            id="id_maintainer",
+            username="username_maintainer",
+            name="",
+            email="email_maintainer@example.com",
+            primary_email=pretend.stub(
+                email="email_maintainer@example.com", verified=True
+            ),
+        )
+        subject_renderer = pyramid_config.testing_add_renderer(
+            f"email/{ template_name }/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            f"email/{ template_name }/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            f"email/{ template_name }/body.html"
+        )
+        html_renderer.string_response = "Email HTML Body"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        pyramid_request.db = pretend.stub(
+            query=lambda a: pretend.stub(
+                filter=lambda *a: pretend.stub(
+                    one=lambda: pretend.stub(user_id=stub_user.id)
+                )
+            ),
+        )
+        pyramid_request.user = stub_user
+        pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
+
+        project_name = "test_project"
+        result = email.send_api_token_used_in_trusted_publisher_project_email(
+            pyramid_request,
+            [stub_user, stub_user_maintainer],
+            project_name=project_name,
+            token_owner_username=stub_user.username,
+        )
+
+        assert result == {
+            "project_name": project_name,
+            "token_owner_username": stub_user.username,
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(
+            project_name=project_name, token_owner_username=stub_user.username
+        )
+        html_renderer.assert_(
+            project_name=project_name, token_owner_username=stub_user.username
+        )
+        assert pyramid_request.task.calls == [
+            pretend.call(send_email),
+            pretend.call(send_email),
+        ]
+        assert send_email.delay.calls == [
+            pretend.call(
+                f"{stub_user.username} <{stub_user.email}>",
+                {
+                    "subject": "Email Subject",
+                    "body_text": "Email Body",
+                    "body_html": (
+                        "<html>\n<head></head>\n"
+                        "<body><p>Email HTML Body</p></body>\n</html>\n"
+                    ),
+                },
+                {
+                    "tag": "account:email:sent",
+                    "user_id": stub_user.id,
+                    "additional": {
+                        "from_": "noreply@example.com",
+                        "to": stub_user.email,
+                        "subject": "Email Subject",
+                        "redact_ip": False,
+                    },
+                },
+            ),
+            pretend.call(
+                f"{stub_user_maintainer.username} <{stub_user_maintainer.email}>",
+                {
+                    "subject": "Email Subject",
+                    "body_text": "Email Body",
+                    "body_html": (
+                        "<html>\n<head></head>\n"
+                        "<body><p>Email HTML Body</p></body>\n</html>\n"
+                    ),
+                },
+                {
+                    "tag": "account:email:sent",
+                    "user_id": stub_user_maintainer.id,
+                    "additional": {
+                        "from_": "noreply@example.com",
+                        "to": stub_user_maintainer.email,
+                        "subject": "Email Subject",
+                        "redact_ip": False,
+                    },
+                },
+            ),
+        ]

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -1036,6 +1036,13 @@ def send_pending_trusted_publisher_invalidated_email(request, user, project_name
     }
 
 
+@_email("api-token-used-in-trusted-publisher-project")
+def send_api_token_used_in_trusted_publisher_project_email(
+    request, user, project_name, token_owner_username
+):
+    return {"token_owner_username": token_owner_username, "project_name": project_name}
+
+
 def includeme(config):
     email_sending_class = config.maybe_dotted(config.registry.settings["mail.backend"])
     config.register_service_factory(email_sending_class.create_service, IEmailSender)

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1857,6 +1857,25 @@ msgid ""
 "\"%(previous_organization_name)s\" to \"%(organization_name)s\"."
 msgstr ""
 
+#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:19
+#, python-format
+msgid ""
+"An API token belonging to user <strong>%(token_owner_username)s</strong> "
+"was used to upload files to the project "
+"<strong>%(project_name)s</strong>, even though the project has a Trusted "
+"Publisher configured. We suggest you remove the API token and use Trusted"
+" Publishing instead."
+msgstr ""
+
+#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:28
+#: warehouse/templates/email/pending-trusted-publisher-invalidated/body.html:27
+#, python-format
+msgid ""
+"If you believe this was done in error, you can email <a "
+"href=\"%(href)s\">%(email_address)s</a> to communicate with the PyPI "
+"administrators."
+msgstr ""
+
 #: warehouse/templates/email/canceled-as-invited-organization-member/body.html:19
 #, python-format
 msgid ""
@@ -2249,14 +2268,6 @@ msgid ""
 "You registered an pending OpenID Connect publisher for a project "
 "(<strong>%(project_name)s</strong>), but someone else has invalidated "
 "your pending publisher by creating the project before you did."
-msgstr ""
-
-#: warehouse/templates/email/pending-trusted-publisher-invalidated/body.html:27
-#, python-format
-msgid ""
-"If you believe this was done in error, you can email <a "
-"href=\"%(href)s\">%(email_address)s</a> to communicate with the PyPI "
-"administrators."
 msgstr ""
 
 #: warehouse/templates/email/primary-email-change/body.html:18

--- a/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html
+++ b/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html
@@ -1,0 +1,34 @@
+{#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+
+{% block content %}
+<p>
+    {% trans token_owner_username=token_owner_username, project_name=project_name %}
+    An API token belonging to user <strong>{{ token_owner_username }}</strong>
+    was used to upload files to the project <strong>{{ project_name }}</strong>,
+    even though the project has a Trusted Publisher configured. We suggest you
+    remove the API token and use Trusted Publishing instead.
+    {% endtrans %}
+</p>
+
+<p>
+    {% trans href='mailto:admin@pypi.org', email_address='admin@pypi.org' %}
+    If you believe this was done in error, you can email
+    <a href="{{ href }}">{{ email_address }}</a> to communicate with the PyPI
+    administrators.
+    {% endtrans %}
+</p>
+{% endblock %}

--- a/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.txt
+++ b/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.txt
@@ -1,0 +1,30 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+{% trans token_owner_username=token_owner_username, project_name=project_name %}
+An API token belonging to user {{ token_owner_username }} was used to upload
+files to the project {{ project_name }}, even though the project has a Trusted
+Publisher configured. We suggest you remove the API token and use Trusted
+Publishing instead.
+{% endtrans %}
+
+{% trans email_address='admin@pypi.org' %}
+If you believe this was done in error, you can email
+{{ email_address }} to communicate with the PyPI administrators.
+{% endtrans %}
+
+{% endblock %}
+

--- a/warehouse/templates/email/api-token-used-in-trusted-publisher-project/subject.txt
+++ b/warehouse/templates/email/api-token-used-in-trusted-publisher-project/subject.txt
@@ -1,0 +1,21 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}
+{% trans project_name=project_name %}
+User API token used in project {{ project_name }} with Trusted Publishing enabled
+{% endtrans %}
+{% endblock %}


### PR DESCRIPTION
First part of https://github.com/pypi/warehouse/issues/14171

If a user uploads files using an API token to a project that has a Trusted Publisher configured, send an email to all the project's users notifying them of the API token use, suggesting they remove it and use Trusted Publishing instead.

This warning is only sent if the upload is for a new release of the project. Uploads of files for existing releases do not trigger the warning.