### PR TITLE
Fix GitLab Trusted Publisher not accepting valid namespaces

### DIFF
--- a/tests/unit/oidc/forms/test_gitlab.py
+++ b/tests/unit/oidc/forms/test_gitlab.py
@@ -48,14 +48,22 @@ class TestPendingGitLabPublisherForm:
 
 
 class TestGitLabPublisherForm:
-    def test_validate(self):
-        data = MultiDict(
+    @pytest.mark.parametrize(
+        "data",
+        [
             {
                 "namespace": "some-owner",
                 "project": "some-repo",
                 "workflow_filepath": "subfolder/some-workflow.yml",
-            }
-        )
+            },
+            {
+                "namespace": "some-group/some-subgroup",
+                "project": "some-repo",
+                "workflow_filepath": "subfolder/some-workflow.yml",
+            },
+        ],
+    )
+    def test_validate(self, data):
         form = gitlab.GitLabPublisherForm(MultiDict(data))
 
         # We're testing only the basic validation here.
@@ -73,6 +81,11 @@ class TestGitLabPublisherForm:
             },
             {
                 "namespace": "invalid_parethen(sis",
+                "project": "some",
+                "workflow_filepath": "some",
+            },
+            {
+                "namespace": "/start_with_slash",
                 "project": "some",
                 "workflow_filepath": "some",
             },

--- a/warehouse/oidc/forms/gitlab.py
+++ b/warehouse/oidc/forms/gitlab.py
@@ -20,7 +20,7 @@ from warehouse.oidc.forms._core import PendingPublisherMixin
 
 # https://docs.gitlab.com/ee/user/reserved_names.html#limitations-on-project-and-group-names
 _VALID_GITLAB_PROJECT = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-_.]*$")
-_VALID_GITLAB_NAMESPACE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-_.]*$")
+_VALID_GITLAB_NAMESPACE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-_./]*$")
 _VALID_GITLAB_ENVIRONMENT = re.compile(r"^[a-zA-Z0-9\-_/${} ]+$")
 
 


### PR DESCRIPTION
Fixes https://github.com/pypi/warehouse/issues/15836.

GitLab namespaces can have forward slash ("/") characters, since a repo inside a subgroup will have a namespace where the subgroups are delimited using slashes (e.g: `gitlab.com/group/subgroup/repo` has a namespace of `group/subgroup`).

I double checked by generating an OIDC token from a GitLab CI workflow in a repo inside a subgroup, the namespace claim is of the form `group/subgroup`.

cc @di @woodruffw 