### PR TITLE
Fix stateful test failure

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3983,7 +3983,7 @@ class TestFileUpload:
             assert send_email.calls == [
                 pretend.call(
                     db_request,
-                    [owner, maintainer],
+                    {owner, maintainer},
                     project_name=project.name,
                     token_owner_username=maintainer.username,
                     token_name=macaroon.description,

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -629,7 +629,7 @@ def file_upload(request):
         if not warning_exists:
             send_api_token_used_in_trusted_publisher_project_email(
                 request,
-                project.users,
+                set(project.users),
                 project_name=project.name,
                 token_owner_username=request.user.username,
                 token_name=macaroon.description,


### PR DESCRIPTION
This fixes a test failure with `--randomly-seed=999435887`, as discovered here: https://github.com/pypi/warehouse/actions/runs/8695732355/job/23847539984?pr=15737