### PR TITLE
Admin updates for support

### DIFF
--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -467,7 +467,7 @@ class TestUserResetPassword:
         db_request.find_service = pretend.call_recorder(lambda iface, context: service)
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(views, "send_password_compromised_email", send_email)
+        monkeypatch.setattr(views, "send_password_reset_by_admin_email", send_email)
 
         result = views.user_reset_password(user, db_request)
 
@@ -476,7 +476,7 @@ class TestUserResetPassword:
         ]
         assert send_email.calls == [pretend.call(db_request, user)]
         assert service.disable_password.calls == [
-            pretend.call(user.id, db_request, reason=DisableReason.CompromisedPassword)
+            pretend.call(user.id, db_request, reason=DisableReason.AdminInitiated)
         ]
         assert db_request.route_path.calls == [
             pretend.call("admin.user.detail", username=user.username)
@@ -498,7 +498,7 @@ class TestUserResetPassword:
         db_request.find_service = pretend.call_recorder(lambda iface, context: service)
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(views, "send_password_compromised_email", send_email)
+        monkeypatch.setattr(views, "send_password_reset_by_admin_email", send_email)
 
         result = views.user_reset_password(user, db_request)
 
@@ -558,7 +558,7 @@ class TestUserWipeFactors:
         db_request.find_service = pretend.call_recorder(lambda iface, context: service)
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(views, "send_password_compromised_email", send_email)
+        monkeypatch.setattr(views, "send_password_reset_by_admin_email", send_email)
 
         result = views.user_wipe_factors(user, db_request)
 
@@ -570,7 +570,7 @@ class TestUserWipeFactors:
         ]
         assert send_email.calls == [pretend.call(db_request, user)]
         assert service.disable_password.calls == [
-            pretend.call(user.id, db_request, reason=DisableReason.CompromisedPassword)
+            pretend.call(user.id, db_request, reason=DisableReason.AdminInitiated)
         ]
         assert db_request.route_path.calls == [
             pretend.call("admin.user.detail", username=user.username)
@@ -592,7 +592,7 @@ class TestUserWipeFactors:
         db_request.find_service = pretend.call_recorder(lambda iface, context: service)
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(views, "send_password_compromised_email", send_email)
+        monkeypatch.setattr(views, "send_password_reset_by_admin_email", send_email)
 
         result = views.user_wipe_factors(user, db_request)
 

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -1384,6 +1384,76 @@ class TestPasswordCompromisedEmail:
         ]
 
 
+class TestPasswordResetByAdminEmail:
+    @pytest.mark.parametrize("verified", [True, False])
+    def test_password_reset_by_admin_email(
+        self, pyramid_request, pyramid_config, monkeypatch, verified
+    ):
+        stub_user = pretend.stub(
+            id="id",
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=verified),
+        )
+        subject_renderer = pyramid_config.testing_add_renderer(
+            "email/password-reset-by-admin/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            "email/password-reset-by-admin/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            "email/password-reset-by-admin/body.html"
+        )
+        html_renderer.string_response = "Email HTML Body"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        pyramid_request.db = pretend.stub(
+            query=lambda a: pretend.stub(
+                filter=lambda *a: pretend.stub(
+                    one=lambda: pretend.stub(user_id=stub_user.id)
+                )
+            ),
+        )
+        pyramid_request.user = stub_user
+        pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
+
+        result = email.send_password_reset_by_admin_email(pyramid_request, stub_user)
+
+        assert result == {}
+        assert pyramid_request.task.calls == [pretend.call(send_email)]
+        assert send_email.delay.calls == [
+            pretend.call(
+                f"{stub_user.username} <{stub_user.email}>",
+                {
+                    "subject": "Email Subject",
+                    "body_text": "Email Body",
+                    "body_html": (
+                        "<html>\n<head></head>\n"
+                        "<body><p>Email HTML Body</p></body>\n</html>\n"
+                    ),
+                },
+                {
+                    "tag": "account:email:sent",
+                    "user_id": stub_user.id,
+                    "additional": {
+                        "from_": "noreply@example.com",
+                        "to": stub_user.email,
+                        "subject": "Email Subject",
+                        "redact_ip": False,
+                    },
+                },
+            )
+        ]
+
+
 class Test2FAonUploadEmail:
     def test_send_two_factor_not_yet_enabled_email(
         self, pyramid_request, pyramid_config, monkeypatch

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -69,6 +69,7 @@ class UserFactory:
 class DisableReason(enum.Enum):
     CompromisedPassword = "password compromised"
     AccountFrozen = "account frozen"
+    AdminInitiated = "admin initiated"
 
 
 class User(SitemapMixin, HasObservers, HasEvents, db.Model):

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -48,10 +48,11 @@ if TYPE_CHECKING:
     from warehouse.organizations.models import (
         Organization,
         OrganizationApplication,
+        OrganizationInvitation,
         OrganizationRole,
         Team,
     )
-    from warehouse.packaging.models import Project
+    from warehouse.packaging.models import Project, RoleInvitation
 
 
 class UserFactory:
@@ -125,6 +126,11 @@ class User(SitemapMixin, HasObservers, HasEvents, db.Model):
         order_by="Macaroon.created.desc()",
     )
 
