### PR TITLE
Improve Pending Trusted Publishers UX when project already exists

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -3308,6 +3308,7 @@ class TestManageAccountPublishingViews:
     def test_initializes(self, metrics):
         request = pretend.stub(
             find_service=pretend.call_recorder(lambda *a, **kw: metrics),
+            route_url=pretend.stub(),
             POST=MultiDict(),
             registry=pretend.stub(
                 settings={
@@ -3363,6 +3364,7 @@ class TestManageAccountPublishingViews:
                     "github.token": "fake-api-token",
                 }
             ),
+            route_url=pretend.stub(),
         )
 
         view = views.ManageAccountPublishingViews(request)
@@ -3391,8 +3393,10 @@ class TestManageAccountPublishingViews:
             view._check_ratelimits()
 
     def test_manage_publishing(self, metrics, monkeypatch):
+        route_url = pretend.stub()
         request = pretend.stub(
             user=pretend.stub(),
+            route_url=route_url,
             registry=pretend.stub(
                 settings={
                     "github.token": "fake-api-token",
@@ -3467,12 +3471,14 @@ class TestManageAccountPublishingViews:
             pretend.call(
                 request.POST,
                 api_token="fake-api-token",
+                route_url=route_url,
                 project_factory=project_factory,
             )
         ]
         assert pending_gitlab_publisher_form_cls.calls == [
             pretend.call(
                 request.POST,
+                route_url=route_url,
                 project_factory=project_factory,
             )
         ]
@@ -3561,12 +3567,14 @@ class TestManageAccountPublishingViews:
             pretend.call(
                 pyramid_request.POST,
                 api_token="fake-api-token",
+                route_url=pyramid_request.route_url,
                 project_factory=project_factory,
             )
         ]
         assert pending_gitlab_publisher_form_cls.calls == [
             pretend.call(
                 pyramid_request.POST,
+                route_url=pyramid_request.route_url,
                 project_factory=project_factory,
             )
         ]
@@ -3689,12 +3697,14 @@ class TestManageAccountPublishingViews:
             pretend.call(
                 pyramid_request.POST,
                 api_token="fake-api-token",
+                route_url=pyramid_request.route_url,
                 project_factory=project_factory,
             )
         ]
         assert pending_gitlab_publisher_form_cls.calls == [
             pretend.call(
                 pyramid_request.POST,
+                route_url=pyramid_request.route_url,
                 project_factory=project_factory,
             )
         ]
@@ -3828,12 +3838,14 @@ class TestManageAccountPublishingViews:
             pretend.call(
                 pyramid_request.POST,
                 api_token="fake-api-token",
+                route_url=pyramid_request.route_url,
                 project_factory=project_factory,
             )
         ]
         assert pending_gitlab_publisher_form_cls.calls == [
             pretend.call(
                 pyramid_request.POST,
+                route_url=pyramid_request.route_url,
                 project_factory=project_factory,
             )
         ]
@@ -4545,12 +4557,14 @@ class TestManageAccountPublishingViews:
             pretend.call(
                 pyramid_request.POST,
                 api_token="fake-api-token",
+                route_url=pyramid_request.route_url,
                 project_factory=project_factory,
             )
         ]
         assert pending_gitlab_publisher_form_cls.calls == [
             pretend.call(
                 pyramid_request.POST,
+                route_url=pyramid_request.route_url,
                 project_factory=project_factory,
             )
         ]

--- a/tests/unit/oidc/forms/test_activestate.py
+++ b/tests/unit/oidc/forms/test_activestate.py
@@ -37,6 +37,7 @@ def _raise(exception):
 class TestPendingActiveStatePublisherForm:
     def test_validate(self, monkeypatch):
         project_factory = []
+        route_url = pretend.stub()
         data = MultiDict(
             {
                 "organization": "some-org",
@@ -46,7 +47,7 @@ class TestPendingActiveStatePublisherForm:
             }
         )
         form = activestate.PendingActiveStatePublisherForm(
-            MultiDict(data), project_factory=project_factory
+            MultiDict(data), route_url=route_url, project_factory=project_factory
         )
 
         # Test built-in validations
@@ -55,17 +56,27 @@ class TestPendingActiveStatePublisherForm:
         monkeypatch.setattr(form, "_lookup_organization", lambda *o: None)
 
         assert form._project_factory == project_factory
+        assert form._route_url == route_url
         assert form.validate()
 
     def test_validate_project_name_already_in_use(self):
         project_factory = ["some-project"]
