### PR TITLE
fix(dev): restore default behavior of debugtoolbar

### DIFF
--- a/docker-compose.override.yaml-sample
+++ b/docker-compose.override.yaml-sample
@@ -55,7 +55,7 @@ services:
 
   web:
     # Similar to environment, you can selectively override other settings
-    command: ddtrace-run gunicorn --reload -b 0.0.0.0:8000 --access-logfile - --error-logfile - warehouse.wsgi:application
+    command: ddtrace-run gunicorn --reload --workers 4 -b 0.0.0.0:8000 --access-logfile - --error-logfile - warehouse.wsgi:application
     environment:
       # Using `<<:` overrides merges with the existing values, instead of overwriting it
       <<: *environment-vars

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   web:
     image: warehouse:docker-compose
-    command: gunicorn --reload --reload-extra-file=warehouse/api/openapi.yaml -w 4 -b 0.0.0.0:8000 --access-logfile - --error-logfile - warehouse.wsgi:application
+    command: gunicorn --reload --reload-extra-file=warehouse/api/openapi.yaml -b 0.0.0.0:8000 --access-logfile - --error-logfile - warehouse.wsgi:application
     env_file: dev/environment
     pull_policy: never
     volumes: *base_volumes


### PR DESCRIPTION
Needs a single worker as it uses global state, which is generally good enough for development.

Showcase the extra workers in an override command.