### PR TITLE
refactor: replace `upload` with Permission

### DIFF
--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -285,7 +285,7 @@ class TestMacaroonSecurityPolicy:
         )
 
         policy = security_policy.MacaroonSecurityPolicy()
-        result = policy.permits(request, pretend.stub(), "upload")
+        result = policy.permits(request, pretend.stub(), Permissions.ProjectsUpload)
 
         assert result == Denied("")
         assert result.s == "Invalid API Token: foo"
@@ -308,10 +308,12 @@ class TestMacaroonSecurityPolicy:
             security_policy, "_extract_http_macaroon", _extract_http_macaroon
         )
 
-        context = pretend.stub(__acl__=[(Allow, "user:5", ["upload"])])
+        context = pretend.stub(
+            __acl__=[(Allow, "user:5", [Permissions.ProjectsUpload])]
+        )
 
         policy = security_policy.MacaroonSecurityPolicy()
-        result = policy.permits(request, context, "upload")
+        result = policy.permits(request, context, Permissions.ProjectsUpload)
 
         assert bool(result) == expected
 

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -194,28 +194,45 @@ class TestProject:
                 Permissions.APIObservationsAdd,
             ),
         ] + sorted(
-            [(Allow, f"oidc:{publisher.id}", ["upload"])], key=lambda x: x[1]
+            [(Allow, f"oidc:{publisher.id}", [Permissions.ProjectsUpload])],
+            key=lambda x: x[1],
         ) + sorted(
             [
                 (
                     Allow,
                     f"user:{owner1.user.id}",
-                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
+                    [
+                        Permissions.ProjectsRead,
+                        Permissions.ProjectsUpload,
+                        Permissions.ProjectsWrite,
+                    ],
                 ),
                 (
                     Allow,
                     f"user:{owner2.user.id}",
-                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
+                    [
+                        Permissions.ProjectsRead,
+                        Permissions.ProjectsUpload,
+                        Permissions.ProjectsWrite,
+                    ],
                 ),
                 (
                     Allow,
                     f"user:{owner3.user.id}",
-                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
+                    [
+                        Permissions.ProjectsRead,
+                        Permissions.ProjectsUpload,
+                        Permissions.ProjectsWrite,
+                    ],
                 ),
                 (
                     Allow,
                     f"user:{owner4.user.id}",
-                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
+                    [
+                        Permissions.ProjectsRead,
+                        Permissions.ProjectsUpload,
+                        Permissions.ProjectsWrite,
+                    ],
                 ),
             ],
             key=lambda x: x[1],
@@ -224,12 +241,12 @@ class TestProject:
                 (
                     Allow,
                     f"user:{maintainer1.user.id}",
-                    ["upload"],
+                    [Permissions.ProjectsUpload],
                 ),
                 (
                     Allow,
                     f"user:{maintainer2.user.id}",
-                    ["upload"],
+                    [Permissions.ProjectsUpload],
                 ),
             ],
             key=lambda x: x[1],
@@ -487,19 +504,27 @@ class TestRelease:
                 (
                     Allow,
                     f"user:{owner1.user.id}",
-                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
+                    [
+                        Permissions.ProjectsRead,
+                        Permissions.ProjectsUpload,
+                        Permissions.ProjectsWrite,
+                    ],
                 ),
                 (
                     Allow,
                     f"user:{owner2.user.id}",
-                    [Permissions.ProjectsRead, Permissions.ProjectsWrite, "upload"],
+                    [
+                        Permissions.ProjectsRead,
+                        Permissions.ProjectsUpload,
+                        Permissions.ProjectsWrite,
+                    ],
                 ),
             ],
             key=lambda x: x[1],
         ) + sorted(
             [
-                (Allow, f"user:{maintainer1.user.id}", ["upload"]),
-                (Allow, f"user:{maintainer2.user.id}", ["upload"]),
+                (Allow, f"user:{maintainer1.user.id}", [Permissions.ProjectsUpload]),
+                (Allow, f"user:{maintainer2.user.id}", [Permissions.ProjectsUpload]),
             ],
             key=lambda x: x[1],
         )

--- a/warehouse/authnz/_permissions.py
+++ b/warehouse/authnz/_permissions.py
@@ -92,6 +92,7 @@ class Permissions(StrEnum):
 
     # Projects Permissions
     ProjectsRead = "projects:read"
+    ProjectsUpload = "projects:upload"
     ProjectsWrite = "projects:write"  # TODO: Worth splitting out ProjectDelete?
 
     # Organization Permissions

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -46,6 +46,7 @@ from trove_classifiers import classifiers, deprecated_classifiers
 
 from warehouse import forms
 from warehouse.admin.flags import AdminFlagValue
+from warehouse.authnz import Permissions
 from warehouse.classifiers.models import Classifier
 from warehouse.email import (
     send_gpg_signature_uploaded_email,
@@ -959,7 +960,7 @@ def file_upload(request):
     # Check that the identity has permission to do things to this project, if this
     # is a new project this will act as a sanity check for the role we just
     # added above.
-    allowed = request.has_permission("upload", project)
+    allowed = request.has_permission(Permissions.ProjectsUpload, project)
     if not allowed:
         reason = getattr(allowed, "reason", None)
         if request.user:

--- a/warehouse/macaroons/security_policy.py
+++ b/warehouse/macaroons/security_policy.py
@@ -156,7 +156,7 @@ class MacaroonSecurityPolicy:
         #       complicated if we want to allow the use of macaroons for actions other
         #       than uploading.
         if permission not in [
-            "upload",
+            Permissions.ProjectsUpload,
             # TODO: Adding API-specific routes here is not sustainable. However,
             #  removing this guard would allow Macaroons to be used for Session-based
             #  operations, bypassing any 2FA requirements.

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -294,7 +294,7 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
         # The project has zero or more OIDC publishers registered to it,
         # each of which serves as an identity with the ability to upload releases.
         for publisher in self.oidc_publishers:
-            acls.append((Allow, f"oidc:{publisher.id}", ["upload"]))
+            acls.append((Allow, f"oidc:{publisher.id}", [Permissions.ProjectsUpload]))
 
         # Get all of the users for this project.
         query = session.query(Role).filter(Role.project == self)
@@ -333,13 +333,13 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
                         f"user:{user_id}",
                         [
                             Permissions.ProjectsRead,
+                            Permissions.ProjectsUpload,
                             Permissions.ProjectsWrite,
-                            "upload",
                         ],
                     )
                 )
             else:
-                acls.append((Allow, f"user:{user_id}", ["upload"]))
+                acls.append((Allow, f"user:{user_id}", [Permissions.ProjectsUpload]))
         return acls
 
     @property


### PR DESCRIPTION
Make it clearer that these are specific to Projects, in case we support non-project-related upload operations.