### PR TITLE
Migrate pip-tools settings to shared config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ translations: .state/docker-build-base
 	docker compose run --rm base bin/translations
 
 requirements/%.txt: requirements/%.in
-	docker compose run --rm base bin/pip-compile --allow-unsafe --generate-hashes --output-file=$@ $<
+	docker compose run --rm base bin/pip-compile --generate-hashes --output-file=$@ $<
 
 initdb: .state/docker-build-base
 	docker compose run --rm web psql -h db -d postgres -U postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname ='warehouse';"

--- a/bin/deps
+++ b/bin/deps
@@ -12,13 +12,13 @@ set -x
 
 export TMPDIR=$(mktemp -d)
 mkdir -p $TMPDIR/docs
-pip-compile --upgrade --allow-unsafe -o $TMPDIR/deploy.txt requirements/deploy.in > /dev/null
-pip-compile --upgrade --allow-unsafe -o $TMPDIR/main.txt requirements/main.in > /dev/null
-pip-compile --upgrade --allow-unsafe -o $TMPDIR/lint.txt requirements/lint.in > /dev/null
-pip-compile --upgrade --allow-unsafe -o $TMPDIR/tests.txt requirements/tests.in > /dev/null
-pip-compile --upgrade --allow-unsafe -o $TMPDIR/docs-dev.txt requirements/docs-dev.in > /dev/null
-pip-compile --upgrade --allow-unsafe -o $TMPDIR/docs-user.txt requirements/docs-user.in > /dev/null
-pip-compile --upgrade --allow-unsafe -o $TMPDIR/docs-blog.txt requirements/docs-blog.in > /dev/null
+pip-compile --upgrade -o $TMPDIR/deploy.txt requirements/deploy.in > /dev/null
+pip-compile --upgrade -o $TMPDIR/main.txt requirements/main.in > /dev/null
+pip-compile --upgrade -o $TMPDIR/lint.txt requirements/lint.in > /dev/null
+pip-compile --upgrade -o $TMPDIR/tests.txt requirements/tests.in > /dev/null
+pip-compile --upgrade -o $TMPDIR/docs-dev.txt requirements/docs-dev.in > /dev/null
+pip-compile --upgrade -o $TMPDIR/docs-user.txt requirements/docs-user.in > /dev/null
+pip-compile --upgrade -o $TMPDIR/docs-blog.txt requirements/docs-blog.in > /dev/null
 python bin/depchecker.py $TMPDIR/deploy.txt requirements/deploy.txt
 python bin/depchecker.py $TMPDIR/main.txt requirements/main.txt
 python bin/depchecker.py $TMPDIR/lint.txt requirements/lint.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,4 +102,6 @@ filterwarnings = [
 ]
 
 [tool.pip-tools.compile]
+# TODO: This can be removed once it becomes the default.
+# See: https://github.com/jazzband/pip-tools/issues/989
 allow-unsafe = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,6 @@ filterwarnings = [
     'ignore::warehouse.utils.exceptions.InsecureOIDCPublisherWarning',
     'ignore::warehouse.packaging.services.InsecureStorageWarning',
 ]
+
+[tool.pip-tools.compile]
+allow-unsafe = true


### PR DESCRIPTION
Specify a global configuration for the `pip-compile` option `--allow-unsafe` in the `pyproject.toml` file.

Closes #15406.