### PR TITLE
fast(er) fail b2 interactions

### DIFF
--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -74,20 +74,8 @@ def test_sync_file_to_cache(db_request, monkeypatch, cached):
 
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", mock_named_temporary_file)
 
-    sync_file_to_cache(db_request, file.id)
-
-    assert file.cached
-
-    if not cached:
-        assert archive_stub.get_metadata.calls == [pretend.call(file.path)]
-        assert archive_stub.get.calls == [pretend.call(file.path)]
-        assert cache_stub.store.calls == [
-            pretend.call(file.path, "/tmp/wutang", meta={"fizz": "buzz"}),
-        ]
-    else:
-        assert archive_stub.get_metadata.calls == []
-        assert archive_stub.get.calls == []
-        assert cache_stub.store.calls == []
+    with pytest.raises(Exception):
+        sync_file_to_cache(db_request, file.id)
 
 
 def test_compute_packaging_metrics(db_request, metrics):
@@ -139,27 +127,8 @@ def test_sync_file_to_cache_includes_bonus_files(db_request, monkeypatch, cached
 
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", mock_named_temporary_file)
 
-    sync_file_to_cache(db_request, file.id)
-
-    assert file.cached
-
-    if not cached:
-        assert archive_stub.get_metadata.calls == [
-            pretend.call(file.path),
-            pretend.call(file.metadata_path),
-        ]
-        assert archive_stub.get.calls == [
-            pretend.call(file.path),
-            pretend.call(file.metadata_path),
-        ]
-        assert cache_stub.store.calls == [
-            pretend.call(file.path, "/tmp/wutang", meta={"fizz": "buzz"}),
-            pretend.call(file.metadata_path, "/tmp/wutang", meta={"fizz": "buzz"}),
-        ]
-    else:
-        assert archive_stub.get_metadata.calls == []
-        assert archive_stub.get.calls == []
-        assert cache_stub.store.calls == []
+    with pytest.raises(Exception):
+        sync_file_to_cache(db_request, file.id)
 
 
 def test_check_file_cache_tasks_outstanding(db_request, metrics):

--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -74,8 +74,20 @@ def test_sync_file_to_cache(db_request, monkeypatch, cached):
 
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", mock_named_temporary_file)
 
-    with pytest.raises(Exception):
-        sync_file_to_cache(db_request, file.id)
+    sync_file_to_cache(db_request, file.id)
+
+    assert file.cached
+
+    if not cached:
+        assert archive_stub.get_metadata.calls == [pretend.call(file.path)]
+        assert archive_stub.get.calls == [pretend.call(file.path)]
+        assert cache_stub.store.calls == [
+            pretend.call(file.path, "/tmp/wutang", meta={"fizz": "buzz"}),
+        ]
+    else:
+        assert archive_stub.get_metadata.calls == []
+        assert archive_stub.get.calls == []
+        assert cache_stub.store.calls == []
 
 
 def test_compute_packaging_metrics(db_request, metrics):
@@ -127,8 +139,27 @@ def test_sync_file_to_cache_includes_bonus_files(db_request, monkeypatch, cached
 
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", mock_named_temporary_file)
 
-    with pytest.raises(Exception):
-        sync_file_to_cache(db_request, file.id)
+    sync_file_to_cache(db_request, file.id)
+
+    assert file.cached
+
+    if not cached:
+        assert archive_stub.get_metadata.calls == [
+            pretend.call(file.path),
+            pretend.call(file.metadata_path),
+        ]
+        assert archive_stub.get.calls == [
+            pretend.call(file.path),
+            pretend.call(file.metadata_path),
+        ]
+        assert cache_stub.store.calls == [
+            pretend.call(file.path, "/tmp/wutang", meta={"fizz": "buzz"}),
+            pretend.call(file.metadata_path, "/tmp/wutang", meta={"fizz": "buzz"}),
+        ]
+    else:
+        assert archive_stub.get_metadata.calls == []
+        assert archive_stub.get.calls == []
+        assert cache_stub.store.calls == []
 
 
 def test_check_file_cache_tasks_outstanding(db_request, metrics):

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -17,6 +17,7 @@ import tempfile
 from collections import namedtuple
 from itertools import product
 
+from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from google.cloud.bigquery import LoadJobConfig
 from sqlalchemy.orm import joinedload
 
@@ -40,7 +41,15 @@ def _copy_file_to_cache(archive_storage, cache_storage, path):
         cache_storage.store(path, file_for_cache.name, meta=metadata)
 
 
-@tasks.task(ignore_result=True, acks_late=True)
+@tasks.task(
+    ignore_result=True,
+    acks_late=True,
+    time_limit=30,
+    autoretry_for=(
+        SoftTimeLimitExceeded,
+        TimeLimitExceeded,
+    ),
+)
 def sync_file_to_cache(request, file_id):
     file = request.db.get(File, file_id)
 

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -40,19 +40,13 @@ def _copy_file_to_cache(archive_storage, cache_storage, path):
         cache_storage.store(path, file_for_cache.name, meta=metadata)
 
 
-@tasks.task(ignore_result=True, acks_late=True)
+@tasks.task(
+    ignore_result=True,
+    acks_late=True,
+    autoretry_for=(Exception,),
+)
 def sync_file_to_cache(request, file_id):
-    file = request.db.get(File, file_id)
-
-    if file and not file.cached:
-        archive_storage = request.find_service(IFileStorage, name="archive")
-        cache_storage = request.find_service(IFileStorage, name="cache")
-
-        _copy_file_to_cache(archive_storage, cache_storage, file.path)
-        if file.metadata_file_sha256_digest is not None:
-            _copy_file_to_cache(archive_storage, cache_storage, file.metadata_path)
-
-        file.cached = True
+    raise Exception()
 
 
 @tasks.task(ignore_result=True, acks_late=True)

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -40,13 +40,19 @@ def _copy_file_to_cache(archive_storage, cache_storage, path):
         cache_storage.store(path, file_for_cache.name, meta=metadata)
 
 
-@tasks.task(
-    ignore_result=True,
-    acks_late=True,
-    autoretry_for=(Exception,),
-)
+@tasks.task(ignore_result=True, acks_late=True)
 def sync_file_to_cache(request, file_id):
-    raise Exception()
+    file = request.db.get(File, file_id)
+
+    if file and not file.cached:
+        archive_storage = request.find_service(IFileStorage, name="archive")
+        cache_storage = request.find_service(IFileStorage, name="cache")
+
+        _copy_file_to_cache(archive_storage, cache_storage, file.path)
+        if file.metadata_file_sha256_digest is not None:
+            _copy_file_to_cache(archive_storage, cache_storage, file.metadata_path)
+
+        file.cached = True
 
 
 @tasks.task(ignore_result=True, acks_late=True)


### PR DESCRIPTION
currently our worker queue is spinning on b2 interactions that exponentially backoff for up to ~1300 seconds

lets just bail on these tasks for now and revert this when b2 is feelign better