### PR TITLE
lint: run mypy with correct Python 3.12 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ combine_as_imports = true
 known_first_party = ['warehouse', 'tests']
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_unused_configs = true
 warn_unused_ignores = true
 plugins = ["mypy_zope:plugin"]

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 import base64
-import distutils.util
 import enum
 import json
 import os
@@ -28,6 +27,7 @@ from pyramid import renderers
 from pyramid.authorization import Allow, Authenticated
 from pyramid.config import Configurator as _Configurator
 from pyramid.exceptions import HTTPForbidden
+from pyramid.settings import asbool
 from pyramid.tweens import EXCVIEW
 from pyramid_rpc.xmlrpc import XMLRPCRenderer
 
@@ -334,7 +334,7 @@ def configure(settings=None):
         settings,
         "warehouse.xmlrpc.search.enabled",
         "WAREHOUSE_XMLRPC_SEARCH",
-        coercer=distutils.util.strtobool,
+        coercer=asbool,
         default=True,
     )
     maybe_set(settings, "warehouse.xmlrpc.cache.url", "REDIS_URL")


### PR DESCRIPTION
Previously not able to update, as `distutils` was removed from Python, and mypy didn't know how to resolve the types from the vendored `distutils` inside `setuptools`.

```console
warehouse/config.py:14: error: Cannot find implementation or library stub for module named "distutils" [import-not-found]
warehouse/config.py:14: note: See mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

Instead of figuring that out, use a Pyramid built-in to coerce the string to a boolean.

Refs: https://docs.pylonsproject.org/projects/pyramid/en/2.0-branch/api/settings.html#pyramid.settings.asbool
Refs: https://docs.pylonsproject.org/projects/pyramid/en/2.0-branch/_modules/pyramid/settings.html#asbool
Refs: https://github.com/pypa/setuptools/blob/477f713450ff57de126153f3034d032542916d03/setuptools/_distutils/util.py#L328-L341