### PR TITLE
Handle invalid sdist filenames

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2909,6 +2909,10 @@ class TestFileUpload:
                 "400 Invalid wheel filename (invalid version): "
                 "foo-0.0.4test1-py3-none-any",
             ),
+            (
+                "something.tar.gz",
+                "400 Invalid source distribution filename: something.tar.gz",
+            ),
         ],
     )
     def test_upload_fails_with_invalid_filename(
@@ -2932,8 +2936,8 @@ class TestFileUpload:
                 "metadata_version": "1.2",
                 "name": project.name,
                 "version": release.version,
-                "filetype": "bdist_wheel",
-                "pyversion": "cp34",
+                "filetype": "bdist_wheel" if filename.endswith(".whl") else "sdist",
+                "pyversion": "cp34" if filename.endswith(".whl") else "source",
                 "md5_digest": hashlib.md5(filebody).hexdigest(),
                 "content": pretend.stub(
                     filename=filename,

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -963,7 +963,13 @@ def file_upload(request):
             # enforcing this, so we permit a filename with a project name and
             # version that normalizes to be what we expect
 
-            name, version = packaging.utils.parse_sdist_filename(filename)
+            try:
+                name, version = packaging.utils.parse_sdist_filename(filename)
+            except packaging.utils.InvalidSdistFilename:
+                raise _exc_with_message(
+                    HTTPBadRequest,
+                    f"Invalid source distribution filename: {filename}",
+                )
 
             # The previous function fails to accomodate the edge case where
             # versions may contain hyphens, so we handle that here based on


### PR DESCRIPTION
Fixes [WAREHOUSE-PRODUCTION-1Y7](https://python-software-foundation.sentry.io/issues/5227870128/).