### PR TITLE
refactor: replace integers with durations in seconds

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -21,7 +21,6 @@ from sqlalchemy.exc import NoResultFound
 
 from warehouse import email
 from warehouse.accounts.interfaces import IUserService
-from warehouse.constants import THREE_DAYS_IN_SECONDS
 from warehouse.email.interfaces import IEmailSender
 from warehouse.email.services import EmailMessage
 
@@ -2207,7 +2206,7 @@ class TestOrganizationMemberEmails:
         self.organization_name = "example"
         self.message = "test message"
         self.email_token = "token"
-        self.token_age = THREE_DAYS_IN_SECONDS
+        self.token_age = datetime.timedelta(days=3).total_seconds()
 
     @pytest.mark.usefixtures("_organization_invite")
     def test_send_organization_member_invited_email(

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -21,6 +21,7 @@ from sqlalchemy.exc import NoResultFound
 
 from warehouse import email
 from warehouse.accounts.interfaces import IUserService
+from warehouse.constants import THREE_DAYS_IN_SECONDS
 from warehouse.email.interfaces import IEmailSender
 from warehouse.email.services import EmailMessage
 
@@ -2206,7 +2207,7 @@ class TestOrganizationMemberEmails:
         self.organization_name = "example"
         self.message = "test message"
         self.email_token = "token"
-        self.token_age = 72 * 60 * 60
+        self.token_age = THREE_DAYS_IN_SECONDS
 
     @pytest.mark.usefixtures("_organization_invite")
     def test_send_organization_member_invited_email(

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -39,7 +39,7 @@ from warehouse.accounts.interfaces import (
     TokenExpired,
 )
 from warehouse.admin.flags import AdminFlagValue
-from warehouse.constants import MAX_FILESIZE, MAX_PROJECT_SIZE
+from warehouse.constants import MAX_FILESIZE, MAX_PROJECT_SIZE, SIX_HOURS_IN_SECONDS
 from warehouse.events.tags import EventTag
 from warehouse.macaroons import caveats
 from warehouse.macaroons.interfaces import IMacaroonService
@@ -4806,7 +4806,9 @@ class TestManageProjectRoles:
             find_userid=lambda username: new_user.id, get_user=lambda userid: new_user
         )
         token_service = pretend.stub(
-            dumps=lambda data: "TOKEN", max_age=6 * 60 * 60, loads=lambda data: None
+            dumps=lambda data: "TOKEN",
+            max_age=SIX_HOURS_IN_SECONDS,
+            loads=lambda data: None,
         )
         db_request.find_service = pretend.call_recorder(
             lambda iface, context=None, name=None: {
@@ -4891,7 +4893,9 @@ class TestManageProjectRoles:
             find_userid=lambda username: user.id, get_user=lambda userid: user
         )
         token_service = pretend.stub(
-            dumps=lambda data: "TOKEN", max_age=6 * 60 * 60, loads=lambda data: None
+            dumps=lambda data: "TOKEN",
+            max_age=SIX_HOURS_IN_SECONDS,
+            loads=lambda data: None,
         )
         db_request.find_service = pretend.call_recorder(
             lambda iface, context=None, name=None: {
@@ -4950,7 +4954,9 @@ class TestManageProjectRoles:
             find_userid=lambda username: new_user.id, get_user=lambda userid: new_user
         )
         token_service = pretend.stub(
-            dumps=lambda data: "TOKEN", max_age=6 * 60 * 60, loads=lambda data: None
+            dumps=lambda data: "TOKEN",
+            max_age=SIX_HOURS_IN_SECONDS,
+            loads=lambda data: None,
         )
         db_request.find_service = pretend.call_recorder(
             lambda iface, context=None, name=None: {
@@ -5039,7 +5045,7 @@ class TestManageProjectRoles:
         )
         token_service = pretend.stub(
             dumps=lambda data: "TOKEN",
-            max_age=6 * 60 * 60,
+            max_age=SIX_HOURS_IN_SECONDS,
             loads=lambda data: None,
         )
         db_request.find_service = pretend.call_recorder(
@@ -5103,7 +5109,7 @@ class TestManageProjectRoles:
         )
         token_service = pretend.stub(
             dumps=lambda data: "TOKEN",
-            max_age=6 * 60 * 60,
+            max_age=SIX_HOURS_IN_SECONDS,
             loads=lambda data: {"desired_role": "Maintainer"},
         )
         db_request.find_service = pretend.call_recorder(

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -39,7 +39,7 @@ from warehouse.accounts.interfaces import (
     TokenExpired,
 )
 from warehouse.admin.flags import AdminFlagValue
-from warehouse.constants import MAX_FILESIZE, MAX_PROJECT_SIZE, SIX_HOURS_IN_SECONDS
+from warehouse.constants import MAX_FILESIZE, MAX_PROJECT_SIZE
 from warehouse.events.tags import EventTag
 from warehouse.macaroons import caveats
 from warehouse.macaroons.interfaces import IMacaroonService
@@ -4807,7 +4807,7 @@ class TestManageProjectRoles:
         )
         token_service = pretend.stub(
             dumps=lambda data: "TOKEN",
-            max_age=SIX_HOURS_IN_SECONDS,
+            max_age=datetime.timedelta(hours=6).total_seconds(),
             loads=lambda data: None,
         )
         db_request.find_service = pretend.call_recorder(
@@ -4894,7 +4894,7 @@ class TestManageProjectRoles:
         )
         token_service = pretend.stub(
             dumps=lambda data: "TOKEN",
-            max_age=SIX_HOURS_IN_SECONDS,
+            max_age=datetime.timedelta(hours=6).total_seconds(),
             loads=lambda data: None,
         )
         db_request.find_service = pretend.call_recorder(
@@ -4955,7 +4955,7 @@ class TestManageProjectRoles:
         )
         token_service = pretend.stub(
             dumps=lambda data: "TOKEN",
-            max_age=SIX_HOURS_IN_SECONDS,
+            max_age=datetime.timedelta(hours=6).total_seconds(),
             loads=lambda data: None,
         )
         db_request.find_service = pretend.call_recorder(
@@ -5045,7 +5045,7 @@ class TestManageProjectRoles:
         )
         token_service = pretend.stub(
             dumps=lambda data: "TOKEN",
-            max_age=SIX_HOURS_IN_SECONDS,
+            max_age=datetime.timedelta(hours=6).total_seconds(),
             loads=lambda data: None,
         )
         db_request.find_service = pretend.call_recorder(
@@ -5109,7 +5109,7 @@ class TestManageProjectRoles:
         )
         token_service = pretend.stub(
             dumps=lambda data: "TOKEN",
-            max_age=SIX_HOURS_IN_SECONDS,
+            max_age=datetime.timedelta(hours=6).total_seconds(),
             loads=lambda data: {"desired_role": "Maintainer"},
         )
         db_request.find_service = pretend.call_recorder(

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -23,6 +23,7 @@ import warehouse.sessions
 import warehouse.utils.otp as otp
 import warehouse.utils.webauthn as webauthn
 
+from warehouse.constants import TWELVE_HOURS_IN_SECONDS
 from warehouse.sessions import (
     InvalidSession,
     Session,
@@ -420,7 +421,7 @@ class TestSessionFactory:
         )
 
         assert session_factory.signer.unsign.calls == [
-            pretend.call("123456", max_age=12 * 60 * 60)
+            pretend.call("123456", max_age=TWELVE_HOURS_IN_SECONDS)
         ]
 
         assert session_factory.redis.get.calls == [
@@ -450,7 +451,7 @@ class TestSessionFactory:
         )
 
         assert session_factory.signer.unsign.calls == [
-            pretend.call("123456", max_age=12 * 60 * 60)
+            pretend.call("123456", max_age=TWELVE_HOURS_IN_SECONDS)
         ]
 
         assert session_factory.redis.get.calls == [
@@ -485,7 +486,7 @@ class TestSessionFactory:
         )
 
         assert session_factory.signer.unsign.calls == [
-            pretend.call("123456", max_age=12 * 60 * 60)
+            pretend.call("123456", max_age=TWELVE_HOURS_IN_SECONDS)
         ]
 
         assert session_factory.redis.get.calls == [
@@ -570,7 +571,11 @@ class TestSessionFactory:
             )
         ]
         assert session_factory.redis.setex.calls == [
-            pretend.call("warehouse/session/data/123456", 12 * 60 * 60, b"msgpack data")
+            pretend.call(
+                "warehouse/session/data/123456",
+                TWELVE_HOURS_IN_SECONDS,
+                b"msgpack data",
+            )
         ]
         assert pyramid_request.session.should_save.calls == [
             pretend.call(),
@@ -581,7 +586,7 @@ class TestSessionFactory:
             pretend.call(
                 "session_id",
                 "cookie data",
-                max_age=12 * 60 * 60,
+                max_age=TWELVE_HOURS_IN_SECONDS,
                 httponly=True,
                 secure=False,
                 samesite=b"lax",

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -12,6 +12,8 @@
 
 import time
 
+from datetime import timedelta
+
 import msgpack
 import pretend
 import pytest
@@ -23,7 +25,6 @@ import warehouse.sessions
 import warehouse.utils.otp as otp
 import warehouse.utils.webauthn as webauthn
 
-from warehouse.constants import TWELVE_HOURS_IN_SECONDS
 from warehouse.sessions import (
     InvalidSession,
     Session,
@@ -421,7 +422,7 @@ class TestSessionFactory:
         )
 
         assert session_factory.signer.unsign.calls == [
-            pretend.call("123456", max_age=TWELVE_HOURS_IN_SECONDS)
+            pretend.call("123456", max_age=timedelta(hours=12).total_seconds())
         ]
 
         assert session_factory.redis.get.calls == [
@@ -451,7 +452,7 @@ class TestSessionFactory:
         )
 
         assert session_factory.signer.unsign.calls == [
-            pretend.call("123456", max_age=TWELVE_HOURS_IN_SECONDS)
+            pretend.call("123456", max_age=timedelta(hours=12).total_seconds())
         ]
 
         assert session_factory.redis.get.calls == [
@@ -486,7 +487,7 @@ class TestSessionFactory:
         )
 
         assert session_factory.signer.unsign.calls == [
-            pretend.call("123456", max_age=TWELVE_HOURS_IN_SECONDS)
+            pretend.call("123456", max_age=timedelta(hours=12).total_seconds())
         ]
 
         assert session_factory.redis.get.calls == [
@@ -573,7 +574,7 @@ class TestSessionFactory:
         assert session_factory.redis.setex.calls == [
             pretend.call(
                 "warehouse/session/data/123456",
-                TWELVE_HOURS_IN_SECONDS,
+                timedelta(hours=12).total_seconds(),
                 b"msgpack data",
             )
         ]
@@ -586,7 +587,7 @@ class TestSessionFactory:
             pretend.call(
                 "session_id",
                 "cookie data",
-                max_age=TWELVE_HOURS_IN_SECONDS,
+                max_age=timedelta(hours=12).total_seconds(),
                 httponly=True,
                 secure=False,
                 samesite=b"lax",

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -63,7 +63,6 @@ from warehouse.admin.flags import AdminFlagValue
 from warehouse.authnz import Permissions
 from warehouse.cache.origin import origin_cache
 from warehouse.captcha.interfaces import ICaptchaService
-from warehouse.constants import ONE_DAY_IN_SECONDS
 from warehouse.email import (
     send_added_as_collaborator_email,
     send_added_as_organization_member_email,
@@ -160,7 +159,12 @@ def incomplete_password_resets(exc, request):
     route_name="accounts.profile",
     context=User,
     renderer="accounts/profile.html",
-    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=ONE_DAY_IN_SECONDS)],
+    decorator=[
+        origin_cache(
+            datetime.timedelta(days=1).total_seconds(),
+            stale_if_error=datetime.timedelta(days=1).total_seconds(),
+        )
+    ],
     has_translations=True,
 )
 def profile(user, request):

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -63,6 +63,7 @@ from warehouse.admin.flags import AdminFlagValue
 from warehouse.authnz import Permissions
 from warehouse.cache.origin import origin_cache
 from warehouse.captcha.interfaces import ICaptchaService
+from warehouse.constants import ONE_DAY_IN_SECONDS
 from warehouse.email import (
     send_added_as_collaborator_email,
     send_added_as_organization_member_email,
@@ -159,9 +160,7 @@ def incomplete_password_resets(exc, request):
     route_name="accounts.profile",
     context=User,
     renderer="accounts/profile.html",
-    decorator=[
-        origin_cache(1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60)  # 1 day each.
-    ],
+    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=ONE_DAY_IN_SECONDS)],
     has_translations=True,
 )
 def profile(user, request):

--- a/warehouse/admin/__init__.py
+++ b/warehouse/admin/__init__.py
@@ -10,8 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
+
 from warehouse.admin.services import ISponsorLogoStorage
-from warehouse.constants import TEN_YEARS_IN_SECONDS
 from warehouse.utils.static import ManifestCacheBuster
 
 
@@ -33,7 +34,9 @@ def includeme(config):
         "warehouse.admin:static/dist",
         # Don't cache at all if prevent_http_cache is true, else we'll cache
         # the files for 10 years.
-        cache_max_age=0 if prevent_http_cache else TEN_YEARS_IN_SECONDS,
+        cache_max_age=(
+            0 if prevent_http_cache else timedelta(days=365 * 10).total_seconds()
+        ),
     )
     config.add_cache_buster(
         "warehouse.admin:static/dist/",

--- a/warehouse/admin/__init__.py
+++ b/warehouse/admin/__init__.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from warehouse.admin.services import ISponsorLogoStorage
+from warehouse.constants import TEN_YEARS_IN_SECONDS
 from warehouse.utils.static import ManifestCacheBuster
 
 
@@ -32,7 +33,7 @@ def includeme(config):
         "warehouse.admin:static/dist",
         # Don't cache at all if prevent_http_cache is true, else we'll cache
         # the files for 10 years.
-        cache_max_age=0 if prevent_http_cache else 10 * 365 * 24 * 60 * 60,
+        cache_max_age=0 if prevent_http_cache else TEN_YEARS_IN_SECONDS,
     )
     config.add_cache_buster(
         "warehouse.admin:static/dist/",

--- a/warehouse/api/simple.py
+++ b/warehouse/api/simple.py
@@ -18,6 +18,11 @@ from sqlalchemy import func
 
 from warehouse.cache.http import add_vary, cache_control
 from warehouse.cache.origin import origin_cache
+from warehouse.constants import (
+    FIVE_MINUTES_IN_SECONDS,
+    ONE_DAY_IN_SECONDS,
+    TEN_MINUTES_IN_SECONDS,
+)
 from warehouse.packaging.models import JournalEntry, Project
 from warehouse.packaging.utils import _simple_detail, _simple_index
 from warehouse.utils.cors import _CORS_HEADERS
@@ -57,11 +62,11 @@ def _select_content_type(request: Request) -> str:
     renderer="api/simple/index.html",
     decorator=[
         add_vary("Accept"),
-        cache_control(10 * 60),  # 10 minutes
+        cache_control(TEN_MINUTES_IN_SECONDS),
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=5 * 60,  # 5 minutes
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=FIVE_MINUTES_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
         ),
     ],
 )
@@ -88,11 +93,11 @@ def simple_index(request):
     renderer="api/simple/detail.html",
     decorator=[
         add_vary("Accept"),
-        cache_control(10 * 60),  # 10 minutes
+        cache_control(TEN_MINUTES_IN_SECONDS),
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=5 * 60,  # 5 minutes
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=FIVE_MINUTES_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
         ),
     ],
 )

