### PR TITLE
Verify URLs ending with `.git` for GitHub and GitLab

### DIFF
--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -659,6 +659,9 @@ class TestGitHubPublisher:
     @pytest.mark.parametrize(
         ("url", "expected"),
         [
+            ("https://github.com/repository_owner/repository_name.git", True),
+            ("https://github.com/repository_owner/repository_name.git/", True),
+            ("https://github.com/repository_owner/repository_name.git/issues", False),
             ("https://repository_owner.github.io/repository_name/", True),
             ("https://repository_owner.github.io/repository_name", True),
             ("https://repository_owner.github.io/repository_name/subpage", True),

--- a/tests/unit/oidc/models/test_gitlab.py
+++ b/tests/unit/oidc/models/test_gitlab.py
@@ -612,6 +612,23 @@ class TestGitLabPublisher:
             db_request.db.add(publisher2)
             db_request.db.commit()
 
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://gitlab.com/repository_owner/repository_name.git", True),
+            ("https://gitlab.com/repository_owner/repository_name.git/", True),
+            ("https://gitlab.com/repository_owner/repository_name.git/issues", False),
+        ],
+    )
+    def test_gitlab_publisher_verify_url(self, url, expected):
+        publisher = gitlab.GitLabPublisher(
+            project="repository_name",
+            namespace="repository_owner",
+            workflow_filepath="workflow_filename.yml",
+            environment="",
+        )
+        assert publisher.verify_url(url) == expected
+
 
 class TestPendingGitLabPublisher:
     def test_reify_does_not_exist_yet(self, db_request):

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -348,8 +348,14 @@ class GitHubPublisher(GitHubPublisherMixin, OIDCPublisher):
         but we normalize using `rfc3986` to reject things like
         `https://${OWNER}.github.io/${REPO_NAME}/../malicious`, which would
         resolve to a URL outside the `/$REPO_NAME` path.
+
+        The suffix `.git` in repo URLs is ignored, since `github.com/org/repo.git`
+        always redirects to `github.com/org/repo`. This does not apply to subpaths,
+        like `github.com/org/repo.git/issues`, which do not redirect to the correct URL.
         """
-        if super().verify_url(url):
+        url_for_generic_check = url.removesuffix("/").removesuffix(".git")
+
+        if super().verify_url(url_for_generic_check):
             return True
 
         docs_url = f"https://{self.repository_owner}.github.io/{self.repository_name}"

--- a/warehouse/oidc/models/gitlab.py
+++ b/warehouse/oidc/models/gitlab.py
@@ -280,6 +280,19 @@ class GitLabPublisher(GitLabPublisherMixin, OIDCPublisher):
         UUID(as_uuid=True), ForeignKey(OIDCPublisher.id), primary_key=True
     )
 
+    def verify_url(self, url: str):
+        """
+        Verify a given URL against this GitLab's publisher information
+
+        In addition to the generic Trusted Publisher verification logic in
+        the parent class, the GitLab Trusted Publisher ignores the suffix `.git`
+        in repo URLs, since `gitlab.com/org/repo.git` always redirects to
+        `gitlab.com/org/repo`. This does not apply to subpaths like
+        `gitlab.com/org/repo.git/issues`, which do not redirect to the correct URL.
+        """
+        url_for_generic_check = url.removesuffix("/").removesuffix(".git")
+        return super().verify_url(url_for_generic_check)
+
 
 class PendingGitLabPublisher(GitLabPublisherMixin, PendingOIDCPublisher):
     __tablename__ = "pending_gitlab_oidc_publishers"


### PR DESCRIPTION
Fixes https://github.com/pypi/warehouse/issues/16475

cc @woodruffw 