### PR TITLE
Issue 15274: Use eslint stylistic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ static_pipeline: .state/docker-build-static
 reformat: .state/docker-build-base
 	docker compose run --rm base bin/reformat
 
-lint: .state/docker-build-base
+lint: .state/docker-build-base .state/docker-build-static
 	docker compose run --rm base bin/lint
 	docker compose run --rm static bin/static_lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/core": "^7.21.3",
         "@babel/eslint-parser": "^7.21.3",
         "@babel/preset-env": "^7.21.4",
+        "@stylistic/eslint-plugin-js": "^1.7.0",
         "@testing-library/dom": "^9.2.0",
         "@testing-library/jest-dom": "^5.16.5",
         "babel-jest": "^29.5.0",
@@ -3043,6 +3044,49 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.7.0.tgz",
+      "integrity": "sha512-PN6On/+or63FGnhhMKSQfYcWutRlzOiYlVdLM6yN7lquoBTqUJHYnl4TA4MHwiAt46X5gRxDr1+xPZ1lOLcL+Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^8.56.2",
+        "acorn": "^8.11.3",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@sweetalert2/theme-bootstrap-4": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/core": "^7.21.3",
     "@babel/eslint-parser": "^7.21.3",
     "@babel/preset-env": "^7.21.4",
+    "@stylistic/eslint-plugin-js": "^1.7.0",
     "@testing-library/dom": "^9.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "babel-jest": "^29.5.0",
@@ -77,24 +78,27 @@
     "parserOptions": {
       "sourceType": "module"
     },
+    "plugins": [
+      "@stylistic/js"
+    ],
     "rules": {
-      "comma-dangle": [
+      "@stylistic/js/comma-dangle": [
         "error",
         "always-multiline"
       ],
-      "indent": [
+      "@stylistic/js/indent": [
         "error",
         2
       ],
-      "linebreak-style": [
+      "@stylistic/js/linebreak-style": [
         "error",
         "unix"
       ],
-      "quotes": [
+      "@stylistic/js/quotes": [
         "error",
         "double"
       ],
-      "semi": [
+      "@stylistic/js/semi": [
         "error",
         "always"
       ]


### PR DESCRIPTION
Draft PR, initial attempt to address #15274 

There are a few things I'm not clear about with this PR, but perhaps it will help start correct work for the open issue:

* `make lint` fails, but `npm run lint` passes (details for this are below)
* committed package-lock: Docker didn't like it when the package-lock didn't match the package.json, so I committed it.  Not sure what the right thing to do here was.
* I'm new to stylistic, and so while the changes appear to be correct, I'm not completely confident.

Failing `make lint` details: `npm run lint` (outside of Docker) passes, but `make lint` fails after building the image:

<details>
<summary>make lint failure</summary>

```
Oops! Something went wrong! :(
ESLint: 8.47.0
ESLint couldn't find the plugin "@stylistic/eslint-plugin".
(The package "@stylistic/eslint-plugin" was not found when loaded as a Node module from the directory "/opt/warehouse/src".)

It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:
    npm install @stylistic/eslint-plugin@latest --save-dev
The plugin "@stylistic/eslint-plugin" was referenced from the config file in "package.json".
```

</details>

---

**UPDATE:** Branch updated, rebased to single commit, and re-pushed.  Thanks @miketheman for the feedback.

Both `make lint` and `npm run lint` pass now.