--- a/warehouse/api/simple.py
+++ b/warehouse/api/simple.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
 
 from pyramid.httpexceptions import HTTPMovedPermanently
 from pyramid.request import Request
@@ -18,11 +19,6 @@ from sqlalchemy import func
 
 from warehouse.cache.http import add_vary, cache_control
 from warehouse.cache.origin import origin_cache
-from warehouse.constants import (
-    FIVE_MINUTES_IN_SECONDS,
-    ONE_DAY_IN_SECONDS,
-    TEN_MINUTES_IN_SECONDS,
-)
 from warehouse.packaging.models import JournalEntry, Project
 from warehouse.packaging.utils import _simple_detail, _simple_index
 from warehouse.utils.cors import _CORS_HEADERS
@@ -62,11 +58,11 @@ def _select_content_type(request: Request) -> str:
     renderer="api/simple/index.html",
     decorator=[
         add_vary("Accept"),
-        cache_control(TEN_MINUTES_IN_SECONDS),
+        cache_control(timedelta(minutes=10).total_seconds()),
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=FIVE_MINUTES_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            timedelta(days=1).total_seconds(),
+            stale_while_revalidate=timedelta(minutes=5).total_seconds(),
+            stale_if_error=timedelta(days=1).total_seconds(),
         ),
     ],
 )
