### PR TITLE
Add missing translation for Trusted Publishing error

### DIFF
--- a/tests/unit/oidc/forms/test_activestate.py
+++ b/tests/unit/oidc/forms/test_activestate.py
@@ -59,7 +59,7 @@ class TestPendingActiveStatePublisherForm:
         assert form._route_url == route_url
         assert form.validate()
 
-    def test_validate_project_name_already_in_use(self):
+    def test_validate_project_name_already_in_use(self, pyramid_config):
         project_factory = ["some-project"]
         route_url = pretend.call_recorder(lambda *args, **kwargs: "")
 

--- a/tests/unit/oidc/forms/test_github.py
+++ b/tests/unit/oidc/forms/test_github.py
@@ -47,7 +47,7 @@ class TestPendingGitHubPublisherForm:
         assert form._route_url == route_url
         assert form.validate()
 
-    def test_validate_project_name_already_in_use(self):
+    def test_validate_project_name_already_in_use(self, pyramid_config):
         project_factory = ["some-project"]
         route_url = pretend.call_recorder(lambda *args, **kwargs: "")
 

--- a/tests/unit/oidc/forms/test_gitlab.py
+++ b/tests/unit/oidc/forms/test_gitlab.py
@@ -40,7 +40,7 @@ class TestPendingGitLabPublisherForm:
         # We're testing only the basic validation here.
         assert form.validate()
 
-    def test_validate_project_name_already_in_use(self):
+    def test_validate_project_name_already_in_use(self, pyramid_config):
         project_factory = ["some-project"]
         route_url = pretend.call_recorder(lambda *args, **kwargs: "my_url")
 

--- a/tests/unit/oidc/forms/test_google.py
+++ b/tests/unit/oidc/forms/test_google.py
@@ -38,7 +38,7 @@ class TestPendingGooglePublisherForm:
         assert form._route_url == route_url
         assert form.validate()
 
-    def test_validate_project_name_already_in_use(self):
+    def test_validate_project_name_already_in_use(self, pyramid_config):
         project_factory = ["some-project"]
         route_url = pretend.call_recorder(lambda *args, **kwargs: "my_url")
         form = google.PendingGooglePublisherForm(

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -578,17 +578,17 @@ msgstr ""
 msgid "Invalid project name"
 msgstr ""
 
-#: warehouse/oidc/forms/_core.py:49
+#: warehouse/oidc/forms/_core.py:46
 msgid ""
 "This project already exists, use the project's publishing settings <a "
-"href='{url}'>here</a> to create a Trusted Publisher for it."
-msgstr ""
-
-#: warehouse/oidc/forms/_core.py:65
-msgid "Specify a publisher ID"
+"href='${url}'>here</a> to create a Trusted Publisher for it."
 msgstr ""
 
 #: warehouse/oidc/forms/_core.py:66
+msgid "Specify a publisher ID"
+msgstr ""
+
+#: warehouse/oidc/forms/_core.py:67
 msgid "Publisher must be specified by ID"
 msgstr ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -578,11 +578,17 @@ msgstr ""
 msgid "Invalid project name"
 msgstr ""
 
-#: warehouse/oidc/forms/_core.py:63
+#: warehouse/oidc/forms/_core.py:49
+msgid ""
+"This project already exists, use the project's publishing settings <a "
+"href='{url}'>here</a> to create a Trusted Publisher for it."
+msgstr ""
+
+#: warehouse/oidc/forms/_core.py:65
 msgid "Specify a publisher ID"
 msgstr ""
 
-#: warehouse/oidc/forms/_core.py:64
+#: warehouse/oidc/forms/_core.py:66
 msgid "Publisher must be specified by ID"
 msgstr ""
 

--- a/warehouse/oidc/forms/_core.py
+++ b/warehouse/oidc/forms/_core.py
@@ -45,8 +45,9 @@ class PendingPublisherMixin:
                 markupsafe.Markup(
                     _(
                         "This project already exists, use the project's publishing"
-                        " settings <a href='{url}'>here</a> to create a Trusted"
-                        " Publisher for it.".format(url=url)
+                        " settings <a href='${url}'>here</a> to create a Trusted"
+                        " Publisher for it.",
+                        mapping={"url": url},
                     )
                 )
             )

--- a/warehouse/oidc/forms/_core.py
+++ b/warehouse/oidc/forms/_core.py
@@ -43,9 +43,11 @@ class PendingPublisherMixin:
             # not escaped by Jinja
             raise wtforms.validators.ValidationError(
                 markupsafe.Markup(
-                    f"This project already exists, use the project's publishing"
-                    f" settings <a href='{url}'>here</a> to create a Trusted"
-                    f" Publisher for it."
+                    _(
+                        "This project already exists, use the project's publishing"
+                        " settings <a href='{url}'>here</a> to create a Trusted"
+                        " Publisher for it.".format(url=url)
+                    )
                 )
             )
 


### PR DESCRIPTION
As pointed out [here](https://github.com/pypi/warehouse/pull/16515#discussion_r1722642347), the error message added in that PR was not marked for translation. This PR fixes that.

cc @woodruffw 