### PR TITLE
Remove view statistics blurb

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -773,11 +773,8 @@ msgstr ""
 #: warehouse/templates/base.html:319 warehouse/templates/base.html:320
 #: warehouse/templates/base.html:321 warehouse/templates/base.html:331
 #: warehouse/templates/base.html:344
-#: warehouse/templates/includes/accounts/profile-actions.html:21
-#: warehouse/templates/includes/accounts/profile-actions.html:30
 #: warehouse/templates/includes/accounts/profile-callout.html:18
 #: warehouse/templates/includes/hash-modal.html:23
-#: warehouse/templates/includes/packaging/project-data.html:106
 #: warehouse/templates/index.html:100 warehouse/templates/index.html:104
 #: warehouse/templates/manage/account.html:228
 #: warehouse/templates/manage/account.html:234
@@ -1111,10 +1108,7 @@ msgstr ""
 msgid "Infrastructure dashboard"
 msgstr ""
 
-#: warehouse/templates/base.html:293
-#: warehouse/templates/includes/accounts/profile-actions.html:19
-#: warehouse/templates/includes/accounts/profile-actions.html:28
-#: warehouse/templates/pages/sitemap.html:40
+#: warehouse/templates/base.html:293 warehouse/templates/pages/sitemap.html:40
 #: warehouse/templates/pages/stats.html:16
 msgid "Statistics"
 msgstr ""
@@ -2833,25 +2827,6 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: warehouse/templates/includes/accounts/profile-actions.html:21
-#, python-format
-msgid ""
-"View statistics for your projects via <a href=\"%(libs_io_href)s\" "
-"title=\"%(title)s\" target=\"_blank\" rel=\"noopener\">Libraries.io</a>, "
-"or by using <a href=\"%(gbq_href)s\" target=\"_blank\" "
-"rel=\"noopener\">our public dataset on Google BigQuery</a>"
-msgstr ""
-
-#: warehouse/templates/includes/accounts/profile-actions.html:30
-#, python-format
-msgid ""
-"View statistics for %(username)s's projects via <a "
-"href=\"%(libs_io_href)s\" title=\"%(title)s\" target=\"_blank\" "
-"rel=\"noopener\">Libraries.io</a>, or by using <a href=\"%(gbq_href)s\" "
-"target=\"_blank\" rel=\"noopener\">our public dataset on Google "
-"BigQuery</a>"
-msgstr ""
-
 #: warehouse/templates/includes/accounts/profile-callout.html:18
 #, python-format
 msgid ""
@@ -2987,47 +2962,38 @@ msgstr ""
 msgid "Open PRs:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:106
-#, python-format
-msgid ""
-"View statistics for this project via <a href=\"%(libs_io_href)s\" "
-"title=\"%(title)s\" target=\"_blank\" rel=\"noopener\">Libraries.io</a>, "
-"or by using <a href=\"%(gbq_href)s\" target=\"_blank\" "
-"rel=\"noopener\">our public dataset on Google BigQuery</a>"
-msgstr ""
-
-#: warehouse/templates/includes/packaging/project-data.html:113
+#: warehouse/templates/includes/packaging/project-data.html:108
 msgid "Meta"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:115
+#: warehouse/templates/includes/packaging/project-data.html:110
 msgid "License:"
+msgstr ""
+
+#: warehouse/templates/includes/packaging/project-data.html:113
+#: warehouse/templates/includes/packaging/project-data.html:115
+msgid "Author:"
 msgstr ""
 
 #: warehouse/templates/includes/packaging/project-data.html:118
 #: warehouse/templates/includes/packaging/project-data.html:120
-msgid "Author:"
-msgstr ""
-
-#: warehouse/templates/includes/packaging/project-data.html:123
-#: warehouse/templates/includes/packaging/project-data.html:125
 #: warehouse/templates/pages/help.html:610
 msgid "Maintainer:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:130
+#: warehouse/templates/includes/packaging/project-data.html:125
 msgid "Tags"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:140
