### PR TITLE
feat: observation.additional for flexible data

### DIFF
--- a/tests/unit/observations/test_tasks.py
+++ b/tests/unit/observations/test_tasks.py
@@ -69,6 +69,7 @@ def test_report_observation_to_helpscout(kind, payload, db_request, monkeypatch)
         responses.POST,
         "https://api.helpscout.net/v2/conversations",
         json={"id": 123},
+        headers={"Location": "https://api.helpscout.net/v2/conversations/123"},
     )
 
     report_observation_to_helpscout(None, db_request, observation.id)
@@ -76,4 +77,8 @@ def test_report_observation_to_helpscout(kind, payload, db_request, monkeypatch)
     assert len(responses.calls) == 1
     assert (
         responses.calls[0].request.url == "https://api.helpscout.net/v2/conversations"
+    )
+    assert (
+        observation.additional["helpscout_conversation_url"]
+        == "https://api.helpscout.net/v2/conversations/123"
     )

--- a/warehouse/migrations/versions/73c201ff90f3_add_additional_column_to_observations.py
+++ b/warehouse/migrations/versions/73c201ff90f3_add_additional_column_to_observations.py
@@ -1,0 +1,54 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add additional column to Observations
+
+Revision ID: 73c201ff90f3
+Revises: 34c3175f4bea
+Create Date: 2024-04-11 18:22:08.928952
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "73c201ff90f3"
+down_revision = "34c3175f4bea"
+
+
+def upgrade():
+    op.add_column(
+        "project_observations",
+        sa.Column(
+            "additional",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+            comment="Additional data for the observation",
+        ),
+    )
+    op.add_column(
+        "release_observations",
+        sa.Column(
+            "additional",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+            comment="Additional data for the observation",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("release_observations", "additional")
+    op.drop_column("project_observations", "additional")

--- a/warehouse/observations/models.py
+++ b/warehouse/observations/models.py
@@ -18,7 +18,7 @@ import typing
 
 from uuid import UUID
 
-from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKey, sql
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.declarative import AbstractConcreteBase
@@ -150,6 +150,11 @@ class Observation(AbstractConcreteBase, db.Model):
     summary: Mapped[str] = mapped_column(comment="A short summary of the observation")
     payload: Mapped[dict] = mapped_column(
         JSONB, comment="The observation payload we received"
+    )
+    additional: Mapped[dict] = mapped_column(
+        JSONB,
+        comment="Additional data for the observation",
+        server_default=sql.text("'{}'"),
     )
 
     def __repr__(self):

--- a/warehouse/observations/tasks.py
+++ b/warehouse/observations/tasks.py
@@ -141,6 +141,9 @@ def report_observation_to_helpscout(task, request: Request, model_id: UUID) -> N
         timeout=10,
     )
     resp.raise_for_status()
+    # Add the conversation URL back to the Observation for tracking purposes.
+    model.additional["helpscout_conversation_url"] = resp.headers["Location"]
+    request.db.add(model)
 
 
 def _authenticate_helpscout(request: Request) -> str:  # pragma: no cover (manual test)


### PR DESCRIPTION
Specifically, capture the Help Scout conversation URL for now, so we can use that later on in further communications.