### PR TITLE
local development: add intervals to our hupper command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
   worker:
     image: warehouse:docker-compose
     pull_policy: never
-    command: hupper -m celery -A warehouse worker --beat --scheduler redbeat.RedBeatScheduler -l info
+    command: hupper --shutdown-interval 10 --reload-interval 10 -m celery -A warehouse worker --beat --scheduler redbeat.RedBeatScheduler -l info
     volumes:
       - ./warehouse:/opt/warehouse/src/warehouse:z
       - packages:/var/opt/warehouse/packages


### PR DESCRIPTION
while investigating something _entirely_ unrelated in another codebase, i recognized an issue with using hupper without these.

effectively this was leading to our local celery worker being shutdown too fast without cleaning up. these intervals give it a bit more time to cleanly shutdown before a new instance is created.