+#: warehouse/templates/includes/packaging/project-data.html:135
 msgid "Requires:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:145
+#: warehouse/templates/includes/packaging/project-data.html:140
 msgid "Provides-Extra:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:153
+#: warehouse/templates/includes/packaging/project-data.html:148
 #: warehouse/templates/pages/classifiers.html:16
 #: warehouse/templates/pages/classifiers.html:21
 #: warehouse/templates/pages/sitemap.html:39
@@ -4560,7 +4526,7 @@ msgstr ""
 #: warehouse/templates/manage/project/documentation.html:35
 #: warehouse/templates/manage/project/publishing.html:155
 #: warehouse/templates/manage/project/release.html:129
-#: warehouse/templates/pages/stats.html:42
+#: warehouse/templates/pages/stats.html:73
 msgid "Project name"
 msgstr ""
 
@@ -8861,31 +8827,57 @@ msgid "PyPI statistics"
 msgstr ""
 
 #: warehouse/templates/pages/stats.html:23
-msgid ""
-"We all love stats, so here are some useful statistics about PyPI. The "
-"statistics page is cached for 24 hours, so don't expect the numbers to be"
-" realtime."
+msgid "We all love stats, so here are some useful statistics about PyPI."
+msgstr ""
+
+#: warehouse/templates/pages/stats.html:28
+msgid "First-party statistics"
 msgstr ""
 
 #: warehouse/templates/pages/stats.html:30
+msgid "These statistics are provided directly by PyPI."
+msgstr ""
+
+#: warehouse/templates/pages/stats.html:37
+msgid ""
+"PyPI provides public datasets, including download statistics and metadata"
+" via BigQuery"
+msgstr ""
+
+#: warehouse/templates/pages/stats.html:42
+msgid "PyPI provides a public dashboard with statistics on usage and performance"
+msgstr ""
+
+#: warehouse/templates/pages/stats.html:47
+msgid "Third-party statistics"
+msgstr ""
+
+#: warehouse/templates/pages/stats.html:49
+msgid ""
+"These statistics are provided by other third-party services unaffiliated "
+"with PyPI."
+msgstr ""
+
+#: warehouse/templates/pages/stats.html:60
 msgid "Top projects by total package size"
 msgstr ""
 
-#: warehouse/templates/pages/stats.html:32
+#: warehouse/templates/pages/stats.html:62
 msgid ""
 "Here is a list of the top 100 projects based on the sum of their "
-"packages' sizes (in bytes)."
+"packages' sizes (in bytes). This page is cached for 24 hours, so don't "
+"expect the numbers to be realtime."
 msgstr ""
 
-#: warehouse/templates/pages/stats.html:39
+#: warehouse/templates/pages/stats.html:70
 msgid "Statistics by project"
 msgstr ""
 
-#: warehouse/templates/pages/stats.html:43
+#: warehouse/templates/pages/stats.html:74
 msgid "Sum of release files (bytes)"
 msgstr ""
 
-#: warehouse/templates/pages/stats.html:48
+#: warehouse/templates/pages/stats.html:79
 msgid "All of PyPI"
 msgstr ""
 

--- a/warehouse/templates/includes/accounts/profile-actions.html
+++ b/warehouse/templates/includes/accounts/profile-actions.html
@@ -14,22 +14,4 @@
 
 {% if request.user == user %}
   <a href="{{ request.route_path('manage.account') }}" class="button button--primary author-profile__edit-button">{% trans %}Edit profile{% endtrans %}</a>
