### PR TITLE
Replaced DateTime utc method to timezone aware method

### DIFF
--- a/tests/common/db/ses.py
+++ b/tests/common/db/ses.py
@@ -25,7 +25,8 @@ class EmailMessageFactory(WarehouseFactory):
 
     created = factory.Faker(
         "date_time_between_dates",
-        datetime_start=datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=14),
+        datetime_start=datetime.datetime.now(datetime.UTC)
+        - datetime.timedelta(days=14),
     )
     message_id = factory.Faker("pystr", max_chars=12)
     from_ = factory.Faker("safe_email")
@@ -39,7 +40,8 @@ class EventFactory(WarehouseFactory):
 
     created = factory.Faker(
         "date_time_between_dates",
-        datetime_start=datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=14),
+        datetime_start=datetime.datetime.now(datetime.UTC)
+        - datetime.timedelta(days=14),
     )
     email = factory.SubFactory(EmailMessageFactory)
     event_id = factory.Faker("pystr", max_chars=12)

--- a/tests/common/db/ses.py
+++ b/tests/common/db/ses.py
@@ -25,7 +25,7 @@ class EmailMessageFactory(WarehouseFactory):
 
     created = factory.Faker(
         "date_time_between_dates",
-        datetime_start=datetime.datetime.utcnow() - datetime.timedelta(days=14),
+        datetime_start=datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=14),
     )
     message_id = factory.Faker("pystr", max_chars=12)
     from_ = factory.Faker("safe_email")
@@ -39,7 +39,7 @@ class EventFactory(WarehouseFactory):
 
     created = factory.Faker(
         "date_time_between_dates",
-        datetime_start=datetime.datetime.utcnow() - datetime.timedelta(days=14),
+        datetime_start=datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=14),
     )
     email = factory.SubFactory(EmailMessageFactory)
     event_id = factory.Faker("pystr", max_chars=12)

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -992,7 +992,7 @@ class TestDatabaseUserService:
         assert [c.id for c in initial_codes] != [c.id for c in new_codes]
 
     def test_get_password_timestamp(self, user_service):
-        create_time = datetime.datetime.utcnow()
+        create_time = datetime.datetime.now(datetime.UTC)
         with freezegun.freeze_time(create_time):
             user = UserFactory.create()
             user.password_date = create_time
@@ -1031,7 +1031,7 @@ class TestTokenService:
         assert token_service.loads(token) == {"foo": "bar"}
 
     def test_loads_return_timestamp(self, token_service):
-        sign_time = pytz.UTC.localize(datetime.datetime.utcnow())
+        sign_time = pytz.UTC.localize(datetime.datetime.now(datetime.UTC))
         with freezegun.freeze_time(sign_time):
             token = token_service.dumps({"foo": "bar"})
 
@@ -1046,7 +1046,7 @@ class TestTokenService:
             token_service.loads(token)
 
     def test_loads_token_is_expired(self, token_service):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
 
         with freezegun.freeze_time(now) as frozen_time:
             token = token_service.dumps({"foo": "bar"})
@@ -1064,7 +1064,7 @@ class TestTokenService:
 
     def test_unsafe_load_payload(self, token_service):
         sign_time = pytz.UTC.localize(
-            datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
         )
         with freezegun.freeze_time(sign_time):
             token = token_service.dumps({"foo": "bar"})
