### PR TITLE
Uncomment provides-extra and adds dynamic to release_detail

### DIFF
--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -308,7 +308,6 @@
             {% endfor %}
           </td>
         </tr>
-        {#
           <tr>
           <td>Provides-Extra</td>
           <td>
@@ -317,7 +316,14 @@
             {% endfor %}
           </td>
         </tr>
-        #}
+          <tr>
+          <td>Dynamic</td>
+          <td>
+            {% for dynamic in release.dynamic %}
+            <code>{{ dynamic }}</code><br>
+            {% endfor %}
+          </td>
+        </tr>
       </table>
     </div>
   </div>

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -311,7 +311,7 @@
           <tr>
           <td>Provides-Extra</td>
           <td>
-            {% for extra in release.provides_extras %}
+            {% for extra in release.provides_extra %}
             <code>{{ extra }}</code><br>
             {% endfor %}
           </td>


### PR DESCRIPTION
Closes #15492

It adds `Dynamic` and uncomment `Provides-Extra` from release_details.html. Both are already provided by the release object.

<img width="1722" alt="image" src="https://github.com/pypi/warehouse/assets/23180089/c8383bf4-7bda-4ba8-9898-312f9f634298">



cc @di 