### PR TITLE
oidc/gitlab: make project path comparison case insensitive

### DIFF
--- a/tests/unit/oidc/models/test_gitlab.py
+++ b/tests/unit/oidc/models/test_gitlab.py
@@ -239,6 +239,32 @@ class TestGitLabPublisher:
         )
 
     @pytest.mark.parametrize(
+        ("truth", "claim", "valid"),
+        [
+            # invalid: claim should never be empty or missing
+            ("", None, False),
+            ("foo/bar", None, False),
+            ("", "", False),
+            ("foo/bar", "", False),
+            # valid: exact and case-insensitive matches
+            ("foo/bar", "foo/bar", True),
+            ("Foo/bar", "foo/bar", True),
+            ("Foo/bar", "Foo/bar", True),
+            ("foo/bar", "Foo/bar", True),
+            ("FOO/bar", "foo/bar", True),
+            ("foo/bar", "FOO/bar", True),
+            ("foo/Bar", "foo/bar", True),
+            ("foo/Bar", "Foo/Bar", True),
+            ("foo/bar", "foo/Bar", True),
+            ("foo/BAR", "foo/bar", True),
+            ("foo/bar", "foo/BAR", True),
+        ],
+    )
+    def test_check_project_path(self, truth, claim, valid):
+        check = gitlab.GitLabPublisher.__required_verifiable_claims__["project_path"]
+        assert check(truth, claim, pretend.stub()) == valid
+
+    @pytest.mark.parametrize(
         ("claim", "ref_path", "sha", "valid", "expected"),
         [
             # okay: workflow name, followed by a nonempty ref_path

--- a/warehouse/oidc/models/gitlab.py
+++ b/warehouse/oidc/models/gitlab.py
@@ -23,8 +23,16 @@ from warehouse.oidc.models._core import (
     CheckClaimCallable,
     OIDCPublisher,
     PendingOIDCPublisher,
-    check_claim_binary,
 )
+
+
+def _check_project_path(ground_truth, signed_claim, all_signed_claims):
+    # Defensive: GitLab should never give us an empty project_path claim.
+    if not signed_claim:
+        return False
+
+    # GitLab project paths are case-insensitive.
+    return signed_claim.lower() == ground_truth.lower()
 
 
 def _check_ci_config_ref_uri(ground_truth, signed_claim, all_signed_claims):
@@ -108,7 +116,7 @@ class GitLabPublisherMixin:
 
     __required_verifiable_claims__: dict[str, CheckClaimCallable[Any]] = {
         "sub": _check_sub,
-        "project_path": check_claim_binary(str.__eq__),
+        "project_path": _check_project_path,
         "ci_config_ref_uri": _check_ci_config_ref_uri,
     }
 


### PR DESCRIPTION
Following the discussion at https://github.com/pypi/warehouse/issues/15498, and the corresponding GitHub fix in https://github.com/pypi/warehouse/pull/15501, this PR fixes the corresponding issue in GitLab trusted publishers.

The GitLab `project_path` claim corresponds to the string `namespace/project` (or `org/repo`, in GH terms). This path is case insensitive, so we change the claim comparison accordingly.

/cc @di @woodruffw 