### PR TITLE
Bump `sync_file_to_cache` `time_limit` to 120s

### DIFF
--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -44,7 +44,7 @@ def _copy_file_to_cache(archive_storage, cache_storage, path):
 @tasks.task(
     ignore_result=True,
     acks_late=True,
-    time_limit=60,
+    time_limit=120,
     autoretry_for=(
         SoftTimeLimitExceeded,
         TimeLimitExceeded,


### PR DESCRIPTION
We're still hitting the limit with some large files at 60s: https://python-software-foundation.sentry.io/issues/5043650347/