### PR TITLE
Move to depot GHA runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,48 +8,46 @@ on:
     types: [checks_requested]
   workflow_dispatch:  # generally only for the "combine-prs" workflow
 permissions:
+  id-token: write
   contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
-  deps:
-    runs-on: ubuntu-latest
+  build:
+    if: github.repository_owner == 'pypi'
+    runs-on: depot-ubuntu-22.04
+    outputs:
+      buildId: ${{ steps.build.outputs.build-id}}
+      token: ${{ steps.pull-token.outputs.token }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Install platform dependencies
-        run: |
-          sudo apt -y update
-          sudo apt -y install libcurl4-openssl-dev libssl-dev pkg-config libxml2-dev libxslt-dev
-      - uses: actions/setup-python@v5
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
         with:
-          python-version-file: '.python-version'
-      - name: pip cache
-        uses: actions/cache@v4
+          oidc: true
+      - name: Build image
+        id: build
+        uses: depot/build-push-action@v1
         with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}
-      - name: Cache built Python environment
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
-      - name: Install Python dependencies
-        run: |
-          pip install -U setuptools wheel pip
-          pip install -r requirements.txt --no-deps
-          pip install -r requirements/dev.txt
-          pip check
+          save: true
+          build-args: |
+            DEVEL=yes
+            CI=yes
+          tags: pypi/warehouse:ci-${{ github.run_id }}
+      - name: Export Token
+        id: pull-token
+        run: echo "token=$(depot pull-token)" >> "$GITHUB_OUTPUT"
   test:
     # Time out if our test suite has gotten hung
     timeout-minutes: 15
-    needs: deps
+    needs: build
     strategy:
       matrix:
         include:
           - name: Tests
-            command: bin/tests --postgresql-host localhost
+            command: bin/tests --postgresql-host postgres
           - name: Lint
             command: bin/lint
           - name: User Documentation
@@ -57,12 +55,19 @@ jobs:
           - name: Developer Documentation
             command: bin/dev-docs
           - name: Dependencies
-            command: bin/github-actions-deps
+            command: bin/deps
           - name: Licenses
             command: bin/licenses
           - name: Translations
             command: bin/translations
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04
+    container:
+      image: registry.depot.dev/rltf7cln5v:${{ needs.build.outputs.buildId }}
+      credentials:
+        username: x-token
+        password: ${{ needs.build.outputs.token }}
+      env:
+        BILLING_BACKEND: warehouse.subscriptions.services.MockStripeBillingService api_base=http://stripe:12111 api_version=2020-08-27
     services:
       postgres:
         image: ${{ (matrix.name == 'Tests') && 'postgres:14.11' || '' }}
@@ -77,18 +82,9 @@ jobs:
         ports:
           - 12111:12111
     name: ${{ matrix.name }}
-    env:
-      BILLING_BACKEND: warehouse.subscriptions.services.MockStripeBillingService api_base=http://localhost:12111 api_version=2020-08-27
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Install platform dependencies
-        run: |
-          sudo apt -y update
-          sudo apt -y install libcurl4-openssl-dev libssl-dev pkg-config libxml2-dev libxslt-dev
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: '.python-version'
       - name: Cache mypy results
         if: ${{ (matrix.name == 'Lint') }}
         uses: actions/cache@v4
@@ -96,12 +92,5 @@ jobs:
           path: |
               dev/.mypy_cache
           key: ${{ runner.os }}-mypy-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
-      - name: Restore built Python environment from deps
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
-          # Since we don't install deps again, we fail if we can't restore the cache (timeout, etc)
-          fail-on-cache-miss: true
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,46 +8,48 @@ on:
     types: [checks_requested]
   workflow_dispatch:  # generally only for the "combine-prs" workflow
 permissions:
-  id-token: write
   contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
-  build:
-    if: github.repository_owner == 'pypi'
-    runs-on: depot-ubuntu-22.04
-    outputs:
-      buildId: ${{ steps.build.outputs.build-id}}
-      token: ${{ steps.pull-token.outputs.token }}
+  deps:
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Set up Depot CLI
-        uses: depot/setup-action@v1
+      - name: Install platform dependencies
+        run: |
+          sudo apt -y update
+          sudo apt -y install libcurl4-openssl-dev libssl-dev pkg-config libxml2-dev libxslt-dev
+      - uses: actions/setup-python@v5
         with:
-          oidc: true
-      - name: Build image
-        id: build
-        uses: depot/build-push-action@v1
+          python-version-file: '.python-version'
+      - name: pip cache
+        uses: actions/cache@v4
         with:
-          save: true
-          build-args: |
-            DEVEL=yes
-            CI=yes
-          tags: pypi/warehouse:ci-${{ github.run_id }}
-      - name: Export Token
-        id: pull-token
-        run: echo "token=$(depot pull-token)" >> "$GITHUB_OUTPUT"
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}
+      - name: Cache built Python environment
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+      - name: Install Python dependencies
+        run: |
+          pip install -U setuptools wheel pip
+          pip install -r requirements.txt --no-deps
+          pip install -r requirements/dev.txt
+          pip check
   test:
     # Time out if our test suite has gotten hung
     timeout-minutes: 15