+    role_invitations: Mapped[list[RoleInvitation]] = orm.relationship(
+        "RoleInvitation",
+        back_populates="user",
+    )
+
     organization_applications: Mapped[list[OrganizationApplication]] = orm.relationship(
         back_populates="submitted_by",
     )
@@ -156,6 +162,10 @@ class User(SitemapMixin, HasObservers, HasEvents, db.Model):
         cascade="all, delete-orphan",
         lazy=True,
         viewonly=True,
+    )
+
+    organization_invitations: Mapped[list[OrganizationInvitation]] = orm.relationship(
+        back_populates="user",
     )
 
     teams: Mapped[list[Team]] = orm.relationship(

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -348,6 +348,11 @@
                     Breaches: {{ breached_email_count[field.email.data] }}
                   </div>
                   {% endif %}
+                  {% if field.unverify_reason.data %}
+                  <div class="col">
+                    <i class="fa fa-times text-red"></i> Unverify Reason: {{ field.unverify_reason.data.value }}
+                  </div>
+                  {% endif %}
                 </div>
                 {% endfor %}
               </div>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -672,7 +672,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for event in user.recent_events %}
+              {% for event in user.events %}
               <tr>
                 <td>{{ event.tag }}</td>
                 <td>{{ event.time }}</td>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -505,6 +505,32 @@
         </div>
       </div> <!-- .card -->
 
+      {% if user.role_invitations %}
+      <div class="card">
+        <div class="card-header with-border">
+          <h3 class="card-title">Project Invitations</h3>
+        </div>
+
+        <div class="card-body">
+          <table class="table table-hover" id="projects">
+            <thead>
+              <tr>
+                <th>Project Name</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for invitation in user.role_invitations %}
+              <tr>
+                <td><a href="{{ request.route_path('admin.project.detail', project_name=invitation.project.normalized_name) }}">{{ invitation.project.name }}</a></td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+
+      </div> <!-- .card -->
+      {% endif %}
+
       <div class="card">
         <div class="card-header with-border">
           <h3 class="card-title">Projects</h3>
@@ -531,6 +557,58 @@
           </table>
         </div>
       </div> <!-- .card -->
+
+      {% if user.organization_invitations %}
+      <div class="card">
+        <div class="card-header with-border">
+          <h3 class="card-title">Organization Invitations</h3>
+        </div>
+
+        <div class="card-body">
+          <table class="table table-hover" id="organization-invitations">
+            <thead>
+              <tr>
+                <th>Organization Name</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for invitation in user.organization_invitations %}
+              <tr>
+                <td><a href="{{ request.route_path('admin.organization.detail', organization_id=invitation.organization.id) }}">{{ invitation.organization.name }}</a></td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div> <!-- .card -->
+      {% endif %}
+
+      {% if user.organizations %}
+      <div class="card">
+        <div class="card-header with-border">
+          <h3 class="card-title">Organizations</h3>
+        </div>
+
+        <div class="card-body">
+          <table class="table table-hover" id="organizations">
+            <thead>
+              <tr>
+                <th>Organization Name</th>
+                <th>Organization Role</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for organization in user.organization_roles %}
+              <tr>
+                <td><a href="{{ request.route_path('admin.organization.detail', organization_id=organization.organization.id) }}">{{ organization.organization.name }}</a></td>
+                <td>{{ organization.role_name.value }}</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div> <!-- .card -->
+      {% endif %}
 
       <div class="card">
         <div class="card-header with-border">

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -32,7 +32,7 @@ from warehouse.accounts.models import (
     User,
 )
 from warehouse.authnz import Permissions
