### PR TITLE
chore(deps): update b2sdk

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -65,9 +65,9 @@ automat==22.10.0 \
     --hash=sha256:c3164f8742b9dc440f3682482d32aaff7bb53f71740dd018533f9de286b64180 \
     --hash=sha256:e56beb84edad19dcc11d30e8d9b895f75deeb5ef5e96b84a467066b3b84bb04e
     # via -r requirements/main.in
-b2sdk==1.33.0 \
-    --hash=sha256:bb4b52081491146776326dced464f14fafc54853a062d2acc326159dddb7d76e \
-    --hash=sha256:e7eeb8e95694ad8f9495a4ed4d39d011db865adfe9a6c9a6852245d703ebd476
+b2sdk==2.0.0 \
+    --hash=sha256:0e49cd0fdc989b1bdf8a2509b06badb41e5b9384ac509ab82d09d677037ea93e \
+    --hash=sha256:e1be966e312f08cb33edefcd2449cb16c6cef66994e5a353f07bdbd310e139a6
     # via -r requirements/main.in
 babel==2.14.0 \
     --hash=sha256:6919867db036398ba21eb5c7a0f6b28ab8cbc3ae7a73a44ebe34ae74a4e7d363 \
@@ -1282,7 +1282,6 @@ packaging==24.0 \
     --hash=sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9
     # via
     #   -r requirements/main.in
-    #   b2sdk
     #   forcediphttpsadapter
     #   google-cloud-bigquery
     #   limits
@@ -1903,10 +1902,6 @@ text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
     --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93
     # via python-slugify
-tqdm==4.66.2 \
-    --hash=sha256:1ee4f8a893eb9bef51c6e35730cebf234d5d0b6bd112b0271e10ed7c24a02bd9 \
-    --hash=sha256:6cd52cdf0fef0e0f543299cfc96fec90d7b8a7e88745f411ec33eb44d5ed3531
-    # via b2sdk
 transaction==4.0 \
     --hash=sha256:68035db913f60d1be12f6563d201daab36c83e763de15899ff8338f26e5e62f2 \
     --hash=sha256:e2519a316a05b14b3d483ac777df311087daaffeeafd3e9f7de62fc087ce3209

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -14,7 +14,7 @@ import hashlib
 import io
 import os.path
 
-import b2sdk.v2
+import b2sdk.v2.exception
 import boto3.session
 import botocore.exceptions
 import pretend

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -21,7 +21,7 @@ import warnings
 
 from itertools import chain
 
-import b2sdk
+import b2sdk.v2.exception
 import botocore.exceptions
 import google.api_core.exceptions
 import google.api_core.retry


### PR DESCRIPTION
Version 2.0.0 was released with some import changes, and removed the dependency on tqdm and packaging.

Refs: https://github.com/Backblaze/b2-sdk-python/releases/tag/v2.0.0