### PR TITLE
Disallow trailing new line in `PROJECT_NAME_RE` (redux)

### DIFF
--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -26,6 +26,7 @@ from warehouse.packaging.models import (
     Role,
 )
 from warehouse.utils.project import (
+    PROJECT_NAME_RE,
     clear_project_quarantine,
     confirm_project,
     destroy_docs,
@@ -42,6 +43,18 @@ from ...common.db.packaging import (
     ReleaseFactory,
     RoleFactory,
 )
+
+
+@pytest.mark.parametrize(
+    "name", ["django", "zope.interface", "Twisted", "foo_bar", "abc123"]
+)
+def test_project_name_re_ok(name: str) -> None:
+    assert PROJECT_NAME_RE.match(name) is not None
+
+
+@pytest.mark.parametrize("name", ["", "foo\n", "foo\nbar", "..."])
+def test_project_name_re_invalid(name: str) -> None:
+    assert PROJECT_NAME_RE.match(name) is None
 
 
 def test_confirm():

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -37,7 +37,7 @@ def remove_documentation(task, request, project_name):
 
 
 PROJECT_NAME_RE = re.compile(
-    r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.IGNORECASE
+    r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])\Z", re.IGNORECASE
 )
 
 


### PR DESCRIPTION
Recreating #16278 since that PR seems to be stuck in some unmergeable state on GitHub's side.

Closes #16278.