@@ -1076,7 +1076,7 @@ class TestTokenService:
 
     def test_unsafe_load_payload_signature_invalid(self, token_service):
         sign_time = pytz.UTC.localize(
-            datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
+            datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=10)
         )
         with freezegun.freeze_time(sign_time):
             token = services.TokenService("wrongsecret", "pepper", max_age=3600).dumps(

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -17,7 +17,6 @@ import freezegun
 import passlib.exc
 import pretend
 import pytest
-import pytz
 import requests
 
 from webauthn.helpers import bytes_to_base64url
@@ -1031,7 +1030,7 @@ class TestTokenService:
         assert token_service.loads(token) == {"foo": "bar"}
 
     def test_loads_return_timestamp(self, token_service):
-        sign_time = pytz.UTC.localize(datetime.datetime.now(datetime.UTC))
+        sign_time = datetime.datetime.now(datetime.UTC)
         with freezegun.freeze_time(sign_time):
             token = token_service.dumps({"foo": "bar"})
 
@@ -1063,9 +1062,7 @@ class TestTokenService:
             token_service.loads("invalid")
 
     def test_unsafe_load_payload(self, token_service):
-        sign_time = pytz.UTC.localize(
-            datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
-        )
+        sign_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
         with freezegun.freeze_time(sign_time):
             token = token_service.dumps({"foo": "bar"})
 
@@ -1075,9 +1072,7 @@ class TestTokenService:
         assert token_service.unsafe_load_payload(token) == {"foo": "bar"}
 
     def test_unsafe_load_payload_signature_invalid(self, token_service):
-        sign_time = pytz.UTC.localize(
-            datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=10)
-        )
+        sign_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=10)
         with freezegun.freeze_time(sign_time):
             token = services.TokenService("wrongsecret", "pepper", max_age=3600).dumps(
                 {"foo": "bar"}

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -14,12 +14,9 @@ import datetime
 import json
 import uuid
 
-from datetime import timedelta
-
 import freezegun
 import pretend
 import pytest
-import pytz
 
 from pyramid.httpexceptions import (
     HTTPBadRequest,
@@ -503,7 +500,9 @@ class TestLogin:
 class TestTwoFactor:
     def test_get_two_factor_data_invalid_after_login(self, pyramid_request):
         sign_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=30)
-        last_login_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=1)
+        last_login_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            seconds=1
+        )
 
         query_params = {"userid": 1}
         token_service = pretend.stub(
@@ -555,7 +554,8 @@ class TestTwoFactor:
             name="Joe",
             password="any",
             is_active=True,
-            last_login=datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=+1),
+            last_login=datetime.datetime.now(datetime.UTC)
+            + datetime.timedelta(days=+1),
         )
         token_data = {"userid": user.id}
 
@@ -587,7 +587,10 @@ class TestTwoFactor:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
+                lambda *args, **kwargs: (
+                    query_params,
+                    datetime.datetime.now(datetime.UTC),
+                )
             )
         )
 
@@ -595,7 +598,9 @@ class TestTwoFactor:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
+                    last_login=(
+                        datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+                    )
                 )
             ),
             update_user=lambda *a, **k: None,
@@ -640,7 +645,10 @@ class TestTwoFactor:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
+                lambda *args, **kwargs: (
+                    query_params,
+                    datetime.datetime.now(datetime.UTC),
+                )
             )
         )
 
@@ -648,7 +656,9 @@ class TestTwoFactor:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
+                    last_login=(
+                        datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+                    )
                 )
             ),
             update_user=lambda *a, **k: None,
@@ -681,7 +691,10 @@ class TestTwoFactor:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
+                lambda *args, **kwargs: (
+                    query_params,
+                    datetime.datetime.now(datetime.UTC),
+                )
             )
         )
 
@@ -689,7 +702,9 @@ class TestTwoFactor:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
+                    last_login=(
+                        datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+                    )
                 )
             ),
             update_user=lambda *a, **k: None,
@@ -737,12 +752,17 @@ class TestTwoFactor:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
+                lambda *args, **kwargs: (
+                    query_params,
+                    datetime.datetime.now(datetime.UTC),
+                )
             )
         )
 
         user = pretend.stub(
-            last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)),
+            last_login=(
+                datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+            ),
             has_recovery_codes=has_recovery_codes,
             record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
@@ -843,14 +863,19 @@ class TestTwoFactor:
         token_data = {"userid": 1}
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (token_data, datetime.datetime.now(datetime.UTC))
+                lambda *args, **kwargs: (
+                    token_data,
+                    datetime.datetime.now(datetime.UTC),
+                )
             )
         )
 
         user_service = pretend.stub(
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
+                    last_login=(
+                        datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+                    )
                 )
             ),
             has_totp=lambda userid: True,
@@ -1173,7 +1198,11 @@ class TestRememberDevice:
                 record_event=pretend.call_recorder(lambda *a, **kw: None)
             ),
             registry=pretend.stub(
-                settings={"remember_device.seconds": timedelta(days=30).total_seconds()}
+                settings={
+                    "remember_device.seconds": datetime.timedelta(
+                        days=30
+                    ).total_seconds()
+                }
             ),
         )
         response = pretend.stub(set_cookie=pretend.call_recorder(lambda *a, **kw: None))
