### PR TITLE
chore(dev): revert localstack upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     image: redis:4.0
 
   localstack:
-    image: localstack/localstack:3.2
+    image: localstack/localstack:1.4
     stop_signal: SIGKILL
     environment:
       SERVICES: "sqs"


### PR DESCRIPTION
Something along the upgrade path changed the way queues work, didn't have time to dig in why, but let's go back for now.

Tasks were being produced to the queue, but never **consumed**.

Refs: #15680