### PR TITLE
tests/functional: assert R_OK/W_OK for XDG dirs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,15 +225,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Warehouse runs as `nobody` with `/nonexistent` as `$HOME`, which causes
-# significant shpilkes for libraries that expect to use XDG dirs.
-# Placate everybody by making some directories for runtime use.
-# Note that this happens right after `/tmp/*` is blown away, because we want
-# to keep these.
-RUN mkdir -p /tmp/share /tmp/cache
-ENV XDG_DATA_HOME /tmp/share
-ENV XDG_CACHE_HOME /tmp/cache
-
 # Copy the directory into the container, this is done last so that changes to
 # Warehouse itself require the least amount of layers being invalidated from
 # the cache. This is most important in development, but it also useful for

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -36,6 +36,7 @@ packaging_legacy
 paginate>=0.5.2
 paginate_sqlalchemy
 passlib>=1.6.4
+platformdirs>=4.2
 premailer
 psycopg[c]
 pycurl

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1516,7 +1516,9 @@ plaster-pastedeploy==1.0.1 \
 platformdirs==4.2.2 \
     --hash=sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee \
     --hash=sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3
-    # via sigstore
+    # via
+    #   -r requirements/main.in
+    #   sigstore
 premailer==3.10.0 \
     --hash=sha256:021b8196364d7df96d04f9ade51b794d0b77bcc19e998321c515633a2273be1a \
     --hash=sha256:d1875a8411f5dc92b53ef9f193db6c0f879dc378d618e0ad292723e388bfe4c2

--- a/tests/functional/test_environment.py
+++ b/tests/functional/test_environment.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import platformdirs
 
 
@@ -20,3 +21,6 @@ def test_xdg_environment():
 
     assert user_data == "/tmp/share"
     assert user_cache == "/tmp/cache"
+
+    assert os.access(user_data, os.R_OK | os.W_OK)
+    assert os.access(user_cache, os.R_OK | os.W_OK)

--- a/tests/functional/test_environment.py
+++ b/tests/functional/test_environment.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import os
+
 import platformdirs
 
 

--- a/tests/functional/test_environment.py
+++ b/tests/functional/test_environment.py
@@ -19,8 +19,8 @@ def test_xdg_environment():
     # NOTE: We don't check the exact paths here, because they vary between
     # environments: they're in `$HOME` in local and CI builds, and in `/tmp`
     # when deployed.
-    user_data = platformdirs.user_data_dir()
-    user_cache = platformdirs.user_cache_dir()
+    user_data = platformdirs.user_data_dir(ensure_exists=True)
+    user_cache = platformdirs.user_cache_dir(ensure_exists=True)
 
     assert os.access(user_data, os.R_OK | os.W_OK)
     assert os.access(user_cache, os.R_OK | os.W_OK)

--- a/tests/functional/test_environment.py
+++ b/tests/functional/test_environment.py
@@ -16,11 +16,11 @@ import platformdirs
 
 def test_xdg_environment():
     # Backstop checks for Warehouse's (Dockerfile-configured) environment.
+    # NOTE: We don't check the exact paths here, because they vary between
+    # environments: they're in `$HOME` in local and CI builds, and in `/tmp`
+    # when deployed.
     user_data = platformdirs.user_data_dir()
     user_cache = platformdirs.user_cache_dir()
-
-    assert user_data == "/tmp/share"
-    assert user_cache == "/tmp/cache"
 
     assert os.access(user_data, os.R_OK | os.W_OK)
     assert os.access(user_cache, os.R_OK | os.W_OK)

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -15,6 +15,7 @@ import distutils.util
 import enum
 import json
 import os
+import secrets
 import shlex
 
 from datetime import timedelta
@@ -244,8 +245,8 @@ def from_base64_encoded_json(configuration):
 def configure(settings=None):
     # Sanity check: regardless of what we're configuring, some of Warehouse's
     # application state depends on a handful of XDG directories existing.
-    platformdirs.user_data_dir(ensure_exists=True)
-    platformdirs.user_cache_dir(ensure_exists=True)
+    platformdirs.user_data_dir(appname=secrets.token_urlsafe(), ensure_exists=True)
+    platformdirs.user_cache_dir(appname=secrets.token_urlsafe(), ensure_exists=True)
 
     if settings is None:
         settings = {}

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -19,9 +19,8 @@ import shlex
 
 from datetime import timedelta
 
-import platformdirs
-
 import orjson
+import platformdirs
 import transaction
 
 from pyramid import renderers

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -19,6 +19,8 @@ import shlex
 
 from datetime import timedelta
 
+import platformdirs
+
 import orjson
 import transaction
 
@@ -241,6 +243,11 @@ def from_base64_encoded_json(configuration):
 
 
 def configure(settings=None):
+    # Sanity check: regardless of what we're configuring, some of Warehouse's
+    # application state depends on a handful of XDG directories existing.
+    platformdirs.user_data_dir(ensure_exists=True)
+    platformdirs.user_cache_dir(ensure_exists=True)
+
     if settings is None:
         settings = {}
     settings["warehouse.forklift.legacy.MAX_FILESIZE_MIB"] = MAX_FILESIZE / ONE_MIB


### PR DESCRIPTION
This follows https://github.com/pypi/warehouse/pull/16304 -- this test passes for local and CI runs because they don't use the `nobody` user, which then fails at runtime (in deployment) to access these dirs.

https://github.com/cabotage/cabotage-app/pull/85 fixes the above by moving the XDG dir creation to within Cabotage's wrapper; this updates the backstop test to be permission/access based, rather than existence based.