@@ -93,11 +89,11 @@ def simple_index(request):
     renderer="api/simple/detail.html",
     decorator=[
         add_vary("Accept"),
-        cache_control(TEN_MINUTES_IN_SECONDS),
+        cache_control(timedelta(minutes=10).total_seconds()),
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=FIVE_MINUTES_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            timedelta(days=1).total_seconds(),
+            stale_while_revalidate=timedelta(minutes=5).total_seconds(),
+            stale_if_error=timedelta(days=1).total_seconds(),
         ),
     ],
 )

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -33,7 +33,13 @@ from pyramid.tweens import EXCVIEW
 from pyramid_rpc.xmlrpc import XMLRPCRenderer
 
 from warehouse.authnz import Permissions
-from warehouse.constants import MAX_FILESIZE, MAX_PROJECT_SIZE, ONE_GIB, ONE_MIB
+from warehouse.constants import (
+    MAX_FILESIZE,
+    MAX_PROJECT_SIZE,
+    ONE_GIB,
+    ONE_MIB,
+    TEN_YEARS_IN_SECONDS,
+)
 from warehouse.utils.static import ManifestCacheBuster
 from warehouse.utils.wsgi import ProxyFixer, VhmRootRemover
 
@@ -396,7 +402,7 @@ def configure(settings=None):
         "token.default.max_age",
         "TOKEN_DEFAULT_MAX_AGE",
         coercer=int,
-        default=21600,  # 6 hours
+        default=timedelta(hours=6).total_seconds(),
     )
     maybe_set(
         settings,
@@ -824,7 +830,7 @@ def configure(settings=None):
         "warehouse:static/dist/",
         # Don't cache at all if prevent_http_cache is true, else we'll cache
         # the files for 10 years.
-        cache_max_age=0 if prevent_http_cache else 10 * 365 * 24 * 60 * 60,
+        cache_max_age=0 if prevent_http_cache else TEN_YEARS_IN_SECONDS,
     )
     config.add_cache_buster(
         "warehouse:static/dist/",
@@ -836,7 +842,7 @@ def configure(settings=None):
     )
     config.whitenoise_serve_static(
         autorefresh=prevent_http_cache,
-        max_age=0 if prevent_http_cache else 10 * 365 * 24 * 60 * 60,
+        max_age=0 if prevent_http_cache else TEN_YEARS_IN_SECONDS,
     )
     config.whitenoise_add_files("warehouse:static/dist/", prefix="/static/")
     config.whitenoise_add_manifest(

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -33,13 +33,7 @@ from pyramid.tweens import EXCVIEW
 from pyramid_rpc.xmlrpc import XMLRPCRenderer
 
 from warehouse.authnz import Permissions
-from warehouse.constants import (
-    MAX_FILESIZE,
-    MAX_PROJECT_SIZE,
-    ONE_GIB,
-    ONE_MIB,
-    TEN_YEARS_IN_SECONDS,
-)
+from warehouse.constants import MAX_FILESIZE, MAX_PROJECT_SIZE, ONE_GIB, ONE_MIB
 from warehouse.utils.static import ManifestCacheBuster
 from warehouse.utils.wsgi import ProxyFixer, VhmRootRemover
 
@@ -830,7 +824,9 @@ def configure(settings=None):
         "warehouse:static/dist/",
         # Don't cache at all if prevent_http_cache is true, else we'll cache
         # the files for 10 years.
-        cache_max_age=0 if prevent_http_cache else TEN_YEARS_IN_SECONDS,
+        cache_max_age=(
+            0 if prevent_http_cache else timedelta(days=365 * 10).total_seconds()
+        ),
     )
     config.add_cache_buster(
         "warehouse:static/dist/",
@@ -842,7 +838,7 @@ def configure(settings=None):
     )
     config.whitenoise_serve_static(
         autorefresh=prevent_http_cache,
-        max_age=0 if prevent_http_cache else TEN_YEARS_IN_SECONDS,
+        max_age=0 if prevent_http_cache else timedelta(days=365 * 10).total_seconds(),
     )
     config.whitenoise_add_files("warehouse:static/dist/", prefix="/static/")
     config.whitenoise_add_manifest(

--- a/warehouse/constants.py
+++ b/warehouse/constants.py
@@ -10,7 +10,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
+
 ONE_MIB = 1 * 1024 * 1024
 ONE_GIB = 1 * 1024 * 1024 * 1024
 MAX_FILESIZE = 100 * ONE_MIB
 MAX_PROJECT_SIZE = 10 * ONE_GIB
+
+# Time durations, in seconds, as a float
+FIVE_MINUTES_IN_SECONDS = timedelta(minutes=5).total_seconds()
+TEN_MINUTES_IN_SECONDS = timedelta(minutes=10).total_seconds()
+FIFTEEN_MINUTES_IN_SECONDS = timedelta(minutes=15).total_seconds()
+THIRTY_MINUTES_IN_SECONDS = timedelta(minutes=30).total_seconds()
+ONE_HOUR_IN_SECONDS = timedelta(hours=1).total_seconds()
+SIX_HOURS_IN_SECONDS = timedelta(hours=6).total_seconds()
+TWELVE_HOURS_IN_SECONDS = timedelta(hours=12).total_seconds()
+ONE_DAY_IN_SECONDS = timedelta(days=1).total_seconds()
+TWENTY_FIVE_HOURS_IN_SECONDS = timedelta(hours=25).total_seconds()
+TWO_DAYS_IN_SECONDS = timedelta(days=2).total_seconds()
+THREE_DAYS_IN_SECONDS = timedelta(days=3).total_seconds()
+FIVE_DAYS_IN_SECONDS = timedelta(days=5).total_seconds()
+TEN_YEARS_IN_SECONDS = timedelta(days=365 * 10).total_seconds()

--- a/warehouse/constants.py
+++ b/warehouse/constants.py
@@ -10,24 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import timedelta
-
 ONE_MIB = 1 * 1024 * 1024
 ONE_GIB = 1 * 1024 * 1024 * 1024
 MAX_FILESIZE = 100 * ONE_MIB
 MAX_PROJECT_SIZE = 10 * ONE_GIB
-
-# Time durations, in seconds, as a float
-FIVE_MINUTES_IN_SECONDS = timedelta(minutes=5).total_seconds()
-TEN_MINUTES_IN_SECONDS = timedelta(minutes=10).total_seconds()
-FIFTEEN_MINUTES_IN_SECONDS = timedelta(minutes=15).total_seconds()
-THIRTY_MINUTES_IN_SECONDS = timedelta(minutes=30).total_seconds()
-ONE_HOUR_IN_SECONDS = timedelta(hours=1).total_seconds()
-SIX_HOURS_IN_SECONDS = timedelta(hours=6).total_seconds()
-TWELVE_HOURS_IN_SECONDS = timedelta(hours=12).total_seconds()
-ONE_DAY_IN_SECONDS = timedelta(days=1).total_seconds()
-TWENTY_FIVE_HOURS_IN_SECONDS = timedelta(hours=25).total_seconds()
-TWO_DAYS_IN_SECONDS = timedelta(days=2).total_seconds()
-THREE_DAYS_IN_SECONDS = timedelta(days=3).total_seconds()
-FIVE_DAYS_IN_SECONDS = timedelta(days=5).total_seconds()
-TEN_YEARS_IN_SECONDS = timedelta(days=365 * 10).total_seconds()

--- a/warehouse/integrations/github/utils.py
+++ b/warehouse/integrations/github/utils.py
@@ -17,6 +17,7 @@ import time
 import requests
 
 from warehouse import integrations
+from warehouse.constants import THIRTY_MINUTES_IN_SECONDS
 from warehouse.email import send_token_compromised_email_leak
 from warehouse.events.tags import EventTag
 from warehouse.macaroons import InvalidMacaroonError
@@ -113,7 +114,7 @@ class GitHubPublicKeyMetaAPIError(InvalidTokenLeakRequestError):
     pass
 
 
-PUBLIC_KEYS_CACHE_TIME = 60 * 30  # 30 minutes
+PUBLIC_KEYS_CACHE_TIME = THIRTY_MINUTES_IN_SECONDS
 PUBLIC_KEYS_CACHE = integrations.PublicKeysCache(cache_time=PUBLIC_KEYS_CACHE_TIME)
 
 

--- a/warehouse/integrations/github/utils.py
+++ b/warehouse/integrations/github/utils.py
@@ -14,10 +14,11 @@ import json
 import re
 import time
 
+from datetime import timedelta
+
 import requests
 
 from warehouse import integrations
-from warehouse.constants import THIRTY_MINUTES_IN_SECONDS
 from warehouse.email import send_token_compromised_email_leak
 from warehouse.events.tags import EventTag
 from warehouse.macaroons import InvalidMacaroonError
@@ -114,7 +115,7 @@ class GitHubPublicKeyMetaAPIError(InvalidTokenLeakRequestError):
     pass
 
 
-PUBLIC_KEYS_CACHE_TIME = THIRTY_MINUTES_IN_SECONDS
+PUBLIC_KEYS_CACHE_TIME = timedelta(minutes=30).total_seconds()
 PUBLIC_KEYS_CACHE = integrations.PublicKeysCache(cache_time=PUBLIC_KEYS_CACHE_TIME)
 
 

--- a/warehouse/integrations/vulnerabilities/__init__.py
+++ b/warehouse/integrations/vulnerabilities/__init__.py
@@ -10,8 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
+
 from warehouse import integrations
-from warehouse.constants import THIRTY_MINUTES_IN_SECONDS
 
 
 class InvalidVulnerabilityReportError(Exception):
@@ -77,7 +78,7 @@ class VulnerabilityReportRequest:
         )
 
 