@@ -1184,7 +1213,7 @@ class TestRememberDevice:
             pretend.call(
                 REMEMBER_DEVICE_COOKIE,
                 "token_data",
-                max_age=timedelta(days=30).total_seconds(),
+                max_age=datetime.timedelta(days=30).total_seconds(),
                 httponly=True,
                 secure=True,
                 samesite=b"strict",
@@ -1230,7 +1259,10 @@ class TestRecoveryCode:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
+                lambda *args, **kwargs: (
+                    query_params,
+                    datetime.datetime.now(datetime.UTC),
+                )
             )
         )
 
@@ -1238,7 +1270,9 @@ class TestRecoveryCode:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
+                    last_login=(
+                        datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+                    )
                 )
             ),
             update_user=lambda *a, **k: None,
@@ -1282,12 +1316,17 @@ class TestRecoveryCode:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
+                lambda *args, **kwargs: (
+                    query_params,
+                    datetime.datetime.now(datetime.UTC),
+                )
             )
         )
 
         user = pretend.stub(
-            last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)),
+            last_login=(
+                datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+            ),
             record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         user_service = pretend.stub(
@@ -1371,7 +1410,10 @@ class TestRecoveryCode:
         token_data = {"userid": 1}
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (token_data, datetime.datetime.now(datetime.UTC))
+                lambda *args, **kwargs: (
+                    token_data,
+                    datetime.datetime.now(datetime.UTC),
+                )
             )
         )
 
@@ -1379,7 +1421,9 @@ class TestRecoveryCode:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
+                    last_login=(
+                        datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+                    )
                 )
             ),
             has_recovery_codes=lambda userid: True,
@@ -2284,7 +2328,7 @@ class TestResetPassword:
         assert user_service.get_user.calls == [pretend.call(uuid.UUID(data["user.id"]))]
 
     def test_reset_password_last_login_changed(self, pyramid_request):
-        now = pytz.UTC.localize(datetime.datetime.now(datetime.UTC))
+        now = datetime.datetime.now(datetime.UTC)
         later = now + datetime.timedelta(hours=1)
         data = {
             "action": "password-reset",
@@ -2316,7 +2360,7 @@ class TestResetPassword:
         ]
 
     def test_reset_password_password_date_changed(self, pyramid_request):
-        now = pytz.UTC.localize(datetime.datetime.now(datetime.UTC))
+        now = datetime.datetime.now(datetime.UTC)
         later = now + datetime.timedelta(hours=1)
         data = {
             "action": "password-reset",

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -333,7 +333,7 @@ class TestLogin:
 
         pyramid_request.route_path = pretend.call_recorder(lambda a: "/the-redirect")
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
 
         with freezegun.freeze_time(now):
             result = views.login(pyramid_request, _form_class=form_class)
@@ -502,8 +502,8 @@ class TestLogin:
 
 class TestTwoFactor:
     def test_get_two_factor_data_invalid_after_login(self, pyramid_request):
-        sign_time = datetime.datetime.utcnow() - datetime.timedelta(seconds=30)
-        last_login_time = datetime.datetime.utcnow() - datetime.timedelta(seconds=1)
+        sign_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=30)
+        last_login_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=1)
 
         query_params = {"userid": 1}
         token_service = pretend.stub(
@@ -555,7 +555,7 @@ class TestTwoFactor:
             name="Joe",
             password="any",
             is_active=True,
-            last_login=datetime.datetime.utcnow() + datetime.timedelta(days=+1),
+            last_login=datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=+1),
         )
         token_data = {"userid": user.id}
 
@@ -587,7 +587,7 @@ class TestTwoFactor:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.utcnow())
+                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
             )
         )
 
@@ -595,7 +595,7 @@ class TestTwoFactor:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1))
+                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
                 )
             ),
             update_user=lambda *a, **k: None,
@@ -640,7 +640,7 @@ class TestTwoFactor:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.utcnow())
+                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
             )
         )
 
@@ -648,7 +648,7 @@ class TestTwoFactor:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1))
+                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
                 )
             ),
             update_user=lambda *a, **k: None,
