### PR TITLE
Warn users when API token is used in Trusted Publishing project (take 2)

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -5850,3 +5850,130 @@ class TestTrustedPublisherEmails:
                 },
             )
         ]
+
+    def test_api_token_warning_with_trusted_publisher_emails(
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
+        template_name = "api-token-used-in-trusted-publisher-project"
+        # We set up two users to receive the email. The owner of the API token
+        # will be stub_user, their username should be the one mentioned in the
+        # email body.
+        stub_user = pretend.stub(
+            id="id",
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+        )
+        stub_user_maintainer = pretend.stub(
+            id="id_maintainer",
+            username="username_maintainer",
+            name="",
+            email="email_maintainer@example.com",
+            primary_email=pretend.stub(
+                email="email_maintainer@example.com", verified=True
+            ),
+        )
+        subject_renderer = pyramid_config.testing_add_renderer(
+            f"email/{ template_name }/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            f"email/{ template_name }/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            f"email/{ template_name }/body.html"
+        )
+        html_renderer.string_response = "Email HTML Body"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        pyramid_request.db = pretend.stub(
+            query=lambda a: pretend.stub(
+                filter=lambda *a: pretend.stub(
+                    one=lambda: pretend.stub(user_id=stub_user.id)
+                )
+            ),
+        )
+        pyramid_request.user = stub_user
+        pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
+
+        project_name = "test_project"
+        api_token_name = "old_api_token"
+        result = email.send_api_token_used_in_trusted_publisher_project_email(
+            pyramid_request,
+            [stub_user, stub_user_maintainer],
+            project_name=project_name,
+            token_owner_username=stub_user.username,
+            token_name=api_token_name,
+        )
+
+        assert result == {
+            "project_name": project_name,
+            "token_owner_username": stub_user.username,
+            "token_name": api_token_name,
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(
+            project_name=project_name,
+            token_owner_username=stub_user.username,
+            token_name=api_token_name,
+        )
+        html_renderer.assert_(
+            project_name=project_name,
+            token_owner_username=stub_user.username,
+            token_name=api_token_name,
+        )
+        assert pyramid_request.task.calls == [
+            pretend.call(send_email),
+            pretend.call(send_email),
+        ]
+        assert send_email.delay.calls == [
+            pretend.call(
+                f"{stub_user.username} <{stub_user.email}>",
+                {
+                    "subject": "Email Subject",
+                    "body_text": "Email Body",
+                    "body_html": (
+                        "<html>\n<head></head>\n"
+                        "<body><p>Email HTML Body</p></body>\n</html>\n"
+                    ),
+                },
+                {
+                    "tag": "account:email:sent",
+                    "user_id": stub_user.id,
+                    "additional": {
+                        "from_": "noreply@example.com",
+                        "to": stub_user.email,
+                        "subject": "Email Subject",
+                        "redact_ip": False,
+                    },
+                },
+            ),
+            pretend.call(
+                f"{stub_user_maintainer.username} <{stub_user_maintainer.email}>",
+                {
+                    "subject": "Email Subject",
+                    "body_text": "Email Body",
+                    "body_html": (
+                        "<html>\n<head></head>\n"
+                        "<body><p>Email HTML Body</p></body>\n</html>\n"
+                    ),
+                },
+                {
+                    "tag": "account:email:sent",
+                    "user_id": stub_user_maintainer.id,
+                    "additional": {
+                        "from_": "noreply@example.com",
+                        "to": stub_user_maintainer.email,
+                        "subject": "Email Subject",
+                        "redact_ip": False,
+                    },
+                },
+            ),
+        ]

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -33,6 +33,7 @@ from warehouse.accounts.utils import UserTokenContext
 from warehouse.admin.flags import AdminFlag, AdminFlagValue
 from warehouse.classifiers.models import Classifier
 from warehouse.forklift import legacy, metadata
+from warehouse.macaroons import IMacaroonService, caveats, security_policy
 from warehouse.metrics import IMetricsService
 from warehouse.oidc.interfaces import SignedClaims
 from warehouse.oidc.utils import PublisherTokenContext
@@ -3770,6 +3771,139 @@ class TestFileUpload:
             "403 Invalid or non-existent authentication information. "
             "See /the/help/url/ for more information."
         )
+
+    @pytest.mark.parametrize(
+        # The only case where we expect the warning email to be sent is the first one:
+        # A project that has a trusted publisher, with an upload authenticated using an
+        # API token, where the warning has not already been sent.
+        (
+            "has_trusted_publisher",
+            "auth_with_api_token",
+            "warning_already_sent",
+            "expect_warning",
+        ),
+        [
+            (True, True, False, True),
+            (True, False, False, False),
+            (False, True, False, False),
+            (True, True, True, False),
+            (True, False, True, False),
+            (False, True, True, False),
+        ],
+    )
+    def test_upload_with_token_api_warns_if_trusted_publisher_configured(
+        self,
+        monkeypatch,
+        pyramid_config,
+        db_request,
+        metrics,
+        project_service,
+        macaroon_service,
+        has_trusted_publisher,
+        auth_with_api_token,
+        warning_already_sent,
+        expect_warning,
+    ):
+        # Sanity check: If we're not authenticating with an API token,
+        # that means we have at least one trusted publisher
+        assert auth_with_api_token or has_trusted_publisher
+
+        project = ProjectFactory.create()
+        publisher = None
+        owner = UserFactory.create()
+        maintainer = UserFactory.create()
+        RoleFactory.create(user=owner, project=project, role_name="Owner")
+        RoleFactory.create(user=maintainer, project=project, role_name="Maintainer")
+
+        if has_trusted_publisher:
+            publisher = GitHubPublisherFactory.create(projects=[project])
+            project.oidc_publishers = [publisher]
+
+        if auth_with_api_token:
+            EmailFactory.create(user=maintainer)
+            db_request.user = maintainer
+            raw_macaroon, macaroon = macaroon_service.create_macaroon(
+                "fake location",
+                "fake description",
+                [caveats.RequestUser(user_id=str(maintainer.id))],
+                user_id=maintainer.id,
+            )
+            identity = UserTokenContext(maintainer, macaroon)
+        else:
+            claims = {"sha": "somesha"}
+            identity = PublisherTokenContext(publisher, SignedClaims(claims))
+            db_request.oidc_publisher = identity.publisher
+            db_request.oidc_claims = identity.claims
+            db_request.user = None
+            raw_macaroon, macaroon = macaroon_service.create_macaroon(
+                "fake location",
+                "fake description",
+                [
+                    caveats.OIDCPublisher(
+                        oidc_publisher_id=str(publisher.id), oidc_claims=identity.claims
+                    )
+                ],
+                oidc_publisher_id=str(publisher.id),
+            )
+        if warning_already_sent:
+            project.macaroons_tp_warning.append(macaroon)
+
+        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+
+        pyramid_config.testing_securitypolicy(identity=identity)
+        db_request.POST = MultiDict(
+            {
+                "metadata_version": "1.2",
+                "name": project.name,
+                "version": "1.0",
+                "filetype": "sdist",
+                "md5_digest": _TAR_GZ_PKG_MD5,
+                "content": pretend.stub(
+                    filename=filename,
+                    file=io.BytesIO(_TAR_GZ_PKG_TESTDATA),
+                    type="application/tar",
+                ),
+            }
+        )
+
+        storage_service = pretend.stub(store=lambda path, filepath, meta: None)
+        extract_http_macaroon = pretend.call_recorder(lambda r, _: raw_macaroon)
+        monkeypatch.setattr(
+            security_policy, "_extract_http_macaroon", extract_http_macaroon
+        )
+
+        db_request.find_service = lambda svc, name=None, context=None: {
+            IFileStorage: storage_service,
+            IMacaroonService: macaroon_service,
+            IMetricsService: metrics,
+            IProjectService: project_service,
+        }.get(svc)
+        db_request.user_agent = "warehouse-tests/6.6.6"
+
+        send_email = pretend.call_recorder(lambda *a, **kw: None)
+        monkeypatch.setattr(
+            legacy, "send_api_token_used_in_trusted_publisher_project_email", send_email
+        )
+
+        resp = legacy.file_upload(db_request)
+
+        assert resp.status_code == 200
+
+        if expect_warning:
+            assert send_email.calls == [
+                pretend.call(
+                    db_request,
+                    [owner, maintainer],
+                    project_name=project.name,
+                    token_owner_username=maintainer.username,
+                    token_name=macaroon.description,
+                ),
+            ]
+            assert project.macaroons_tp_warning == [macaroon]
+        else:
+            assert send_email.calls == []
+            if not warning_already_sent:
+                assert project.macaroons_tp_warning == []
 
 
 def test_submit(pyramid_request):

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -1036,6 +1036,17 @@ def send_pending_trusted_publisher_invalidated_email(request, user, project_name
     }
 
 
+@_email("api-token-used-in-trusted-publisher-project")
+def send_api_token_used_in_trusted_publisher_project_email(
+    request, users, project_name, token_owner_username, token_name
+):
+    return {
+        "token_owner_username": token_owner_username,
+        "project_name": project_name,
+        "token_name": token_name,
+    }
+
+
 def includeme(config):
     email_sending_class = config.maybe_dotted(config.registry.settings["mail.backend"])
     config.register_service_factory(email_sending_class.create_service, IEmailSender)

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1910,6 +1910,32 @@ msgid ""
 "\"%(previous_organization_name)s\" to \"%(organization_name)s\"."
 msgstr ""
 
+#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:19
+#, python-format
+msgid ""
+"An API token belonging to user <a "
+"href=\"%(account_href)s\">%(token_owner_username)s</a> was used to upload"
+" files to the project <a href=\"%(project_href)s\">%(project_name)s</a>, "
+"even though the project has a Trusted Publisher configured. We suggest "
+"you remove the API token and use Trusted Publishing instead."
+msgstr ""
+
+#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:31
+#, python-format
+msgid ""
+"If you are the owner of this token, you can delete it by going to your <a"
+" href=\"%(href)s#api-tokens\">API tokens configuration</a> and deleting "
+"the token named <strong>%(token_name)s</strong>."
+msgstr ""
+
+#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:38
+#, python-format
+msgid ""
+"If you believe this was done in error, you can email <a "
+"href=\"%(href)s\">%(email_address)s</a> to communicate with the PyPI "
+"administrators."
+msgstr ""
+
 #: warehouse/templates/email/canceled-as-invited-organization-member/body.html:19
 #, python-format
 msgid ""

--- a/warehouse/migrations/versions/56b3ef8e8af3_add_project_macaroon_warning_table.py
+++ b/warehouse/migrations/versions/56b3ef8e8af3_add_project_macaroon_warning_table.py
@@ -1,0 +1,51 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add_project_macaroon_warning_table
+
+Revision ID: 56b3ef8e8af3
+Revises: 93a1ca43e356
+Create Date: 2024-03-11 19:41:22.997939
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "56b3ef8e8af3"
+down_revision = "93a1ca43e356"
+
+
+def upgrade():
+    op.create_table(
+        "project_macaroon_warning_association",
+        sa.Column("macaroon_id", sa.UUID(), nullable=False),
+        sa.Column("project_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["macaroon_id"],
+            ["macaroons.id"],
+            onupdate="CASCADE",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+        ),
+        sa.PrimaryKeyConstraint("macaroon_id", "project_id", "id"),
+    )
+
+
+def downgrade():
+    op.drop_table("project_macaroon_warning_association")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -39,7 +39,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import ARRAY, CITEXT, ENUM, UUID as PG_UUID
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
-from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
     Mapped,
@@ -72,6 +72,7 @@ from warehouse.utils.attrs import make_repr
 from warehouse.utils.db.types import bool_false, datetime_now
 
 if typing.TYPE_CHECKING:
+    from warehouse.macaroons.models import Macaroon
     from warehouse.oidc.models import OIDCPublisher
 
 
@@ -205,6 +206,19 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
         cascade="all, delete-orphan",
         order_by=lambda: Release._pypi_ordering.desc(),
         passive_deletes=True,
+    )
+
+    # Link to association table that keeps track of warnings for API
+    # token usage in projects that have Trusted Publishing configured.
+    _macaroons_tp_warning: Mapped[list[ProjectMacaroonWarningAssociation]] = (
+        orm.relationship(cascade="all, delete")
+    )
+    macaroons_tp_warning: AssociationProxy[list[Project]] = association_proxy(
+        "_macaroons_tp_warning",
+        "macaroon",
+        creator=lambda macaroon_obj: ProjectMacaroonWarningAssociation(
+            macaroon=macaroon_obj
+        ),
     )
 
     __table_args__ = (
@@ -874,3 +888,29 @@ class ProhibitedProjectName(db.Model):
     )
     prohibited_by: Mapped[User] = orm.relationship()
     comment: Mapped[str] = mapped_column(server_default="")
