### PR TITLE
misc: fix some sentry captures

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -425,7 +425,7 @@ def _process_attestations(request, artifact_path: Path):
             )
         except Exception as e:
             with sentry_sdk.push_scope() as scope:
-                scope.fingerprint = e
+                scope.fingerprint = [e]
                 sentry_sdk.capture_message(
                     f"Unexpected error while verifying attestation: {e}"
                 )

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -266,7 +266,7 @@ class OIDCPublisherService:
             )
             if not isinstance(e, jwt.PyJWTError):
                 with sentry_sdk.push_scope() as scope:
-                    scope.fingerprint = e
+                    scope.fingerprint = [e]
                     # We expect pyjwt to only raise subclasses of PyJWTError, but
                     # we can't enforce this. Other exceptions indicate an abstraction
                     # leak, so we log them for upstream reporting.

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -130,7 +130,7 @@ def mint_token_from_oidc(request: Request):
         # an abstraction leak in jwt that we'll log for upstream reporting.
         if not isinstance(e, (jwt.PyJWTError, KeyError)):
             with sentry_sdk.push_scope() as scope:
-                scope.fingerprint = e
+                scope.fingerprint = [e]
                 sentry_sdk.capture_message(f"jwt.decode raised generic error: {e}")
 
         return _invalid(


### PR DESCRIPTION
These were using `fingerprint` incorrectly;
I've removed their custom scopes and made them
use the top-level APIs instead, since the scope
isn't adding much more.