### PR TITLE
Add `base_publisher_url` to file/release events.

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3255,6 +3255,9 @@ class TestFileUpload:
                 identity.username if test_with_user else "OpenID created token"
             ),
             "canonical_version": release.canonical_version,
+            "base_publisher_url": (
+                f"{identity.publisher.publisher_url()}" if not test_with_user else None
+            ),
             "publisher_url": (
                 f"{identity.publisher.publisher_url()}/commit/somesha"
                 if not test_with_user
@@ -3269,6 +3272,9 @@ class TestFileUpload:
                 identity.username if test_with_user else "OpenID created token"
             ),
             "canonical_version": release.canonical_version,
+            "base_publisher_url": (
+                f"{identity.publisher.publisher_url()}" if not test_with_user else None
+            ),
             "publisher_url": (
                 f"{identity.publisher.publisher_url()}/commit/somesha"
                 if not test_with_user

--- a/tests/unit/oidc/models/test_activestate.py
+++ b/tests/unit/oidc/models/test_activestate.py
@@ -84,6 +84,18 @@ class TestActiveStatePublisher:
 
         assert publisher.publisher_name == "ActiveState"
 
+    def test_base_publisher_url(self):
+        org_name = "fakeorg"
+        project_name = "fakeproject"
+        publisher = ActiveStatePublisher(
+            organization=org_name, activestate_project_name=project_name
+        )
+
+        assert (
+            publisher.base_publisher_url()
+            == f"https://platform.activestate.com/{org_name}/{project_name}"
+        )
+
     def test_publisher_url(self):
         org_name = "fakeorg"
         project_name = "fakeproject"

--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -96,6 +96,7 @@ class TestGitHubPublisher:
             assert getattr(publisher, claim_name) is not None
 
         assert str(publisher) == "fakeworkflow.yml"
+        assert publisher.base_publisher_url() == "https://github.com/fakeowner/fakerepo"
         assert publisher.publisher_url() == "https://github.com/fakeowner/fakerepo"
         assert (
             publisher.publisher_url({"sha": "somesha"})

--- a/tests/unit/oidc/models/test_gitlab.py
+++ b/tests/unit/oidc/models/test_gitlab.py
@@ -94,6 +94,7 @@ class TestGitLabPublisher:
             assert getattr(publisher, claim_name) is not None
 
         assert str(publisher) == "subfolder/fakeworkflow.yml"
+        assert publisher.base_publisher_url() == "https://gitlab.com/fakeowner/fakerepo"
         assert publisher.publisher_url() == "https://gitlab.com/fakeowner/fakerepo"
         assert (
             publisher.publisher_url({"sha": "somesha"})

--- a/tests/unit/oidc/models/test_google.py
+++ b/tests/unit/oidc/models/test_google.py
@@ -33,6 +33,11 @@ class TestGooglePublisher:
 
         assert publisher.publisher_name == "Google"
 
+    def test_base_publisher_url(self):
+        publisher = google.GooglePublisher(email="fake@example.com")
+
+        assert publisher.base_publisher_url() is None
+
     def test_publisher_url(self):
         publisher = google.GooglePublisher(email="fake@example.com")
 

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -763,7 +763,8 @@ class TestRelease:
         [
             ("xpto.com", "https://pub/url/", False),  # Totally different
             ("https://pub/", "https://pub/url/", False),  # Missing parts
-            ("https://pub/url/", "https://pub/url/", True),  # Exactly the same
+            ("https://pub/url/", "https://pub/url/", True),  # Exactly the same with /
+            ("https://pub/url", "https://pub/url", True),  # The same without /
             ("https://pub/url/blah.md", "https://pub/url/", True),  # Additonal parts
             ("https://pub/url", "https://pub/url/", True),  # Missing trailing slash
             ("https://pub/url/", "https://pub/url", True),  # Extratrailing slash

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -759,7 +759,7 @@ class TestRelease:
         assert release.trusted_published
 
     @pytest.mark.parametrize(
-        "url, publisher_url, expected",
+        "url, base_publisher_url, expected",
         [
             ("xpto.com", "https://pub/url/", False),  # Totally different
             ("https://pub/", "https://pub/url/", False),  # Missing parts
@@ -770,7 +770,7 @@ class TestRelease:
             ("https://pub/url/", "https://pub/url", True),  # Extratrailing slash
         ],
     )
-    def test_is_url_verified(self, db_session, url, publisher_url, expected):
+    def test_is_url_verified(self, db_session, url, base_publisher_url, expected):
         project = DBProjectFactory.create()
         release = DBReleaseFactory.create(project=project)
         release_file = DBFileFactory.create(
@@ -781,12 +781,12 @@ class TestRelease:
         DBFileEventFactory.create(
             source=release_file,
             tag="fake:event",
-            additional={"publisher_url": publisher_url},
+            additional={"base_publisher_url": base_publisher_url},
         )
         DBFileEventFactory.create(
             source=release_file,
             tag="fake:event",
-            additional={"publisher_url": publisher_url},
+            additional={"base_publisher_url": base_publisher_url},
         )
 
         assert project.is_verified_url(url) is expected

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -800,6 +800,11 @@ def file_upload(request):
                     request.user.username if request.user else "OpenID created token"
                 ),
                 "canonical_version": release.canonical_version,
+                "base_publisher_url": (
+                    request.oidc_publisher.base_publisher_url(request.oidc_claims)
+                    if request.oidc_publisher
+                    else None
+                ),
                 "publisher_url": (
                     request.oidc_publisher.publisher_url(request.oidc_claims)
                     if request.oidc_publisher
@@ -1120,6 +1125,11 @@ def file_upload(request):
                     request.user.username if request.user else "OpenID created token"
                 ),
                 "canonical_version": release.canonical_version,
+                "base_publisher_url": (
+                    request.oidc_publisher.base_publisher_url(request.oidc_claims)
+                    if request.oidc_publisher
+                    else None
+                ),
                 "publisher_url": (
                     request.oidc_publisher.publisher_url(request.oidc_claims)
                     if request.oidc_publisher

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -235,6 +235,16 @@ class OIDCPublisherMixin:
         # Only concrete subclasses are constructed.
         raise NotImplementedError
 
+    def base_publisher_url(
+        self, claims: SignedClaims | None = None
+    ) -> str | None:  # pragma: no cover
+        """
+        NOTE: This is **NOT** a `@property` because we pass `claims` to it.
+        When calling, make sure to use `publisher_url()`
+        """
+        # Only concrete subclasses are constructed.
+        raise NotImplementedError
+
     def publisher_url(
         self, claims: SignedClaims | None = None
     ) -> str | None:  # pragma: no cover

--- a/warehouse/oidc/models/activestate.py
+++ b/warehouse/oidc/models/activestate.py
@@ -118,10 +118,13 @@ class ActiveStatePublisherMixin:
     def project(self) -> str:
         return self.activestate_project_name
 
-    def publisher_url(self, claims: SignedClaims | None = None) -> str:
+    def base_publisher_url(self, claims: SignedClaims | None = None) -> str:
         return urllib.parse.urljoin(
             _ACTIVESTATE_URL, f"{self.organization}/{self.activestate_project_name}"
         )
+
+    def publisher_url(self, claims: SignedClaims | None = None) -> str:
+        return self.base_publisher_url(claims)
 
     def stored_claims(self, claims=None):
         return {}

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -227,8 +227,11 @@ class GitHubPublisherMixin:
     def sub(self):
         return f"repo:{self.repository}"
 
+    def base_publisher_url(self, claims=None):
+        return f"https://github.com/{self.repository}"
+
     def publisher_url(self, claims=None):
-        base = f"https://github.com/{self.repository}"
+        base = self.base_publisher_url(claims)
         sha = claims.get("sha") if claims else None
 
         if sha:

--- a/warehouse/oidc/models/gitlab.py
+++ b/warehouse/oidc/models/gitlab.py
@@ -221,8 +221,11 @@ class GitLabPublisherMixin:
     def publisher_name(self):
         return "GitLab"
 
+    def base_publisher_url(self, claims=None):
+        return f"https://gitlab.com/{self.project_path}"
+
     def publisher_url(self, claims=None):
-        base = f"https://gitlab.com/{self.project_path}"
+        base = self.base_publisher_url(claims)
         return f"{base}/commit/{claims['sha']}" if claims else base
 
     def stored_claims(self, claims=None):

--- a/warehouse/oidc/models/google.py
+++ b/warehouse/oidc/models/google.py
@@ -81,6 +81,9 @@ class GooglePublisherMixin:
     def publisher_name(self):
         return "Google"
 
+    def base_publisher_url(self, claims=None):
+        return None
+
     def publisher_url(self, claims=None):
         return None
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -411,7 +411,7 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
             .filter(Project.id == self.id)
             .filter(
                 literal(url).ilike(
-                    File.Event.additional.op("->>")("publisher_url") + "%"
+                    File.Event.additional.op("->>")("base_publisher_url") + "%"
                 )
             )
             .first()


### PR DESCRIPTION
This fixes an issue with #15862, where the `publisher_url` for _most_ events contained a commit SHA, and therefore had additional parts that made it hard to compare with project URLs.

The workaround is to introduce a `base_publisher_url` additional field that represents the unique "root" of the publisher for all publishers (i.e. the github repo) which we can use to compare to project URLs to verify them.

This means that these links will become verified only once a new event is published with this additional field, which should slowly happen over time.

To speed this up, we _could_ do a one-off data migration to add `base_publisher_url` to existing events, but I think this should be fine as-is.