### PR TITLE
Disable fsync in test postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_HOST_AUTH_METHOD: trust  # never do this in production!
+          POSTGRES_INITDB_ARGS: '--no-sync --set fsync=off --set full_page_writes=off'
         # Set health checks to wait until postgres has started
         options: --health-cmd "pg_isready --username=postgres --dbname=postgres" --health-interval 10s --health-timeout 5s --health-retries 5
       stripe:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "5433:5432"
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust  # never do this in production!
+      POSTGRES_INITDB_ARGS: '--no-sync --set fsync=off --set full_page_writes=off'
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres", "-d", "postgres"]
       interval: 1s


### PR DESCRIPTION
This shaves ~15 seconds (6%) from the runtime of the test suite on my machine, which has a slowish SATA SSD (~1:30 → ~1:15).

Extracted from #16295.
