### PR TITLE
fix: use output from packaging.metadata parsed

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -1047,6 +1047,7 @@ class TestFileUpload:
                 "pyversion": "source",
                 "content": content,
                 "description": "an example description",
+                "keywords": "keyword1, keyword2",
             }
         )
         db_request.POST.extend([("classifiers", "Environment :: Other Environment")])
@@ -1143,7 +1144,7 @@ class TestFileUpload:
                     "maintainer": None,
                     "maintainer_email": None,
                     "license": None,
-                    "keywords": None,
+                    "keywords": ["keyword1", "keyword2"],
                     "classifiers": ["Environment :: Other Environment"],
                     "platform": None,
                     "home_page": None,

--- a/tests/unit/utils/test_release.py
+++ b/tests/unit/utils/test_release.py
@@ -12,19 +12,18 @@
 
 import pytest
 
-from warehouse.utils.release import split_and_strip_keywords
+from warehouse.utils.release import strip_keywords
 
 
 @pytest.mark.parametrize(
     ("keyword_input", "expected"),
     [
-        ("", []),
-        ("foo, bar", ["foo", "bar"]),
-        ("foo,bar", ["foo", "bar"]),
-        ("foo bar baz", ["foo bar baz"]),
-        ("foo, bar baz, ", ["foo", "bar baz"]),
-        ("foo, bar, baz, ,", ["foo", "bar", "baz"]),
+        ([], []),
+        ([""], []),
+        (["foo", "bar"], ["foo", "bar"]),
+        (["foo", "bar baz", ""], ["foo", "bar baz"]),
+        (["foo", "bar", "baz", "",""], ["foo", "bar", "baz"]),
     ],
 )
 def test_split_and_strip_keywords(keyword_input, expected):
-    assert split_and_strip_keywords(keyword_input) == expected
+    assert strip_keywords(keyword_input) == expected

--- a/tests/unit/utils/test_release.py
+++ b/tests/unit/utils/test_release.py
@@ -22,7 +22,7 @@ from warehouse.utils.release import strip_keywords
         ([""], []),
         (["foo", "bar"], ["foo", "bar"]),
         (["foo", "bar baz", ""], ["foo", "bar baz"]),
-        (["foo", "bar", "baz", "",""], ["foo", "bar", "baz"]),
+        (["foo", "bar", "baz", "", ""], ["foo", "bar", "baz"]),
     ],
 )
 def test_split_and_strip_keywords(keyword_input, expected):

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -75,7 +75,7 @@ from warehouse.packaging.models import (
 from warehouse.packaging.tasks import sync_file_to_cache, update_bigquery_release_files
 from warehouse.rate_limiting.interfaces import RateLimiterException
 from warehouse.utils import readme
-from warehouse.utils.release import split_and_strip_keywords
+from warehouse.utils.release import strip_keywords
 
 PATH_HASHER = "blake2_256"
 
@@ -843,9 +843,7 @@ def file_upload(request):
             #       which we now go and turn it back into a string, we should fix
             #       this and store this as a list.
             keywords=", ".join(meta.keywords) if meta.keywords else None,
-            keywords_array=(
-                split_and_strip_keywords(meta.keywords) if meta.keywords else None
-            ),
+            keywords_array=(strip_keywords(meta.keywords) if meta.keywords else None),
             requires_python=str(meta.requires_python) if meta.requires_python else None,
             # Since dynamic field values are RFC 822 email headers, which are
             # case-insensitive, normalize them to title-case so we don't have

--- a/warehouse/utils/release.py
+++ b/warehouse/utils/release.py
@@ -13,7 +13,7 @@
 
 def strip_keywords(keywords: list[str]) -> list[str]:
     """
-    Strip whitespace, remove empties.
+    Remove empties.
     Useful to cleanse user input prior to storing in Release.keywords_array.
     """
-    return [stripped for keyword in keywords if (stripped := keyword.strip())]
+    return [keyword for keyword in keywords if keyword]

--- a/warehouse/utils/release.py
+++ b/warehouse/utils/release.py
@@ -11,13 +11,9 @@
 # limitations under the License.
 
 
-def split_and_strip_keywords(keyword_input: str) -> list[str]:
+def strip_keywords(keywords: list[str]) -> list[str]:
     """
-    Split keywords on commas and strip whitespace, remove empties.
+    Strip whitespace, remove empties.
     Useful to cleanse user input prior to storing in Release.keywords_array.
     """
-    return [
-        stripped
-        for keyword in keyword_input.split(",")
-        if (stripped := keyword.strip())
-    ]
+    return [stripped for keyword in keywords if (stripped := keyword.strip())]


### PR DESCRIPTION
Now that we use `packaging.metadata` to pre-parse the inbound metadata, we no longer have to split a string to keywords, as that's being done for us already.

Fixes WAREHOUSE-PRODUCTION-21A
Fixes WAREHOUSE-PRODUCTION-21B
