### PR TITLE
feat(admin): show password disabled status

### DIFF
--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -75,6 +75,12 @@
             Joined on {{ user.date_joined|format_date() }}
           </p>
           {% endif %}
+
+          {% if user.disabled_for %}
+          <p class="text-muted text-center">
+            Password disabled:<br>{{ user.disabled_for.value }}
+          </p>
+          {% endif %}
         </div>
 
         <div class="card-footer p-0">


### PR DESCRIPTION
Add visual indication of user's password disable reason in the admin UI.

Closes #16363