### PR TITLE
properly include `warehouse.attestations`

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -348,6 +348,7 @@ def test_configure(monkeypatch, settings, environment):
             pretend.call(".accounts"),
             pretend.call(".macaroons"),
             pretend.call(".oidc"),
+            pretend.call(".attestations"),
             pretend.call(".manage"),
             pretend.call(".organizations"),
             pretend.call(".subscriptions"),

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -454,12 +454,14 @@ def configure(settings=None):
         "VERIFY_EMAIL_RATELIMIT_STRING",
         default="3 per 6 hours",
     )
-    maybe_set(
-        settings,
-        "warehouse.account.accounts_search_ratelimit_string",
-        "ACCOUNTS_SEARCH_RATELIMIT_STRING",
-        default="100 per hour",
-    ),
+    (
+        maybe_set(
+            settings,
+            "warehouse.account.accounts_search_ratelimit_string",
+            "ACCOUNTS_SEARCH_RATELIMIT_STRING",
+            default="100 per hour",
+        ),
+    )
     maybe_set(
         settings,
         "warehouse.account.password_reset_ratelimit_string",
@@ -738,6 +740,9 @@ def configure(settings=None):
 
     # Register support for OIDC based authentication
     config.include(".oidc")
+
+    # Register support for attestations
+    config.include(".attestations")
 
     # Register logged-in views
     config.include(".manage")


### PR DESCRIPTION
Follows https://github.com/pypi/warehouse/pull/16543: it isn't sufficient to define the `includeme`, we also need to explicitly include it. Will include this in my RCA follow-up as well.