### PR TITLE
GitHub, GitLab: improve claim matching during lookup

### DIFF
--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -27,11 +27,23 @@ from warehouse.oidc.models import _core, github
         # with `@` or extra suffixes or `git` refs that look like workflows.
         ("foo/bar/.github/workflows/basic.yml@refs/heads/main", "basic.yml"),
         ("foo/bar/.github/workflows/has-dash.yml@refs/heads/main", "has-dash.yml"),
-        ("foo/bar/.github/workflows/has--dashes.yml@refs/heads/main", "has--dashes.yml"),
-        ("foo/bar/.github/workflows/has--dashes-.yml@refs/heads/main", "has--dashes-.yml"),
+        (
+            "foo/bar/.github/workflows/has--dashes.yml@refs/heads/main",
+            "has--dashes.yml",
+        ),
+        (
+            "foo/bar/.github/workflows/has--dashes-.yml@refs/heads/main",
+            "has--dashes-.yml",
+        ),
         ("foo/bar/.github/workflows/has.period.yml@refs/heads/main", "has.period.yml"),
-        ("foo/bar/.github/workflows/has..periods.yml@refs/heads/main", "has..periods.yml"),
-        ("foo/bar/.github/workflows/has..periods..yml@refs/heads/main", "has..periods..yml"),
+        (
+            "foo/bar/.github/workflows/has..periods.yml@refs/heads/main",
+            "has..periods.yml",
+        ),
+        (
+            "foo/bar/.github/workflows/has..periods..yml@refs/heads/main",
+            "has..periods..yml",
+        ),
         (
             "foo/bar/.github/workflows/has_underscore.yml@refs/heads/main",
             "has_underscore.yml",

--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -20,17 +20,65 @@ from warehouse.oidc.errors import InvalidPublisherError
 from warehouse.oidc.models import _core, github
 
 
+@pytest.mark.parametrize(
+    ("workflow_ref", "expected"),
+    [
+        # Well-formed workflow refs, including exceedingly obnoxious ones
+        # with `@` or extra suffixes or `git` refs that look like workflows.
+        ("foo/bar/.github/workflows/basic.yml@refs/heads/main", "basic.yml"),
+        ("foo/bar/.github/workflows/has-dash.yml@refs/heads/main", "has-dash.yml"),
+        ("foo/bar/.github/workflows/has--dashes.yml@refs/heads/main", "has--dashes.yml"),
+        ("foo/bar/.github/workflows/has--dashes-.yml@refs/heads/main", "has--dashes-.yml"),
+        ("foo/bar/.github/workflows/has.period.yml@refs/heads/main", "has.period.yml"),
+        ("foo/bar/.github/workflows/has..periods.yml@refs/heads/main", "has..periods.yml"),
+        ("foo/bar/.github/workflows/has..periods..yml@refs/heads/main", "has..periods..yml"),
+        (
+            "foo/bar/.github/workflows/has_underscore.yml@refs/heads/main",
+            "has_underscore.yml",
+        ),
+        (
+            "foo/bar/.github/workflows/nested@evil.yml@refs/heads/main",
+            "nested@evil.yml",
+        ),
+        (
+            "foo/bar/.github/workflows/nested.yml@evil.yml@refs/heads/main",
+            "nested.yml@evil.yml",
+        ),
+        (
+            "foo/bar/.github/workflows/extra@nested.yml@evil.yml@refs/heads/main",
+            "extra@nested.yml@evil.yml",
+        ),
+        (
+            "foo/bar/.github/workflows/extra.yml@nested.yml@evil.yml@refs/heads/main",
+            "extra.yml@nested.yml@evil.yml",
+        ),
+        (
+            "foo/bar/.github/workflows/basic.yml@refs/heads/misleading@branch.yml",
+            "basic.yml",
+        ),
+        (
+            "foo/bar/.github/workflows/basic.yml@refs/heads/misleading@branch@causestwomatches.yml",
+            "basic.yml",
+        ),
+        ("foo/bar/.github/workflows/foo.yml.yml@refs/heads/main", "foo.yml.yml"),
+        (
+            "foo/bar/.github/workflows/foo.yml.foo.yml@refs/heads/main",
+            "foo.yml.foo.yml",
+        ),
+        # Malformed workflow refs.
+        ("foo/bar/.github/workflows/@refs/heads/main", None),
+        ("foo/bar/.github/workflows/nosuffix@refs/heads/main", None),
+        ("foo/bar/.github/workflows/.yml@refs/heads/main", None),
+        ("foo/bar/.github/workflows/main.yml", None),
+    ],
+)
+def test_extract_workflow_filename(workflow_ref, expected):
+    assert github._extract_workflow_filename(workflow_ref) == expected
+
+
 @pytest.mark.parametrize("claim", ["", "repo", "repo:"])
 def test_check_sub(claim):
     assert github._check_sub(pretend.stub(), claim, pretend.stub()) is False
-
-
-def test_lookup_strategies():
-    assert (
-        len(github.GitHubPublisher.__lookup_strategies__)
-        == len(github.PendingGitHubPublisher.__lookup_strategies__)
-        == 2
-    )
 
 
 class TestGitHubPublisher:

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -23,7 +23,6 @@ from sigstore.verify.policy import (
 from sqlalchemy import ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Query, mapped_column
-from sqlalchemy.sql.expression import func, literal
 
 from warehouse.oidc.errors import InvalidPublisherError
 from warehouse.oidc.interfaces import SignedClaims
@@ -193,7 +192,7 @@ class GitHubPublisherMixin:
 
         repository = signed_claims["repository"]
         repository_owner, repository_name = repository.split("/", 1)
-        workflow_ref: str = signed_claims["job_workflow_ref"]
+        workflow_ref = signed_claims["job_workflow_ref"]
         workflow_filename = _extract_workflow_filename(workflow_ref)
 
         if workflow_filename is None:

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -193,9 +193,8 @@ class GitHubPublisherMixin:
         repository = signed_claims["repository"]
         repository_owner, repository_name = repository.split("/", 1)
         workflow_ref = signed_claims["job_workflow_ref"]
-        workflow_filename = _extract_workflow_filename(workflow_ref)
 
-        if workflow_filename is None:
+        if not (workflow_filename := _extract_workflow_filename(workflow_ref)):
             return None
 
         return Query(klass).filter_by(
@@ -211,9 +210,8 @@ class GitHubPublisherMixin:
         repository = signed_claims["repository"]
         repository_owner, repository_name = repository.split("/", 1)
         workflow_ref = signed_claims["job_workflow_ref"]
-        workflow_filename = _extract_workflow_filename(workflow_ref)
 
-        if workflow_filename is None:
+        if not (workflow_filename := _extract_workflow_filename(workflow_ref)):
             return None
 
         return Query(klass).filter_by(

--- a/warehouse/oidc/models/gitlab.py
+++ b/warehouse/oidc/models/gitlab.py
@@ -179,9 +179,8 @@ class GitLabPublisherMixin:
         project_path = signed_claims["project_path"]
         ci_config_ref_uri = signed_claims["ci_config_ref_uri"]
         namespace, project = project_path.rsplit("/", 1)
-        workflow_filepath = _extract_workflow_filepath(ci_config_ref_uri)
 
-        if not workflow_filepath:
+        if not (workflow_filepath := _extract_workflow_filepath(ci_config_ref_uri)):
             return None
 
         return Query(klass).filter_by(
@@ -196,9 +195,8 @@ class GitLabPublisherMixin:
         project_path = signed_claims["project_path"]
         ci_config_ref_uri = signed_claims["ci_config_ref_uri"]
         namespace, project = project_path.rsplit("/", 1)
-        workflow_filepath = _extract_workflow_filepath(ci_config_ref_uri)
 
-        if not workflow_filepath:
+        if not (workflow_filepath := _extract_workflow_filepath(ci_config_ref_uri)):
             return None
 
         return Query(klass).filter_by(

--- a/warehouse/oidc/models/gitlab.py
+++ b/warehouse/oidc/models/gitlab.py
@@ -176,7 +176,20 @@ class GitLabPublisherMixin:
                 environment=environment,
             )
             .filter(
-                literal(ci_config_ref).like(func.concat(klass.workflow_filepath, "%"))
+                literal(ci_config_ref).startswith(
+                    # See `__lookup_all__` in GitHubPublisherMixin for an
+                    # explanation of this mess.
+                    func.replace(
+                        func.replace(
+                            func.replace(klass.workflow_filepath, "\\", "\\\\"),
+                            "%",
+                            "\\%",
+                        ),
+                        "_",
+                        "\\_",
+                    ),
+                    escape="\\",
+                )
             )
         )
 
@@ -197,7 +210,18 @@ class GitLabPublisherMixin:
                 environment="",
             )
             .filter(
-                literal(ci_config_ref).like(func.concat(klass.workflow_filepath, "%"))
+                literal(ci_config_ref).startswith(
+                    func.replace(
+                        func.replace(
+                            func.replace(klass.workflow_filepath, "\\", "\\\\"),
+                            "%",
+                            "\\%",
+                        ),
+                        "_",
+                        "\\_",
+                    ),
+                    escape="\\",
+                )
             )
         )
 


### PR DESCRIPTION
This fixes a constraint violation that users were previously able to induce by registering two similar-looking-but-not-exact Trusted Publishers. For example:

```
repo: foo/bar
workflow: publish-pypi.yml
```

and:

```
repo: foo/bar
workflow: publish_pypi.yml
```

Before this change, PyPI's publisher lookup would treat the `_` in `publish_pypi.yml` as a match expression, resulting in both publishers being matched when only exactly one publisher was expected to match. As a result, a user could configure two publishers in such a way that minting would *always* fail.

~~To fix this, we replace our use of a raw `like` with a more constrained `startswith` *and* escape `_` and `%` when they appear in the workflow identifier being matched on. We would ideally do this using SQLAlchemy's `autoescape`, but `autoescape` only supports string clauses and not column clauses. Instead, we build up a somewhat verbose chain of escape replacements manually.~~

Update: this PR now fixes the above by removing the SQL-level string matching entirely, and instead using regular expressions to extract the relevant claim component. This is both faster and much easier to test than the previous approach, as well as less brittle.

Fixes https://python-software-foundation.sentry.io/issues/5695739612