### PR TITLE
Add method to find a Macaroon from a request

### DIFF
--- a/warehouse/macaroons/interfaces.py
+++ b/warehouse/macaroons/interfaces.py
@@ -20,6 +20,12 @@ class IMacaroonService(Interface):
         InvalidMacaroon if not found or for malformed macaroons.
         """
 
+    def find_from_request(request, increase_metrics: bool):
+        """
+        Returns a macaroon model from the DB from a request, or raises
+        InvalidMacaroon if not found or for malformed request.
+        """
+
     def find_macaroon(macaroon_id):
         """
         Returns a macaroon model from the DB by its identifier.


### PR DESCRIPTION
While working on https://github.com/pypi/warehouse/pull/15453 (warn users if they use an API token to upload to a project that has Trusted Publishing configured), I needed to get a Macaroon from a request sent to `forklift.legacy.file_upload()`. 

This Macaroon is needed to check if we have already warned a user about this token in particular (in which case we don't send the warning email).

The problem is that `file_upload()` only takes a request, and currently the only way of extracting the Macaroon from the request is to use an internal utility function `_extract_http_macaroon` located in `macaroons.security_policy`, doing something like:
```python
raw_macaroon = _extract_http_macaroon(request)
if raw_macaroon is not None:
    macaroon_service = request.find_service(IMacaroonService, context=None)
    try:
        macaroon: Macaroon = macaroon_service.find_from_raw(raw_macaroon)
```

This PR introduces a `macaroon_service.find_from_request()` method that does the above (it wraps the use of `_extract_http_macaroon` and `find_from_raw`). This also simplifies the `MacaroonSecurityPolicy`'s `identity()` and `permits()` methods, since both of them extracted the Macaroon from a request using the above procedure. Now they simply call `macaroon_service.find_from_request()`.

As part of this, the utility functions `_extract_http_macaroon` and `_extract_basic_macaroon` were moved from `macaroons.security_policy` to `macaroon.services` (since they are now only used by `services.find_from_request())`.

There is another subtlety to take into account: before, calling `_extract_http_macaroon` increased the metrics for the auth method used in the request. Since `_extract_http_macaroon` was called by both `MacaroonSecurityPolicy.identity()` and `MacaroonSecurityPolicy.permits()`, this means the metrics were duplicated:
https://github.com/pypi/warehouse/blob/dc1d9543ac4db87f1d0ba4d6e627f92eb0b1fde2/warehouse/macaroons/security_policy.py#L71-L74

In order to fix this, `find_from_request` takes a second parameter `increase_metrics: bool`, that specifies whether the authentication metrics should be increased or not. Then, `MacaroonSecurityPolicy` is modified so that only `MacaroonSecurityPolicy.permits()` pass `increase_metrics=True`, fixing the issue of duplicated metrics.