-DEFAULT_PUBLIC_KEYS_CACHE_SECONDS = THIRTY_MINUTES_IN_SECONDS
+DEFAULT_PUBLIC_KEYS_CACHE_SECONDS = timedelta(minutes=30).total_seconds()
 DEFAULT_PUBLIC_KEYS_CACHE = integrations.PublicKeysCache(
     cache_time=DEFAULT_PUBLIC_KEYS_CACHE_SECONDS
 )

--- a/warehouse/integrations/vulnerabilities/__init__.py
+++ b/warehouse/integrations/vulnerabilities/__init__.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from warehouse import integrations
+from warehouse.constants import THIRTY_MINUTES_IN_SECONDS
 
 
 class InvalidVulnerabilityReportError(Exception):
@@ -76,7 +77,7 @@ class VulnerabilityReportRequest:
         )
 
 
-DEFAULT_PUBLIC_KEYS_CACHE_SECONDS = 60 * 30  # 30 minutes
+DEFAULT_PUBLIC_KEYS_CACHE_SECONDS = THIRTY_MINUTES_IN_SECONDS
 DEFAULT_PUBLIC_KEYS_CACHE = integrations.PublicKeysCache(
     cache_time=DEFAULT_PUBLIC_KEYS_CACHE_SECONDS
 )

--- a/warehouse/integrations/vulnerabilities/osv/__init__.py
+++ b/warehouse/integrations/vulnerabilities/osv/__init__.py
@@ -16,6 +16,7 @@ import time
 import requests
 
 from warehouse import integrations
+from warehouse.constants import THIRTY_MINUTES_IN_SECONDS
 from warehouse.integrations import vulnerabilities
 
 
@@ -24,7 +25,7 @@ class OSVPublicKeyAPIError(vulnerabilities.InvalidVulnerabilityReportError):
 
 
 OSV_PUBLIC_KEYS_URL = "https://osv.dev/public_keys/pypa"
-DEFAULT_PUBLIC_KEYS_CACHE_SECONDS = 60 * 30  # 30 minutes
+DEFAULT_PUBLIC_KEYS_CACHE_SECONDS = THIRTY_MINUTES_IN_SECONDS
 DEFAULT_PUBLIC_KEYS_CACHE = integrations.PublicKeysCache(
     cache_time=DEFAULT_PUBLIC_KEYS_CACHE_SECONDS
 )

--- a/warehouse/integrations/vulnerabilities/osv/__init__.py
+++ b/warehouse/integrations/vulnerabilities/osv/__init__.py
@@ -13,10 +13,11 @@
 import json
 import time
 
+from datetime import timedelta
+
 import requests
 
 from warehouse import integrations
-from warehouse.constants import THIRTY_MINUTES_IN_SECONDS
 from warehouse.integrations import vulnerabilities
 
 
@@ -25,7 +26,7 @@ class OSVPublicKeyAPIError(vulnerabilities.InvalidVulnerabilityReportError):
 
 
 OSV_PUBLIC_KEYS_URL = "https://osv.dev/public_keys/pypa"