-from warehouse.email import send_password_compromised_email
+from warehouse.email import send_password_reset_by_admin_email
 from warehouse.packaging.models import JournalEntry, Project, Role
 from warehouse.utils.paginate import paginate_url_factory
 
@@ -304,9 +304,9 @@ def user_freeze(user, request):
 
 def _user_reset_password(user, request):
     login_service = request.find_service(IUserService, context=None)
-    send_password_compromised_email(request, user)
+    send_password_reset_by_admin_email(request, user)
     login_service.disable_password(
-        user.id, request, reason=DisableReason.CompromisedPassword
+        user.id, request, reason=DisableReason.AdminInitiated
     )
 
 

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -85,6 +85,7 @@ class EmailForm(forms.Form):
     primary = wtforms.fields.BooleanField()
     verified = wtforms.fields.BooleanField()
     public = wtforms.fields.BooleanField()
+    unverify_reason = wtforms.fields.StringField(render_kw={"readonly": True})
 
 
 class UserForm(forms.Form):

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -330,6 +330,11 @@ def send_password_compromised_email_hibp(request, user):
     return {}
 
 
+@_email("password-reset-by-admin", allow_unverified=True)
+def send_password_reset_by_admin_email(request, user):
+    return {}
+
+
 @_email("token-compromised-leak", allow_unverified=True)
 def send_token_compromised_email_leak(request, user, *, public_url, origin):
     return {"username": user.username, "public_url": public_url, "origin": origin}

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2186,6 +2186,7 @@ msgstr ""
 
 #: warehouse/templates/email/password-compromised-hibp/body.html:18
 #: warehouse/templates/email/password-compromised/body.html:18
+#: warehouse/templates/email/password-reset-by-admin/body.html:18
 msgid "What?"
 msgstr ""
 
@@ -2205,10 +2206,12 @@ msgstr ""
 
 #: warehouse/templates/email/password-compromised-hibp/body.html:32
 #: warehouse/templates/email/password-compromised/body.html:31
+#: warehouse/templates/email/password-reset-by-admin/body.html:24
 msgid "What should I do?"
 msgstr ""
 
 #: warehouse/templates/email/password-compromised/body.html:33
+#: warehouse/templates/email/password-reset-by-admin/body.html:26
 #, python-format
 msgid ""
 "To regain access to your account, <a href=\"%(href)s\">reset your "
@@ -2216,10 +2219,12 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/email/password-compromised/body.html:39
+#: warehouse/templates/email/password-reset-by-admin/body.html:32
 msgid "How can I contact you?"
 msgstr ""
 
 #: warehouse/templates/email/password-compromised/body.html:41
+#: warehouse/templates/email/password-reset-by-admin/body.html:34
 #, python-format
 msgid ""
 "For more information, you can email %(email_address)s to communicate with"
@@ -2299,6 +2304,13 @@ msgstr[1] ""
 #: warehouse/templates/email/password-reset/body.html:24
 #: warehouse/templates/email/verify-email/body.html:24
 msgid "If you did not make this request, you can safely ignore this email."
+msgstr ""
+
+#: warehouse/templates/email/password-reset-by-admin/body.html:20
+msgid ""
+"PyPI administrators have have initiated a password reset for your "
+"account. You will no longer be able to log in or upload to PyPI with your"
+" existing password."
 msgstr ""
 
 #: warehouse/templates/email/primary-email-change/body.html:18

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2186,7 +2186,6 @@ msgstr ""
 
 #: warehouse/templates/email/password-compromised-hibp/body.html:18
 #: warehouse/templates/email/password-compromised/body.html:18
-#: warehouse/templates/email/password-reset-by-admin/body.html:18
 msgid "What?"
 msgstr ""
 
@@ -2206,12 +2205,10 @@ msgstr ""
 
 #: warehouse/templates/email/password-compromised-hibp/body.html:32
 #: warehouse/templates/email/password-compromised/body.html:31
-#: warehouse/templates/email/password-reset-by-admin/body.html:24
 msgid "What should I do?"
 msgstr ""
 
 #: warehouse/templates/email/password-compromised/body.html:33
-#: warehouse/templates/email/password-reset-by-admin/body.html:26
 #, python-format
 msgid ""
 "To regain access to your account, <a href=\"%(href)s\">reset your "
