### PR TITLE
fix: add focus exclusion to textarea as well

### DIFF
--- a/warehouse/static/js/warehouse/controllers/search_focus_controller.js
+++ b/warehouse/static/js/warehouse/controllers/search_focus_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
   focusSearchField(event) {
     // When we receive a keydown event, check if it's `/` and that we're not
     // already focused on the search field, or any other input field.
-    if (event.key === "/" && event.target.tagName !== "INPUT") {
+    if (event.key === "/" && event.target.tagName !== "INPUT" && event.target.tagName !== "TEXTAREA") {
       // Prevent the key from being handled as an actual input
       event.preventDefault();
       this.searchFieldTarget.focus();


### PR DESCRIPTION
`wtforms.TextAreaField` does not create an `input` HTML tag, so exclude that as well from changing focus.

Fixes #16371