### PR TITLE
Treat SA cartesian products as warnings under test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ filterwarnings = [
     'ignore::warehouse.admin.services.InsecureStorageWarning',
     'ignore::warehouse.utils.exceptions.InsecureOIDCPublisherWarning',
     'ignore::warehouse.packaging.services.InsecureStorageWarning',
+    'error:SELECT statement has a cartesian product:sqlalchemy.exc.SAWarning',
 ]
 
 [tool.pip-tools.compile]


### PR DESCRIPTION
This is a commonly-hit SQLAlchemy footgun, but one easily remedied
by treating the warning SQLALchemy raises as an error under pytest.

I verified this by running against commit 8a5ad08a1bf, which produced
these failures:

    FAILED tests/unit/forklift/test_legacy.py::TestFileUpload::test_new_release_url_verified[https://github.com/foo/bar/readme.md-True] - sqlalchemy.exc.SAWarning: SELECT statement has a cartesian product between FROM element(s) "release_urls" and FROM element "releases".  A...
    FAILED tests/unit/forklift/test_legacy.py::TestFileUpload::test_new_release_url_verified[https://google.com-False] - sqlalchemy.exc.SAWarning: SELECT statement has a cartesian product between FROM element(s) "releases" and FROM element "release_urls".  A...
    FAILED tests/unit/forklift/test_legacy.py::TestFileUpload::test_new_release_url_verified[https://github.com/foo/bar-True] - sqlalchemy.exc.SAWarning: SELECT statement has a cartesian product between FROM element(s) "release_urls" and FROM element "releases".  A...
    FAILED tests/unit/forklift/test_legacy.py::TestFileUpload::test_new_release_url_verified[https://github.com/foo-False] - sqlalchemy.exc.SAWarning: SELECT statement has a cartesian product between FROM element(s) "releases" and FROM element "release_urls".  A...
    FAILED tests/unit/forklift/test_legacy.py::TestFileUpload::test_new_publisher_verifies_existing_release_url - sqlalchemy.exc.SAWarning: SELECT statement has a cartesian product between FROM element(s) "releases" and FROM element "release_urls".  A...
    FAILED tests/unit/forklift/test_legacy.py::TestFileUpload::test_new_release_url_verified[https://github.com/foo/bar/-True] - sqlalchemy.exc.SAWarning: SELECT statement has a cartesian product between FROM element(s) "releases" and FROM element "release_urls".  A...

    Results (84.29s (0:01:24)):
        4209 passed
           6 failed
             - tests/unit/forklift/test_legacy.py:3842 TestFileUpload.test_new_release_url_verified[https://github.com/foo/bar/readme.md-True]
             - tests/unit/forklift/test_legacy.py:3842 TestFileUpload.test_new_release_url_verified[https://google.com-False]
             - tests/unit/forklift/test_legacy.py:3842 TestFileUpload.test_new_release_url_verified[https://github.com/foo/bar-True]
             - tests/unit/forklift/test_legacy.py:3842 TestFileUpload.test_new_release_url_verified[https://github.com/foo-False]
             - tests/unit/forklift/test_legacy.py:3911 TestFileUpload.test_new_publisher_verifies_existing_release_url
             - tests/unit/forklift/test_legacy.py:3842 TestFileUpload.test_new_release_url_verified[https://github.com/foo/bar/-True]

On 9de75b86eb the build is clean.
