### PR TITLE
fix: delete org apps for user

### DIFF
--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -135,6 +135,7 @@ class User(SitemapMixin, HasObservers, HasObservations, HasEvents, db.Model):
 
     organization_applications: Mapped[list[OrganizationApplication]] = orm.relationship(
         back_populates="submitted_by",
+        cascade="all, delete-orphan",
     )
 
     organizations: Mapped[list[Organization]] = orm.relationship(


### PR DESCRIPTION
The other side of the relationship does this already, so no migration is needed.

Fixes https://python-software-foundation.sentry.io/share/issue/72d2321796b54c949037e5c497dfe202/