### PR TITLE
feat: implement quarantined projects restrictions

### DIFF
--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -16,7 +16,7 @@ import pytest
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 
 from warehouse.legacy.api import json
-from warehouse.packaging.models import ReleaseURL
+from warehouse.packaging.models import LifecycleStatus, ReleaseURL
 
 from ....common.db.accounts import UserFactory
 from ....common.db.integrations import VulnerabilityRecordFactory
@@ -117,6 +117,18 @@ class TestLatestReleaseFactory:
         release = ReleaseFactory.create(project=project, version="2.0.dev0")
         db_request.matchdict = {"name": project.normalized_name}
         assert json.latest_release_factory(db_request) == release
+
+    def test_project_quarantined(self, monkeypatch, db_request):
+        project = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineEnter
+        )
+        ReleaseFactory.create(project=project, version="1.0")
+
+        db_request.matchdict = {"name": project.normalized_name}
+        resp = json.latest_release_factory(db_request)
+
+        assert isinstance(resp, HTTPNotFound)
+        _assert_has_cors_headers(resp.headers)
 
 
 class TestJSONProject:
@@ -396,6 +408,18 @@ class TestReleaseFactory:
         ReleaseFactory.create(project=project, version="3.0.0.0")
         db_request.matchdict = {"name": project.normalized_name, "version": "3.0"}
         resp = json.release_factory(db_request)
+        assert isinstance(resp, HTTPNotFound)
+        _assert_has_cors_headers(resp.headers)
+
+    def test_project_quarantined(self, db_request):
+        project = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineEnter
+        )
+        ReleaseFactory.create(project=project, version="1.0")
+
+        db_request.matchdict = {"name": project.normalized_name, "version": "1.0"}
+        resp = json.release_factory(db_request)
+
         assert isinstance(resp, HTTPNotFound)
         _assert_has_cors_headers(resp.headers)
 

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -300,6 +300,10 @@ class TestProject:
 
             acls.extend(acl)
 
+        _perms_read_and_upload = [
+            Permissions.ProjectsRead,
+            Permissions.ProjectsUpload,
+        ]
         assert acls == [
             (
                 Allow,
@@ -345,16 +349,16 @@ class TestProject:
             key=lambda x: x[1],
         ) + sorted(
             [
-                (Allow, f"user:{owner1.user.id}", [Permissions.ProjectsRead]),
-                (Allow, f"user:{owner2.user.id}", [Permissions.ProjectsRead]),
-                (Allow, f"user:{owner3.user.id}", [Permissions.ProjectsRead]),
-                (Allow, f"user:{owner4.user.id}", [Permissions.ProjectsRead]),
+                (Allow, f"user:{owner1.user.id}", _perms_read_and_upload),
+                (Allow, f"user:{owner2.user.id}", _perms_read_and_upload),
+                (Allow, f"user:{owner3.user.id}", _perms_read_and_upload),
+                (Allow, f"user:{owner4.user.id}", _perms_read_and_upload),
             ],
             key=lambda x: x[1],
         ) + sorted(
             [
-                (Allow, f"user:{maintainer1.user.id}", [Permissions.ProjectsRead]),
-                (Allow, f"user:{maintainer2.user.id}", [Permissions.ProjectsRead]),
+                (Allow, f"user:{maintainer1.user.id}", _perms_read_and_upload),
+                (Allow, f"user:{maintainer2.user.id}", _perms_read_and_upload),
             ],
             key=lambda x: x[1],
         )

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -266,6 +266,99 @@ class TestProject:
             key=lambda x: x[1],
         )
 
