### PR TITLE
Simplify link underlining

### DIFF
--- a/warehouse/static/sass/base/_typography.scss
+++ b/warehouse/static/sass/base/_typography.scss
@@ -107,10 +107,6 @@ strong {
 }
 
 a {
-  text-decoration: none;
-  background-position: 0 1.15em;
-  background-repeat: repeat-x;
-  background-size: 100% 1.5px;
   @include primary-underlined-link;
 
   // Add 'external link' icon to most external links

--- a/warehouse/static/sass/blocks/_language-switcher.scss
+++ b/warehouse/static/sass/blocks/_language-switcher.scss
@@ -45,9 +45,7 @@
       border: 0;
       background-color: transparent;
       padding: 0;
-      background-position: 0 1.3em;
-      background-repeat: repeat-x;
-      background-size: 100% 1.5px;
+      text-decoration: underline;
       @include white-underlined-link;
     }
 

--- a/warehouse/static/sass/tools/_link-utilities.scss
+++ b/warehouse/static/sass/tools/_link-utilities.scss
@@ -21,11 +21,9 @@
 
 @mixin colored-link($color) {
   color: $color;
-  background-image: linear-gradient(to right, $color, transparentize($color, 0.3));
 
   &:hover {
     color: darken($color, 10);
-    background-image: linear-gradient(to right, darken($color, 10), darken($color, 10));
   }
 
   @include link-focus-state($color);
@@ -49,15 +47,14 @@
 
 @mixin white-underlined-link {
   color: transparentize($white, 0.05);
-  background-image: linear-gradient(to right, $white, transparentize($white, 0.3));
 
   @include link-focus-state($white);
 }
 
 @mixin link-without-underline {
-  background-image: none;
+  text-decoration: none;
 
   &:hover {
-    background-image: none;
+    text-decoration: none;
   }
 }

--- a/warehouse/static/sass/tools/_link-utilities.scss
+++ b/warehouse/static/sass/tools/_link-utilities.scss
@@ -46,9 +46,7 @@
 }
 
 @mixin white-underlined-link {
-  color: transparentize($white, 0.05);
-
-  @include link-focus-state($white);
+  @include colored-link($white);
 }
 
 @mixin link-without-underline {


### PR DESCRIPTION
We were using a background image (!) with a gradient (!!) to underline links instead of just using regular text decoration. This should make things slightly simpler and look slightly nicer, and also I'm pretty sure this fixes #16191 as well (which is how I got sniped into changing this). Click to embiggen:

| Before | After |
|--------|--------|
| ![image](https://github.com/pypi/warehouse/assets/294415/63ee155b-6a15-4d56-a5a9-c6e87c39c7ca) | ![image](https://github.com/pypi/warehouse/assets/294415/56536d3e-a913-4cbc-8d91-026f7d1ff58a) |

Note that on platforms that support it, descenders will now clear the underline as well:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2ca34d8a-0920-4930-92e8-0ba81240a3d6) | ![image](https://github.com/user-attachments/assets/968d1d91-81d8-4bac-b7aa-b7ee4af8212a) |

This PR also adds a slight color change on hover for white links that matches what we do for other links.