### PR TITLE
Move verified Release URLs to the Verified section

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2812,66 +2812,67 @@ msgstr ""
 msgid "Avatar for {username} from gravatar.com"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:49
-msgid "Unverified details"
-msgstr ""
-
-#: warehouse/templates/includes/packaging/project-data.html:52
+#: warehouse/templates/includes/packaging/project-data.html:47
+#: warehouse/templates/includes/packaging/project-data.html:67
 msgid "Project links"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:67
-msgid "GitHub Statistics"
-msgstr ""
-
-#: warehouse/templates/includes/packaging/project-data.html:74
-msgid "Stars:"
+#: warehouse/templates/includes/packaging/project-data.html:64
+msgid "Unverified details"
 msgstr ""
 
 #: warehouse/templates/includes/packaging/project-data.html:82
+msgid "GitHub Statistics"
+msgstr ""
+
+#: warehouse/templates/includes/packaging/project-data.html:89
+msgid "Stars:"
+msgstr ""
+
+#: warehouse/templates/includes/packaging/project-data.html:97
 msgid "Forks:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:90
+#: warehouse/templates/includes/packaging/project-data.html:105
 msgid "Open issues:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:98
+#: warehouse/templates/includes/packaging/project-data.html:113
 msgid "Open PRs:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:108
+#: warehouse/templates/includes/packaging/project-data.html:123
 msgid "Meta"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:110
+#: warehouse/templates/includes/packaging/project-data.html:125
 msgid "License:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:113
-#: warehouse/templates/includes/packaging/project-data.html:115
+#: warehouse/templates/includes/packaging/project-data.html:128
+#: warehouse/templates/includes/packaging/project-data.html:130
 msgid "Author:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:118
-#: warehouse/templates/includes/packaging/project-data.html:120
+#: warehouse/templates/includes/packaging/project-data.html:133
+#: warehouse/templates/includes/packaging/project-data.html:135
 #: warehouse/templates/pages/help.html:612
 msgid "Maintainer:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:125
+#: warehouse/templates/includes/packaging/project-data.html:140
 msgid "Tags"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:135
+#: warehouse/templates/includes/packaging/project-data.html:150
 msgid "Requires:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:140
+#: warehouse/templates/includes/packaging/project-data.html:155
 msgid "Provides-Extra:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:148
+#: warehouse/templates/includes/packaging/project-data.html:163
 #: warehouse/templates/pages/classifiers.html:16
 #: warehouse/templates/pages/classifiers.html:21
 #: warehouse/templates/pages/sitemap.html:39

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -689,6 +689,21 @@ class Release(HasObservations, db.Model):
 
         return _urls
 
+    def urls_by_verify_status(self, verified: bool):
+        matching_urls = {
+            release_url.url
+            for release_url in self._project_urls.values()  # type: ignore[attr-defined]
+            if release_url.verified == verified
+        }
+
+        # Filter the output of `Release.urls`, since it has custom logic to de-duplicate
+        # release URLs
+        _urls = OrderedDict()
+        for name, url in self.urls.items():
+            if url in matching_urls:
+                _urls[name] = url
+        return _urls
+
     @staticmethod
     def get_user_name_and_repo_name(urls):
         for url in urls:

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -42,16 +42,31 @@
         </a>
       </span>
     {% endfor %}
+  {% endif %}{##}
+  {% if release.urls_by_verify_status(True).values() | contains_valid_uris %}
+    <h6>{% trans %}Project links{% endtrans %}</h6>
+    <ul class="vertical-tabs__list">
+      {% for name, url in release.urls_by_verify_status(True).items() %}
+      {% if is_valid_uri(url) %}
+      <li>
+        <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed" href="{{ url }}" rel="nofollow">
+          {{ url_icon(name, url) }}{{ name }}
+        </a>
+        <i class="fa fa-circle-check check" title="URL verified by PyPI"></i>
+      </li>
+      {% endif %}
+      {% endfor %}
+    </ul>
   {% endif %}
 </div>
 
 <div class="sidebar-section verified">
   <h3 class="sidebar-section__title">{% trans %}Unverified details{% endtrans %}</h3>
   <small><i>These details have <b>not</b> been verified by PyPI</i></small>
-{% if release.urls.values() | contains_valid_uris %}
+{% if release.urls_by_verify_status(False).values() | contains_valid_uris %}
   <h6>{% trans %}Project links{% endtrans %}</h6>
   <ul class="vertical-tabs__list">
-    {% for name, url in release.urls.items() %}
+    {% for name, url in release.urls_by_verify_status(False).items() %}
     {% if is_valid_uri(url) %}
     <li>
       <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed" href="{{ url }}" rel="nofollow">


### PR DESCRIPTION
This moves a release's project URLs that have been verified via Trusted Publishing to the "Verified details" section of the release page:
<img width="249" alt="image" src="https://github.com/user-attachments/assets/f0da11b4-1740-4b92-ae4c-aec6312c0624">


The backend side of this (marking URLs as verified or not depending on the Trusted Publisher) was merged [here](https://github.com/pypi/warehouse/pull/16205). This fixes https://github.com/pypi/warehouse/issues/8635.


@woodruffw @di 