@@ -681,7 +681,7 @@ class TestTwoFactor:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.utcnow())
+                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
             )
         )
 
@@ -689,7 +689,7 @@ class TestTwoFactor:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1))
+                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
                 )
             ),
             update_user=lambda *a, **k: None,
@@ -737,12 +737,12 @@ class TestTwoFactor:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.utcnow())
+                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
             )
         )
 
         user = pretend.stub(
-            last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1)),
+            last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)),
             has_recovery_codes=has_recovery_codes,
             record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
@@ -843,14 +843,14 @@ class TestTwoFactor:
         token_data = {"userid": 1}
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (token_data, datetime.datetime.utcnow())
+                lambda *args, **kwargs: (token_data, datetime.datetime.now(datetime.UTC))
             )
         )
 
         user_service = pretend.stub(
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1))
+                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
                 )
             ),
             has_totp=lambda userid: True,
@@ -1230,7 +1230,7 @@ class TestRecoveryCode:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.utcnow())
+                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
             )
         )
 
@@ -1238,7 +1238,7 @@ class TestRecoveryCode:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1))
+                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
                 )
             ),
             update_user=lambda *a, **k: None,
@@ -1282,12 +1282,12 @@ class TestRecoveryCode:
 
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (query_params, datetime.datetime.utcnow())
+                lambda *args, **kwargs: (query_params, datetime.datetime.now(datetime.UTC))
             )
         )
 
         user = pretend.stub(
-            last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1)),
+            last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)),
             record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
         user_service = pretend.stub(
@@ -1371,7 +1371,7 @@ class TestRecoveryCode:
         token_data = {"userid": 1}
         token_service = pretend.stub(
             loads=pretend.call_recorder(
-                lambda *args, **kwargs: (token_data, datetime.datetime.utcnow())
+                lambda *args, **kwargs: (token_data, datetime.datetime.now(datetime.UTC))
             )
         )
 
@@ -1379,7 +1379,7 @@ class TestRecoveryCode:
             find_userid=pretend.call_recorder(lambda username: 1),
             get_user=pretend.call_recorder(
                 lambda userid: pretend.stub(
-                    last_login=(datetime.datetime.utcnow() - datetime.timedelta(days=1))
+                    last_login=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1))
                 )
             ),
             has_recovery_codes=lambda userid: True,
@@ -2089,7 +2089,7 @@ class TestResetPassword:
         )
         db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
 
         with freezegun.freeze_time(now):
             result = views.reset_password(db_request, _form_class=form_class)
@@ -2284,7 +2284,7 @@ class TestResetPassword:
         assert user_service.get_user.calls == [pretend.call(uuid.UUID(data["user.id"]))]
 
     def test_reset_password_last_login_changed(self, pyramid_request):
-        now = pytz.UTC.localize(datetime.datetime.utcnow())
+        now = pytz.UTC.localize(datetime.datetime.now(datetime.UTC))
         later = now + datetime.timedelta(hours=1)
         data = {
             "action": "password-reset",
@@ -2316,7 +2316,7 @@ class TestResetPassword:
         ]
 
     def test_reset_password_password_date_changed(self, pyramid_request):
