### PR TITLE
chore: add tracing to worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -3,3 +3,4 @@ web: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-prod.c
 web-uploads: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
 worker: bin/start-worker celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
 worker-beat: bin/start-worker celery -A warehouse beat -S redbeat.RedBeatScheduler -l info
+worker-traced: env DD_SERVICE=warehouse-worker bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32


### PR DESCRIPTION
Instead of previous attempts where we applied tracing to all workers, create an individual service that we can control how many workers run to build trust tracing.