### PR TITLE
fix: Add Trim leading and trailing whitespace from username in forms

### DIFF
--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -78,7 +78,8 @@ class UsernameMixin:
         validators=[
             wtforms.validators.InputRequired(),
             PreventNullBytesValidator(message=INVALID_USERNAME_MESSAGE),
-        ]
+        ],
+        filters=[lambda x: x.strip() if x else None]
     )
 
     def validate_username(self, field):


### PR DESCRIPTION
fix; #15356 


https://github.com/pypi/warehouse/assets/81439109/fc69b528-6c33-4ca4-b298-0ca8b0180627

