### PR TITLE
Dockerfile: Fix FROM ... AS casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # First things first, we build an image which is where we're going to compile
 # our static assets with. We use this stage in development.
-FROM node:22.4.0-bookworm as static-deps
+FROM node:22.4.0-bookworm AS static-deps
 
 WORKDIR /opt/warehouse/src/
 
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
 
 
 # This is our actual build stage, where we'll compile our static assets.
-FROM static-deps as static
+FROM static-deps AS static
 
 # Actually copy over our static files, we only copy over the static files to
 # save a small amount of space in our image and because we don't need them. We
@@ -36,7 +36,7 @@ RUN NODE_ENV=production npm run build
 
 
 # We'll build a light-weight layer along the way with just docs stuff
-FROM python:3.12.4-slim-bookworm as docs
+FROM python:3.12.4-slim-bookworm AS docs
 
 # By default, Docker has special steps to avoid keeping APT caches in the layers, which
 # is good, but in our case, we're going to mount a special cache volume (kept between
@@ -105,7 +105,7 @@ USER docs
 
 # Now we're going to build our actual application, but not the actual production
 # image that it gets deployed into.
-FROM python:3.12.4-slim-bookworm as build
+FROM python:3.12.4-slim-bookworm AS build
 
 # Define whether we're building a production or a development image. This will
 # generally be used to control whether or not we install our development and


### PR DESCRIPTION
This silences some warnings emitted under Docker 27.0.3:

```
❯ make tests
# Build our base container for this project.
docker compose build --build-arg IPYTHON=no --force-rm base
[+] Building 3.6s (20/30)                                                                                                      docker:default
 => [base internal] load build definition from Dockerfile                                                                                0.0s
 => => transferring dockerfile: 10.55kB                                                                                                  0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)                                                           0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 22)                                                          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 39)                                                          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 108)                                                         0.0s
 => [base internal] load metadata for docker.io/library/python:3.12.4-slim-bookworm                                                      1.1s
 => [base internal] load metadata for docker.io/library/node:22.4.0-bookworm                                                             1.1s
[...]
```