### PR TITLE
chore(dev): upgrade localstack image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,13 +33,11 @@ services:
     image: redis:7.0
 
   localstack:
-    image: localstack/localstack:1.4
+    image: localstack/localstack:3.5
     stop_signal: SIGKILL
     environment:
       SERVICES: "sqs"
-      HOSTNAME: "localstack"
-      HOSTNAME_EXTERNAL: "localstack"
-      DEFAULT_REGION: "us-east-2"
+      LOCALSTACK_HOST: "localstack"
       LS_LOG: "error"
     ports:
       - "4566:4566"


### PR DESCRIPTION
With the update to boto3/botocore, the protocol to interact with SQS no longer works in this old instance.

The config changes are noted from the "How to Migrate" section from the release notes for v2 and v3.

Refs: https://github.com/localstack/localstack/releases/tag/v2.0.0
Refs: https://github.com/localstack/localstack/releases/tag/v3.0.0