### PR TITLE
Dockerfile, tests: fix typo, add backstop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -232,7 +232,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # to keep these.
 RUN mkdir -p /tmp/share /tmp/cache
 ENV XDG_DATA_HOME /tmp/share
-ENV XDG_CACHE_COME /tmp/cache
+ENV XDG_CACHE_HOME /tmp/cache
 
 # Copy the directory into the container, this is done last so that changes to
 # Warehouse itself require the least amount of layers being invalidated from

--- a/tests/functional/test_environment.py
+++ b/tests/functional/test_environment.py
@@ -12,7 +12,9 @@
 
 import platformdirs
 
+
 def test_xdg_environment():
+    # Backstop checks for Warehouse's (Dockerfile-configured) environment.
     user_data = platformdirs.user_data_dir()
     user_cache = platformdirs.user_cache_dir()
 

--- a/tests/functional/test_environment.py
+++ b/tests/functional/test_environment.py
@@ -1,0 +1,20 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import platformdirs
+
+def test_xdg_environment():
+    user_data = platformdirs.user_data_dir()
+    user_cache = platformdirs.user_cache_dir()
+
+    assert user_data == "/tmp/share"
+    assert user_cache == "/tmp/cache"


### PR DESCRIPTION
Fixes a typo in #16304, and adds a backstop functional test to confirm the variables get used as expected.

Signed-off-by: William Woodruff <william@trailofbits.com>