### PR TITLE
Remove `HasObservers.observations` helper attribute

### DIFF
--- a/tests/unit/observations/test_models.py
+++ b/tests/unit/observations/test_models.py
@@ -99,4 +99,3 @@ def test_user_observations_relationship(db_request):
     db_request.db.flush()  # so Observer is created
 
     assert len(user.observer.observations) == 2
-    assert len(user.observations) == 2

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -37,7 +37,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from warehouse import db
 from warehouse.authnz import Permissions
 from warehouse.events.models import HasEvents
-from warehouse.observations.models import HasObserversMixin
+from warehouse.observations.models import HasObservers
 from warehouse.sitemap.models import SitemapMixin
 from warehouse.utils.attrs import make_repr
 from warehouse.utils.db.types import TZDateTime, bool_false, datetime_now
@@ -70,7 +70,7 @@ class DisableReason(enum.Enum):
     AccountFrozen = "account frozen"
 
 
-class User(SitemapMixin, HasObserversMixin, HasEvents, db.Model):
+class User(SitemapMixin, HasObservers, HasEvents, db.Model):
     __tablename__ = "users"
     __table_args__ = (
         CheckConstraint("length(username) <= 50", name="users_valid_username_length"),

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -605,7 +605,7 @@
         </div>
       </div> <!-- .card -->
 
-    {% if user.observations %}
+    {% if user.observer.observations %}
       <div class="card">
         <div class="card-header with-border">
           <h3 class="card-title">Observations</h3>
@@ -622,7 +622,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for observation in user.observations %}
+              {% for observation in user.observer.observations %}
               <tr>
                 <td>{{ observation.created }}</td>
                 <td>{{ observation.related }}</td>

--- a/warehouse/observations/models.py
+++ b/warehouse/observations/models.py
@@ -63,7 +63,7 @@ class Observer(db.Model):
     parent: AssociationProxy = association_proxy("_association", "parent")
 
 
-class HasObserversMixin:
+class HasObservers:
     """A mixin for models that can have observers."""
 
     @declared_attr
@@ -97,14 +97,6 @@ class HasObserversMixin:
             creator=lambda o: assoc_cls(observer=o),
         )
         return relationship(assoc_cls)
-
-    @declared_attr
-    def observations(cls):  # noqa: N805
-        """Simplify `foo.observer.observations` to `foo.observations`."""
-        return association_proxy(
-            "observer_association",
-            "observer.observations",
-        )
 
 
 class ObservationKind(enum.Enum):


### PR DESCRIPTION
This clobbers the `.observations` attribute when used with `HasObservations`.