### PR TITLE
test: update postgres server version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: ${{ (matrix.name == 'Tests') && 'postgres:14.4' || '' }}
+        image: ${{ (matrix.name == 'Tests') && 'postgres:14.11' || '' }}
         ports:
           - 5432:5432
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
 
 services:
   db:
-    image: postgres:14.4
+    image: postgres:14.11
     ports:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,7 +255,7 @@ def database(request):
     pg_port = config.get("port") or os.environ.get("PGPORT", 5432)
     pg_user = config.get("user")
     pg_db = config.get("db", "tests")
-    pg_version = config.get("version", 14.4)
+    pg_version = config.get("version", 14.11)
 
     janitor = DatabaseJanitor(pg_user, pg_host, pg_port, pg_db, pg_version)
 


### PR DESCRIPTION
Our production implementation will update minor updates periodically, leaving us naturally behind.
Update us to the latest release 14.11.

Refs: https://www.postgresql.org/about/news/postgresql-162-156-1411-1314-and-1218-released-2807/