### PR TITLE
Dockerfile: put some XDG dirs under /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,6 +225,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Warehouse runs as `nobody` with `/nonexistent` as `$HOME`, which causes
+# significant shpilkes for libraries that expect to use XDG dirs.
+# Placate everybody by making some directories for runtime use.
+# Note that this happens right after `/tmp/*` is blown away, because we want
+# to keep these.
+RUN mkdir -p /tmp/share /tmp/cache
+ENV XDG_DATA_HOME /tmp/share
+ENV XDG_CACHE_COME /tmp/cache
+
 # Copy the directory into the container, this is done last so that changes to
 # Warehouse itself require the least amount of layers being invalidated from
 # the cache. This is most important in development, but it also useful for


### PR DESCRIPTION
Opening this up for consideration/feedback, not sure if this is the best approach yet 🙂 

Background context:

1. PEP 740 requires us to maintain a TUF repository containing the Sigstore root of trust (essentially a bundle of public keys/key materials for verifying the attestations uploaded to PyPI)
2. This TUF repository needs to get stored somewhere on disk; `sigstore-python` currently uses `platformdirs` to place it somewhere sensible under the user's local data/cache dirs
3. This doesn't work on Warehouse deployments, since Warehouse seems to run as `uid=nobody` with `$HOME=/nonexistent`, meaning that the XDG dirs don't exist.
4. This ~~gracefully addresses~~ hacks around the above by creating two new directories under `/tmp` and using them as Warehouse's XDG dirs.

From a functionality/correctness perspective, this should have no impact on Warehouse: nothing else appears to use the XDG dirs and, if anything in the future does, it should be redirected to these new ones.

From a security perspective: this puts the XDG dirs in a "global" temporary directory within the container. However (AFAICT), Warehouse intentionally runs as `nobody` with a rootless configuration to mitigate this kind of minor risk.

CC @di