### PR TITLE
Clarify that GitHub is not the sole Identity Provider

### DIFF
--- a/docs/user/trusted-publishers/using-a-publisher.md
+++ b/docs/user/trusted-publishers/using-a-publisher.md
@@ -108,9 +108,6 @@ below describe the setup process for each supported trusted publisher.
     2. Submit that token to PyPI, which will return a short-lived API key;
     3. Use that API key as you normally would (e.g. with `twine`)
 
-    While the examples below demonstrate using GitHub as an identity providers, 
-    this process is also compatible with the other identity providers.
-
     All code below assumes that it's being run in a GitHub Actions
     workflow runner with `id-token: write` permissions. That permission is
     **critical**; without it, GitHub Actions will refuse to give you an OIDC token.

--- a/docs/user/trusted-publishers/using-a-publisher.md
+++ b/docs/user/trusted-publishers/using-a-publisher.md
@@ -108,8 +108,8 @@ below describe the setup process for each supported trusted publisher.
     2. Submit that token to PyPI, which will return a short-lived API key;
     3. Use that API key as you normally would (e.g. with `twine`)
 
-    GitHub is currently the only OIDC identity provider supported, so we'll use it
-    for examples below.
+    While the examples below demonstrate using GitHub as an identity providers, 
+    this process is also compatible with the other identity providers.
 
     All code below assumes that it's being run in a GitHub Actions
     workflow runner with `id-token: write` permissions. That permission is


### PR DESCRIPTION
Since https://github.com/pypi/warehouse/commit/b00ec3eae7, the documentation for Trusted Publishers is slighty out-of-date.

Indeed, several Identity Providers are now supported ( Gitlab, Google Cloud...).

This PR reformulates the documentation to emphasize that the example in the doc is using GitHub only as a placeholder and not because it is the only identity provider.