### PR TITLE
Backfill: skip wheels with missing METADATA file

### DIFF
--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -1030,7 +1030,7 @@ def test_metadata_backfill_individual(db_request, monkeypatch, metrics):
 
 
 @pytest.mark.parametrize(
-    "exception", [InvalidWheel("foo", "bar"), UnsupportedWheel, BadZipFile]
+    "exception", [InvalidWheel("foo", "bar"), UnsupportedWheel, BadZipFile, KeyError]
 )
 def test_metadata_backfill_file_invalid_wheel(
     db_request, monkeypatch, metrics, exception

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -107,7 +107,7 @@ def metadata_backfill_individual(request, file_id):
             file_.release.project.normalized_name, file_url, session
         )
         wheel_metadata_contents = lazy_dist._dist._files[Path("METADATA")]
-    except (InvalidWheel, UnsupportedWheel, BadZipFile):
+    except (InvalidWheel, UnsupportedWheel, BadZipFile, KeyError):
         file_.metadata_file_unbackfillable = True
         return
 


### PR DESCRIPTION
Fixes [WAREHOUSE-PRODUCTION-1QE](https://python-software-foundation.sentry.io/issues/5006657647/).