### PR TITLE
refactor: extract validator from form class

### DIFF
--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 import re
 
@@ -76,23 +78,23 @@ class PreventNullBytesValidator:
             raise wtforms.validators.StopValidation(self.message)
 
 
+def _check_for_existing_username(form: LoginForm, field):
+    field.data = field.data.strip()
+
+    userid = form.user_service.find_userid(field.data)
+
+    if userid is None:
+        raise wtforms.validators.ValidationError(_("No user found with that username"))
+
+
 class UsernameMixin:
     username = wtforms.StringField(
         validators=[
             wtforms.validators.InputRequired(),
-            PreventNullBytesValidator(message=INVALID_USERNAME_MESSAGE),
+            PreventNullBytesValidator(),
+            _check_for_existing_username,
         ],
     )
-
-    def validate_username(self, field):
-        field.data = field.data.strip()
-
-        userid = self.user_service.find_userid(field.data)
-
-        if userid is None:
-            raise wtforms.validators.ValidationError(
-                _("No user found with that username")
-            )
 
 
 class TOTPValueMixin:
@@ -327,11 +329,13 @@ class HoneypotMixin:
     confirm_form = wtforms.StringField()
 
 
-class UsernameSearchForm(UsernameMixin, forms.Form):
-    def validate_username(self, field):
-        # Override this function from UsernameMixin. We don't care if the
-        # username is valid or not
-        return True
+class UsernameSearchForm(forms.Form):
+    username = wtforms.StringField(
+        validators=[
+            wtforms.validators.InputRequired(),
+            PreventNullBytesValidator(),
+        ],
+    )
 
 
 class RegistrationForm(  # type: ignore[misc]

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -14,103 +14,103 @@ msgstr ""
 msgid "Locale updated"
 msgstr ""
 
-#: warehouse/accounts/forms.py:52
+#: warehouse/accounts/forms.py:54
 msgid "The password is invalid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:53
+#: warehouse/accounts/forms.py:55
 msgid ""
 "The username is invalid. Usernames must be composed of letters, numbers, "
 "dots, hyphens and underscores. And must also start and finish with a "
 "letter or number. Choose a different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:71
+#: warehouse/accounts/forms.py:73
 msgid "Null bytes are not allowed."
 msgstr ""
 
-#: warehouse/accounts/forms.py:94
+#: warehouse/accounts/forms.py:87
 msgid "No user found with that username"
 msgstr ""
 
-#: warehouse/accounts/forms.py:105
+#: warehouse/accounts/forms.py:107
 msgid "TOTP code must be ${totp_length} digits."
 msgstr ""
 
-#: warehouse/accounts/forms.py:125
+#: warehouse/accounts/forms.py:127
 msgid "Recovery Codes must be ${recovery_code_length} characters."
 msgstr ""
 
-#: warehouse/accounts/forms.py:140
+#: warehouse/accounts/forms.py:142
 msgid "Choose a username with 50 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:157
+#: warehouse/accounts/forms.py:159
 msgid ""
 "This username is already being used by another account. Choose a "
 "different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:171 warehouse/accounts/forms.py:220
-#: warehouse/accounts/forms.py:233
+#: warehouse/accounts/forms.py:173 warehouse/accounts/forms.py:222
+#: warehouse/accounts/forms.py:235
 msgid "Password too long."
 msgstr ""
 
-#: warehouse/accounts/forms.py:207
+#: warehouse/accounts/forms.py:209
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for ${time}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/forms.py:236
+#: warehouse/accounts/forms.py:238
 msgid "Your passwords don't match. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:270
+#: warehouse/accounts/forms.py:272
 msgid "The email address is too long. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:285
+#: warehouse/accounts/forms.py:287
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:299
+#: warehouse/accounts/forms.py:301
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:310
+#: warehouse/accounts/forms.py:312
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:317
+#: warehouse/accounts/forms.py:319
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:350 warehouse/manage/forms.py:139
+#: warehouse/accounts/forms.py:354 warehouse/manage/forms.py:139
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:442
+#: warehouse/accounts/forms.py:446
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:459
+#: warehouse/accounts/forms.py:463
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:528
+#: warehouse/accounts/forms.py:532
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:537
+#: warehouse/accounts/forms.py:541
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:567
+#: warehouse/accounts/forms.py:571
 msgid "The username isn't valid. Try again."
 msgstr ""
 


### PR DESCRIPTION
In-line custom validators will fire prior to field-configured
validators, so by extracting the logic to a function, we can be specific
as to when it fires in the `validators` list.

Refs: https://wtforms.readthedocs.io/en/3.1.x/validators/#custom-validators

Signed-off-by: Mike Fiedler <miketheman@gmail.com>