### PR TITLE
fix: disallow urls in `full_name` during registration

### DIFF
--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -356,6 +356,10 @@ class RegistrationForm(  # type: ignore[misc]
                     "Choose a name with 100 characters or less."
                 ),
             ),
+            wtforms.validators.Regexp(
+                r"(?i)(?:(?!:\/\/).)*$",
+                message=_("URLs are not allowed in the name field."),
+            ),
             PreventNullBytesValidator(),
         ]
     )

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -94,23 +94,27 @@ msgstr ""
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:446
+#: warehouse/accounts/forms.py:361
+msgid "URLs are not allowed in the name field."
+msgstr ""
+
+#: warehouse/accounts/forms.py:450
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:463
+#: warehouse/accounts/forms.py:467
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:532
+#: warehouse/accounts/forms.py:536
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:541
+#: warehouse/accounts/forms.py:545
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:571
+#: warehouse/accounts/forms.py:575
 msgid "The username isn't valid. Try again."
 msgstr ""
 


### PR DESCRIPTION
Signed-off-by: Mike Fiedler <miketheman@gmail.com>