-        now = pytz.UTC.localize(datetime.datetime.utcnow())
+        now = pytz.UTC.localize(datetime.datetime.now(datetime.UTC))
         later = now + datetime.timedelta(hours=1)
         data = {
             "action": "password-reset",

--- a/tests/unit/email/ses/test_tasks.py
+++ b/tests/unit/email/ses/test_tasks.py
@@ -19,7 +19,7 @@ from ....common.db.ses import EmailMessageFactory
 
 
 def test_cleanup_cleans_correctly(db_request):
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.UTC)
 
     EmailMessageFactory.create(
         status="Delivered",

--- a/tests/unit/integration/vulnerabilities/test_tasks.py
+++ b/tests/unit/integration/vulnerabilities/test_tasks.py
@@ -110,7 +110,7 @@ def test_analyze_vulnerability_update_metadata(db_request, metrics):
 
     metrics.increment.calls = []  # reset
 
-    withdrawn_date = datetime.datetime.utcnow()
+    withdrawn_date = datetime.datetime.now(datetime.UTC)
 
     tasks.analyze_vulnerability_task(
         request=db_request,

--- a/tests/unit/manage/views/test_organizations.py
+++ b/tests/unit/manage/views/test_organizations.py
@@ -1747,7 +1747,7 @@ class TestManageOrganizationRoles:
             "organizations_with_sole_owner": [],
         }
 
-    @freeze_time(datetime.datetime.utcnow())
+    @freeze_time(datetime.datetime.now(datetime.UTC))
     @pytest.mark.parametrize("orgtype", list(OrganizationType))
     def test_post_new_organization_role(
         self,
@@ -2016,7 +2016,7 @@ class TestManageOrganizationRoles:
         ]
         assert isinstance(result, HTTPSeeOther)
 
-    @freeze_time(datetime.datetime.utcnow())
+    @freeze_time(datetime.datetime.now(datetime.UTC))
     def test_reinvite_organization_role_after_expiration(
         self,
         db_request,
@@ -2147,7 +2147,7 @@ class TestManageOrganizationRoles:
 
 
 class TestResendOrganizationInvitations:
-    @freeze_time(datetime.datetime.utcnow())
+    @freeze_time(datetime.datetime.now(datetime.UTC))
     def test_resend_invitation(
         self, db_request, token_service, enable_organizations, monkeypatch
     ):

--- a/tests/unit/metrics/test_event_handlers.py
+++ b/tests/unit/metrics/test_event_handlers.py
@@ -28,7 +28,7 @@ from warehouse.metrics.event_handlers import (
 
 
 def test_time_ms():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.UTC)
     with freezegun.freeze_time(now):
         assert time_ms() == now.timestamp() * 1000
 
@@ -36,7 +36,7 @@ def test_time_ms():
 def test_on_new_request(pyramid_request):
     assert not hasattr(pyramid_request, "timings")
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.UTC)
     with freezegun.freeze_time(now):
         on_new_request(pretend.stub(request=pyramid_request))
 
@@ -44,7 +44,7 @@ def test_on_new_request(pyramid_request):
 
 
 def test_on_before_traversal(pyramid_request, metrics):
-    new_request = datetime.datetime.utcnow()
+    new_request = datetime.datetime.now(datetime.UTC)
     route_match_duration = new_request + datetime.timedelta(seconds=1)
 
     pyramid_request.timings = {"new_request_start": new_request.timestamp() * 1000}
@@ -65,7 +65,7 @@ def test_on_before_traversal(pyramid_request, metrics):
 
 
 def test_on_context_found(pyramid_request, metrics):
-    new_request = datetime.datetime.utcnow()
+    new_request = datetime.datetime.now(datetime.UTC)
     traversal_duration = new_request + datetime.timedelta(seconds=2)
     view_code_start = new_request + datetime.timedelta(seconds=2)
 
@@ -87,7 +87,7 @@ def test_on_context_found(pyramid_request, metrics):
 
 class TestOnBeforeRender:
     def test_without_view_duration(self, pyramid_request, metrics):
-        before_render_start = datetime.datetime.utcnow()
+        before_render_start = datetime.datetime.now(datetime.UTC)
 
         pyramid_request.timings = {}
         pyramid_request.matched_route = None
@@ -107,7 +107,7 @@ class TestOnBeforeRender:
     def test_with_view_duration(
         self, pyramid_request, metrics, matched_route, route_tag
     ):
-        view_code_start = datetime.datetime.utcnow()
+        view_code_start = datetime.datetime.now(datetime.UTC)
         before_render_start = view_code_start + datetime.timedelta(seconds=1.5)
 
         pyramid_request.timings = {
@@ -137,7 +137,7 @@ class TestOnNewResponse:
     def test_without_route(self, pyramid_request, metrics):
         response = pretend.stub(status_code="200")
 
-        new_request = datetime.datetime.utcnow()
+        new_request = datetime.datetime.now(datetime.UTC)
         new_response = new_request + datetime.timedelta(seconds=1)
 
         pyramid_request.timings = {"new_request_start": new_request.timestamp() * 1000}
@@ -161,7 +161,7 @@ class TestOnNewResponse:
     def test_without_render(self, pyramid_request, metrics):
         response = pretend.stub(status_code="200")
 
-        new_request = datetime.datetime.utcnow()
+        new_request = datetime.datetime.now(datetime.UTC)
         new_response = new_request + datetime.timedelta(seconds=1)
 
         pyramid_request.timings = {"new_request_start": new_request.timestamp() * 1000}
@@ -185,7 +185,7 @@ class TestOnNewResponse:
     def test_with_render(self, pyramid_request, metrics):
         response = pretend.stub(status_code="200")
 
-        new_request = datetime.datetime.utcnow()
+        new_request = datetime.datetime.now(datetime.UTC)
         before_render = new_request + datetime.timedelta(seconds=1)
         new_response = new_request + datetime.timedelta(seconds=2)
 

--- a/tests/unit/sitemap/test_views.py
+++ b/tests/unit/sitemap/test_views.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, timedelta
+import datetime
 
 import pretend
 import pytest
@@ -29,14 +29,20 @@ def test_sitemap_index(db_request):
     )
 
     project = ProjectFactory.create(
-        name="foobar", created=(datetime.utcnow() - timedelta(days=15))
+        name="foobar",
+        created=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=15)),
     )
     users = [
         UserFactory.create(
-            username="a", date_joined=(datetime.utcnow() - timedelta(days=15))
+            username="a",
+            date_joined=(
+                datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=15)
+            ),
         ),
         UserFactory.create(username="b"),
