### PR TITLE
add clickpy as option for analytics

### DIFF
--- a/warehouse/templates/includes/accounts/profile-actions.html
+++ b/warehouse/templates/includes/accounts/profile-actions.html
@@ -18,8 +18,8 @@
   <div class="sidebar-section">
     <h3 class="sidebar-section__title">{% trans %}Statistics{% endtrans %}</h3>
     <p>
-      {% trans libs_io_href='https://libraries.io/', title=gettext('External link'), gbq_href='https://packaging.python.org/guides/analyzing-pypi-package-downloads/' %}
-        View statistics for your projects via <a href="{{ libs_io_href }}" title="{{ title }}" target="_blank" rel="noopener">Libraries.io</a>, or by using <a href="{{ gbq_href }}" target="_blank" rel="noopener">our public dataset on Google BigQuery</a>
+      {% trans libs_io_href='https://libraries.io/', title=gettext('External link'), clickpy_href='https://clickpy.clickhouse.com/{project_name}'.format(project_name=release.project.name), gbq_href='https://packaging.python.org/guides/analyzing-pypi-package-downloads/' %}
+        View statistics for your projects via <a href="{{ libs_io_href }}" title="{{ title }}" target="_blank" rel="noopener">Libraries.io</a>, <a href="{{ clickpy_href }}" title="{{ title }}" target="_blank" rel="noopener">clickpy.clickhouse.com</a>, or by using <a href="{{ gbq_href }}" target="_blank" rel="noopener">our public dataset on Google BigQuery</a>
       {% endtrans %}
     </p>
   </div>

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -103,8 +103,8 @@
   </div>
   {% endif %}
   <p>
-    {% trans libs_io_href='https://libraries.io/pypi/{project_name}'.format(project_name=release.project.name), gbq_href='https://packaging.python.org/guides/analyzing-pypi-package-downloads/', title=gettext('External link') %}
-      View statistics for this project via <a href="{{ libs_io_href }}" title="{{ title }}" target="_blank" rel="noopener">Libraries.io</a>, or by using <a href="{{ gbq_href }}" target="_blank" rel="noopener">our public dataset on Google BigQuery</a>
+    {% trans libs_io_href='https://libraries.io/pypi/{project_name}'.format(project_name=release.project.name), clickpy_href='https://clickpy.clickhouse.com/{project_name}'.format(project_name=release.project.name), gbq_href='https://packaging.python.org/guides/analyzing-pypi-package-downloads/', title=gettext('External link') %}
+      View statistics for this project via <a href="{{ libs_io_href }}" title="{{ title }}" target="_blank" rel="noopener">Libraries.io</a>, <a href="{{ clickpy_href }}" title="{{ title }}" target="_blank" rel="noopener">clickpy.clickhouse.com</a>, or by using <a href="{{ gbq_href }}" target="_blank" rel="noopener">our public dataset on Google BigQuery</a>
     {% endtrans %}
   </p>
 


### PR DESCRIPTION
We are the maintainers of ClickHouse, the open source database, index the data for pypi daily and provide a free app and clickhouse service to query at clickpy.clickhouse.com.

We'd like to add this as a link. From what i can tell we also need to provide translations. Do we need to provide this for all languages?