### PR TITLE
Disallow trailing new line in `PROJECT_NAME_RE`

### DIFF
--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -26,6 +26,7 @@ from warehouse.packaging.models import (
     Role,
 )
 from warehouse.utils.project import (
+    PROJECT_NAME_RE,
     clear_project_quarantine,
     confirm_project,
     destroy_docs,
@@ -42,6 +43,18 @@ from ...common.db.packaging import (
     ReleaseFactory,
     RoleFactory,
 )
+
+
+@pytest.mark.parametrize(
+    "name", ["django", "zope.interface", "Twisted", "foo_bar", "abc123"]
+)
+def test_project_name_re_ok(name: str) -> None:
+    assert PROJECT_NAME_RE.match(name) is not None
+
+
+@pytest.mark.parametrize("name", ["", "foo\n", "foo\nbar", "..."])
+def test_project_name_re_invalid(name: str) -> None:
+    assert PROJECT_NAME_RE.match(name) is None
 
 
 def test_confirm():

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -37,7 +37,7 @@ def remove_documentation(task, request, project_name):
 
 
 PROJECT_NAME_RE = re.compile(
-    r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.IGNORECASE
+    r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])\Z", re.IGNORECASE
 )
 
 


### PR DESCRIPTION
I noticed this while working on #16260: the regex used to validate project names in some context permits trailing newlines in the project name. This is because in Python regexes `$` matches the end of the string *or* a trailing newline. `\Z` is how you match the end of the string.

I do not _think_ that this has any security implications because, though the [equivalent Postgres constraint](https://github.com/pypi/warehouse/blob/2876c73261e51330faf17e9079211aeb3c3cf012/warehouse/migrations/versions/283c68f2ab2_initial_migration.py#L82-L85) uses `$`, in Postgres `$` [matches only the end of the string](https://www.postgresql.org/docs/16/functions-matching.html#POSIX-SYNTAX-DETAILS). The constraint has been present since [time immemorial](https://github.com/pypi/warehouse/commit/82965a56fc67d0c75fce32a2320d2fdb5899f51c).