### PR TITLE
Remove depot/setup-action with.oidc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
-        with:
-          oidc: true
       - name: Build image
         id: build
         uses: depot/build-push-action@v1


### PR DESCRIPTION
This removes the `with.oidc` option from the `depot/setup-action` - the Depot CLI should now natively handle this for public PRs ✨ 