+
+
+class ProjectMacaroonWarningAssociation(db.Model):
+    """
+    Association table for Projects and Macaroons where a row (P, M) exists in
+    the table iff all of the following statements are true:
+    - M is an API-token Macaroon
+    - M was used to upload a file to project P
+    - P had a Trusted Publisher configured at the time of the upload
+    - An email warning was sent to P's maintainers about the use of M
+
+    In other words, this table tracks if we have warned a project's
+    maintainers about a specific API token being used in spite of a Trusted
+    Publisher being present. This is used in order to only send the warning
+    once per project and API token.
+    """
+
+    __tablename__ = "project_macaroon_warning_association"
+
+    macaroon_id = mapped_column(
+        ForeignKey("macaroons.id", onupdate="CASCADE", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    project_id = mapped_column(ForeignKey("projects.id"), primary_key=True)
+
+    macaroon: Mapped[Macaroon] = orm.relationship()

--- a/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html
+++ b/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html
@@ -1,0 +1,44 @@
+{#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+
+{% block content %}
+  <p>
+    {% trans token_owner_username=token_owner_username, project_name=project_name,
+    account_href=request.route_url('accounts.profile', username=token_owner_username),
+    project_href=request.route_url('packaging.project', name=project_name)
+    %}
+      An API token belonging to user <a href="{{ account_href }}">{{ token_owner_username }}</a>
+      was used to upload files to the project
+      <a href="{{ project_href }}">{{ project_name }}</a>,
+      even though the project has a Trusted Publisher configured. We suggest you
+      remove the API token and use Trusted Publishing instead.
+    {% endtrans %}
+  </p>
+  <p>
+    {% trans href=request.route_url('manage.account'), token_name=token_name %}
+      If you are the owner of this token, you can delete it by going to your
+      <a href="{{ href }}#api-tokens">API tokens configuration</a> and deleting the token named
+      <strong>{{ token_name }}</strong>.
+    {% endtrans %}
+  </p>
+  <p>
+    {% trans href='mailto:admin@pypi.org', email_address='admin@pypi.org' %}
+      If you believe this was done in error, you can email
+      <a href="{{ href }}">{{ email_address }}</a> to communicate with the PyPI
+      administrators.
+    {% endtrans %}
+  </p>
+{% endblock %}

--- a/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.txt
+++ b/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.txt
@@ -1,0 +1,38 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+  {% trans token_owner_username=token_owner_username, project_name=project_name,
+     account_href=request.route_url('accounts.profile', username=token_owner_username),
+     project_href=request.route_url('packaging.project', name=project_name)
+  %}
+    An API token belonging to user {{ token_owner_username }} ({{ account_href }})
+    was used to upload files to the project {{ project_name }} ({{ project_href }}),
+    even though the project has a Trusted Publisher configured. We suggest you remove the
+    API token and use Trusted Publishing instead.
+  {% endtrans %}
+
+  {% trans href=request.route_url('manage.account'), token_name=token_name %}
+    If you are the owner of this token, you can delete it by going to your API tokens
+    configuration at {{ href }} and deleting the token named {{ token_name }}.
+  {% endtrans %}
+
+  {% trans email_address='admin@pypi.org' %}
+    If you believe this was done in error, you can email
+    {{ email_address }} to communicate with the PyPI administrators.
+  {% endtrans %}
+
+{% endblock %}
+

--- a/warehouse/templates/email/api-token-used-in-trusted-publisher-project/subject.txt
+++ b/warehouse/templates/email/api-token-used-in-trusted-publisher-project/subject.txt
@@ -1,0 +1,21 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}
+{% trans project_name=project_name %}
+User API token used in project {{ project_name }} with Trusted Publishing enabled
+{% endtrans %}
+{% endblock %}


### PR DESCRIPTION
If a user uploads files using an API token to a project that has a Trusted Publisher configured, send an email to all the project's users notifying them of the API token use, suggesting they remove it and use Trusted Publishing instead.

This warning is only sent once per (project, API token) combination.

This is a re-implementation of https://github.com/pypi/warehouse/pull/15453, taking into account the following requirements:
1. Send warnings for API tokens both project-scoped and account-level scoped.
2. Send only one email per `(API token, Project)` combination
3. Send the email to all of the project's maintainers
4. The email should be immediately actionable, including a link to the URL where the token owner can delete the token.

The actual logic being added is small, most of the line changes in the PR are tests and the new email body text being added.

cc @di @woodruffw 