### PR TITLE
fix(admin): need to pass host for background tasks

### DIFF
--- a/tests/unit/observations/test_tasks.py
+++ b/tests/unit/observations/test_tasks.py
@@ -52,9 +52,7 @@ def test_report_observation_to_helpscout(
     kind, reports, payload, db_request, monkeypatch
 ):
     db_request.registry.settings = {"helpscout.app_secret": "fake-sekret"}
-    db_request.route_url = (
-        lambda route_url, project_name="deadbeef": "/admin/malware_reports/"
-    )
+    db_request.route_url = lambda *a, **kw: "/admin/malware_reports/"
 
     # Mock out the authentication to HelpScout
     monkeypatch.setattr(

--- a/warehouse/observations/tasks.py
+++ b/warehouse/observations/tasks.py
@@ -93,7 +93,9 @@ def report_observation_to_helpscout(task, request: Request, model_id: UUID) -> N
             Inspector URL: {model.payload.get("inspector_url")}
 
             Malware Reports URL: {request.route_url(
-                "admin.malware_reports.project.list", project_name=target_name,
+                "admin.malware_reports.project.list",
+                project_name=target_name,
+                _host=request.registry.settings.get("warehouse.domain"),
             )}
             """
         )


### PR DESCRIPTION
Without it, we get `localhost` in the output, since there's no user-facing active request.