### PR TITLE
forklift/legacy: add a scope to fallthrough error

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -426,7 +426,9 @@ def _process_attestations(request, artifact_path: Path):
         except Exception as e:
             with sentry_sdk.push_scope() as scope:
                 scope.fingerprint = e
-                sentry_sdk.capture_message(f"Unexpected error while verifying attestation: {e}")
+                sentry_sdk.capture_message(
+                    f"Unexpected error while verifying attestation: {e}"
+                )
 
             raise _exc_with_message(
                 HTTPBadRequest,

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -424,12 +424,13 @@ def _process_attestations(request, artifact_path: Path):
                 f"attestation: {e}",
             )
         except Exception as e:
-            sentry_sdk.capture_message(
-                f"Unexpected error while verifying attestation: {e}"
-            )
+            with sentry_sdk.push_scope() as scope:
+                scope.fingerprint = e
+                sentry_sdk.capture_message(f"Unexpected error while verifying attestation: {e}")
+
             raise _exc_with_message(
                 HTTPBadRequest,
-                f"Unknown error while trying to verify included " f"attestations: {e}",
+                f"Unknown error while trying to verify included attestations: {e}",
             )
 
         if predicate_type != AttestationType.PYPI_PUBLISH_V1:
@@ -438,7 +439,7 @@ def _process_attestations(request, artifact_path: Path):
             )
             raise _exc_with_message(
                 HTTPBadRequest,
-                f"Attestation with unsupported predicate type: " f"{predicate_type}",
+                f"Attestation with unsupported predicate type: {predicate_type}",
             )
 
         # Log successful attestation upload


### PR DESCRIPTION
This should improve the debuggability of this fallthrough case.