@@ -2219,12 +2216,10 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/email/password-compromised/body.html:39
-#: warehouse/templates/email/password-reset-by-admin/body.html:32
 msgid "How can I contact you?"
 msgstr ""
 
 #: warehouse/templates/email/password-compromised/body.html:41
-#: warehouse/templates/email/password-reset-by-admin/body.html:34
 #, python-format
 msgid ""
 "For more information, you can email %(email_address)s to communicate with"
@@ -2304,13 +2299,6 @@ msgstr[1] ""
 #: warehouse/templates/email/password-reset/body.html:24
 #: warehouse/templates/email/verify-email/body.html:24
 msgid "If you did not make this request, you can safely ignore this email."
-msgstr ""
-
-#: warehouse/templates/email/password-reset-by-admin/body.html:20
-msgid ""
-"PyPI administrators have have initiated a password reset for your "
-"account. You will no longer be able to log in or upload to PyPI with your"
-" existing password."
 msgstr ""
 
 #: warehouse/templates/email/primary-email-change/body.html:18

--- a/warehouse/migrations/versions/82b2ebed68b6_add_admin_initiated_password_reset.py
+++ b/warehouse/migrations/versions/82b2ebed68b6_add_admin_initiated_password_reset.py
@@ -1,0 +1,52 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add admin initiated password reset
+
+Revision ID: 82b2ebed68b6
+Revises: 14ad61e054cf
+Create Date: 2024-07-09 21:18:50.979790
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "82b2ebed68b6"
+down_revision = "14ad61e054cf"
+
+
+def upgrade():
+    op.sync_enum_values(
+        "public",
+        "disablereason",
+        ["password compromised", "account frozen", "admin initiated"],
+        [
+            TableReference(
+                table_schema="public", table_name="users", column_name="disabled_for"
+            )
+        ],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade():
+    op.sync_enum_values(
+        "public",
+        "disablereason",
+        ["password compromised", "account frozen"],
+        [
+            TableReference(
+                table_schema="public", table_name="users", column_name="disabled_for"
+            )
+        ],
+        enum_values_to_rename=[],
+    )

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -559,7 +559,9 @@ class OrganizationInvitation(db.Model):
         index=True,
     )
 
-    user: Mapped[User] = relationship(lazy=False)
+    user: Mapped[User] = relationship(
+        back_populates="organization_invitations", lazy=False
+    )
     organization: Mapped[Organization] = relationship(lazy=False)
 
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -135,7 +135,7 @@ class RoleInvitation(db.Model):
         index=True,
     )
 
-    user: Mapped[User] = orm.relationship(lazy=False)
+    user: Mapped[User] = orm.relationship(lazy=False, back_populates="role_invitations")
     project: Mapped[Project] = orm.relationship(lazy=False)
 
 

--- a/warehouse/templates/email/password-reset-by-admin/body.html
+++ b/warehouse/templates/email/password-reset-by-admin/body.html
@@ -15,23 +15,23 @@
 
 
 {% block content %}
-<h3>{% trans %}What?{% endtrans %}</h3>
+<h3>What?</h3>
 <p>
-  {% trans %}PyPI administrators have have initiated a password reset for your account.
-  You will no longer be able to log in or upload to PyPI with your existing password.{% endtrans %}
+  PyPI administrators have have initiated a password reset for your account.
+  You will no longer be able to log in to PyPI with your existing password.
 </p>
 
-<h3>{% trans %}What should I do?{% endtrans %}</h3>
+<h3>What should I do?</h3>
 <p>
-  {% trans href=request.route_url('accounts.request-password-reset', _host=request.registry.settings.get('warehouse.domain')) %}
-  To regain access to your account, <a href="{{ href }}">reset your password</a> on PyPI.
-  {% endtrans %}
+  To regain access to your account,
+  <a href="{{ request.route_url('accounts.request-password-reset', _host=request.registry.settings.get('warehouse.domain')) }}">reset your password</a>
+  on PyPI.
 </p>
 
 
-<h3>{% trans %}How can I contact you?{% endtrans %}</h3>
+<h3>How can I contact you?</h3>
 <p>
-  {% trans email_address='admin@pypi.org' %}For more information, you can email {{ email_address }} to communicate with
-  the PyPI administrators.{% endtrans %}
+  For more information, you can email admin@pypi.org to communicate with
+  the PyPI administrators.
 </p>
 {% endblock %}