+        route_url = pretend.call_recorder(lambda *args, **kwargs: "")
+
         form = activestate.PendingActiveStatePublisherForm(
-            project_factory=project_factory
+            route_url=route_url, project_factory=project_factory
         )
 
         field = pretend.stub(data="some-project")
         with pytest.raises(wtforms.validators.ValidationError):
             form.validate_project_name(field)
+        assert route_url.calls == [
+            pretend.call(
+                "manage.project.settings.publishing",
+                project_name="some-project",
+                _query={"provider": {"activestate"}},
+            )
+        ]
 
 
 class TestActiveStatePublisherForm:

--- a/tests/unit/oidc/forms/test_github.py
+++ b/tests/unit/oidc/forms/test_github.py
@@ -23,6 +23,7 @@ from warehouse.oidc.forms import github
 class TestPendingGitHubPublisherForm:
     def test_validate(self, monkeypatch):
         project_factory = []
+        route_url = pretend.stub()
         data = MultiDict(
             {
                 "owner": "some-owner",
@@ -32,7 +33,10 @@ class TestPendingGitHubPublisherForm:
             }
         )
         form = github.PendingGitHubPublisherForm(
-            MultiDict(data), api_token=pretend.stub(), project_factory=project_factory
+            MultiDict(data),
+            api_token=pretend.stub(),
+            route_url=route_url,
+            project_factory=project_factory,
         )
 
         # We're testing only the basic validation here.
@@ -40,17 +44,27 @@ class TestPendingGitHubPublisherForm:
         monkeypatch.setattr(form, "_lookup_owner", lambda o: owner_info)
 
         assert form._project_factory == project_factory
+        assert form._route_url == route_url
         assert form.validate()
 
     def test_validate_project_name_already_in_use(self):
         project_factory = ["some-project"]
+        route_url = pretend.call_recorder(lambda *args, **kwargs: "")
+
         form = github.PendingGitHubPublisherForm(
-            api_token="fake-token", project_factory=project_factory
+            api_token="fake-token", route_url=route_url, project_factory=project_factory
         )
 
         field = pretend.stub(data="some-project")
         with pytest.raises(wtforms.validators.ValidationError):
             form.validate_project_name(field)
+        assert route_url.calls == [
+            pretend.call(
+                "manage.project.settings.publishing",
+                project_name="some-project",
+                _query={"provider": {"github"}},
+            )
+        ]
 
 
 class TestGitHubPublisherForm:

--- a/tests/unit/oidc/forms/test_gitlab.py
+++ b/tests/unit/oidc/forms/test_gitlab.py
@@ -22,6 +22,7 @@ from warehouse.oidc.forms import gitlab
 class TestPendingGitLabPublisherForm:
     def test_validate(self, monkeypatch):
         project_factory = []
+        route_url = pretend.stub()
         data = MultiDict(
             {
                 "namespace": "some-owner",
@@ -31,20 +32,32 @@ class TestPendingGitLabPublisherForm:
             }
         )
         form = gitlab.PendingGitLabPublisherForm(
-            MultiDict(data), project_factory=project_factory
+            MultiDict(data), route_url=route_url, project_factory=project_factory
         )
 
+        assert form._route_url == route_url
         assert form._project_factory == project_factory
         # We're testing only the basic validation here.
         assert form.validate()
 
     def test_validate_project_name_already_in_use(self):
         project_factory = ["some-project"]
-        form = gitlab.PendingGitLabPublisherForm(project_factory=project_factory)
+        route_url = pretend.call_recorder(lambda *args, **kwargs: "my_url")
+
+        form = gitlab.PendingGitLabPublisherForm(
+            route_url=route_url, project_factory=project_factory
+        )
 
         field = pretend.stub(data="some-project")
         with pytest.raises(wtforms.validators.ValidationError):
             form.validate_project_name(field)
+        assert route_url.calls == [
+            pretend.call(
+                "manage.project.settings.publishing",
+                project_name="some-project",
+                _query={"provider": {"gitlab"}},
+            )
+        ]
 
 
 class TestGitLabPublisherForm:

--- a/tests/unit/oidc/forms/test_google.py
+++ b/tests/unit/oidc/forms/test_google.py
@@ -22,6 +22,7 @@ from warehouse.oidc.forms import google
 class TestPendingGooglePublisherForm:
     def test_validate(self, monkeypatch):
         project_factory = []
+        route_url = pretend.stub()
         data = MultiDict(
             {
                 "sub": "some-subject",
@@ -30,19 +31,30 @@ class TestPendingGooglePublisherForm:
             }
         )
         form = google.PendingGooglePublisherForm(
-            MultiDict(data), project_factory=project_factory
+            MultiDict(data), route_url=route_url, project_factory=project_factory
         )
 
         assert form._project_factory == project_factory
