### PR TITLE
fix: use instantiated MutableDict to track state

### DIFF
--- a/warehouse/email/ses/models.py
+++ b/warehouse/email/ses/models.py
@@ -285,5 +285,5 @@ class Event(db.Model):
     )
 
     data: Mapped[dict] = mapped_column(
-        MutableDict.as_mutable(JSONB), server_default=sql.text("'{}'")  # type: ignore[arg-type] # noqa: E501
+        MutableDict.as_mutable(JSONB()), server_default=sql.text("'{}'")
     )

--- a/warehouse/observations/models.py
+++ b/warehouse/observations/models.py
@@ -22,6 +22,7 @@ from sqlalchemy import ForeignKey, sql
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.declarative import AbstractConcreteBase
+from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from warehouse import db
@@ -152,12 +153,12 @@ class Observation(AbstractConcreteBase, db.Model):
         JSONB, comment="The observation payload we received"
     )
     additional: Mapped[dict] = mapped_column(
-        JSONB,
+        MutableDict.as_mutable(JSONB()),
         comment="Additional data for the observation",
         server_default=sql.text("'{}'"),
     )
     actions: Mapped[dict] = mapped_column(
-        JSONB,
+        MutableDict.as_mutable(JSONB()),
         comment="Actions taken based on the observation",
         server_default=sql.text("'{}'"),
     )


### PR DESCRIPTION
Since we are updating the object's dictionary **contents**, and not replacing the entirety of the column, we need to tell SQLAlchemy that it should track that state, and persist it when complete.

Refs: https://docs.sqlalchemy.org/en/20/orm/extensions/mutable.html