### PR TITLE
Remove deprecated `version` property from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 volumes:
   simple:
   packages:


### PR DESCRIPTION
Currently, running any of the `make` commands that make use of `docker compose` shows the following warning:
```
WARN[0000] /warehouse/docker-compose.yml: `version` is obsolete 
```

The `version` property [has been deprecated](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete) and `compose` does not use it to validate the `docker-compose.yml` file.

See [this issue](https://github.com/docker/compose/issues/11628) for more context.

cc @miketheman @woodruffw 