### PR TITLE
Canonicalize the correct side of the name comparison when verifying sdist filenames with post releases

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2699,6 +2699,7 @@ class TestFileUpload:
             ("foo-.bar", "foo_bar", "1.0.0"),
             ("leo", "leo", "6.7.9-9"),
             ("leo_something", "leo-something", "6.7.9-9"),
+            ("PyAlgoEngine", "PyAlgoEngine", "0.3.12.post4"),
         ],
     )
     def test_upload_succeeds_pep625_normalized_filename(

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -970,7 +970,7 @@ def file_upload(request):
             # what we were expecting
             if (
                 meta.version.is_postrelease
-                and packaging.utils.canonicalize_name(name) != meta.name
+                and name != packaging.utils.canonicalize_name(meta.name)
             ):
                 # The distribution is a source distribution, the version is a
                 # postrelease, and the project name doesn't match, so


### PR DESCRIPTION
Fixes [WAREHOUSE-PRODUCTION-1Y6](https://python-software-foundation.sentry.io/issues/5222040364/).

The project name is already canonicalized after calling `parse_sdist_filename`, what we actually need to canonicalize is the name that was provided to us in the POST data, which isn't guaranteed to be canonicalized.