### PR TITLE
use sentry_sdk.new_scope

### DIFF
--- a/tests/unit/oidc/models/test_activestate.py
+++ b/tests/unit/oidc/models/test_activestate.py
@@ -161,7 +161,7 @@ class TestActiveStatePublisher:
         scope = pretend.stub()
         sentry_sdk = pretend.stub(
             capture_message=pretend.call_recorder(lambda s: None),
-            push_scope=pretend.call_recorder(
+            new_scope=pretend.call_recorder(
                 lambda: pretend.stub(
                     __enter__=lambda *a: scope, __exit__=lambda *a: None
                 )
@@ -212,7 +212,7 @@ class TestActiveStatePublisher:
         scope = pretend.stub()
         sentry_sdk = pretend.stub(
             capture_message=pretend.call_recorder(lambda s: None),
-            push_scope=pretend.call_recorder(
+            new_scope=pretend.call_recorder(
                 lambda: pretend.stub(
                     __enter__=lambda *a: scope, __exit__=lambda *a: None
                 )

--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -244,7 +244,7 @@ class TestGitHubPublisher:
         scope = pretend.stub()
         sentry_sdk = pretend.stub(
             capture_message=pretend.call_recorder(lambda s: None),
-            push_scope=pretend.call_recorder(
+            new_scope=pretend.call_recorder(
                 lambda: pretend.stub(
                     __enter__=lambda *a: scope, __exit__=lambda *a: None
                 )
@@ -284,7 +284,7 @@ class TestGitHubPublisher:
         scope = pretend.stub()
         sentry_sdk = pretend.stub(
             capture_message=pretend.call_recorder(lambda s: None),
-            push_scope=pretend.call_recorder(
+            new_scope=pretend.call_recorder(
                 lambda: pretend.stub(
                     __enter__=lambda *a: scope, __exit__=lambda *a: None
                 )

--- a/tests/unit/oidc/models/test_gitlab.py
+++ b/tests/unit/oidc/models/test_gitlab.py
@@ -204,7 +204,7 @@ class TestGitLabPublisher:
         scope = pretend.stub()
         sentry_sdk = pretend.stub(
             capture_message=pretend.call_recorder(lambda s: None),
-            push_scope=pretend.call_recorder(
+            new_scope=pretend.call_recorder(
                 lambda: pretend.stub(
                     __enter__=lambda *a: scope, __exit__=lambda *a: None
                 )
@@ -243,7 +243,7 @@ class TestGitLabPublisher:
         scope = pretend.stub()
         sentry_sdk = pretend.stub(
             capture_message=pretend.call_recorder(lambda s: None),
-            push_scope=pretend.call_recorder(
+            new_scope=pretend.call_recorder(
                 lambda: pretend.stub(
                     __enter__=lambda *a: scope, __exit__=lambda *a: None
                 )

--- a/tests/unit/oidc/models/test_google.py
+++ b/tests/unit/oidc/models/test_google.py
@@ -80,7 +80,7 @@ class TestGooglePublisher:
         scope = pretend.stub()
         sentry_sdk = pretend.stub(
             capture_message=pretend.call_recorder(lambda s: None),
-            push_scope=pretend.call_recorder(
+            new_scope=pretend.call_recorder(
                 lambda: pretend.stub(
                     __enter__=lambda *a: scope, __exit__=lambda *a: None
                 )
@@ -117,7 +117,7 @@ class TestGooglePublisher:
         scope = pretend.stub()
         sentry_sdk = pretend.stub(
             capture_message=pretend.call_recorder(lambda s: None),
-            push_scope=pretend.call_recorder(
+            new_scope=pretend.call_recorder(
                 lambda: pretend.stub(
                     __enter__=lambda *a: scope, __exit__=lambda *a: None
                 )

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -434,7 +434,7 @@ def _process_attestations(request, distribution: Distribution):
                 f"attestation: {e}",
             )
         except Exception as e:
-            with sentry_sdk.push_scope() as scope:
+            with sentry_sdk.new_scope() as scope:
                 scope.fingerprint = [e]
                 sentry_sdk.capture_message(
                     f"Unexpected error while verifying attestation: {e}"

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -220,7 +220,7 @@ class OIDCPublisherMixin:
             list(signed_claims.keys() - self.all_known_claims())
         )
         if unaccounted_claims:
-            with sentry_sdk.push_scope() as scope:
+            with sentry_sdk.new_scope() as scope:
                 scope.fingerprint = unaccounted_claims
                 sentry_sdk.capture_message(
                     f"JWT for {self.__class__.__name__} has unaccounted claims: "
@@ -238,7 +238,7 @@ class OIDCPublisherMixin:
             # change in the JWT's payload.
             signed_claim = signed_claims.get(claim_name)
             if signed_claim is None:
-                with sentry_sdk.push_scope() as scope:
+                with sentry_sdk.new_scope() as scope:
                     scope.fingerprint = [claim_name]
                     sentry_sdk.capture_message(
                         f"JWT for {self.__class__.__name__} is missing claim: "

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -301,7 +301,7 @@ class OIDCPublisherService:
                 tags=[f"publisher:{self.publisher}"],
             )
             if not isinstance(e, jwt.PyJWTError):
-                with sentry_sdk.push_scope() as scope:
+                with sentry_sdk.new_scope() as scope:
                     scope.fingerprint = [e]
                     # We expect pyjwt to only raise subclasses of PyJWTError, but
                     # we can't enforce this. Other exceptions indicate an abstraction

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -129,7 +129,7 @@ def mint_token_from_oidc(request: Request):
         # We expect only PyJWTError and KeyError; anything else indicates
         # an abstraction leak in jwt that we'll log for upstream reporting.
         if not isinstance(e, (jwt.PyJWTError, KeyError)):
-            with sentry_sdk.push_scope() as scope:
+            with sentry_sdk.new_scope() as scope:
                 scope.fingerprint = [e]
                 sentry_sdk.capture_message(f"jwt.decode raised generic error: {e}")
 


### PR DESCRIPTION
Replaces calls to `push_scope` with `new_scope`,
and confirmed that the deprecation warnings for the former are no longer present when running `make tests`.

Closes #16665.