### PR TITLE
Add metrics for GH Trusted Publishers with reusable workflows

### DIFF
--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -18,11 +18,16 @@ import pretend
 import pytest
 
 from tests.common.db.accounts import UserFactory
-from tests.common.db.oidc import GitHubPublisherFactory, PendingGitHubPublisherFactory
+from tests.common.db.oidc import (
+    GitHubPublisherFactory,
+    GitLabPublisherFactory,
+    PendingGitHubPublisherFactory,
+)
 from tests.common.db.packaging import ProhibitedProjectFactory, ProjectFactory
 from warehouse.events.tags import EventTag
 from warehouse.macaroons import caveats
 from warehouse.macaroons.interfaces import IMacaroonService
+from warehouse.metrics import IMetricsService
 from warehouse.oidc import errors, views
 from warehouse.oidc.interfaces import IOIDCPublisherService
 from warehouse.packaging import services
@@ -677,3 +682,99 @@ def test_mint_token_with_invalid_name_fails(
         assert err["description"] == (
             f"The name {pending_publisher.project_name!r} is invalid."
         )
+
+
+@pytest.mark.parametrize(
+    ("claims_in_token", "is_reusable", "is_github"),
+    [
+        (
+            {
+                "ref": "someref",
+                "sha": "somesha",
+                "workflow_ref": "org/repo/.github/workflows/parent.yml@someref",
+                "job_workflow_ref": "org2/repo2/.github/workflows/reusable.yml@v1",
+            },
+            True,
+            True,
+        ),
+        (
+            {
+                "ref": "someref",
+                "sha": "somesha",
+                "workflow_ref": "org/repo/.github/workflows/workflow.yml@someref",
+                "job_workflow_ref": "org/repo/.github/workflows/workflow.yml@someref",
+            },
+            False,
+            True,
+        ),
+        (
+            {
+                "ref": "someref",
+                "sha": "somesha",
+            },
+            False,
+            False,
+        ),
+    ],
+)
+def test_mint_token_github_reusable_workflow_metrics(
+    monkeypatch,
+    db_request,
+    claims_in_token,
+    is_reusable,
+    is_github,
+    dummy_github_oidc_jwt,
+    metrics,
+):
+    time = pretend.stub(time=pretend.call_recorder(lambda: 0))
+    monkeypatch.setattr(views, "time", time)
+
+    project = pretend.stub(
+        id="fakeprojectid",
+        record_event=pretend.call_recorder(lambda **kw: None),
+    )
+
+    publisher = GitHubPublisherFactory() if is_github else GitLabPublisherFactory()
+    monkeypatch.setattr(publisher.__class__, "projects", [project])
+    publisher.publisher_url = pretend.call_recorder(lambda **kw: "https://fake/url")
+    # NOTE: Can't set __str__ using pretend.stub()
+    monkeypatch.setattr(publisher.__class__, "__str__", lambda s: "fakespecifier")
+
+    def _find_publisher(claims, pending=False):
+        if pending:
+            return None
+        else:
+            return publisher
+
+    oidc_service = pretend.stub(
+        verify_jwt_signature=pretend.call_recorder(lambda token: claims_in_token),
+        find_publisher=pretend.call_recorder(_find_publisher),
+    )
+
+    db_macaroon = pretend.stub(description="fakemacaroon")
+    macaroon_service = pretend.stub(
+        create_macaroon=pretend.call_recorder(
+            lambda *a, **kw: ("raw-macaroon", db_macaroon)
+        )
+    )
+
+    def find_service(iface, **kw):
+        if iface == IOIDCPublisherService:
+            return oidc_service
+        elif iface == IMacaroonService:
+            return macaroon_service
+        elif iface == IMetricsService:
+            return metrics
+        assert False, iface
+
+    monkeypatch.setattr(db_request, "find_service", find_service)
+    monkeypatch.setattr(db_request, "domain", "fakedomain")
+
+    views.mint_token(oidc_service, dummy_github_oidc_jwt, db_request)
+
+    if is_reusable:
+        assert metrics.increment.calls == [
+            pretend.call("warehouse.oidc.mint_token.github_reusable_workflow"),
+        ]
+    else:
+        assert not metrics.increment.calls

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -30,7 +30,7 @@ from warehouse.macaroons.services import DatabaseMacaroonService
 from warehouse.metrics.interfaces import IMetricsService
 from warehouse.oidc.errors import InvalidPublisherError
 from warehouse.oidc.interfaces import IOIDCPublisherService
-from warehouse.oidc.models import OIDCPublisher, PendingOIDCPublisher
+from warehouse.oidc.models import GitHubPublisher, OIDCPublisher, PendingOIDCPublisher
 from warehouse.oidc.services import OIDCPublisherService
 from warehouse.oidc.utils import OIDC_ISSUER_ADMIN_FLAGS, OIDC_ISSUER_SERVICE_NAMES
 from warehouse.packaging.interfaces import IProjectService
@@ -284,4 +284,17 @@ def mint_token(
                 "publisher_url": publisher.publisher_url(),
             },
         )
+
+    if isinstance(publisher, GitHubPublisher) and claims:
+        job_workflow_ref = claims.get("job_workflow_ref")
+        workflow_ref = claims.get("workflow_ref")
+
+        # When using reusable workflows, `job_workflow_ref` contains the reusable (
+        # called) workflow and `workflow_ref` contains the parent (caller) workflow.
+        # With non-reusable workflows they are the same, so we count reusable
+        # workflows by checking if they are different.
+        if job_workflow_ref and workflow_ref and job_workflow_ref != workflow_ref:
+            metrics = request.find_service(IMetricsService, context=None)
+            metrics.increment("warehouse.oidc.mint_token.github_reusable_workflow")
+
     return {"success": True, "token": serialized}


### PR DESCRIPTION
While looking into adding support for reusable workflows in GitHub Trusted Publishers (https://github.com/pypi/warehouse/issues/11096), I found that we (accidentally) already support a subset of reusable workflow scenarios.
If the reusable workflow is located in the same repository as the top-level workflow, then the OIDC claims will look something like this:
```json
{
    "job_workflow_ref": "org/repo/.github/workflows/reusable.yml@sha",
    "workflow_ref": "org/repo/.github/workflows/top-level.yml@sha",
}
```

That is, the `job_workflow_ref` claim will refer to the reusable workflow file, and `workflow_ref` to the top level workflow file, both in the same repository.

Since we check the Trusted Publisher's workflow filename against the `job_workflow_ref` claim, if the user set up the Trusted Publisher with `reusable.yml` in the workflow filename field, then verification will pass and the Trusted Publisher will work. This is the only scenario where reusable workflows currently work.

The problem is that we should be checking against `workflow_ref` instead. The other fields we check against (repo owner and repo name) refer to the repository that contains the top-level workflow, so the filename field should also refer to the top-level workflow.

One way of fixing this is to change the checks from using `job_workflow_ref` to using `workflow_ref`. This is fine for non-reusable workflows, since there those claims are equal (they contain the same path). However, there might be users who depend on the incorrect behavior mentioned above. They might have configured their Trusted Publisher to trust `reusable.yml`, and changing the check to `workflow_ref` (which contains `top-level.yml`) would break their Publisher.

In order to understand how many users depend on this behavior, this PR adds a counter for every time a user mints an API token using a GitHub Trusted Publisher with a reusable workflow. This way we can understand the impact of changing the behavior, and if it makes sense to do so.

cc @woodruffw @di 
 