### PR TITLE
Makefile: optimize sub-test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,12 @@ endif
 # higher than running a small handful of specific tests).
 # Only do this when the user doesn't set any explicit `TESTARGS` to avoid
 # confusion.
+COVERAGE := yes
 ifneq ($(T),)
-ifeq ($(TESTARGS),)
-	TESTARGS = -n 0
-endif
+		COVERAGE = no
+		ifeq ($(TESTARGS),)
+				TESTARGS = -n 0
+		endif
 endif
 
 default:
@@ -74,7 +76,7 @@ debug: .state/docker-build-base
 	docker compose run --rm --service-ports web
 
 tests: .state/docker-build-base
-	docker compose run --rm tests bin/tests --postgresql-host db $(T) $(TESTARGS)
+	docker compose run --rm --env COVERAGE=$(COVERAGE) tests bin/tests --postgresql-host db $(T) $(TESTARGS)
 
 static_tests: .state/docker-build-static
 	docker compose run --rm static bin/static_tests $(T) $(TESTARGS)

--- a/bin/tests
+++ b/bin/tests
@@ -37,7 +37,11 @@ mkdir -p warehouse/admin/static/dist/
 mkdir -p warehouse/static/dist/
 
 # Actually run our tests.
-python -m coverage run -m pytest --strict-markers "${COMMAND_ARGS[@]}"
-python -m coverage combine
-python -m coverage html --show-contexts
-python -m coverage report -m --fail-under 100
+if [ "${COVERAGE:-yes}" != "no" ]; then
+  python -m coverage run -m pytest --strict-markers "${COMMAND_ARGS[@]}"
+  python -m coverage combine
+  python -m coverage html --show-contexts
+  python -m coverage report -m --fail-under 100
+else
+  python -m pytest --strict-markers "${COMMAND_ARGS[@]}"
+fi;

--- a/docs/dev/development/getting-started.rst
+++ b/docs/dev/development/getting-started.rst
@@ -696,6 +696,14 @@ If you want to run a specific test, you can use the ``T`` variable:
 
     T=tests/unit/i18n/test_filters.py TESTARGS="-n auto" make tests
 
+  It also turns off test coverage reporting because it is almost guaranteed
+  to fail and add test time overhead. To re-enable the coverage report, you
+  can pass explicit ``COVERAGE``:
+
+  .. code-block:: console
+
+    T=tests/unit/i18n/test_filters.py COVERAGE=1 make tests
+
 You can also add arguments to the test runner by using the ``TESTARGS``
 variable:
 


### PR DESCRIPTION
To build on https://github.com/pypi/warehouse/pull/16323 and this [comment](https://github.com/pypi/warehouse/pull/16323#pullrequestreview-2207949548), this PR disables the coverage report if a specific subset of tests is selected (using `T`).

It is possible to re-enable it using the `COVERAGE` variable and set it to any value that is not `no`.