+        assert form._route_url == route_url
         assert form.validate()
 
     def test_validate_project_name_already_in_use(self):
         project_factory = ["some-project"]
-        form = google.PendingGooglePublisherForm(project_factory=project_factory)
+        route_url = pretend.call_recorder(lambda *args, **kwargs: "my_url")
+        form = google.PendingGooglePublisherForm(
+            route_url=route_url, project_factory=project_factory
+        )
 
         field = pretend.stub(data="some-project")
         with pytest.raises(wtforms.validators.ValidationError):
             form.validate_project_name(field)
+        assert route_url.calls == [
+            pretend.call(
+                "manage.project.settings.publishing",
+                project_name="some-project",
+                _query={"provider": {"google"}},
+            )
+        ]
 
 
 class TestGooglePublisherForm:

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1469,18 +1469,22 @@ class ManageAccountPublishingViews:
         self.pending_github_publisher_form = PendingGitHubPublisherForm(
             self.request.POST,
             api_token=self.request.registry.settings.get("github.token"),
+            route_url=self.request.route_url,
             project_factory=self.project_factory,
         )
         self.pending_gitlab_publisher_form = PendingGitLabPublisherForm(
             self.request.POST,
+            route_url=self.request.route_url,
             project_factory=self.project_factory,
         )
         self.pending_google_publisher_form = PendingGooglePublisherForm(
             self.request.POST,
+            route_url=self.request.route_url,
             project_factory=self.project_factory,
         )
         self.pending_activestate_publisher_form = PendingActiveStatePublisherForm(
             self.request.POST,
+            route_url=self.request.route_url,
             project_factory=self.project_factory,
         )
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -280,28 +280,28 @@ msgstr ""
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1544 warehouse/accounts/views.py:1787
+#: warehouse/accounts/views.py:1548 warehouse/accounts/views.py:1791
 #: warehouse/manage/views/__init__.py:1249
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1565
+#: warehouse/accounts/views.py:1569
 msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1581
+#: warehouse/accounts/views.py:1585
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1594
+#: warehouse/accounts/views.py:1598
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1610 warehouse/manage/views/__init__.py:1304
+#: warehouse/accounts/views.py:1614 warehouse/manage/views/__init__.py:1304
 #: warehouse/manage/views/__init__.py:1417
 #: warehouse/manage/views/__init__.py:1529
 #: warehouse/manage/views/__init__.py:1639
@@ -310,29 +310,29 @@ msgid ""
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1621 warehouse/manage/views/__init__.py:1318
+#: warehouse/accounts/views.py:1625 warehouse/manage/views/__init__.py:1318
 #: warehouse/manage/views/__init__.py:1431
 #: warehouse/manage/views/__init__.py:1543
 #: warehouse/manage/views/__init__.py:1653
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1635
+#: warehouse/accounts/views.py:1639
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1662
+#: warehouse/accounts/views.py:1666
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1801 warehouse/accounts/views.py:1814
-#: warehouse/accounts/views.py:1821
+#: warehouse/accounts/views.py:1805 warehouse/accounts/views.py:1818
+#: warehouse/accounts/views.py:1825
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1827
+#: warehouse/accounts/views.py:1831
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -578,15 +578,11 @@ msgstr ""
 msgid "Invalid project name"
 msgstr ""
 
-#: warehouse/oidc/forms/_core.py:35
-msgid "This project already exists, create an ordinary Trusted Publisher instead"
-msgstr ""
-
-#: warehouse/oidc/forms/_core.py:47
+#: warehouse/oidc/forms/_core.py:63
 msgid "Specify a publisher ID"
 msgstr ""
 
-#: warehouse/oidc/forms/_core.py:48
+#: warehouse/oidc/forms/_core.py:64
 msgid "Publisher must be specified by ID"
 msgstr ""
 

--- a/warehouse/oidc/forms/_core.py
+++ b/warehouse/oidc/forms/_core.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import markupsafe
 import wtforms
 
 from warehouse import forms
@@ -31,12 +31,28 @@ class PendingPublisherMixin:
         project_name = field.data
 
         if project_name in self._project_factory:
+            url_params = {name: value for name, value in self.data.items() if value}
+            url_params["provider"] = {self.provider}
+            url = self._route_url(
+                "manage.project.settings.publishing",
+                project_name=project_name,
+                _query=url_params,
+            )
+
+            # We mark the error message as safe, so that the HTML hyperlink is
+            # not escaped by Jinja
             raise wtforms.validators.ValidationError(
-                _(
-                    "This project already exists, create an ordinary Trusted "
-                    "Publisher instead"
+                markupsafe.Markup(
+                    f"This project already exists, use the project's publishing"
+                    f" settings <a href='{url}'>here</a> to create a Trusted"
+                    f" Publisher for it."
                 )
             )
+
+    @property
+    def provider(self) -> str:  # pragma: no cover
+        # Only concrete subclasses are constructed.
+        raise NotImplementedError
 
 
 class DeletePublisherForm(forms.Form):

--- a/warehouse/oidc/forms/activestate.py
+++ b/warehouse/oidc/forms/activestate.py
@@ -192,9 +192,14 @@ class ActiveStatePublisherBase(forms.Form):
 class PendingActiveStatePublisherForm(ActiveStatePublisherBase, PendingPublisherMixin):
     __params__ = ActiveStatePublisherBase.__params__ + ["project_name"]
 
-    def __init__(self, *args, project_factory, **kwargs):
+    def __init__(self, *args, route_url, project_factory, **kwargs):
         super().__init__(*args, **kwargs)
+        self._route_url = route_url
         self._project_factory = project_factory
+
+    @property
+    def provider(self) -> str:
+        return "activestate"
 
 
 class ActiveStatePublisherForm(ActiveStatePublisherBase):

--- a/warehouse/oidc/forms/github.py
+++ b/warehouse/oidc/forms/github.py
@@ -169,9 +169,14 @@ class GitHubPublisherBase(forms.Form):
 class PendingGitHubPublisherForm(GitHubPublisherBase, PendingPublisherMixin):
     __params__ = GitHubPublisherBase.__params__ + ["project_name"]
 
-    def __init__(self, *args, project_factory, **kwargs):
+    def __init__(self, *args, route_url, project_factory, **kwargs):
         super().__init__(*args, **kwargs)
+        self._route_url = route_url
         self._project_factory = project_factory
+
+    @property
+    def provider(self) -> str:
+        return "github"
 
 
 class GitHubPublisherForm(GitHubPublisherBase):

--- a/warehouse/oidc/forms/gitlab.py
+++ b/warehouse/oidc/forms/gitlab.py
@@ -97,9 +97,14 @@ class GitLabPublisherBase(forms.Form):
 class PendingGitLabPublisherForm(GitLabPublisherBase, PendingPublisherMixin):
     __params__ = GitLabPublisherBase.__params__ + ["project_name"]
 
-    def __init__(self, *args, project_factory, **kwargs):
+    def __init__(self, *args, route_url, project_factory, **kwargs):
         super().__init__(*args, **kwargs)
+        self._route_url = route_url
         self._project_factory = project_factory
+
+    @property
+    def provider(self) -> str:
+        return "gitlab"
 
 
 class GitLabPublisherForm(GitLabPublisherBase):

--- a/warehouse/oidc/forms/google.py
+++ b/warehouse/oidc/forms/google.py
@@ -35,9 +35,14 @@ class GooglePublisherBase(forms.Form):
 class PendingGooglePublisherForm(GooglePublisherBase, PendingPublisherMixin):
     __params__ = GooglePublisherBase.__params__ + ["project_name"]
 
-    def __init__(self, *args, project_factory, **kwargs):
+    def __init__(self, *args, route_url, project_factory, **kwargs):
         super().__init__(*args, **kwargs)
+        self._route_url = route_url
         self._project_factory = project_factory
+
+    @property
+    def provider(self) -> str:
+        return "google"
 
 
 class GooglePublisherForm(GooglePublisherBase):


### PR DESCRIPTION
This PR changes the error message displayed when a user tries to create a Pending Trusted Publisher for a project that already exists. The new error message includes a link to the regular Trusted Publisher form for that project, with URL parameters that will pre-fill the form with the values the user already input in the Pending form:


<img src="https://github.com/user-attachments/assets/312626e3-f983-41d8-a4b7-8607b647fb49" width="300">


The link will be something like:
```
https://pypi.org/manage/project/ruff/settings/publishing/?project_name=ruff&owner=my_user&repository=my_project&workflow_filename=release.yml&provider=github
```


The main logic change is in `forms/_core.py`. The validator for the `project_name` field (`validate_project_name()`) is changed so that the link to the pre-filled Trusted Publisher form is included in the error message when the project already exists.

Creating the link requires us to have access to the `request.route_url` method, which we pass the same way the `project_factory` parameter is currently passed to the validator (through the form constructor)


See the comment in https://github.com/pypi/warehouse/issues/14232#issuecomment-2276538291 for more context on why we use this approach rather than implicitly creating a Trusted Publisher for the existing project.

Fixes https://github.com/pypi/warehouse/issues/14232

cc @woodruffw 