-DEFAULT_PUBLIC_KEYS_CACHE_SECONDS = THIRTY_MINUTES_IN_SECONDS
+DEFAULT_PUBLIC_KEYS_CACHE_SECONDS = timedelta(minutes=30).total_seconds()
 DEFAULT_PUBLIC_KEYS_CACHE = integrations.PublicKeysCache(
     cache_time=DEFAULT_PUBLIC_KEYS_CACHE_SECONDS
 )

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
+
 from packaging.utils import canonicalize_name, canonicalize_version
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
@@ -18,11 +20,6 @@ from sqlalchemy.orm import Load, contains_eager, joinedload
 
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache
-from warehouse.constants import (
-    FIFTEEN_MINUTES_IN_SECONDS,
-    FIVE_MINUTES_IN_SECONDS,
-    ONE_DAY_IN_SECONDS,
-)
 from warehouse.packaging.models import (
     Description,
     File,
@@ -34,21 +31,21 @@ from warehouse.packaging.models import (
 from warehouse.utils.cors import _CORS_HEADERS
 
 _RELEASE_CACHE_DECORATOR = [
-    cache_control(FIFTEEN_MINUTES_IN_SECONDS),
+    cache_control(timedelta(minutes=15).total_seconds()),
     origin_cache(
-        ONE_DAY_IN_SECONDS,
-        stale_while_revalidate=FIVE_MINUTES_IN_SECONDS,
-        stale_if_error=ONE_DAY_IN_SECONDS,
+        timedelta(days=1).total_seconds(),
+        stale_while_revalidate=timedelta(minutes=5).total_seconds(),
+        stale_if_error=timedelta(days=1).total_seconds(),
         keys=["all-legacy-json", "release-legacy-json"],
     ),
 ]
 
 _PROJECT_CACHE_DECORATOR = [
-    cache_control(FIFTEEN_MINUTES_IN_SECONDS),
+    cache_control(timedelta(minutes=15).total_seconds()),
     origin_cache(
-        ONE_DAY_IN_SECONDS,
-        stale_while_revalidate=FIVE_MINUTES_IN_SECONDS,
-        stale_if_error=ONE_DAY_IN_SECONDS,
+        timedelta(days=1).total_seconds(),
+        stale_while_revalidate=timedelta(minutes=5).total_seconds(),
+        stale_if_error=timedelta(days=1).total_seconds(),
         keys=["all-legacy-json", "project-legacy-json"],
     ),
 ]

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -18,6 +18,11 @@ from sqlalchemy.orm import Load, contains_eager, joinedload
 
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache
+from warehouse.constants import (
+    FIFTEEN_MINUTES_IN_SECONDS,
+    FIVE_MINUTES_IN_SECONDS,
+    ONE_DAY_IN_SECONDS,
+)
 from warehouse.packaging.models import (
     Description,
     File,
@@ -29,21 +34,21 @@ from warehouse.packaging.models import (
 from warehouse.utils.cors import _CORS_HEADERS
 
 _RELEASE_CACHE_DECORATOR = [
-    cache_control(15 * 60),  # 15 minutes
+    cache_control(FIFTEEN_MINUTES_IN_SECONDS),
     origin_cache(
-        1 * 24 * 60 * 60,  # 1 day
-        stale_while_revalidate=5 * 60,  # 5 minutes
-        stale_if_error=1 * 24 * 60 * 60,  # 1 day
+        ONE_DAY_IN_SECONDS,
+        stale_while_revalidate=FIVE_MINUTES_IN_SECONDS,
+        stale_if_error=ONE_DAY_IN_SECONDS,
         keys=["all-legacy-json", "release-legacy-json"],
     ),
 ]
 
 _PROJECT_CACHE_DECORATOR = [
-    cache_control(15 * 60),  # 15 minutes
+    cache_control(FIFTEEN_MINUTES_IN_SECONDS),
     origin_cache(
-        1 * 24 * 60 * 60,  # 1 day
-        stale_while_revalidate=5 * 60,  # 5 minutes
-        stale_if_error=1 * 24 * 60 * 60,  # 1 day
+        ONE_DAY_IN_SECONDS,
+        stale_while_revalidate=FIVE_MINUTES_IN_SECONDS,
+        stale_if_error=ONE_DAY_IN_SECONDS,
         keys=["all-legacy-json", "project-legacy-json"],
     ),
 ]

--- a/warehouse/legacy/api/xmlrpc/cache/__init__.py
+++ b/warehouse/legacy/api/xmlrpc/cache/__init__.py
@@ -12,6 +12,8 @@
 
 import collections
 
+from datetime import timedelta
+
 from pyramid.exceptions import ConfigurationError
 from sqlalchemy.orm.base import NO_VALUE
 from sqlalchemy.orm.session import Session
@@ -19,7 +21,6 @@ from urllib3.util import parse_url
 
 from warehouse import db
 from warehouse.accounts.models import Email, User
-from warehouse.constants import TWENTY_FIVE_HOURS_IN_SECONDS
 from warehouse.legacy.api.xmlrpc.cache.derivers import cached_return_view
 from warehouse.legacy.api.xmlrpc.cache.fncache import RedisLru
 from warehouse.legacy.api.xmlrpc.cache.interfaces import IXMLRPCCache
@@ -87,7 +88,7 @@ def email_primary_receive_set(config, target, value, oldvalue, initiator):
 def includeme(config):
     xmlrpc_cache_url = config.registry.settings.get("warehouse.xmlrpc.cache.url")
     xmlrpc_cache_expires = config.registry.settings.get(
-        "warehouse.xmlrpc.cache.expires", TWENTY_FIVE_HOURS_IN_SECONDS
+        "warehouse.xmlrpc.cache.expires", timedelta(hours=25).total_seconds()
     )
 
     if xmlrpc_cache_url is None:

--- a/warehouse/legacy/api/xmlrpc/cache/__init__.py
+++ b/warehouse/legacy/api/xmlrpc/cache/__init__.py
@@ -19,6 +19,7 @@ from urllib3.util import parse_url
 
 from warehouse import db
 from warehouse.accounts.models import Email, User
+from warehouse.constants import TWENTY_FIVE_HOURS_IN_SECONDS
 from warehouse.legacy.api.xmlrpc.cache.derivers import cached_return_view
 from warehouse.legacy.api.xmlrpc.cache.fncache import RedisLru
 from warehouse.legacy.api.xmlrpc.cache.interfaces import IXMLRPCCache
@@ -86,7 +87,7 @@ def email_primary_receive_set(config, target, value, oldvalue, initiator):
 def includeme(config):
     xmlrpc_cache_url = config.registry.settings.get("warehouse.xmlrpc.cache.url")
     xmlrpc_cache_expires = config.registry.settings.get(
-        "warehouse.xmlrpc.cache.expires", 25 * 60 * 60
+        "warehouse.xmlrpc.cache.expires", TWENTY_FIVE_HOURS_IN_SECONDS
     )
 
     if xmlrpc_cache_url is None:

--- a/warehouse/legacy/api/xmlrpc/cache/services.py
+++ b/warehouse/legacy/api/xmlrpc/cache/services.py
@@ -15,6 +15,7 @@ import redis
 from zope.interface import implementer
 
 from warehouse import tasks
+from warehouse.constants import TWENTY_FIVE_HOURS_IN_SECONDS
 from warehouse.legacy.api.xmlrpc import cache
 from warehouse.legacy.api.xmlrpc.cache import interfaces
 
@@ -55,7 +56,7 @@ class RedisXMLRPCCache:
             name=request.registry.settings.get("warehouse.xmlrpc.cache.name", "xmlrpc"),
             expires=int(
                 request.registry.settings.get(
-                    "warehouse.xmlrpc.cache.expires", 25 * 60 * 60
+                    "warehouse.xmlrpc.cache.expires", TWENTY_FIVE_HOURS_IN_SECONDS
                 )
             ),
         )

--- a/warehouse/legacy/api/xmlrpc/cache/services.py
+++ b/warehouse/legacy/api/xmlrpc/cache/services.py
@@ -10,12 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
+
 import redis
 
 from zope.interface import implementer
 
 from warehouse import tasks
-from warehouse.constants import TWENTY_FIVE_HOURS_IN_SECONDS
 from warehouse.legacy.api.xmlrpc import cache
 from warehouse.legacy.api.xmlrpc.cache import interfaces
 
@@ -56,7 +57,8 @@ class RedisXMLRPCCache:
             name=request.registry.settings.get("warehouse.xmlrpc.cache.name", "xmlrpc"),
             expires=int(
                 request.registry.settings.get(
-                    "warehouse.xmlrpc.cache.expires", TWENTY_FIVE_HOURS_IN_SECONDS
+                    "warehouse.xmlrpc.cache.expires",
+                    timedelta(hours=25).total_seconds(),
                 )
             ),
         )

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -36,6 +36,7 @@ from sqlalchemy.exc import NoResultFound
 
 from warehouse.accounts.models import User
 from warehouse.classifiers.models import Classifier
+from warehouse.constants import ONE_HOUR_IN_SECONDS, TWO_DAYS_IN_SECONDS
 from warehouse.metrics import IMetricsService
 from warehouse.packaging.models import (
     File,
@@ -164,7 +165,7 @@ def xmlrpc_method(**kwargs):
 xmlrpc_cache_by_project = functools.partial(
     xmlrpc_method,
     xmlrpc_cache=True,
-    xmlrpc_cache_expires=48 * 60 * 60,  # 48 hours
+    xmlrpc_cache_expires=TWO_DAYS_IN_SECONDS,
     xmlrpc_cache_tag="project/%s",
     xmlrpc_cache_arg_index=0,
     xmlrpc_cache_tag_processor=canonicalize_name,
@@ -174,7 +175,7 @@ xmlrpc_cache_by_project = functools.partial(
 xmlrpc_cache_all_projects = functools.partial(
     xmlrpc_method,
     xmlrpc_cache=True,
-    xmlrpc_cache_expires=1 * 60 * 60,  # 1 hours
+    xmlrpc_cache_expires=ONE_HOUR_IN_SECONDS,
     xmlrpc_cache_tag="all-projects",
 )
 

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -36,7 +36,6 @@ from sqlalchemy.exc import NoResultFound
 
 from warehouse.accounts.models import User
 from warehouse.classifiers.models import Classifier
-from warehouse.constants import ONE_HOUR_IN_SECONDS, TWO_DAYS_IN_SECONDS
 from warehouse.metrics import IMetricsService
 from warehouse.packaging.models import (
     File,
@@ -165,7 +164,7 @@ def xmlrpc_method(**kwargs):
 xmlrpc_cache_by_project = functools.partial(
     xmlrpc_method,
     xmlrpc_cache=True,
-    xmlrpc_cache_expires=TWO_DAYS_IN_SECONDS,
+    xmlrpc_cache_expires=datetime.timedelta(days=2).total_seconds(),
     xmlrpc_cache_tag="project/%s",
     xmlrpc_cache_arg_index=0,
     xmlrpc_cache_tag_processor=canonicalize_name,
@@ -175,7 +174,7 @@ xmlrpc_cache_by_project = functools.partial(
 xmlrpc_cache_all_projects = functools.partial(
     xmlrpc_method,
     xmlrpc_cache=True,
-    xmlrpc_cache_expires=ONE_HOUR_IN_SECONDS,
+    xmlrpc_cache_expires=datetime.timedelta(hours=1).total_seconds(),
     xmlrpc_cache_tag="all-projects",
 )
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1,16 +1,16 @@
-#: warehouse/views.py:147
+#: warehouse/views.py:149
 msgid ""
 "You must verify your **primary** email address before you can perform "
 "this action."
 msgstr ""
 
-#: warehouse/views.py:163
+#: warehouse/views.py:165
 msgid ""
 "Two-factor authentication must be enabled on your account to perform this"
 " action."
 msgstr ""
 
-#: warehouse/views.py:299
+#: warehouse/views.py:301
 msgid "Locale updated"
 msgstr ""
 
@@ -137,175 +137,175 @@ msgid ""
 " ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:330 warehouse/accounts/views.py:399
-#: warehouse/accounts/views.py:401 warehouse/accounts/views.py:430
-#: warehouse/accounts/views.py:432 warehouse/accounts/views.py:538
+#: warehouse/accounts/views.py:333 warehouse/accounts/views.py:402
+#: warehouse/accounts/views.py:404 warehouse/accounts/views.py:433
+#: warehouse/accounts/views.py:435 warehouse/accounts/views.py:541
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:393
+#: warehouse/accounts/views.py:396
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:473
+#: warehouse/accounts/views.py:476
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:569 warehouse/manage/views/__init__.py:870
+#: warehouse/accounts/views.py:572 warehouse/manage/views/__init__.py:870
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:661
+#: warehouse/accounts/views.py:664
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:799
+#: warehouse/accounts/views.py:802
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:801
+#: warehouse/accounts/views.py:804
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:803 warehouse/accounts/views.py:904
-#: warehouse/accounts/views.py:1008 warehouse/accounts/views.py:1177
+#: warehouse/accounts/views.py:806 warehouse/accounts/views.py:907
+#: warehouse/accounts/views.py:1011 warehouse/accounts/views.py:1180
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:807
+#: warehouse/accounts/views.py:810
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:812
+#: warehouse/accounts/views.py:815
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:822
+#: warehouse/accounts/views.py:825
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:840
+#: warehouse/accounts/views.py:843
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:872
+#: warehouse/accounts/views.py:875
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:900
+#: warehouse/accounts/views.py:903
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:902
+#: warehouse/accounts/views.py:905
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:908
+#: warehouse/accounts/views.py:911
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:917
+#: warehouse/accounts/views.py:920
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:920
+#: warehouse/accounts/views.py:923
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:937
+#: warehouse/accounts/views.py:940
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:941
+#: warehouse/accounts/views.py:944
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:946
+#: warehouse/accounts/views.py:949
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:1004
+#: warehouse/accounts/views.py:1007
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1006
+#: warehouse/accounts/views.py:1009
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1012
+#: warehouse/accounts/views.py:1015
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1016
+#: warehouse/accounts/views.py:1019
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1025
+#: warehouse/accounts/views.py:1028
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1076
+#: warehouse/accounts/views.py:1079
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1139
+#: warehouse/accounts/views.py:1142
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1173
+#: warehouse/accounts/views.py:1176
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1175
+#: warehouse/accounts/views.py:1178
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1181
+#: warehouse/accounts/views.py:1184
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1185
+#: warehouse/accounts/views.py:1188
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1200
+#: warehouse/accounts/views.py:1203
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1231
+#: warehouse/accounts/views.py:1234
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1297
+#: warehouse/accounts/views.py:1300
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1548 warehouse/accounts/views.py:1791
+#: warehouse/accounts/views.py:1551 warehouse/accounts/views.py:1794
 #: warehouse/manage/views/__init__.py:1249
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1569
+#: warehouse/accounts/views.py:1572
 msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1585
+#: warehouse/accounts/views.py:1588
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1598
+#: warehouse/accounts/views.py:1601
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1614 warehouse/manage/views/__init__.py:1304
+#: warehouse/accounts/views.py:1617 warehouse/manage/views/__init__.py:1304
 #: warehouse/manage/views/__init__.py:1417
 #: warehouse/manage/views/__init__.py:1529
 #: warehouse/manage/views/__init__.py:1639
@@ -314,29 +314,29 @@ msgid ""
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1625 warehouse/manage/views/__init__.py:1318
+#: warehouse/accounts/views.py:1628 warehouse/manage/views/__init__.py:1318
 #: warehouse/manage/views/__init__.py:1431
 #: warehouse/manage/views/__init__.py:1543
 #: warehouse/manage/views/__init__.py:1653
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1639
+#: warehouse/accounts/views.py:1642
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1666
+#: warehouse/accounts/views.py:1669
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1805 warehouse/accounts/views.py:1818
-#: warehouse/accounts/views.py:1825
+#: warehouse/accounts/views.py:1808 warehouse/accounts/views.py:1821
+#: warehouse/accounts/views.py:1828
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1831
+#: warehouse/accounts/views.py:1834
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Provide an Inspector link to specific lines of code."
 msgstr ""
 
-#: warehouse/packaging/views.py:212
+#: warehouse/packaging/views.py:216
 msgid "Your report has been recorded. Thank you for your help."
 msgstr ""
 

--- a/warehouse/manage/__init__.py
+++ b/warehouse/manage/__init__.py
@@ -17,9 +17,10 @@ from pyramid.renderers import render_to_response
 
 from warehouse.accounts.forms import ReAuthenticateForm
 from warehouse.accounts.interfaces import IUserService
+from warehouse.constants import THIRTY_MINUTES_IN_SECONDS
 from warehouse.rate_limiting import IRateLimiter, RateLimit
 
-DEFAULT_TIME_TO_REAUTH = 30 * 60  # 30 minutes
+DEFAULT_TIME_TO_REAUTH = THIRTY_MINUTES_IN_SECONDS
 
 
 def reauth_view(view, info):

--- a/warehouse/manage/__init__.py
+++ b/warehouse/manage/__init__.py
@@ -13,14 +13,15 @@
 import functools
 import json
 
+from datetime import timedelta
+
 from pyramid.renderers import render_to_response
 
 from warehouse.accounts.forms import ReAuthenticateForm
 from warehouse.accounts.interfaces import IUserService
-from warehouse.constants import THIRTY_MINUTES_IN_SECONDS
 from warehouse.rate_limiting import IRateLimiter, RateLimit
 
-DEFAULT_TIME_TO_REAUTH = THIRTY_MINUTES_IN_SECONDS
+DEFAULT_TIME_TO_REAUTH = timedelta(minutes=30).total_seconds()
 
 
 def reauth_view(view, info):

--- a/warehouse/organizations/views.py
+++ b/warehouse/organizations/views.py
@@ -14,6 +14,7 @@ from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
 
 from warehouse.cache.origin import origin_cache
+from warehouse.constants import ONE_DAY_IN_SECONDS
 from warehouse.organizations.models import Organization
 
 
@@ -21,9 +22,7 @@ from warehouse.organizations.models import Organization
     route_name="organizations.profile",
     context=Organization,
     renderer="organizations/profile.html",
-    decorator=[
-        origin_cache(1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60)  # 1 day each.
-    ],
+    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=ONE_DAY_IN_SECONDS)],
     has_translations=True,
 )
 def profile(organization, request):

--- a/warehouse/organizations/views.py
+++ b/warehouse/organizations/views.py
@@ -10,11 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
+
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
 
 from warehouse.cache.origin import origin_cache
-from warehouse.constants import ONE_DAY_IN_SECONDS
 from warehouse.organizations.models import Organization
 
 
@@ -22,7 +23,12 @@ from warehouse.organizations.models import Organization
     route_name="organizations.profile",
     context=Organization,
     renderer="organizations/profile.html",
-    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=ONE_DAY_IN_SECONDS)],
+    decorator=[
+        origin_cache(
+            timedelta(days=1).total_seconds(),
+            stale_if_error=timedelta(days=1).total_seconds(),
+        )
+    ],
     has_translations=True,
 )
 def profile(organization, request):

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -18,6 +18,7 @@ from sqlalchemy.exc import NoResultFound
 from warehouse.accounts.models import User
 from warehouse.authnz import Permissions
 from warehouse.cache.origin import origin_cache
+from warehouse.constants import FIVE_DAYS_IN_SECONDS, ONE_DAY_IN_SECONDS
 from warehouse.observations.models import ObservationKind
 from warehouse.packaging.forms import SubmitMalwareObservationForm
 from warehouse.packaging.models import Description, File, Project, Release, Role
@@ -27,11 +28,7 @@ from warehouse.packaging.models import Description, File, Project, Release, Role
     route_name="packaging.project",
     context=Project,
     renderer="packaging/detail.html",
-    decorator=[
-        origin_cache(
-            1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale
-        )
-    ],
+    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=FIVE_DAYS_IN_SECONDS)],
     has_translations=True,
 )
 def project_detail(project, request):
