### PR TITLE
Bump `sync_file_to_cache` `time_limit` to 60s

### DIFF
--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -44,7 +44,7 @@ def _copy_file_to_cache(archive_storage, cache_storage, path):
 @tasks.task(
     ignore_result=True,
     acks_late=True,
-    time_limit=30,
+    time_limit=60,
     autoretry_for=(
         SoftTimeLimitExceeded,
         TimeLimitExceeded,


### PR DESCRIPTION
With the goal of addressing https://python-software-foundation.sentry.io/issues/5043650347/

Initially added in https://github.com/pypi/warehouse/pull/15545.