### PR TITLE
fix: use correct key name for inspector

### DIFF
--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -206,8 +206,8 @@ def submit_malware_observation(
                 request=request,
                 kind=ObservationKind.IsMalware,
                 actor=request.user,
-                summary=form.summary.data + "\n\n" + form.inspector_link.data,
-                payload={"origin": "web", "inspector_link": form.inspector_link.data},
+                summary=form.summary.data,
+                payload={"origin": "web", "inspector_url": form.inspector_link.data},
             )
             request.session.flash(
                 request._("Your report has been recorded. Thank you for your help."),


### PR DESCRIPTION
Using `inspector_link` doesn't map to anything, so the resulting notice would have the inspector link in the wrong spot.

If it's included in the payload correctly, there's no reason to add it to the summary (a second time).