### PR TITLE
docs: link to docs in Verified Details section

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2806,79 +2806,83 @@ msgstr ""
 msgid "Verified details"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:19
-#: warehouse/templates/includes/packaging/project-data.html:113
+#: warehouse/templates/includes/packaging/project-data.html:18
+msgid "(What is this?)"
+msgstr ""
+
+#: warehouse/templates/includes/packaging/project-data.html:23
+#: warehouse/templates/includes/packaging/project-data.html:117
 msgid "Project links"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:47
+#: warehouse/templates/includes/packaging/project-data.html:51
 msgid "GitHub Statistics"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:53
+#: warehouse/templates/includes/packaging/project-data.html:57
 msgid "Repository"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:60
+#: warehouse/templates/includes/packaging/project-data.html:64
 msgid "Stars:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:68
+#: warehouse/templates/includes/packaging/project-data.html:72
 msgid "Forks:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:76
+#: warehouse/templates/includes/packaging/project-data.html:80
 msgid "Open issues:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:84
+#: warehouse/templates/includes/packaging/project-data.html:88
 msgid "Open PRs:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:92
+#: warehouse/templates/includes/packaging/project-data.html:96
 msgid "Maintainers"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:94
+#: warehouse/templates/includes/packaging/project-data.html:98
 msgid "Avatar for {username} from gravatar.com"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:110
+#: warehouse/templates/includes/packaging/project-data.html:114
 msgid "Unverified details"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:129
+#: warehouse/templates/includes/packaging/project-data.html:133
 msgid "Meta"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:134
+#: warehouse/templates/includes/packaging/project-data.html:138
 msgid "License:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:141
-#: warehouse/templates/includes/packaging/project-data.html:147
+#: warehouse/templates/includes/packaging/project-data.html:145
+#: warehouse/templates/includes/packaging/project-data.html:151
 msgid "Author:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:154
-#: warehouse/templates/includes/packaging/project-data.html:160
+#: warehouse/templates/includes/packaging/project-data.html:158
+#: warehouse/templates/includes/packaging/project-data.html:164
 #: warehouse/templates/pages/help.html:612
 msgid "Maintainer:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:168
+#: warehouse/templates/includes/packaging/project-data.html:172
 msgid "Tags"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:180
+#: warehouse/templates/includes/packaging/project-data.html:184
 msgid "Requires:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:187
+#: warehouse/templates/includes/packaging/project-data.html:191
 msgid "Provides-Extra:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:197
+#: warehouse/templates/includes/packaging/project-data.html:201
 #: warehouse/templates/pages/classifiers.html:16
 #: warehouse/templates/pages/classifiers.html:21
 #: warehouse/templates/pages/sitemap.html:39

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -13,7 +13,11 @@
 -#}
 
 <div class="sidebar-section verified">
-  <h3 class="sidebar-section__title">{% trans %}Verified details{% endtrans %}</h3>
+  <h3 class="sidebar-section__title">{% trans %}Verified details{% endtrans %}&nbsp;
+      <a href="https://docs.pypi.org/project_metadata/#verified-details">
+          <small><i>{% trans %}(What is this?){% endtrans %}</i></small>
+      </a>
+  </h3>
   <small><i>These details have been verified by PyPI</i></small>
   {% if release.urls_by_verify_status(verified=True).values() | contains_valid_uris %}
     <h6>{% trans %}Project links{% endtrans %}</h6>


### PR DESCRIPTION
Adds a "What is this?" link in the Verified Details section, linking to the docs for verified project metadata [(here)](https://docs.pypi.org/project_metadata/#verified-details)

<img width="307" alt="image" src="https://github.com/user-attachments/assets/581c903a-f9b1-4cb5-9c52-1cb518d5d3c2">


cc @woodruffw 