### PR TITLE
Updated TOTP list: Added Aegis

### DIFF
--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -355,6 +355,7 @@
             {% trans %}(proprietary){% endtrans %}
           </li>
           <li><a href="https://authy.com/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">Authy</a> {% trans %}(proprietary){% endtrans %}</li>
+          <li><a href="https://f-droid.org/packages/com.beemdevelopment.aegis" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">Aegis</a> {% trans %}(open source){% endtrans %}</li>
           <li><a href="https://play.google.com/store/apps/details?id=org.liberty.android.freeotpplus" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">FreeOTP+</a> {% trans %}(open source){% endtrans %}</li>
           <li><a href="https://freeotp.github.io/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">FreeOTP</a> {% trans %}(open source){% endtrans %}</li>
         </ul>


### PR DESCRIPTION
Hello everyone. I added Aegis to the totp list on the [help page](https://pypi.org/help/#totp). Aegis is the mainstream opensource application in 2FA for Android. Here are the stars stat on GitHub:

[FreeOTPPlus](https://github.com/helloworld1/FreeOTPPlus) 636 stars
[freeotp-android](https://github.com/freeotp/freeotp-android) 1.4k stars

and

[Aegis](https://github.com/beemdevelopment/Aegis) - 8.6k stars