### PR TITLE
Ignore worker kill exceptions

### DIFF
--- a/tests/unit/test_sentry.py
+++ b/tests/unit/test_sentry.py
@@ -27,20 +27,38 @@ def test_sentry_request_method():
 
 
 class TestSentryBeforeSend:
-    def test_ignore_exception(self):
-        hint = {"exc_info": (SystemExit, SystemExit(), "tracebk")}
-
-        assert sentry.before_send(pretend.stub(), hint) is None
 
     @pytest.mark.parametrize(
-        "hint",
+        ("event", "hint"),
         [
-            {"exc_info": (ConnectionError, ConnectionError(), "tracebk")},
-            {"event_info": "This is a random event."},
+            (
+                {"message": "This is fine."},
+                {"exc_info": (SystemExit, SystemExit(), "tracebk")},
+            ),
+            (
+                {"message": "Worker (pid:35) was sent SIGINT!"},
+                {},
+            ),
+            (
+                {"message": "Worker (pid:1706) was sent code 131!"},
+                {},
+            ),
         ],
     )
-    def test_report_event(self, hint):
-        event = pretend.stub()
+    def test_ignore_exception(self, event, hint):
+        assert sentry.before_send(event, hint) is None
+
+    @pytest.mark.parametrize(
+        ("event", "hint"),
+        [
+            (
+                {"message": "This is fine."},
+                {"exc_info": (ConnectionError, ConnectionError(), "tracebk")},
+            ),
+            ({"message": "This is fine."}, {"event_info": "This is a random event."}),
+        ],
+    )
+    def test_report_event(self, event, hint):
         assert sentry.before_send(event, hint) is event
 
 

--- a/warehouse/sentry.py
+++ b/warehouse/sentry.py
@@ -53,8 +53,16 @@ ignore_exceptions = (
     DisconnectionError,
 )
 
+ignore_strings = [
+    "was sent code 131!",
+    "was sent SIGINT!",
+]
+
 
 def before_send(event, hint):
+    if "message" in event and any(s in event["message"] for s in ignore_strings):
+        return None
+
     if "exc_info" in hint:
         exc_type, exc_value, tb = hint["exc_info"]
         if (


### PR DESCRIPTION
Filters Sentry alerting on a bunch of annoying exceptions when we deploy.