### PR TITLE
Include filename and hash in duplicate file error message

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1096,7 +1096,9 @@ def file_upload(request):
                 # --skip-existing functionality in twine
                 # ref: https://github.com/pypi/warehouse/issues/3482
                 # ref: https://github.com/pypa/twine/issues/332
-                "File already exists. See "
+                "File already exists "
+                + f"({filename!r}, with blake2_256 hash {file_hashes['blake2_256']!r})."
+                + " See "
                 + request.help_url(_anchor="file-name-reuse")
                 + " for more information.",
             )


### PR DESCRIPTION
This PR adds the filename provided and the hash of the file contents provided on upload to the error message generated when a duplicate file is found.

This should help with debugging issues like #14812, and also give the user more information about which file was duplicated in the event of multiple file uploads.