@@ -60,11 +57,7 @@ def project_detail(project, request):
     route_name="packaging.release",
     context=Release,
     renderer="packaging/detail.html",
-    decorator=[
-        origin_cache(
-            1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale
-        )
-    ],
+    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=FIVE_DAYS_IN_SECONDS)],
     has_translations=True,
 )
 def release_detail(release, request):

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
+
 from natsort import natsorted
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
@@ -18,7 +20,6 @@ from sqlalchemy.exc import NoResultFound
 from warehouse.accounts.models import User
 from warehouse.authnz import Permissions
 from warehouse.cache.origin import origin_cache
-from warehouse.constants import FIVE_DAYS_IN_SECONDS, ONE_DAY_IN_SECONDS
 from warehouse.observations.models import ObservationKind
 from warehouse.packaging.forms import SubmitMalwareObservationForm
 from warehouse.packaging.models import Description, File, Project, Release, Role
@@ -28,7 +29,12 @@ from warehouse.packaging.models import Description, File, Project, Release, Role
     route_name="packaging.project",
     context=Project,
     renderer="packaging/detail.html",
-    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=FIVE_DAYS_IN_SECONDS)],
+    decorator=[
+        origin_cache(
+            timedelta(days=1).total_seconds(),
+            stale_if_error=timedelta(days=5).total_seconds(),
+        )
+    ],
     has_translations=True,
 )
 def project_detail(project, request):