-        UserFactory.create(username="c", date_joined=(datetime.utcnow())),
+        UserFactory.create(
+            username="c", date_joined=(datetime.datetime.now(datetime.UTC))
+        ),
     ]
 
     # Have to pass this here, because passing date_joined=None to the create
@@ -69,7 +75,8 @@ def test_sitemap_bucket(db_request):
     db_request.matchdict["bucket"] = "0a"
 
     ProjectFactory.create(
-        name="foobar", created=(datetime.utcnow() - timedelta(days=15))
+        name="foobar",
+        created=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=15)),
     )
     UserFactory.create(username="a")
     UserFactory.create(username="b")
@@ -91,7 +98,9 @@ def test_sitemap_bucket_too_many(monkeypatch, db_request):
     monkeypatch.setattr(sitemap, "SITEMAP_MAXSIZE", 2)
 
     for _ in range(3):
-        p = ProjectFactory.create(created=(datetime.utcnow() - timedelta(days=15)))
+        p = ProjectFactory.create(
+            created=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=15))
+        )
         p.sitemap_bucket = "52"
 
     db_request.db.flush()

--- a/tests/unit/utils/db/test_types.py
+++ b/tests/unit/utils/db/test_types.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from datetime import datetime
+import datetime
 
 import pytz
 
@@ -20,7 +20,7 @@ from warehouse.utils.db.types import TZDateTime
 
 def test_tzdatetime_bind_nonnaive_datetime():
     dt_field = TZDateTime()
-    utc_datetime = pytz.UTC.localize(datetime.utcnow())
+    utc_datetime = pytz.UTC.localize(datetime.datetime.now())
     assert utc_datetime.tzinfo is not None
 
     naive_datetime = dt_field.process_bind_param(utc_datetime, dialect)
@@ -30,7 +30,7 @@ def test_tzdatetime_bind_nonnaive_datetime():
 
 def test_tzdatetime_bind_nonnaive_datetime_naive():
     dt_field = TZDateTime()
-    naive_datetime = datetime.utcnow()
+    naive_datetime = datetime.datetime.now()
     assert naive_datetime.tzinfo is None
 
     assert dt_field.process_bind_param(naive_datetime, dialect) is naive_datetime
@@ -44,7 +44,7 @@ def test_tzdatetime_bind_nonnaive_datetime_none():
 
 def test_tzdatetime_process_result_value():
     dt_field = TZDateTime()
-    naive_datetime = datetime.utcnow()
+    naive_datetime = datetime.datetime.now(datetime.UTC)
 
     utc_datetime = dt_field.process_result_value(naive_datetime, dialect)
     assert utc_datetime

--- a/tests/unit/utils/test_sns.py
+++ b/tests/unit/utils/test_sns.py
@@ -133,7 +133,9 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        )
                     ),
                     "TopicArn": "This is My Topic",
                 },
