### PR TITLE
test: fix sort order

### DIFF
--- a/tests/unit/search/test_tasks.py
+++ b/tests/unit/search/test_tasks.py
@@ -69,7 +69,7 @@ def test_project_docs(db_session):
                 ).description.raw,
             },
         }
-        for p, prs in sorted(releases.items(), key=lambda x: x[0].name)
+        for p, prs in sorted(releases.items(), key=lambda x: x[0].normalized_name)
     ]
 
 


### PR DESCRIPTION
The resulting set uses normalized names as order.

    --randomly-seed=3916416581
    --randomly-seed=3294924425
    --randomly-seed=1890731092

Refs: #15398