### PR TITLE
oidc/services: fix mischaracterized error

### DIFF
--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -13,11 +13,13 @@
 import jwt
 import pretend
 import pytest
+
 from cryptography.hazmat.primitives.asymmetric import rsa
 from jwt import DecodeError, PyJWK, PyJWTError, algorithms
 from zope.interface.verify import verifyClass
 
 import warehouse.utils.exceptions
+
 from tests.common.db.oidc import GitHubPublisherFactory, PendingGitHubPublisherFactory
 from warehouse.oidc import errors, interfaces, services
 

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -222,26 +222,13 @@ class OIDCPublisherService:
     def verify_jwt_signature(self, unverified_token: str) -> SignedClaims | None:
         try:
             key = self._get_key_for_token(unverified_token)
-        except Exception as e:
-            if isinstance(e, jwt.PyJWTError):
-                # The user might feed us an entirely nonsense JWT, e.g. one
-                # with missing components.
-                self.metrics.increment(
-                    "warehouse.oidc.verify_jwt_signature.malformed_jwt",
-                    tags=[f"publisher:{self.publisher}"],
-                )
-            else:
-                # Key retrieval can fail if JWK Set lookup fails for any reason.
-                self.metrics.increment(
-                    "warehouse.oidc.verify_jwt_signature.key_lookup_failure",
-                    tags=[f"publisher:{self.publisher}"],
-                )
-                with sentry_sdk.push_scope() as scope:
-                    scope.fingerprint = e
-                    sentry_sdk.capture_message(
-                        "verify_jwt_signature failed to obtain matching key for JWT: "
-                        f"{type(e).__name__}: {e}"
-                    )
+        except jwt.PyJWTError:
+            # The user might feed us an entirely nonsense JWT, e.g. one
+            # with missing components.
+            self.metrics.increment(
+                "warehouse.oidc.verify_jwt_signature.malformed_jwt",
+                tags=[f"publisher:{self.publisher}"],
+            )
             return None
 
         try:


### PR DESCRIPTION
This fixes a confusing error render, which previously assumed that all non-`PyJWTErrors` were really leaky exceptions from `pyjwt`'s APIs. This is true for the later-down callsite, but not for this one (where the leaky errors have been patched upstream, and any remaining errors are from sporadic Redis or JWK Set retrieval failures).

See: https://python-software-foundation.sentry.io/share/issue/c7d9e2b44bcb4e1da1cb722ac4c13256/