-
-  <div class="sidebar-section">
-    <h3 class="sidebar-section__title">{% trans %}Statistics{% endtrans %}</h3>
-    <p>
-      {% trans libs_io_href='https://libraries.io/', title=gettext('External link'), gbq_href='https://packaging.python.org/guides/analyzing-pypi-package-downloads/' %}
-        View statistics for your projects via <a href="{{ libs_io_href }}" title="{{ title }}" target="_blank" rel="noopener">Libraries.io</a>, or by using <a href="{{ gbq_href }}" target="_blank" rel="noopener">our public dataset on Google BigQuery</a>
-      {% endtrans %}
-    </p>
-  </div>
-{% else %}
-<div class="sidebar-section">
-  <h3 class="sidebar-section__title">{% trans %}Statistics{% endtrans %}</h3>
-  <p>
-    {% trans username=user.username, libs_io_href='https://libraries.io/', title=gettext('External link'), gbq_href='https://packaging.python.org/guides/analyzing-pypi-package-downloads/' %}
-      View statistics for {{ username }}'s projects via <a href="{{ libs_io_href }}" title="{{ title }}" target="_blank" rel="noopener">Libraries.io</a>, or by using <a href="{{ gbq_href }}" target="_blank" rel="noopener">our public dataset on Google BigQuery</a>
-    {% endtrans %}
-  </p>
-</div>
 {% endif %}

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -102,11 +102,6 @@
     </ul>
   </div>
   {% endif %}
-  <p>
-    {% trans libs_io_href='https://libraries.io/pypi/{project_name}'.format(project_name=release.project.name), gbq_href='https://packaging.python.org/guides/analyzing-pypi-package-downloads/', title=gettext('External link') %}
-      View statistics for this project via <a href="{{ libs_io_href }}" title="{{ title }}" target="_blank" rel="noopener">Libraries.io</a>, or by using <a href="{{ gbq_href }}" target="_blank" rel="noopener">our public dataset on Google BigQuery</a>
-    {% endtrans %}
-  </p>
 
 {% if release.has_meta %}
 <div class="sidebar-section">

--- a/warehouse/templates/pages/stats.html
+++ b/warehouse/templates/pages/stats.html
@@ -22,16 +22,47 @@
     <p>
       {% trans %}
         We all love stats, so here are some useful statistics about PyPI.
-        The statistics page is cached for 24 hours, so don't expect the
-        numbers to be realtime.
       {% endtrans %}
     </p>
+
+    <h2>{% trans %}First-party statistics{% endtrans %}</h2>
+    <p>
+      {% trans %}
+        These statistics are provided directly by PyPI.
+      {% endtrans %}
+    </p>
+    <ul>
+      <li>
+        <a href="https://warehouse.pypa.io/api-reference/bigquery-datasets.html">
+          {% trans %}PyPI provides public datasets, including download statistics and metadata via BigQuery{% endtrans %}
+        </a>
+      </li>
+      <li>
+        <a href="https://p.datadoghq.com/sb/7dc8b3250-85dcf667bd">
+          {% trans %}PyPI provides a public dashboard with statistics on usage and performance{% endtrans %}
+        </a>
+      </li>
+    </ul>
+
+    <h2>{% trans %}Third-party statistics{% endtrans %}</h2>
+    <p>
+      {% trans %}
+        These statistics are provided by other third-party services unaffiliated with PyPI.
+      {% endtrans %}
+    </p>
+    <ul>
+      <li><a href="https://libraries.io/pypi">https://libraries.io/pypi</a></li>
+      <li><a href="https://pypistats.org/">https://pypistats.org/</a></li>
+      <li><a href="https://deps.dev/">https://deps.dev/</a></li>
+      <li><a href="https://clickpy.clickhouse.com/">https://clickpy.clickhouse.com/</a></li>
+    </ul>
 
     <h2>{% trans %}Top projects by total package size{% endtrans %}</h2>
     <p>
       {% trans %}
         Here is a list of the top 100 projects based on the sum of their
-        packages' sizes (in bytes).
+        packages' sizes (in bytes). This page is cached for 24 hours, so don't
+        expect the numbers to be realtime.
       {% endtrans %}
     </p>
 


### PR DESCRIPTION
This PR removes a bit of confusion where we link to our BigQuery statistics from the "unverified" section of the project sidebar.

It also removes a bit of favoritism that we had for libraries.io, instead linking to it from the /stats page along with other popular third-party statistics providers.

Closes #16062.