@@ -164,7 +166,8 @@ class TestMessageVerifier:
                     "MessageId": "1",
                     "Timestamp": (
                         (
-                            datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+                            datetime.datetime.now(datetime.UTC)
+                            - datetime.timedelta(days=1)
                         ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                     ),
                     "TopicArn": "This is My Topic",
@@ -181,7 +184,9 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        )
                     ),
                     "TopicArn": "This topic I got but didn't expect",
                 },
@@ -220,7 +225,9 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        )
                     ),
                     "TopicArn": "valid topic",
                 },
@@ -234,7 +241,9 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        )
                     ),
                     "TopicArn": "another valid topic",
                 },
@@ -249,7 +258,9 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        )
                     ),
                     "TopicArn": "valid topic",
                 },
@@ -265,7 +276,9 @@ class TestMessageVerifier:
                     "SubscribeURL": "https://example.com/subscribe",
                     "Token": "1234",
                     "Timestamp": (
-                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        )
                     ),
                     "TopicArn": "valid topic",
                 },

--- a/tests/unit/utils/test_sns.py
+++ b/tests/unit/utils/test_sns.py
@@ -133,7 +133,7 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                     ),
                     "TopicArn": "This is My Topic",
                 },
@@ -164,7 +164,7 @@ class TestMessageVerifier:
                     "MessageId": "1",
                     "Timestamp": (
                         (
-                            datetime.datetime.utcnow() - datetime.timedelta(days=1)
+                            datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
                         ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                     ),
                     "TopicArn": "This is My Topic",
@@ -181,7 +181,7 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                     ),
                     "TopicArn": "This topic I got but didn't expect",
                 },
@@ -220,7 +220,7 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                     ),
                     "TopicArn": "valid topic",
                 },
@@ -234,7 +234,7 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                     ),
                     "TopicArn": "another valid topic",
                 },
@@ -249,7 +249,7 @@ class TestMessageVerifier:
                     "Message": "This is My Message",
                     "MessageId": "1",
                     "Timestamp": (
-                        datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                     ),
                     "TopicArn": "valid topic",
                 },
@@ -265,7 +265,7 @@ class TestMessageVerifier:
                     "SubscribeURL": "https://example.com/subscribe",
                     "Token": "1234",
                     "Timestamp": (
-                        datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                        datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                     ),
                     "TopicArn": "valid topic",
                 },

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1366,7 +1366,7 @@ def _login_user(request, userid, two_factor_method=None, two_factor_label=None):
     # Whenever we log in the user, we want to update their user so that it
     # records when the last login was.
     user_service = request.find_service(IUserService, context=None)
-    user_service.update_user(userid, last_login=datetime.datetime.utcnow())
+    user_service.update_user(userid, last_login=datetime.datetime.now(datetime.UTC))
     user = user_service.get_user(userid)
     user.record_event(
         tag=EventTag.Account.LoginSuccess,

--- a/warehouse/email/ses/tasks.py
+++ b/warehouse/email/ses/tasks.py
@@ -40,6 +40,8 @@ def cleanup(request):
     # will not continue to save the email message data.
     (
         request.db.query(EmailMessage)
-        .filter(EmailMessage.created < (datetime.datetime.now(datetime.UTC) - CLEANUP_AFTER))
+        .filter(
+            EmailMessage.created < (datetime.datetime.now(datetime.UTC) - CLEANUP_AFTER)
+        )
         .delete(synchronize_session=False)
     )

--- a/warehouse/email/ses/tasks.py
+++ b/warehouse/email/ses/tasks.py
@@ -31,7 +31,7 @@ def cleanup(request):
         .filter(EmailMessage.status.in_(["Accepted", "Delivered"]))
         .filter(
             EmailMessage.created
-            < (datetime.datetime.utcnow() - CLEANUP_DELIVERED_AFTER)
+            < (datetime.datetime.now(datetime.UTC) - CLEANUP_DELIVERED_AFTER)
         )
         .delete(synchronize_session=False)
     )
@@ -40,6 +40,6 @@ def cleanup(request):
     # will not continue to save the email message data.
     (
         request.db.query(EmailMessage)
-        .filter(EmailMessage.created < (datetime.datetime.utcnow() - CLEANUP_AFTER))
+        .filter(EmailMessage.created < (datetime.datetime.now(datetime.UTC) - CLEANUP_AFTER))
         .delete(synchronize_session=False)
     )

