### PR TITLE
Move URLs to top of verified section

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2804,17 +2804,17 @@ msgstr ""
 msgid "Verified details"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:31
+#: warehouse/templates/includes/packaging/project-data.html:19
+#: warehouse/templates/includes/packaging/project-data.html:67
+msgid "Project links"
+msgstr ""
+
+#: warehouse/templates/includes/packaging/project-data.html:46
 msgid "Maintainers"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:33
+#: warehouse/templates/includes/packaging/project-data.html:48
 msgid "Avatar for {username} from gravatar.com"
-msgstr ""
-
-#: warehouse/templates/includes/packaging/project-data.html:47
-#: warehouse/templates/includes/packaging/project-data.html:67
-msgid "Project links"
 msgstr ""
 
 #: warehouse/templates/includes/packaging/project-data.html:64

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -15,6 +15,21 @@
 <div class="sidebar-section verified">
   <h3 class="sidebar-section__title">{% trans %}Verified details{% endtrans %}</h3>
   <small><i>These details have been verified by PyPI</i></small>
+  {% if release.urls_by_verify_status(True).values() | contains_valid_uris %}
+    <h6>{% trans %}Project links{% endtrans %}</h6>
+    <ul class="vertical-tabs__list">
+      {% for name, url in release.urls_by_verify_status(True).items() %}
+      {% if is_valid_uri(url) %}
+      <li>
+        <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed" href="{{ url }}" rel="nofollow">
+          {{ url_icon(name, url) }}{{ name }}
+        </a>
+        <i class="fa fa-circle-check check" title="URL verified by PyPI"></i>
+      </li>
+      {% endif %}
+      {% endfor %}
+    </ul>
+  {% endif %}
   {% if project.organization %}
   <h6>Owner</h6>
     <span class="sidebar-section__maintainer">
@@ -42,21 +57,6 @@
         </a>
       </span>
     {% endfor %}
-  {% endif %}{##}
-  {% if release.urls_by_verify_status(True).values() | contains_valid_uris %}
-    <h6>{% trans %}Project links{% endtrans %}</h6>
-    <ul class="vertical-tabs__list">
-      {% for name, url in release.urls_by_verify_status(True).items() %}
-      {% if is_valid_uri(url) %}
-      <li>
-        <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed" href="{{ url }}" rel="nofollow">
-          {{ url_icon(name, url) }}{{ name }}
-        </a>
-        <i class="fa fa-circle-check check" title="URL verified by PyPI"></i>
-      </li>
-      {% endif %}
-      {% endfor %}
-    </ul>
   {% endif %}
 </div>
 


### PR DESCRIPTION
Follow-up to https://github.com/pypi/warehouse/pull/16472, moves verified "Project Links" section to the top, above the maintainers:
<img width="249" alt="image" src="https://github.com/user-attachments/assets/5fb75b41-8520-40aa-b339-4030d5c9d5a8">

@di 