### PR TITLE
refactor: apply 2FA to any non-exempt routes 

### DIFF
--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -527,7 +527,7 @@ class TestPermits:
             identity=pretend.stub(
                 __principals__=lambda: principals,
                 has_primary_verified_email=True,
-                has_two_factor=False,
+                has_two_factor=True,
                 date_joined=datetime(2022, 8, 1),
             ),
             matched_route=pretend.stub(name="random.route"),

--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
-
 import pretend
 import pytest
 
@@ -528,7 +526,6 @@ class TestPermits:
                 __principals__=lambda: principals,
                 has_primary_verified_email=True,
                 has_two_factor=True,
-                date_joined=datetime(2022, 8, 1),
             ),
             matched_route=pretend.stub(name="random.route"),
         )
@@ -561,7 +558,6 @@ class TestPermits:
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
                 has_two_factor=True,
-                date_joined=datetime(2022, 8, 1),
             ),
             matched_route=pretend.stub(name="manage.projects"),
         )
@@ -579,7 +575,6 @@ class TestPermits:
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
                 has_two_factor=False,
-                date_joined=datetime(2023, 8, 9),
             ),
             matched_route=pretend.stub(name="manage.projects"),
         )
@@ -597,7 +592,6 @@ class TestPermits:
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
                 has_two_factor=False,
-                date_joined=datetime(2023, 8, 9),
             ),
             matched_route=pretend.stub(name="forklift.legacy.file_upload"),
         )
@@ -627,7 +621,6 @@ class TestPermits:
                 __principals__=lambda: ["user:5"],
                 has_primary_verified_email=True,
                 has_two_factor=False,
-                date_joined=datetime.now(),
             ),
             matched_route=pretend.stub(name=matched_route),
         )

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -223,15 +223,11 @@ def _check_for_mfa(request, context) -> WarehouseDenied | None:
             "accounts.verify-email",
         ]
 
-        if (
-            request.matched_route.name.startswith("manage")
-            and request.matched_route.name != "manage.account"
-            and not any(
-                request.matched_route.name.startswith(route) for route in _exempt_routes
-            )
+        if request.matched_route.name != "manage.account" and not any(
+            request.matched_route.name.startswith(route) for route in _exempt_routes
         ):
             return WarehouseDenied(
-                "You must enable two factor authentication to manage other settings",
+                "You must enable two factor authentication.",
                 reason="manage_2fa_required",
             )
 

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -205,30 +205,34 @@ def _check_for_mfa(request, context) -> WarehouseDenied | None:
     # at this point, and we only a User in these policies.
     assert isinstance(request.identity, User)
 
-    if not request.identity.has_two_factor:
-        # Return a different message for upload endpoint first.
-        if request.matched_route.name == "forklift.legacy.file_upload":
-            return WarehouseDenied(
-                "You must enable two factor authentication to upload",
-                reason="upload_2fa_required",
-            )
+    if request.identity.has_two_factor:
+        # We're good to go!
+        return None
 
-        # Management routes that don't require 2FA, mostly to set up 2FA.
-        _exempt_routes = [
-            "manage.account.recovery-codes",
-            "manage.account.totp-provision",
-            "manage.account.two-factor",
-            "manage.account.webauthn-provision",
-            "manage.unverified-account",
-            "accounts.verify-email",
-        ]
+    # Return a different message for upload endpoint first.
+    if request.matched_route.name == "forklift.legacy.file_upload":
+        return WarehouseDenied(
+            "You must enable two factor authentication to upload",
+            reason="upload_2fa_required",
+        )
 
-        if request.matched_route.name != "manage.account" and not any(
-            request.matched_route.name.startswith(route) for route in _exempt_routes
-        ):
-            return WarehouseDenied(
-                "You must enable two factor authentication.",
-                reason="manage_2fa_required",
-            )
+    # Management routes that don't require 2FA, mostly to set up 2FA.
+    _exempt_routes = [
+        "manage.account.recovery-codes",
+        "manage.account.totp-provision",
+        "manage.account.two-factor",
+        "manage.account.webauthn-provision",
+        "manage.unverified-account",
+        "accounts.verify-email",
+    ]
 
-    return None
+    if request.matched_route.name == "manage.account" or any(
+        request.matched_route.name.startswith(route) for route in _exempt_routes
+    ):
+        return None
+
+    # No exemptions matched, 2FA is required.
+    return WarehouseDenied(
+        "You must enable two factor authentication.",
+        reason="manage_2fa_required",
+    )

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Provide an Inspector link to specific lines of code."
 msgstr ""
 
-#: warehouse/packaging/views.py:213
+#: warehouse/packaging/views.py:212
 msgid "Your report has been recorded. Thank you for your help."
 msgstr ""
 

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -184,7 +184,6 @@ def includes_submit_malware_observation(project, request):
     renderer="packaging/submit-malware-observation.html",
     require_csrf=True,
     require_methods=False,
-    require_reauth=True,
     route_name="packaging.project.submit_malware_observation",
     uses_session=True,
 )


### PR DESCRIPTION
New actions, such as reporting malware via web UI, now require 2FA.

Contains other commits, making this change easier to implement. Please review individually.