### PR TITLE
Improve test collect time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ addopts = [
   "--numprocesses=auto",
 ]
 cache_dir = "dev/.pytest_cache"
-norecursedirs = ['build', 'dist', 'node_modules', '*.egg-info', '.state requirements']
+testpaths = ["tests/"]
 markers = [
     'unit: Quick running unit tests which test small units of functionality.',
     'functional: Slower running tests which test the entire system is functioning.',


### PR DESCRIPTION
While noticing that this [line](https://github.com/pypi/warehouse/blob/main/pyproject.toml#L96) was slightly wrong, as the last argument should have been split, I decided to test if we could improve the tests discovering time.


# Results

Tested with `python -m pytest --collect-only | grep 'tests collected'`

- Before:

```
 ======================== 4215 tests collected in 5.00s =========================
```

- After

```
======================== 4215 tests collected in 1.42s =========================
```

And with `time make tests`

- Before
```
make tests  0,26s user 0,23s system 0% cpu 59,990 total
```

- After
```
make tests  0,26s user 0,23s system 0% cpu 49,096 total
```

So about 10 second improvement 🎉 