### PR TITLE
fix: add hostname to URLs generated in email

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1911,7 +1911,7 @@ msgid ""
 "\"%(previous_organization_name)s\" to \"%(organization_name)s\"."
 msgstr ""
 
-#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:19
+#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:20
 #, python-format
 msgid ""
 "An API token belonging to user <a "
@@ -1922,7 +1922,7 @@ msgid ""
 "Trusted Publisher to publish."
 msgstr ""
 
-#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:32
+#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:33
 #, python-format
 msgid ""
 "If you are the owner of this token, you can delete it by going to your <a"
@@ -1930,7 +1930,7 @@ msgid ""
 "the token named <strong>%(token_name)s</strong>."
 msgstr ""
 
-#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:39
+#: warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html:40
 #, python-format
 msgid ""
 "If you believe this was done in error, you can email <a "

--- a/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html
+++ b/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.html
@@ -13,12 +13,13 @@
 -#}
 {% extends "email/_base/body.html" %}
 
+{% set domain = request.registry.settings.get('warehouse.domain') %}
 
 {% block content %}
   <p>
     {% trans token_owner_username=token_owner_username, project_name=project_name,
-    account_href=request.route_url('accounts.profile', username=token_owner_username),
-    project_href=request.route_url('packaging.project', name=project_name)
+    account_href=request.route_url('accounts.profile', username=token_owner_username, _host=domain),
+    project_href=request.route_url('packaging.project', name=project_name, _host=domain)
     %}
       An API token belonging to user <a href="{{ account_href }}">{{ token_owner_username }}</a>
       was used to upload files to the project
@@ -29,7 +30,7 @@
     {% endtrans %}
   </p>
   <p>
-    {% trans href=request.route_url('manage.account'), token_name=token_name %}
+    {% trans href=request.route_url('manage.account', _host=domain), token_name=token_name %}
       If you are the owner of this token, you can delete it by going to your
       <a href="{{ href }}#api-tokens">API tokens configuration</a> and deleting the token named
       <strong>{{ token_name }}</strong>.

--- a/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.txt
+++ b/warehouse/templates/email/api-token-used-in-trusted-publisher-project/body.txt
@@ -13,10 +13,12 @@
 -#}
 {% extends "email/_base/body.txt" %}
 
+{% set domain = request.registry.settings.get('warehouse.domain') %}
+
 {% block content %}
   {% trans token_owner_username=token_owner_username, project_name=project_name,
-     account_href=request.route_url('accounts.profile', username=token_owner_username),
-     project_href=request.route_url('packaging.project', name=project_name)
+     account_href=request.route_url('accounts.profile', username=token_owner_username, _host=domain),
+     project_href=request.route_url('packaging.project', name=project_name, _host=domain)
   %}
     An API token belonging to user {{ token_owner_username }} ({{ account_href }})
     was used to upload files to the project {{ project_name }} ({{ project_href }}),
@@ -25,7 +27,7 @@
     We recommend removing the API token and only using the Trusted Publisher to publish.
   {% endtrans %}
 
-  {% trans href=request.route_url('manage.account'), token_name=token_name %}
+  {% trans href=request.route_url('manage.account', _host=domain), token_name=token_name %}
     If you are the owner of this token, you can delete it by going to your API tokens
     configuration at {{ href }} and deleting the token named {{ token_name }}.
   {% endtrans %}


### PR DESCRIPTION
Since this email is triggered during upload, the resulting domain sent
to users is broken, as it's using `uploads.pypi.org` which this domain
doesn't support.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>