-    needs: build
+    needs: deps
     strategy:
       matrix:
         include:
           - name: Tests
-            command: bin/tests --postgresql-host postgres
+            command: bin/tests --postgresql-host localhost
           - name: Lint
             command: bin/lint
           - name: User Documentation
@@ -55,19 +57,12 @@ jobs:
           - name: Developer Documentation
             command: bin/dev-docs
           - name: Dependencies
-            command: bin/deps
+            command: bin/github-actions-deps
           - name: Licenses
             command: bin/licenses
           - name: Translations
             command: bin/translations
-    runs-on: depot-ubuntu-22.04
-    container:
-      image: registry.depot.dev/rltf7cln5v:${{ needs.build.outputs.buildId }}
-      credentials:
-        username: x-token
-        password: ${{ needs.build.outputs.token }}
-      env:
-        BILLING_BACKEND: warehouse.subscriptions.services.MockStripeBillingService api_base=http://stripe:12111 api_version=2020-08-27
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: ${{ (matrix.name == 'Tests') && 'postgres:14.11' || '' }}
@@ -82,9 +77,18 @@ jobs:
         ports:
           - 12111:12111
     name: ${{ matrix.name }}
+    env:
+      BILLING_BACKEND: warehouse.subscriptions.services.MockStripeBillingService api_base=http://localhost:12111 api_version=2020-08-27
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+      - name: Install platform dependencies
+        run: |
+          sudo apt -y update
+          sudo apt -y install libcurl4-openssl-dev libssl-dev pkg-config libxml2-dev libxslt-dev
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: '.python-version'
       - name: Cache mypy results
         if: ${{ (matrix.name == 'Lint') }}
         uses: actions/cache@v4
@@ -92,5 +96,12 @@ jobs:
           path: |
               dev/.mypy_cache
           key: ${{ runner.os }}-mypy-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+      - name: Restore built Python environment from deps
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+          # Since we don't install deps again, we fail if we can't restore the cache (timeout, etc)
+          fail-on-cache-miss: true
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}