--- a/warehouse/organizations/tasks.py
+++ b/warehouse/organizations/tasks.py
@@ -66,7 +66,7 @@ def delete_declined_organizations(request):
         .filter(
             Organization.is_active == False,  # noqa: E712
             Organization.is_approved == False,  # noqa: E712
-            Organization.date_approved < (datetime.datetime.utcnow() - CLEANUP_AFTER),
+            Organization.date_approved < (datetime.datetime.now(datetime.UTC) - CLEANUP_AFTER),
         )
         .all()
     )

--- a/warehouse/organizations/tasks.py
+++ b/warehouse/organizations/tasks.py
@@ -66,7 +66,8 @@ def delete_declined_organizations(request):
         .filter(
             Organization.is_active == False,  # noqa: E712
             Organization.is_approved == False,  # noqa: E712
-            Organization.date_approved < (datetime.datetime.now(datetime.UTC) - CLEANUP_AFTER),
+            Organization.date_approved
+            < (datetime.datetime.now(datetime.UTC) - CLEANUP_AFTER),
         )
         .all()
     )

--- a/warehouse/sitemap/views.py
+++ b/warehouse/sitemap/views.py
@@ -11,9 +11,8 @@
 # limitations under the License.
 
 import collections
+import datetime
 import itertools
-
-from datetime import datetime, timedelta
 
 from pyramid.view import view_config
 from sqlalchemy import func, or_
@@ -23,7 +22,7 @@ from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import Project
 
-AGE_BEFORE_INDEX = timedelta(days=14)
+AGE_BEFORE_INDEX = datetime.timedelta(days=14)
 SITEMAP_MAXSIZE = 50000
 
 
@@ -65,7 +64,9 @@ def sitemap_index(request):
         request.db.query(
             Project.sitemap_bucket, func.max(Project.created).label("modified")
         )
-        .filter(Project.created < datetime.utcnow() - AGE_BEFORE_INDEX)
+        .filter(
+            Project.created < datetime.datetime.now(datetime.UTC) - AGE_BEFORE_INDEX
+        )
         .group_by(Project.sitemap_bucket)
         .all()
     )
@@ -75,7 +76,8 @@ def sitemap_index(request):
         )
         .filter(
             or_(
-                User.date_joined < datetime.utcnow() - AGE_BEFORE_INDEX,
+                User.date_joined
+                < datetime.datetime.now(datetime.UTC) - AGE_BEFORE_INDEX,
                 User.date_joined.is_(None),
             )
         )
@@ -113,7 +115,9 @@ def sitemap_bucket(request):
 
     projects = (
         request.db.query(Project.normalized_name)
-        .filter(Project.created < datetime.utcnow() - AGE_BEFORE_INDEX)
+        .filter(
+            Project.created < datetime.datetime.now(datetime.UTC) - AGE_BEFORE_INDEX
+        )
         .filter(Project.sitemap_bucket == bucket)
         .all()
     )
@@ -122,7 +126,8 @@ def sitemap_bucket(request):
         .filter(User.sitemap_bucket == bucket)
         .filter(
             or_(
-                User.date_joined < datetime.utcnow() - AGE_BEFORE_INDEX,
+                User.date_joined
+                < datetime.datetime.now(datetime.UTC) - AGE_BEFORE_INDEX,
                 User.date_joined.is_(None),
             )
         )

--- a/warehouse/utils/sns.py
+++ b/warehouse/utils/sns.py
@@ -54,7 +54,7 @@ class MessageVerifier:
         try:
             timestamp = datetime.datetime.strptime(
                 timestamp_str, "%Y-%m-%dT%H:%M:%S.%fZ"
-            )
+            ).replace(tzinfo=datetime.UTC)
         except ValueError:
             raise InvalidMessageError("Unknown Timestamp format")
 

--- a/warehouse/utils/sns.py
+++ b/warehouse/utils/sns.py
@@ -49,7 +49,7 @@ class MessageVerifier:
             raise InvalidMessageError("Invalid TopicArn")
 
     def _validate_timestamp(self, timestamp_str):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
 
         try:
             timestamp = datetime.datetime.strptime(


### PR DESCRIPTION
The Following PR replaces the **datetime.datetime.utcnow()** method with **datetime.datetime.now(datetime.UTC)**

Fixes: #16146 