### PR TITLE
move parts of our db initialization into db service

### DIFF
--- a/bin/wait-for-db
+++ b/bin/wait-for-db
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Click requires us to ensure we have a well configured environment to run
+# our click commands. So we'll set our environment to ensure our locale is
+# correct.
+export LC_ALL="${ENCODING:-en_US.UTF-8}"
+export LANG="${ENCODING:-en_US.UTF-8}"
+
+echo -n 'waiting for db to be prepared.'
+
+QUERY="select name from users where username='ewdurbin';"
+
+ATTEMPTS=0
+until [ $ATTEMPTS -eq 60 ] || [ "$(psql -U postgres -d warehouse -A -t -c "$QUERY" 2>&1)" == "Ee Durbin" ]; do
+  >&2 >/dev/null
+  ATTEMPTS=$((ATTEMPTS+1));
+  echo -n "."
+  sleep 1
+done
+
+if [ $ATTEMPTS -eq 60 ]; then
+  >&2 echo ""
+  echo "db failed to prepare, exiting"
+  exit 1
+fi
+
+echo ""

--- a/dev/db/docker-entrypoint-initdb.d/init-dbs.sh
+++ b/dev/db/docker-entrypoint-initdb.d/init-dbs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+psql -d "$POSTGRES_DB" -U "$POSTGRES_USER" <<-EOF
+    SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname ='warehouse';
+    DROP DATABASE IF EXISTS warehouse;
+    CREATE DATABASE warehouse ENCODING 'UTF8';
+    SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname ='rstuf';
+    DROP DATABASE IF EXISTS rstuf;
+    CREATE DATABASE rstuf ENCODING 'UTF8';
+EOF
+
+xz -d -f -k /example.sql.xz --stdout | psql -d warehouse -U "$POSTGRES_USER" -v ON_ERROR_STOP=1 -1 -f -
+
+psql -d warehouse -U "$POSTGRES_USER" <<-EOF
+    UPDATE users SET name='Ee Durbin' WHERE username='ewdurbin'
+EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,10 @@ services:
       test: ["CMD", "pg_isready", "-U", "postgres", "-d", "postgres"]
       interval: 1s
       start_period: 10s
+    volumes:
+      - ./dev/db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:z
+      - ./dev/example.sql.xz:/example.sql.xz:z
+      - ./bin/wait-for-db:/usr/local/bin/wait-for-db:z
 
   stripe:
     image: stripe/stripe-mock:v0.162.0

--- a/docs/dev/development/getting-started.rst
+++ b/docs/dev/development/getting-started.rst
@@ -213,8 +213,7 @@ Once ``make build`` has finished,  run the command:
 
 This command will:
 
-* create a new Postgres database,
-* install example data to the Postgres database,
+* ensure the db is prepared,
 * run migrations,
 * load some example data from `Test PyPI`_, and
 * index all the data for the search database.
@@ -248,6 +247,16 @@ or that the ``static`` container has finished compiling the static assets:
     warehouse-static-1  | webpack 5.75.0 compiled with 1 warning in 6610 ms
 
 or maybe something else.
+
+
+Resetting the development database
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: console
+
+    make resetdb
+
+This command will fully reset the development database.
 
 
 Viewing Warehouse in a browser


### PR DESCRIPTION
Move as much of our database initialization into the db container itself to improve ergonomics for both `rstuf` and `warehouse`.

Running `make initdb` can now work without `make serve` first!