### PR TITLE
Time out after 15 minutes if our test suite has gotten hung

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           pip install -r requirements/dev.txt
           pip check
   test:
+    # Time out after 10 minutes if our test suite has gotten hung
+    timeout-minutes: 10
     needs: deps
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
           pip install -r requirements/dev.txt
           pip check
   test:
-    # Time out after 10 minutes if our test suite has gotten hung
-    timeout-minutes: 10
+    # Time out if our test suite has gotten hung
+    timeout-minutes: 15
     needs: deps
     strategy:
       matrix:


### PR DESCRIPTION
Prevents our job queue from becoming completely blocked with hung test suite runs.