### PR TITLE
Add daily task to purge expired OIDC macaroons

### DIFF
--- a/tests/unit/oidc/test_tasks.py
+++ b/tests/unit/oidc/test_tasks.py
@@ -102,14 +102,14 @@ def test_compute_oidc_metrics(db_request, metrics):
 
 def test_delete_expired_oidc_macaroons(db_request, macaroon_service, metrics):
     # We'll create 3 macaroons:
-    # - An OIDC macaroon with creation time of 15 minutes ago
+    # - An OIDC macaroon with creation time of 1 day ago
     # - An OIDC macaroon with creation time now
-    # - A non-OIDC macaroon with creation time of 15 minutes ago
+    # - A non-OIDC macaroon with creation time of 1 day ago
     # The task should only delete the first one
 
     publisher = GitHubPublisherFactory.create()
     claims = {"sha": "somesha", "ref": "someref"}
-    # Create an OIDC macaroon and set its creation time to 15 minutes ago
+    # Create an OIDC macaroon and set its creation time to 1 day ago
     (_, old_oidc_macaroon) = macaroon_service.create_macaroon(
         "fake location",
         "fake description",
@@ -119,7 +119,7 @@ def test_delete_expired_oidc_macaroons(db_request, macaroon_service, metrics):
         oidc_publisher_id=publisher.id,
         additional={"oidc": publisher.stored_claims(claims)},
     )
-    old_oidc_macaroon.created -= datetime.timedelta(minutes=15)
+    old_oidc_macaroon.created -= datetime.timedelta(days=1)
 
     # Create a normal OIDC macaroon
     macaroon_service.create_macaroon(
@@ -130,7 +130,7 @@ def test_delete_expired_oidc_macaroons(db_request, macaroon_service, metrics):
         additional={"oidc": publisher.stored_claims(claims)},
     )
 
-    # Create a non-OIDC macaroon and set its creation time to 15 min ago
+    # Create a non-OIDC macaroon and set its creation time to 1 day ago
     user = UserFactory.create()
     (_, non_oidc_macaroon) = macaroon_service.create_macaroon(
         "fake location",
@@ -138,7 +138,7 @@ def test_delete_expired_oidc_macaroons(db_request, macaroon_service, metrics):
         [caveats.RequestUser(user_id=str(user.id))],
         user_id=user.id,
     )
-    non_oidc_macaroon.created -= datetime.timedelta(minutes=15)
+    non_oidc_macaroon.created -= datetime.timedelta(days=1)
 
     assert db_request.db.query(Macaroon).count() == 3
 

--- a/tests/unit/oidc/test_tasks.py
+++ b/tests/unit/oidc/test_tasks.py
@@ -100,7 +100,7 @@ def test_compute_oidc_metrics(db_request, metrics):
     ]
 
 
-def test_delete_expired_oidc_macaroons(db_request, macaroon_service):
+def test_delete_expired_oidc_macaroons(db_request, macaroon_service, metrics):
     # We'll create 3 macaroons:
     # - An OIDC macaroon with creation time of 15 minutes ago
     # - An OIDC macaroon with creation time now
@@ -153,3 +153,7 @@ def test_delete_expired_oidc_macaroons(db_request, macaroon_service):
         .count()
         == 0
     )
+
+    assert metrics.gauge.calls == [
+        pretend.call("warehouse.oidc.expired_oidc_tokens_deleted", 1),
+    ]

--- a/warehouse/oidc/__init__.py
+++ b/warehouse/oidc/__init__.py
@@ -81,4 +81,4 @@ def includeme(config):
 
     # Daily purge expired OIDC-minted API tokens. These tokens are temporary in nature
     # and expire after 15 minutes of creation.
-    config.add_periodic_task(crontab(minute=0, hour=0), delete_expired_oidc_macaroons)
+    config.add_periodic_task(crontab(minute=0, hour=6), delete_expired_oidc_macaroons)

--- a/warehouse/oidc/__init__.py
+++ b/warehouse/oidc/__init__.py
@@ -14,7 +14,7 @@ from celery.schedules import crontab
 
 from warehouse.oidc.interfaces import IOIDCPublisherService
 from warehouse.oidc.services import OIDCPublisherServiceFactory
-from warehouse.oidc.tasks import compute_oidc_metrics
+from warehouse.oidc.tasks import compute_oidc_metrics, delete_expired_oidc_macaroons
 from warehouse.oidc.utils import (
     ACTIVESTATE_OIDC_ISSUER_URL,
     GITHUB_OIDC_ISSUER_URL,
@@ -78,3 +78,7 @@ def includeme(config):
 
     # Compute OIDC metrics periodically
     config.add_periodic_task(crontab(minute=0, hour="*"), compute_oidc_metrics)
+
+    # Daily purge expired OIDC-minted API tokens. These tokens are temporary in nature
+    # and expire after 15 minutes of creation.
+    config.add_periodic_task(crontab(minute=0, hour=0), delete_expired_oidc_macaroons)

--- a/warehouse/oidc/tasks.py
+++ b/warehouse/oidc/tasks.py
@@ -74,16 +74,16 @@ def compute_oidc_metrics(request):
 def delete_expired_oidc_macaroons(request):
     """
     Purge all API tokens minted using OIDC Trusted Publishing with a creation time
-    more than 15 minutes ago. Since OIDC-minted macaroons expire 15 minutes after
-    creation, this task cleans up all the expired tokens that have accumulated since
-    the last time this task was run.
+    more than 1 day ago. Since OIDC-minted macaroons expire 15 minutes after
+    creation, this task cleans up tokens that expired several hours ago and that
+    have accumulated since the last time this task was run.
     """
     rows_deleted = (
         request.db.query(Macaroon)
         .filter(Macaroon.oidc_publisher_id.isnot(None))
         .filter(
-            # The expiration time (created + 15 mins) is in the past
-            Macaroon.created + timedelta(minutes=15)
+            # The token has been created at more than 1 day ago
+            Macaroon.created + timedelta(days=1)
             < datetime.now(tz=timezone.utc)
         )
         .delete(synchronize_session=False)


### PR DESCRIPTION
This PR adds a daily task to delete all OIDC-minted macaroons that are no longer valid. Since these OIDC-minted tokens are meant to be short-lived (15 minutes) and are generated automatically by CI/CD processes, it makes sense to not let them accumulate once they have expired.

The task deletes all Macaroons that have an `oidc_publisher_id` field and that have a creation date older than 15 minutes in the past (meaning that they have already expired).

Fixes https://github.com/pypi/warehouse/issues/15432.