### PR TITLE
Remove translation tags from `pending-trusted-publisher-invalided` email

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2285,22 +2285,6 @@ msgstr[1] ""
 msgid "If you did not make this request, you can safely ignore this email."
 msgstr ""
 
-#: warehouse/templates/email/pending-trusted-publisher-invalidated/body.html:19
-#, python-format
-msgid ""
-"You registered an pending OpenID Connect publisher for a project "
-"(<strong>%(project_name)s</strong>), but someone else has invalidated "
-"your pending publisher by creating the project before you did."
-msgstr ""
-
-#: warehouse/templates/email/pending-trusted-publisher-invalidated/body.html:27
-#, python-format
-msgid ""
-"If you believe this was done in error, you can email <a "
-"href=\"%(href)s\">%(email_address)s</a> to communicate with the PyPI "
-"administrators."
-msgstr ""
-
 #: warehouse/templates/email/primary-email-change/body.html:18
 #, python-format
 msgid ""

--- a/warehouse/templates/email/pending-trusted-publisher-invalidated/body.html
+++ b/warehouse/templates/email/pending-trusted-publisher-invalidated/body.html
@@ -13,21 +13,15 @@
 -#}
 {% extends "email/_base/body.html" %}
 
-
 {% block content %}
 <p>
-    {% trans username=username, project_name=project_name %}
     You registered an pending OpenID Connect publisher for a project
     (<strong>{{ project_name }}</strong>), but someone else has invalidated your
     pending publisher by creating the project before you did.
-    {% endtrans %}
 </p>
-
 <p>
-    {% trans href='mailto:admin@pypi.org', email_address='admin@pypi.org' %}
     If you believe this was done in error, you can email
-    <a href="{{ href }}">{{ email_address }}</a> to communicate with the PyPI
+    <a href="mailto:admin@pypi.org"> admin@pypi.org</a> to communicate with the PyPI
     administrators.
-    {% endtrans %}
 </p>
 {% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-invalidated/body.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-invalidated/body.txt
@@ -14,16 +14,12 @@
 {% extends "email/_base/body.txt" %}
 
 {% block content %}
-{% trans project_name=project_name %}
 You registered an pending OpenID Connect publisher for a project
 ({{ project_name }}), but someone else has invalidated your pending publisher
 by creating the project before you did.
-{% endtrans %}
 
-{% trans email_address='admin@pypi.org' %}
-If you believe this was done in error, you can email
-{{ email_address }} to communicate with the PyPI administrators.
-{% endtrans %}
+If you believe this was done in error, you can email admin@pypi.org
+to communicate with the PyPI administrators.
 
 {% endblock %}
 

--- a/warehouse/templates/email/pending-trusted-publisher-invalidated/subject.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-invalidated/subject.txt
@@ -15,7 +15,5 @@
 {% extends "email/_base/subject.txt" %}
 
 {% block subject %}
-{% trans project_name=project_name %}
 Pending OpenID Connect publisher invalidated for {{ project_name }}
-{% endtrans %}
 {% endblock %}


### PR DESCRIPTION
The view that triggers this email is not translate-able.

Fixes #15491.

Fixes [WAREHOUSE-PRODUCTION-1QJ](https://python-software-foundation.sentry.io/issues/5015063697/).