### PR TITLE
oidc/services: use PyJWK directly

### DIFF
--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -88,7 +88,7 @@ class TestOIDCPublisherService:
         assert jwt.decode.calls == [
             pretend.call(
                 token,
-                key=key.key,
+                key=key,
                 algorithms=["RS256"],
                 options=dict(
                     verify_signature=True,

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -236,7 +236,7 @@ class OIDCPublisherService:
             # set them explicitly to assert the intended verification behavior.
             signed_payload = jwt.decode(
                 unverified_token,
-                key=key.key,
+                key=key,
                 algorithms=["RS256"],
                 options=dict(
                     verify_signature=True,


### PR DESCRIPTION
Follows #16378 -- not exactly a dramatic change, but `pyjwt==2.9.0` and newer allow us to use the `PyJWK` directly rather than poking through it for the underlying public key 🙂 