### PR TITLE
docs: self-managed GitLab instances are not supported (for Trusted Publishing)

### DIFF
--- a/docs/user/trusted-publishers/adding-a-publisher.md
+++ b/docs/user/trusted-publishers/adding-a-publisher.md
@@ -106,6 +106,11 @@ each.
 
 === "GitLab CI/CD"
 
+    !!! note
+
+        Currently, only projects hosted on <https://gitlab.com> are supported. Self-managed
+        instances are not supported.
+
     For GitLab CI/CD, you **must** provide the repository's namespace, the
     repository's name, and the filepath of the GitLab CI/CD workflow that's
     authorized to upload to PyPI. In addition, you may **optionally**

--- a/docs/user/trusted-publishers/creating-a-project-through-oidc.md
+++ b/docs/user/trusted-publishers/creating-a-project-through-oidc.md
@@ -75,6 +75,11 @@ provide the name of the PyPI project that will be created.
 
 === "GitLab CI/CD"
 
+    !!! note
+
+        Currently, only projects hosted on <https://gitlab.com> are supported. Self-managed
+        instances are not supported.
+
      If you have a repository at
     `https://gitlab.com/namespace/sampleproject` with a release workflow at
     `release.yml` and an environment named `release` that you would like to publish

--- a/docs/user/trusted-publishers/troubleshooting.md
+++ b/docs/user/trusted-publishers/troubleshooting.md
@@ -43,6 +43,10 @@ endpoint:
 
   No other layouts are supported.
 
+* `invalid-payload` with `unknown trusted publishing issuer` error: the OIDC
+  provider that generated the token is not supported. This can happen when using
+  a self-managed GitLab instance, since currently only projects hosted on
+  <https://gitlab.com> are supported.
 * `invalid-token`: the OIDC token itself is either formatted incorrectly,
   has an invalid signature, is expired, etc. This encompasses pretty much
   any failure mode that can occur with an OIDC token (which is just a JWT)


### PR DESCRIPTION
Motivated by https://github.com/di/id/issues/216, the docs don't make explicit that Trusted Publishing with GitLab only works when using the official `gitlab.com` instance, and doesn't work with self-managed instances.

This changes the docs to clarify that. It also adds a section in the troubleshooting doc to identify the cause of the error generated by using a self-managed instance.

cc @di @woodruffw 