### PR TITLE
feat: Action to comment & close issues based on label

### DIFF
--- a/.github/workflows/not-this-repo.yml
+++ b/.github/workflows/not-this-repo.yml
@@ -1,0 +1,23 @@
+name: Add comment & close
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.name == 'not-this-repo'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        run: gh issue close "$NUMBER" --reason "not planned" --comment "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          BODY: >
+            Hi, this issue tracker is for issues with the codebase behind pypi.org itself,
+            not the projects hosted on PyPI.
+            
+            You should report this issue to the tracker for the project in question instead.


### PR DESCRIPTION
Instead of having to copy/paste manually, apply the `not-this-repo` label to an issue and watch the magic happen.