### PR TITLE
test: use double size runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     if: github.repository == 'pypi/warehouse'
-    runs-on: depot-ubuntu-22.04-arm
+    runs-on: depot-ubuntu-22.04-arm-4
     outputs:
       buildId: ${{ steps.build.outputs.build-id}}
       token: ${{ steps.pull-token.outputs.token }}
@@ -58,7 +58,7 @@ jobs:
             command: bin/licenses
           - name: Translations
             command: bin/translations
-    runs-on: depot-ubuntu-22.04-arm
+    runs-on: depot-ubuntu-22.04-arm-4
     container:
       image: registry.depot.dev/rltf7cln5v:${{ needs.build.outputs.buildId }}
       credentials:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     if: github.repository == 'pypi/warehouse'
-    runs-on: depot-ubuntu-22.04-arm-4
+    runs-on: depot-ubuntu-22.04-arm-8
     outputs:
       buildId: ${{ steps.build.outputs.build-id}}
       token: ${{ steps.pull-token.outputs.token }}
@@ -58,7 +58,7 @@ jobs:
             command: bin/licenses
           - name: Translations
             command: bin/translations
-    runs-on: depot-ubuntu-22.04-arm-4
+    runs-on: depot-ubuntu-22.04-arm-8
     container:
       image: registry.depot.dev/rltf7cln5v:${{ needs.build.outputs.buildId }}
       credentials:


### PR DESCRIPTION
Since the cost is linear to CPU (2x), jobs should cost the same but finish faster.

Refs: https://depot.dev/docs/github-actions/runner-types#arm-runners