### PR TITLE
services: don't send a Path where a str is expected

### DIFF
--- a/warehouse/attestations/services.py
+++ b/warehouse/attestations/services.py
@@ -14,8 +14,6 @@ import tempfile
 import typing
 import warnings
 
-from pathlib import Path
-
 import sentry_sdk
 
 from pydantic import TypeAdapter, ValidationError
@@ -312,12 +310,11 @@ class IntegrityService:
         """
         Persist a Provenance object in storage.
         """
-        provenance_file_path = Path(f"{file.path}.provenance")
         with tempfile.NamedTemporaryFile() as f:
             f.write(provenance.model_dump_json().encode("utf-8"))
             f.flush()
 
             self.storage.store(
-                provenance_file_path,
+                f"{file.path}.provenance",
                 f.name,
             )

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -26,25 +26,25 @@ class IGenericFileStorage(Interface):
         created for, passing a name for settings.
         """
 
-    def get(path):
+    def get(path: str):
         """
         Return a file like object that can be read to access the file located
         at the given path.
         """
 
-    def get_metadata(path):
+    def get_metadata(path: str):
         """
         Return a dictionary containing any user-created metadata associated
         with the file at a given path. Implementations may or may not store
         or provide such metadata.
         """
 
-    def get_checksum(path):
+    def get_checksum(path: str):
         """
         Return the md5 digest of the file at a given path as a lowercase string.
         """
 
-    def store(path, file_path, *, meta=None):
+    def store(path: str, file_path, *, meta=None):
         """
         Save the file located at file_path to the file storage at the location
         specified by path. An additional meta keyword argument may contain

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -173,7 +173,7 @@ class GenericBlobStorage:
         self.bucket = bucket
         self.prefix = prefix
 
-    def _get_path(self, path):
+    def _get_path(self, path: str) -> str:
         # If we have a prefix, then prepend it to our path. This will let us
         # store items inside of a sub directory without exposing that to end
         # users.
@@ -261,7 +261,7 @@ class GenericS3BlobStorage(GenericBlobStorage):
                 raise
             raise FileNotFoundError(f"No such key: {path!r}") from None
 
-    def store(self, path, file_path, *, meta=None):
+    def store(self, path: str, file_path, *, meta=None):
         extra_args = {}
         if meta is not None:
             extra_args["Metadata"] = meta


### PR DESCRIPTION
This removes a use of a `Path` object, which was entirely superfluous since we perform no actual path operations on it.

Fixes https://python-software-foundation.sentry.io/share/issue/ba5ffbe9b9b34c6c841c80aa45e48b17/

