### PR TITLE
Only show GitHub Statistics header if there are details

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3079,7 +3079,7 @@ msgstr ""
 msgid "Project links"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:66
+#: warehouse/templates/includes/packaging/project-data.html:67
 msgid "GitHub Statistics"
 msgstr ""
 

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -63,8 +63,8 @@
   </ul>
 {% endif %}
 
-  <h6>{% trans %}GitHub Statistics{% endtrans %}</h6>
   {% if release.github_repo_info_url and release.github_open_issue_info_url %}
+  <h6>{% trans %}GitHub Statistics{% endtrans %}</h6>
   <div class="hidden github-repo-info" data-controller="github-repo-info">
     <ul class="vertical-tabs__list">
       <li>


### PR DESCRIPTION
Fixes a small bug where the heading would be displayed even if there weren't statistics.