### PR TITLE
Add comments explaining GitHub's `job_workflow_ref` claim behavior

### DIFF
--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -39,7 +39,7 @@ def _check_repository(ground_truth, signed_claim, all_signed_claims):
 def _check_job_workflow_ref(ground_truth, signed_claim, all_signed_claims):
     # We expect a string formatted as follows:
     #   OWNER/REPO/.github/workflows/WORKFLOW.yml@REF
-    # where REF is the value of the `ref` claim.
+    # where REF is the value of either the `ref` or `sha` claims.
 
     # Defensive: GitHub should never give us an empty job_workflow_ref,
     # but we check for one anyways just in case.
@@ -47,6 +47,11 @@ def _check_job_workflow_ref(ground_truth, signed_claim, all_signed_claims):
         raise InvalidPublisherError("The job_workflow_ref claim is empty")
 
     # We need at least one of these to be non-empty
+    # In most cases, the `ref` claim will be present (e.g: "refs/heads/main")
+    # and used in `job_workflow_ref`. However, there are certain cases
+    # (such as creating a GitHub deployment tied to a specific commit SHA), where
+    # a workflow triggered by that deployment will have an empty `ref` claim, and
+    # the `job_workflow_ref` claim will use the `sha` claim instead.
     ref = all_signed_claims.get("ref")
     sha = all_signed_claims.get("sha")
     if not (ref or sha):


### PR DESCRIPTION
The `job_workflow_ref` claim included in GitHub's OIDC tokens is usually something like:
```json
{
  "job_workflow_ref": "org/repository/.github/workflows/release.yml@refs/heads/main"
}
```

Where the last component (`refs/heads/main`) is the same as the `ref` claim, usually the name of a branch or tag.

However, the logic we use to check the claims assumes that last component could also be a commit SHA (the same as the `sha` claim):

https://github.com/pypi/warehouse/blob/15a9a6c39b1bc40f3dbc67b74b86dc0a104b7d44/warehouse/oidc/models/github.py#L55-L60

but there was no explanation of when a SHA would be used instead of the normal `ref`. The [original PR](https://github.com/pypi/warehouse/pull/14335) that introduces this logic mentions that both `ref` and `sha` terminations had been observed, but it was unclear why/when this happened.

This PR adds a comment explaining one of the cases where the `ref` claim will be empty, and the `job_workflow_ref` claim will use the SHA instead.

cc @woodruffw @di 