### PR TITLE
Remove the fallback to rendering descriptions inline

### DIFF
--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -225,9 +225,6 @@ def latest_release_factory(request):
             contains_eager(Release.project),
             contains_eager(Release._project_urls),
             joinedload(Release._requires_dist),
-            joinedload(Release.description).load_only(
-                Description.content_type, Description.raw
-            ),
         )
         .filter(Release.id == latest.id)
         .one()
@@ -286,9 +283,6 @@ def release_factory(request):
             contains_eager(Release.project),
             contains_eager(Release._project_urls),
             joinedload(Release._requires_dist),
-            joinedload(Release.description).load_only(
-                Description.content_type, Description.raw
-            ),
         )
         .filter(Project.normalized_name == normalized_name)
         # Exclude projects in quarantine.

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -225,6 +225,9 @@ def latest_release_factory(request):
             contains_eager(Release.project),
             contains_eager(Release._project_urls),
             joinedload(Release._requires_dist),
+            joinedload(Release.description).load_only(
+                Description.content_type, Description.raw
+            ),
         )
         .filter(Release.id == latest.id)
         .one()
@@ -283,6 +286,9 @@ def release_factory(request):
             contains_eager(Release.project),
             contains_eager(Release._project_urls),
             joinedload(Release._requires_dist),
+            joinedload(Release.description).load_only(
+                Description.content_type, Description.raw
+            ),
         )
         .filter(Project.normalized_name == normalized_name)
         # Exclude projects in quarantine.

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Provide an Inspector link to specific lines of code."
 msgstr ""
 
-#: warehouse/packaging/views.py:216
+#: warehouse/packaging/views.py:212
 msgid "Your report has been recorded. Thank you for your help."
 msgstr ""
 

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -20,8 +20,7 @@ from warehouse.authnz import Permissions
 from warehouse.cache.origin import origin_cache
 from warehouse.observations.models import ObservationKind
 from warehouse.packaging.forms import SubmitMalwareObservationForm
-from warehouse.packaging.models import File, Project, Release, Role
-from warehouse.utils import readme
+from warehouse.packaging.models import Description, File, Project, Release, Role
 
 
 @view_config(
@@ -87,16 +86,13 @@ def release_detail(release, request):
     if project.name != request.matchdict.get("name", project.name):
         return HTTPMovedPermanently(request.current_route_path(name=project.name))
 
-    # Grab the rendered description if it exists, and if it doesn't, then we will render
-    # it inline.
-    # TODO: Remove the fallback to rendering inline and only support displaying the
-    #       already rendered content.
-    if release.description.html:
-        description = release.description.html
-    else:
-        description = readme.render(
-            release.description.raw, release.description.content_type
-        )
+    # Grab the rendered description
+    description_html = (
+        request.db.query(Description.html)
+        .filter(Description.id == release.description_id)
+        .one()
+        .html
+    )
 
     # Get all of the maintainers for this project.
     maintainers = [
@@ -144,7 +140,7 @@ def release_detail(release, request):
     return {
         "project": project,
         "release": release,
-        "description": description,
+        "description": description_html,
         "files": sdists + bdists,
         "sdists": sdists,
         "bdists": bdists,


### PR DESCRIPTION
This resolves a TODO now that we don't have any un-rendered descriptions in the database.