### PR TITLE
fix(admin): guard against rendering inspector link to non-existent project name field

### DIFF
--- a/warehouse/admin/templates/admin/malware_reports/detail.html
+++ b/warehouse/admin/templates/admin/malware_reports/detail.html
@@ -105,7 +105,11 @@
         {% if report.payload.get("inspector_link") %}
           {% set inspector_url = report.payload.get("inspector_link") %}
         {% else %}
-          {% set inspector_url = "https://inspector.pypi.io/project/" + report.related.name %}
+          {% if report.related %}
+            {% set inspector_url = "https://inspector.pypi.io/project/" + report.related.name %}
+          {% else %}
+            {% set inspector_url = "" %}
+          {% endif %}
         {% endif %}
         <iframe class="embed-responsive-item" src="{{ inspector_url }}">
         </iframe>


### PR DESCRIPTION
Add a check to guard against rendering an inspector link to a non-existent project name field when an Observation is removed.

Fixes #16356