### PR TITLE
chore: add now-required message to LockError

### DIFF
--- a/tests/unit/search/test_tasks.py
+++ b/tests/unit/search/test_tasks.py
@@ -268,7 +268,7 @@ class TestReindex:
 
         db_request.registry.settings = {"celery.scheduler_url": "redis://redis:6379/0"}
 
-        le = redis.exceptions.LockError()
+        le = redis.exceptions.LockError("Failed to acquire lock")
         monkeypatch.setattr(SearchLock, "acquire", pretend.raiser(le))
 
         with pytest.raises(celery.exceptions.Retry):
@@ -555,7 +555,7 @@ class TestPartialReindex:
 
         db_request.registry.settings = {"celery.scheduler_url": "redis://redis:6379/0"}
 
-        le = redis.exceptions.LockError()
+        le = redis.exceptions.LockError("Failed to acquire lock")
         monkeypatch.setattr(SearchLock, "acquire", pretend.raiser(le))
 
         with pytest.raises(celery.exceptions.Retry):
@@ -570,7 +570,7 @@ class TestPartialReindex:
 
         db_request.registry.settings = {"celery.scheduler_url": "redis://redis:6379/0"}
 
-        le = redis.exceptions.LockError()
+        le = redis.exceptions.LockError("Failed to acquire lock")
         monkeypatch.setattr(SearchLock, "acquire", pretend.raiser(le))
 
         with pytest.raises(celery.exceptions.Retry):


### PR DESCRIPTION
Refs: https://github.com/redis/redis-py/issues/3168