@@ -57,7 +63,12 @@ def project_detail(project, request):
     route_name="packaging.release",
     context=Release,
     renderer="packaging/detail.html",
-    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=FIVE_DAYS_IN_SECONDS)],
+    decorator=[
+        origin_cache(
+            timedelta(days=1).total_seconds(),
+            stale_if_error=timedelta(days=5).total_seconds(),
+        )
+    ],
     has_translations=True,
 )
 def release_detail(release, request):

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -16,6 +16,7 @@ from pyramid.view import view_config
 from sqlalchemy.orm import joinedload
 
 from warehouse.cache.origin import origin_cache
+from warehouse.constants import FIVE_DAYS_IN_SECONDS, ONE_DAY_IN_SECONDS
 from warehouse.packaging.models import Project, Release
 
 
@@ -48,9 +49,9 @@ def _format_author(release):
     renderer="rss/updates.xml",
     decorator=[
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
-            stale_if_error=5 * 24 * 60 * 60,  # 5 days
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=ONE_DAY_IN_SECONDS,
+            stale_if_error=FIVE_DAYS_IN_SECONDS,
             keys=["all-projects"],
         )
     ],
@@ -75,9 +76,9 @@ def rss_updates(request):
     renderer="rss/packages.xml",
     decorator=[
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
-            stale_if_error=5 * 24 * 60 * 60,  # 5 days
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=ONE_DAY_IN_SECONDS,
+            stale_if_error=FIVE_DAYS_IN_SECONDS,
             keys=["all-projects"],
         )
     ],
@@ -103,11 +104,7 @@ def rss_packages(request):
     route_name="rss.project.releases",
     context=Project,
     renderer="rss/project_releases.xml",
-    decorator=[
-        origin_cache(
-            1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale
-        )
-    ],
+    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=FIVE_DAYS_IN_SECONDS)],
 )
 def rss_project_releases(project, request):
     request.response.content_type = "text/xml"

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -10,13 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
 from email.utils import getaddresses
 
 from pyramid.view import view_config
 from sqlalchemy.orm import joinedload
 
 from warehouse.cache.origin import origin_cache
-from warehouse.constants import FIVE_DAYS_IN_SECONDS, ONE_DAY_IN_SECONDS
 from warehouse.packaging.models import Project, Release
 
 
@@ -49,9 +49,9 @@ def _format_author(release):
     renderer="rss/updates.xml",
     decorator=[
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=ONE_DAY_IN_SECONDS,
-            stale_if_error=FIVE_DAYS_IN_SECONDS,
+            timedelta(days=1).total_seconds(),
+            stale_while_revalidate=timedelta(days=1).total_seconds(),
+            stale_if_error=timedelta(days=5).total_seconds(),
             keys=["all-projects"],
         )
     ],
@@ -76,9 +76,9 @@ def rss_updates(request):
     renderer="rss/packages.xml",
     decorator=[
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=ONE_DAY_IN_SECONDS,
-            stale_if_error=FIVE_DAYS_IN_SECONDS,
+            timedelta(days=1).total_seconds(),
+            stale_while_revalidate=timedelta(days=1).total_seconds(),
+            stale_if_error=timedelta(days=5).total_seconds(),
             keys=["all-projects"],
         )
     ],
@@ -104,7 +104,12 @@ def rss_packages(request):
     route_name="rss.project.releases",
     context=Project,
     renderer="rss/project_releases.xml",
-    decorator=[origin_cache(ONE_DAY_IN_SECONDS, stale_if_error=FIVE_DAYS_IN_SECONDS)],
+    decorator=[
+        origin_cache(
+            timedelta(days=1).total_seconds(),
+            stale_if_error=timedelta(days=5).total_seconds(),
+        )
+    ],
 )
 def rss_project_releases(project, request):
     request.response.content_type = "text/xml"

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -121,7 +121,7 @@ def reindex(self, request):
     try:
         with SearchLock(
             r,
-            timeout=datetime.timedelta(minutes=3).total_seconds(),
+            timeout=datetime.timedelta(minutes=30).total_seconds(),
             blocking_timeout=30,
         ):
             p = parse_url(request.registry.settings["opensearch.url"])

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import binascii
+import datetime
 import os
 import urllib.parse
 