+    def test_acl_for_quarantined_project(self, db_session):
+        """
+        If a Project is quarantined, the Project ACL should disallow any modifications.
+        """
+        project = DBProjectFactory.create(lifecycle_status="quarantine-enter")
+        owner1 = DBRoleFactory.create(project=project)
+        owner2 = DBRoleFactory.create(project=project)
+        maintainer1 = DBRoleFactory.create(project=project, role_name="Maintainer")
+        maintainer2 = DBRoleFactory.create(project=project, role_name="Maintainer")
+
+        organization = DBOrganizationFactory.create()
+        owner3 = DBOrganizationRoleFactory.create(organization=organization)
+        DBOrganizationProjectFactory.create(organization=organization, project=project)
+
+        team = DBTeamFactory.create()
+        owner4 = DBTeamRoleFactory.create(team=team)
+        DBTeamProjectRoleFactory.create(
+            team=team, project=project, role_name=TeamProjectRoleType.Owner
+        )
+
+        publisher = GitHubPublisherFactory.create(projects=[project])
+
+        acls = []
+        for location in lineage(project):
+            try:
+                acl = location.__acl__
+            except AttributeError:
+                continue
+
+            if acl and callable(acl):
+                acl = acl()
+
+            acls.extend(acl)
+
+        assert acls == [
+            (
+                Allow,
+                "group:admins",
+                (
+                    Permissions.AdminDashboardSidebarRead,
+                    Permissions.AdminObservationsRead,
+                    Permissions.AdminObservationsWrite,
+                    Permissions.AdminProhibitedProjectsWrite,
+                    Permissions.AdminProjectsDelete,
+                    Permissions.AdminProjectsRead,
+                    Permissions.AdminProjectsSetLimit,
+                    Permissions.AdminProjectsWrite,
+                    Permissions.AdminRoleAdd,
+                    Permissions.AdminRoleDelete,
+                ),
+            ),
+            (
+                Allow,
+                "group:moderators",
+                (
+                    Permissions.AdminDashboardSidebarRead,
+                    Permissions.AdminObservationsRead,
+                    Permissions.AdminObservationsWrite,
+                    Permissions.AdminProjectsRead,
+                    Permissions.AdminProjectsSetLimit,
+                    Permissions.AdminRoleAdd,
+                    Permissions.AdminRoleDelete,
+                ),
+            ),
+            (
+                Allow,
+                "group:observers",
+                Permissions.APIObservationsAdd,
+            ),
+            (
+                Allow,
+                Authenticated,
+                Permissions.SubmitMalwareObservation,
+            ),
+        ] + sorted(
+            [(Allow, f"oidc:{publisher.id}", [Permissions.ProjectsUpload])],
+            key=lambda x: x[1],
+        ) + sorted(
+            [
+                (Allow, f"user:{owner1.user.id}", [Permissions.ProjectsRead]),
+                (Allow, f"user:{owner2.user.id}", [Permissions.ProjectsRead]),
+                (Allow, f"user:{owner3.user.id}", [Permissions.ProjectsRead]),
+                (Allow, f"user:{owner4.user.id}", [Permissions.ProjectsRead]),
+            ],
+            key=lambda x: x[1],
+        ) + sorted(
+            [
+                (Allow, f"user:{maintainer1.user.id}", [Permissions.ProjectsRead]),
+                (Allow, f"user:{maintainer2.user.id}", [Permissions.ProjectsRead]),
+            ],
+            key=lambda x: x[1],
+        )
+
     def test_repr(self, db_request):
         project = DBProjectFactory()
         assert isinstance(repr(project), str)

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -18,7 +18,14 @@ from sqlalchemy.orm import Load, contains_eager, joinedload
 
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache
-from warehouse.packaging.models import Description, File, Project, Release, ReleaseURL
+from warehouse.packaging.models import (
+    Description,
+    File,
+    LifecycleStatus,
+    Project,
+    Release,
+    ReleaseURL,
+)
 from warehouse.utils.cors import _CORS_HEADERS
 
 _RELEASE_CACHE_DECORATOR = [
@@ -193,6 +200,12 @@ def latest_release_factory(request):
             request.db.query(Release.id, Release.version)
             .join(Release.project)
             .filter(Project.normalized_name == normalized_name)
+            # Exclude projects in quarantine.
+            .filter(
+                Project.lifecycle_status.is_distinct_from(
+                    LifecycleStatus.QuarantineEnter
+                )
+            )
             .order_by(
                 Release.yanked.asc(),
                 Release.is_prerelease.nullslast(),
@@ -272,6 +285,10 @@ def release_factory(request):
             joinedload(Release._requires_dist),
         )
         .filter(Project.normalized_name == normalized_name)
+        # Exclude projects in quarantine.
+        .filter(
+            Project.lifecycle_status.is_distinct_from(LifecycleStatus.QuarantineEnter)
+        )
     )
 
     try:

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -355,9 +355,15 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
             permissions |= {(role.user_id, "Administer") for role in query.all()}
 
         for user_id, permission_name in sorted(permissions, key=lambda x: (x[1], x[0])):
-            # Disallow Upload/Write permissions for Projects in quarantine
+            # Disallow Write permissions for Projects in quarantine, allow Upload
             if self.lifecycle_status == LifecycleStatus.QuarantineEnter:
-                acls.append((Allow, f"user:{user_id}", [Permissions.ProjectsRead]))
+                acls.append(
+                    (
+                        Allow,
+                        f"user:{user_id}",
+                        [Permissions.ProjectsRead, Permissions.ProjectsUpload],
+                    )
+                )
             elif permission_name == "Administer":
                 acls.append(
                     (

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -355,7 +355,10 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
             permissions |= {(role.user_id, "Administer") for role in query.all()}
 
         for user_id, permission_name in sorted(permissions, key=lambda x: (x[1], x[0])):
-            if permission_name == "Administer":
+            # Disallow Upload/Write permissions for Projects in quarantine
+            if self.lifecycle_status == LifecycleStatus.QuarantineEnter:
+                acls.append((Allow, f"user:{user_id}", [Permissions.ProjectsRead]))
+            elif permission_name == "Administer":
                 acls.append(
                     (
                         Allow,

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -20,7 +20,7 @@ from pyramid_jinja2 import IJinja2Environment
 from sqlalchemy.orm import joinedload
 
 from warehouse.packaging.interfaces import ISimpleStorage
-from warehouse.packaging.models import File, Project, Release
+from warehouse.packaging.models import File, LifecycleStatus, Project, Release
 
 API_VERSION = "1.1"
 
@@ -29,6 +29,12 @@ def _simple_index(request, serial):
     # Fetch the name and normalized name for all of our projects
     projects = (
         request.db.query(Project.name, Project.normalized_name, Project.last_serial)
+        # Exclude projects that are in the `quarantine-enter` lifecycle status.
+        # Use `is_distinct_from` method here to ensure that we select `NULL` records,
+        # which would otherwise be excluded by the `==` operator.
+        .filter(
+            Project.lifecycle_status.is_distinct_from(LifecycleStatus.QuarantineEnter)
+        )
         .order_by(Project.normalized_name)
         .all()
     )
@@ -46,6 +52,11 @@ def _simple_detail(project, request):
         .options(joinedload(File.release))
         .join(Release)
         .filter(Release.project == project)
+        # Exclude projects that are in the `quarantine-enter` lifecycle status.
+        .join(Project)
+        .filter(
+            Project.lifecycle_status.is_distinct_from(LifecycleStatus.QuarantineEnter)
+        )
         .all(),
         key=lambda f: (packaging_legacy.version.parse(f.release.version), f.filename),
     )


### PR DESCRIPTION
Disallow `pip install`-style commands and file downloads when in quarantine.

Disallow user-made modifications to project when in quarantine.

Follows #16264