### PR TITLE
feat: add origin to API-submitted payloads

### DIFF
--- a/warehouse/api/echo.py
+++ b/warehouse/api/echo.py
@@ -98,6 +98,9 @@ def api_projects_observations(project: Project, request: Request) -> dict:
                 },
             )
 
+    # Manually add an origin field to the observation for tracking
+    data["origin"] = "api"
+
     project.record_observation(
         request=request,
         kind=kind,


### PR DESCRIPTION
Explicit is better than implicit - currently the only way to distinguish is by `null` vs non-null.
Set a real value to make it clearer where it came from.