@@ -118,7 +119,11 @@ def reindex(self, request):
     """
     r = redis.StrictRedis.from_url(request.registry.settings["celery.scheduler_url"])
     try:
-        with SearchLock(r, timeout=30 * 60, blocking_timeout=30):
+        with SearchLock(
+            r,
+            timeout=datetime.timedelta(minutes=3).total_seconds(),
+            blocking_timeout=30,
+        ):
             p = parse_url(request.registry.settings["opensearch.url"])
             qs = urllib.parse.parse_qs(p.query)
             kwargs = {

--- a/warehouse/sessions.py
+++ b/warehouse/sessions.py
@@ -26,6 +26,7 @@ import warehouse.utils.otp as otp
 import warehouse.utils.webauthn as webauthn
 
 from warehouse.cache.http import add_vary
+from warehouse.constants import TWELVE_HOURS_IN_SECONDS
 from warehouse.utils import crypto
 from warehouse.utils.msgpack import object_encode
 
@@ -222,7 +223,7 @@ class Session(dict):
 @implementer(ISessionFactory)
 class SessionFactory:
     cookie_name = "session_id"
-    max_age = 12 * 60 * 60  # 12 hours
+    max_age = TWELVE_HOURS_IN_SECONDS
 
     def __init__(self, secret, url):
         self.redis = redis.StrictRedis.from_url(url)

--- a/warehouse/sessions.py
+++ b/warehouse/sessions.py
@@ -26,7 +26,6 @@ import warehouse.utils.otp as otp
 import warehouse.utils.webauthn as webauthn
 
 from warehouse.cache.http import add_vary
-from warehouse.constants import TWELVE_HOURS_IN_SECONDS
 from warehouse.utils import crypto
 from warehouse.utils.msgpack import object_encode
 
@@ -223,7 +222,7 @@ class Session(dict):
 @implementer(ISessionFactory)
 class SessionFactory:
     cookie_name = "session_id"
-    max_age = TWELVE_HOURS_IN_SECONDS
+    max_age = datetime.timedelta(hours=12).total_seconds()
 
     def __init__(self, secret, url):
         self.redis = redis.StrictRedis.from_url(url)

--- a/warehouse/sitemap/views.py
+++ b/warehouse/sitemap/views.py
@@ -20,11 +20,6 @@ from sqlalchemy import func, or_
 from warehouse.accounts.models import User
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache
-from warehouse.constants import (
-    ONE_DAY_IN_SECONDS,
-    ONE_HOUR_IN_SECONDS,
-    SIX_HOURS_IN_SECONDS,
-)
 from warehouse.packaging.models import Project
 
 AGE_BEFORE_INDEX = datetime.timedelta(days=14)
@@ -42,11 +37,11 @@ class BucketTooSmallError(ValueError):
     route_name="index.sitemap.xml",
     renderer="sitemap/index.xml",
     decorator=[
-        cache_control(ONE_HOUR_IN_SECONDS),
+        cache_control(datetime.timedelta(hours=1).total_seconds()),
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=SIX_HOURS_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            datetime.timedelta(days=1).total_seconds(),
+            stale_while_revalidate=datetime.timedelta(hours=6).total_seconds(),
+            stale_if_error=datetime.timedelta(days=1).total_seconds(),
             keys=["all-projects"],
         ),
     ],
@@ -108,11 +103,11 @@ def sitemap_index(request):
     route_name="bucket.sitemap.xml",
     renderer="sitemap/bucket.xml",
     decorator=[
-        cache_control(ONE_HOUR_IN_SECONDS),
+        cache_control(datetime.timedelta(hours=1).total_seconds()),
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=SIX_HOURS_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            datetime.timedelta(days=1).total_seconds(),
+            stale_while_revalidate=datetime.timedelta(hours=6).total_seconds(),
+            stale_if_error=datetime.timedelta(days=1).total_seconds(),
             keys=["all-projects"],
         ),
     ],

--- a/warehouse/sitemap/views.py
+++ b/warehouse/sitemap/views.py
@@ -20,6 +20,11 @@ from sqlalchemy import func, or_
 from warehouse.accounts.models import User
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache
+from warehouse.constants import (
+    ONE_DAY_IN_SECONDS,
+    ONE_HOUR_IN_SECONDS,
+    SIX_HOURS_IN_SECONDS,
+)
 from warehouse.packaging.models import Project
 
 AGE_BEFORE_INDEX = datetime.timedelta(days=14)
@@ -37,11 +42,11 @@ class BucketTooSmallError(ValueError):
     route_name="index.sitemap.xml",
     renderer="sitemap/index.xml",
     decorator=[
-        cache_control(1 * 60 * 60),  # 1 hour
+        cache_control(ONE_HOUR_IN_SECONDS),
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=6 * 60 * 60,  # 6 hours
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=SIX_HOURS_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
             keys=["all-projects"],
         ),
     ],
@@ -103,11 +108,11 @@ def sitemap_index(request):
     route_name="bucket.sitemap.xml",
     renderer="sitemap/bucket.xml",
     decorator=[
-        cache_control(1 * 60 * 60),  # 1 hour
+        cache_control(ONE_HOUR_IN_SECONDS),
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=6 * 60 * 60,  # 6 hours
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=SIX_HOURS_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
             keys=["all-projects"],
         ),
     ],

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -48,6 +48,12 @@ from warehouse.accounts.models import User
 from warehouse.cache.http import add_vary, cache_control
 from warehouse.cache.origin import origin_cache
 from warehouse.classifiers.models import Classifier
+from warehouse.constants import (
+    ONE_DAY_IN_SECONDS,
+    ONE_HOUR_IN_SECONDS,
+    SIX_HOURS_IN_SECONDS,
+    TEN_MINUTES_IN_SECONDS,
+)
 from warehouse.db import DatabaseNotAvailableError
 from warehouse.errors import WarehouseDenied
 from warehouse.forms import SetLocaleForm
@@ -205,11 +211,11 @@ def service_unavailable(exc, request):
     route_name="robots.txt",
     renderer="robots.txt",
     decorator=[
-        cache_control(1 * 24 * 60 * 60),  # 1 day
+        cache_control(ONE_DAY_IN_SECONDS),
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=6 * 60 * 60,  # 6 hours
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=SIX_HOURS_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
         ),
     ],
 )
@@ -222,11 +228,11 @@ def robotstxt(request):
     route_name="opensearch.xml",
     renderer="opensearch.xml",
     decorator=[
-        cache_control(1 * 24 * 60 * 60),  # 1 day
+        cache_control(ONE_DAY_IN_SECONDS),
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=6 * 60 * 60,  # 6 hours
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=SIX_HOURS_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
         ),
     ],
 )
@@ -240,9 +246,9 @@ def opensearchxml(request):
     renderer="index.html",
     decorator=[
         origin_cache(
-            1 * 60 * 60,  # 1 hour
-            stale_while_revalidate=10 * 60,  # 10 minutes
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_HOUR_IN_SECONDS,
+            stale_while_revalidate=TEN_MINUTES_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
             keys=["all-projects"],
         )
     ],
@@ -314,8 +320,8 @@ def list_classifiers(request):
     renderer="search/results.html",
     decorator=[
         origin_cache(
-            1 * 60 * 60,  # 1 hour
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_HOUR_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
             keys=["all-projects"],
         )
     ],
@@ -426,11 +432,11 @@ def search(request):
     renderer="pages/stats.html",
     decorator=[
         add_vary("Accept"),
-        cache_control(1 * 24 * 60 * 60),  # 1 day
+        cache_control(ONE_DAY_IN_SECONDS),
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=ONE_DAY_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
         ),
     ],
     has_translations=True,
@@ -440,11 +446,11 @@ def search(request):
     renderer="json",
     decorator=[
         add_vary("Accept"),
-        cache_control(1 * 24 * 60 * 60),  # 1 day
+        cache_control(ONE_DAY_IN_SECONDS),
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            ONE_DAY_IN_SECONDS,
+            stale_while_revalidate=ONE_DAY_IN_SECONDS,
+            stale_if_error=ONE_DAY_IN_SECONDS,
         ),
     ],
     accept="application/json",

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -14,6 +14,8 @@
 import collections
 import re
 
+from datetime import timedelta
+
 import opensearchpy
 
 from pyramid.exceptions import PredicateMismatch
@@ -48,12 +50,6 @@ from warehouse.accounts.models import User
 from warehouse.cache.http import add_vary, cache_control
 from warehouse.cache.origin import origin_cache
 from warehouse.classifiers.models import Classifier
-from warehouse.constants import (
-    ONE_DAY_IN_SECONDS,
-    ONE_HOUR_IN_SECONDS,
-    SIX_HOURS_IN_SECONDS,
-    TEN_MINUTES_IN_SECONDS,
-)
 from warehouse.db import DatabaseNotAvailableError
 from warehouse.errors import WarehouseDenied
 from warehouse.forms import SetLocaleForm
@@ -211,11 +207,11 @@ def service_unavailable(exc, request):
     route_name="robots.txt",
     renderer="robots.txt",
     decorator=[
-        cache_control(ONE_DAY_IN_SECONDS),
+        cache_control(timedelta(days=1).total_seconds()),
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=SIX_HOURS_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            timedelta(days=1).total_seconds(),
+            stale_while_revalidate=timedelta(hours=6).total_seconds(),
+            stale_if_error=timedelta(days=1).total_seconds(),
         ),
     ],
 )
@@ -228,11 +224,11 @@ def robotstxt(request):
     route_name="opensearch.xml",
     renderer="opensearch.xml",
     decorator=[
-        cache_control(ONE_DAY_IN_SECONDS),
+        cache_control(timedelta(days=1).total_seconds()),
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=SIX_HOURS_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            timedelta(days=1).total_seconds(),
+            stale_while_revalidate=timedelta(hours=6).total_seconds(),
+            stale_if_error=timedelta(days=1).total_seconds(),
         ),
     ],
 )
@@ -246,9 +242,9 @@ def opensearchxml(request):
     renderer="index.html",
     decorator=[
         origin_cache(
-            ONE_HOUR_IN_SECONDS,
-            stale_while_revalidate=TEN_MINUTES_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            timedelta(hours=1).total_seconds(),
+            stale_while_revalidate=timedelta(minutes=10).total_seconds(),
+            stale_if_error=timedelta(days=1).total_seconds(),
             keys=["all-projects"],
         )
     ],
@@ -320,8 +316,8 @@ def list_classifiers(request):
     renderer="search/results.html",
     decorator=[
         origin_cache(
-            ONE_HOUR_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            timedelta(hours=1).total_seconds(),
+            stale_if_error=timedelta(days=1).total_seconds(),
             keys=["all-projects"],
         )
     ],
@@ -432,11 +428,11 @@ def search(request):
     renderer="pages/stats.html",
     decorator=[
         add_vary("Accept"),
-        cache_control(ONE_DAY_IN_SECONDS),
+        cache_control(timedelta(days=1).total_seconds()),
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=ONE_DAY_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            timedelta(days=1).total_seconds(),
+            stale_while_revalidate=timedelta(days=1).total_seconds(),
+            stale_if_error=timedelta(days=1).total_seconds(),
         ),
     ],
     has_translations=True,
@@ -446,11 +442,11 @@ def search(request):
     renderer="json",
     decorator=[
         add_vary("Accept"),
-        cache_control(ONE_DAY_IN_SECONDS),
+        cache_control(timedelta(days=1).total_seconds()),
         origin_cache(
-            ONE_DAY_IN_SECONDS,
-            stale_while_revalidate=ONE_DAY_IN_SECONDS,
-            stale_if_error=ONE_DAY_IN_SECONDS,
+            timedelta(days=1).total_seconds(),
+            stale_while_revalidate=timedelta(days=1).total_seconds(),
+            stale_if_error=timedelta(days=1).total_seconds(),
         ),
     ],
     accept="application/json",


### PR DESCRIPTION
Refactor usages of integers to constants calculated from `timedelta` for clarity.

---

Example of some caught:

```python
$ python -m flake8 warehouse --show-source --tee | tee | head -n5
warehouse/accounts/views.py:163:22: WH003 Prefer `datetime.timedelta([seconds|hours|days]=...).total_seconds()` over integer multiplication to create durations. See https://docs.python.org/3/library/datetime.html#datetime.timedelta
        origin_cache(1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60)  # 1 day each.
                     ^
warehouse/accounts/views.py:163:55: WH003 Prefer `datetime.timedelta([seconds|hours|days]=...).total_seconds()` over integer multiplication to create durations. See https://docs.python.org/3/library/datetime.html#datetime.timedelta
        origin_cache(1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60)  # 1 day each.
```

We could also probably create a new [constant](https://github.com/pypi/warehouse/blob/6e9123d44518eaf13a0c03245d9b9e91ffcd98ae/warehouse/constants.py#L1-L0) for things like `DAY_IN_SECONDS` and reuse liberally. 