### PR TITLE
Update `pypi-attestations` to `0.0.9`

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -62,7 +62,7 @@ rfc3986
 sentry-sdk
 setuptools
 sigstore~=3.0.0
-pypi-attestations==0.0.8
+pypi-attestations==0.0.9
 sqlalchemy[asyncio]>=2.0,<3.0
 stdlib-list
 stripe

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1748,9 +1748,9 @@ pyparsing==3.1.2 \
     --hash=sha256:a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad \
     --hash=sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742
     # via linehaul
-pypi-attestations==0.0.8 \
-    --hash=sha256:5a97550821df69b1e40ed7fc59c5c8b8d01659d401e9b9e3c8ee2473709669fe \
-    --hash=sha256:67cb73d4fd4c83710c479b873277d8119ea451f707f6f64c503f4079b0c428ed
+pypi-attestations==0.0.9 \
+    --hash=sha256:3bfc07f64a8db0d6e2646720e70df7c7cb01a2936056c764a2cc3268969332f2 \
+    --hash=sha256:4b38cce5d221c8145cac255bfafe650ec0028d924d2b3572394df8ba8f07a609
     # via -r requirements/main.in
 pyqrcode==1.2.1 \
     --hash=sha256:1b2812775fa6ff5c527977c4cd2ccb07051ca7d0bc0aecf937a43864abe5eff6 \

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -25,6 +25,7 @@ import pytest
 
 from pypi_attestations import (
     Attestation,
+    Distribution,
     Envelope,
     VerificationError,
     VerificationMaterial,
@@ -3467,6 +3468,10 @@ class TestFileUpload:
         assert resp.status_code == 200
 
         assert len(verify.calls) == 1
+        verified_distribution = verify.calls[0].args[3]
+        assert verified_distribution == Distribution(
+            name=filename, digest=_TAR_GZ_PKG_SHA256
+        )
 
     def test_upload_with_invalid_attestation_predicate_type_fails(
         self,

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -19,7 +19,6 @@ import tempfile
 import zipfile
 
 from cgi import FieldStorage
-from pathlib import Path
 
 import packaging.requirements
 import packaging.specifiers
@@ -31,7 +30,12 @@ import wtforms
 import wtforms.validators
 
 from pydantic import TypeAdapter, ValidationError
-from pypi_attestations import Attestation, AttestationType, VerificationError
+from pypi_attestations import (
+    Attestation,
+    AttestationType,
+    Distribution,
+    VerificationError,
+)
 from pyramid.httpexceptions import (
     HTTPBadRequest,
     HTTPException,
@@ -366,7 +370,7 @@ def _is_duplicate_file(db_session, filename, hashes):
     return None
 
 
-def _process_attestations(request, artifact_path: Path):
+def _process_attestations(request, distribution: Distribution):
     """
     Process any attestations included in a file upload request
 
@@ -413,7 +417,7 @@ def _process_attestations(request, artifact_path: Path):
             predicate_type, _ = attestation_model.verify(
                 Verifier.production(),
                 verification_policy,
-                artifact_path,
+                distribution,
             )
         except VerificationError as e:
             # Log invalid (failed verification) attestation upload
@@ -1148,7 +1152,8 @@ def file_upload(request):
 
         if "attestations" in request.POST:
             _process_attestations(
-                request=request, artifact_path=Path(temporary_filename)
+                request=request,
+                distribution=Distribution(name=filename, digest=file_hashes["sha256"]),
             )
 
         # TODO: This should be handled by some sort of database trigger or a


### PR DESCRIPTION
The new attestation verification API now takes a `Distribution` object, containing the filename and the SHA256 digest of the artifact:
```python
class Distribution(BaseModel):
    name: str
    digest: str
```

as opposed to before, where it would take the artifact's `Path`, read the file and compute the digest.

This new API means that we can pass the already computed SHA256 digest directly (instead of having `pypi-attestations` re-compute it), and it also avoids `pypi-attestations` having to do I/O.

cc @di @woodruffw @DarkaMaul 

