### PR TITLE
Remove `repository-service-tuf` dependency from dev.txt

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,4 +3,3 @@ hupper>=1.9
 pip-tools>=1.0
 pyramid_debugtoolbar>=2.5
 pip-api
-repository-service-tuf


### PR DESCRIPTION
~While working on https://github.com/pypi/warehouse/issues/15871, which includes adding `sigstore` as a dependency to `warehouse` (in order to be able to verify attestations), the following dependency conflict came up:~

~The latest version of `repository-service-tuf` (included in `requirements/dev.txt`) [pins](https://github.com/repository-service-tuf/repository-service-tuf-cli/blob/93b88c098a34a2a5f839b1f1be5a8e372d3a8644/requirements.txt#L24) `tuf==3.1.0` as a dependency.
Whereas `sigstore` [requires](https://github.com/sigstore/sigstore-python/blob/3a19f8878a9659f40451560a01f14e2e9b5adb33/pyproject.toml#L41) `tuf~=4.0.0`, creating a conflict.~

~The current PR adding `sigstore` as a dependency is [currently a draft](https://github.com/pypi/warehouse/pull/15952) due to having to comment out the `repository-service-tuf` dependency to avoid the conflict.~

While the conflict mentioned above was solved by `repository-service-tuf==0.12.0b1`, this newly released version has another conflict with `warehouse`, this time with `securesystemslib`:

```
 repository-service-tuf 0.12.0b1 has requirement securesystemslib[crypto]<1.0.0,>=0.31.0, but you have securesystemslib 1.0.0.
```

`warehouse` depends on `securesystemslib==1.0.0` via `boto3`, whereas `repository-service-tuf` requires `<1.0.0`:
```
    # via boto3
securesystemslib==1.0.0 \
    --hash=sha256:50f5053e274066502da7785dfd12b21e61131ca6e8b57ecedd2da0d1e9cd66c1 \
    --hash=sha256:a6d118c24eae8227a1cf2d9c173f47956709958f601eeaa38e86f6505a31455e
```

This PR removes `repository-service-tuf` from the `dev.txt` dependencies.

cc @woodruffw @di @kairoaraujo 