--- a/.github/workflows/provisional-ci.yml
+++ b/.github/workflows/provisional-ci.yml
@@ -1,0 +1,96 @@
+name: Provisional CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:  # generally only for the "combine-prs" workflow
+permissions:
+  id-token: write
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+jobs:
+  build:
+    if: github.repository_owner == 'pypi'
+    runs-on: depot-ubuntu-22.04
+    outputs:
+      buildId: ${{ steps.build.outputs.build-id}}
+      token: ${{ steps.pull-token.outputs.token }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+        with:
+          oidc: true
+      - name: Build image
+        id: build
+        uses: depot/build-push-action@v1
+        with:
+          save: true
+          build-args: |
+            DEVEL=yes
+            CI=yes
+          tags: pypi/warehouse:ci-${{ github.run_id }}
+      - name: Export Token
+        id: pull-token
+        run: echo "token=$(depot pull-token)" >> "$GITHUB_OUTPUT"
+  test:
+    # Time out if our test suite has gotten hung
+    timeout-minutes: 15
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - name: Provisional Tests
+            command: bin/tests --postgresql-host postgres
+          - name: Provisional Lint
+            command: bin/lint
+          - name: Provisional User Documentation
+            command: bin/user-docs
+          - name: Provisional Developer Documentation
+            command: bin/dev-docs
+          - name: Provisional Dependencies
+            command: bin/deps
+          - name: Provisional Licenses
+            command: bin/licenses
+          - name: Provisional Translations
+            command: bin/translations
+    runs-on: depot-ubuntu-22.04
+    container:
+      image: registry.depot.dev/rltf7cln5v:${{ needs.build.outputs.buildId }}
+      credentials:
+        username: x-token
+        password: ${{ needs.build.outputs.token }}
+      env:
+        BILLING_BACKEND: warehouse.subscriptions.services.MockStripeBillingService api_base=http://stripe:12111 api_version=2020-08-27
+    services:
+      postgres:
+        image: ${{ (matrix.name == 'Tests') && 'postgres:14.11' || '' }}
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust  # never do this in production!
+        # Set health checks to wait until postgres has started
+        options: --health-cmd "pg_isready --username=postgres --dbname=postgres" --health-interval 10s --health-timeout 5s --health-retries 5
+      stripe:
+        image: ${{ (matrix.name == 'Tests') && 'stripe/stripe-mock:v0.162.0' || '' }}
+        ports:
+          - 12111:12111
+    name: ${{ matrix.name }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Cache mypy results
+        if: ${{ (matrix.name == 'Lint') }}
+        uses: actions/cache@v4
+        with:
+          path: |
+              dev/.mypy_cache
+          key: ${{ runner.os }}-mypy-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+      - name: Run ${{ matrix.name }}
+        run: ${{ matrix.command }}

--- a/.github/workflows/provisional-ci.yml
+++ b/.github/workflows/provisional-ci.yml
@@ -59,7 +59,7 @@ jobs:
           - name: Provisional Licenses
             command: bin/licenses
           - name: Provisional Translations
-            command: bin/translations
+            command: bin/translations-dockah
     runs-on: depot-ubuntu-22.04
     container:
       image: registry.depot.dev/rltf7cln5v:${{ needs.build.outputs.buildId }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,10 @@ FROM python:3.11.8-slim-bookworm as build
 # test dependencies.
 ARG DEVEL=no
 
+# Define whether we're building a CI image. This will include all the docs stuff
+# as well for the matrix!
+ARG CI=no
+
 # To enable Ipython in the development environment set to yes (for using ipython
 # as the warehouse shell interpreter,
 # i.e. 'docker compose run --rm web python -m warehouse shell --type=ipython')
@@ -176,6 +180,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
                     -r /tmp/requirements/deploy.txt \
                     -r /tmp/requirements/main.txt \
                     $(if [ "$DEVEL" = "yes" ]; then echo '-r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt'; fi) \
+                    $(if [ "$CI" = "yes" ]; then echo '-r /tmp/requirements/docs-dev.txt -r /tmp/requirements/docs-user.txt -r /tmp/requirements/docs-blog.txt'; fi ) \
     && pip check \
     && find /opt/warehouse -name '*.pyc' -delete
 
@@ -198,6 +203,10 @@ WORKDIR /opt/warehouse/src/
 # test dependencies.
 ARG DEVEL=no
 
+# Define whether we're building a CI image. This will include all the docs stuff
+# as well for the matrix!
+ARG CI=no
+
 # This is a work around because otherwise postgresql-client bombs out trying
 # to create symlinks to these directories.
 RUN set -x \
@@ -213,6 +222,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get install --no-install-recommends -y \
         libpq5 libxml2 libxslt1.1 libcurl4  \
         $(if [ "$DEVEL" = "yes" ]; then echo 'bash libjpeg62 postgresql-client build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev libcurl4-openssl-dev libssl-dev vim'; fi) \
+        $(if [ "$CI" = "yes" ]; then echo 'git'; fi) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/bin/translations-dockah
+++ b/bin/translations-dockah
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Click requires us to ensure we have a well configured environment to run
+# our click commands. So we'll set our environment to ensure our locale is
+# correct.
+export LC_ALL="${ENCODING:-en_US.UTF-8}"
+export LANG="${ENCODING:-en_US.UTF-8}"
+
+# Print all the following commands
+set -x
+
+make -C warehouse/locale/ translations-dockah

--- a/depot.json
+++ b/depot.json
@@ -1,0 +1,1 @@
+{"id":"rltf7cln5v"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# This is only used for dependabot and Github Actions CI
+# This is only used for dependabot
 -r requirements/main.txt
 -r requirements/deploy.txt
 -r requirements/docs-dev.txt

--- a/warehouse/locale/Makefile
+++ b/warehouse/locale/Makefile
@@ -39,7 +39,7 @@ build-mos: compile-pot
 translations: compile-pot
 ifneq ($(GITHUB_ACTIONS), false)
 	cd ../../; \
-	git diff --quiet ./warehouse/locale/messages.pot || (echo "There are outstanding translations, run 'make translations' and commit the changes."; exit 1)
+	cmp -s ./warehouse/locale/messages.pot /opt/warehouse/src/warehouse/locale/messages.pot || (echo "There are outstanding translations, run 'make translations' and commit the changes."; exit 1)
 else
 endif
 

--- a/warehouse/locale/Makefile
+++ b/warehouse/locale/Makefile
@@ -36,7 +36,15 @@ build-mos: compile-pot
 		L=$$LOCALE $(MAKE) compile-po ; \
 		done
 
+
 translations: compile-pot
+ifneq ($(GITHUB_ACTIONS), false)
+	cd ../../; \
+        git diff --quiet ./warehouse/locale/messages.pot || (echo "There are outstanding translations, run 'make translations' and commit the changes."; exit 1)
+else
+endif
+
+translations-dockah: compile-pot
 ifneq ($(GITHUB_ACTIONS), false)
 	cd ../../; \
 	cmp -s ./warehouse/locale/messages.pot /opt/warehouse/src/warehouse/locale/messages.pot || (echo "There are outstanding translations, run 'make translations' and commit the changes."; exit 1)


### PR DESCRIPTION
Moves us to GHA runners on depot.dev including:
  - All Docker based CI
  - Ephemeral registry so no need to cleanup CI images
  - Deep and granular docker caching
  - faster!

Caveats:
  - Currently mypy cache is broken, this seems acceptable until depot fixes GHA style caching for runs in containers
  - CI cannot be run internal to forks, just when PRs are opened

Validations:
  - pypi/warehouse -> pypi/warehouse branches ✅ (see this PR)
  - forks -> pypi/warehouse PRs ✅ #15604 
  - forks -> forks PRs CI is skipped 〰️ see https://github.com/ewdurbin/warehouse/pull/595