--- a/warehouse/templates/email/password-reset-by-admin/body.html
+++ b/warehouse/templates/email/password-reset-by-admin/body.html
@@ -1,0 +1,37 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+
+{% block content %}
+<h3>{% trans %}What?{% endtrans %}</h3>
+<p>
+  {% trans %}PyPI administrators have have initiated a password reset for your account.
+  You will no longer be able to log in or upload to PyPI with your existing password.{% endtrans %}
+</p>
+
+<h3>{% trans %}What should I do?{% endtrans %}</h3>
+<p>
+  {% trans href=request.route_url('accounts.request-password-reset', _host=request.registry.settings.get('warehouse.domain')) %}
+  To regain access to your account, <a href="{{ href }}">reset your password</a> on PyPI.
+  {% endtrans %}
+</p>
+
+
+<h3>{% trans %}How can I contact you?{% endtrans %}</h3>
+<p>
+  {% trans email_address='admin@pypi.org' %}For more information, you can email {{ email_address }} to communicate with
+  the PyPI administrators.{% endtrans %}
+</p>
+{% endblock %}

--- a/warehouse/templates/email/password-reset-by-admin/body.txt
+++ b/warehouse/templates/email/password-reset-by-admin/body.txt
@@ -15,19 +15,18 @@
 
 
 {% block content %}
-# {% trans %}What?{% endtrans %}
+# What?
 
-{% trans %}PyPI administrators have have initiated a password reset for your account.
-You will no longer be able to log in or upload to PyPI with your existing password.{% endtrans %}
-
-
-# {% trans %}What should I do?{% endtrans %}
-
-{% trans url=request.route_url('accounts.request-password-reset', _host=request.registry.settings.get('warehouse.domain')) %}
-To regain access to your account, reset your password on PyPI ({{ url }}).{% endtrans %}
+PyPI administrators have have initiated a password reset for your account.
+You will no longer be able to log in to PyPI with your existing password.
 
 
-# {% trans %}How can I contact you?{% endtrans %}
+# What should I do?
 
-{% trans email_address='admin@pypi.org' %}For more information, you can email {{ email_address }} to communicate with the PyPI administrators.{% endtrans %}
+To regain access to your account, reset your password on PyPI ({{ request.route_url('accounts.request-password-reset', _host=request.registry.settings.get('warehouse.domain')) }}).
+
+
+# How can I contact you?
+
+For more information, you can email admin@pypi.org to communicate with the PyPI administrators.
 {% endblock %}

--- a/warehouse/templates/email/password-reset-by-admin/body.txt
+++ b/warehouse/templates/email/password-reset-by-admin/body.txt
@@ -1,0 +1,33 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+
+{% block content %}
+# {% trans %}What?{% endtrans %}
+
+{% trans %}PyPI administrators have have initiated a password reset for your account.
+You will no longer be able to log in or upload to PyPI with your existing password.{% endtrans %}
+
+
+# {% trans %}What should I do?{% endtrans %}
+
+{% trans url=request.route_url('accounts.request-password-reset', _host=request.registry.settings.get('warehouse.domain')) %}
+To regain access to your account, reset your password on PyPI ({{ url }}).{% endtrans %}
+
+
+# {% trans %}How can I contact you?{% endtrans %}
+
+{% trans email_address='admin@pypi.org' %}For more information, you can email {{ email_address }} to communicate with the PyPI administrators.{% endtrans %}
+{% endblock %}

--- a/warehouse/templates/email/password-reset-by-admin/subject.txt
+++ b/warehouse/templates/email/password-reset-by-admin/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}{% trans site=request.registry.settings["site.name"] %}Your {{ site }} password has been reset{% endtrans %}{% endblock %}

--- a/warehouse/templates/email/password-reset-by-admin/subject.txt
+++ b/warehouse/templates/email/password-reset-by-admin/subject.txt
@@ -14,4 +14,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}{% trans site=request.registry.settings["site.name"] %}Your {{ site }} password has been reset{% endtrans %}{% endblock %}
+{% block subject %}Your {{ request.registry.settings["site.name"] }} password has been reset{% endblock %}


### PR DESCRIPTION
While reviewing some support tickets with @Thespi-Brain and @di, a few things were noticed that could be improved:

- Surface Organization membership in user detail
- Surface Organization invitations in user detail
- Surface Project invitations in user detail
- Expose all available User.events in admin (not just most recent)
- When resetting a password via admin, set a unique status (and improve the email! we were sending the "compromised" one!)