### PR TITLE
Prevent duplicate `POST` keys in requests

### DIFF
--- a/tests/functional/manage/test_views.py
+++ b/tests/functional/manage/test_views.py
@@ -64,7 +64,7 @@ class TestManageAccount:
         login_page = webtest.get("/account/login/", status=HTTPStatus.OK)
 
         # Fill & submit the login form
-        login_form = login_page.forms[2]  # TODO: form should have an ID, doesn't yet
+        login_form = login_page.forms["login-form"]
         anonymous_csrf_token = login_form["csrf_token"].value
         login_form["username"] = user.username
         login_form["password"] = "password"
@@ -72,8 +72,7 @@ class TestManageAccount:
 
         two_factor_page = login_form.submit().follow(status=HTTPStatus.OK)
 
-        # TODO: form doesn't have an ID yet
-        two_factor_form = two_factor_page.forms[2]
+        two_factor_form = two_factor_page.forms["totp-auth-form"]
         two_factor_form["csrf_token"] = anonymous_csrf_token
 
         # Generate the correct TOTP value from the known secret
@@ -94,9 +93,8 @@ class TestManageAccount:
         assert anonymous_csrf_token != logged_in_csrf_token
 
         # Fill & submit the change password form
-        # TODO: form doesn't have an ID yet
         new_password = faker.Faker().password()  # a secure-enough password for testing
-        change_password_form = change_password_page.forms[3]
+        change_password_form = change_password_page.forms["change-password-form"]
         change_password_form["csrf_token"] = logged_in_csrf_token
         change_password_form["password"] = "password"
         change_password_form["new_password"] = new_password

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http import HTTPStatus
+
+from webob.multidict import MultiDict
+
+from ..common.db.accounts import UserFactory
+
+
+def test_rejects_duplicate_post_keys(webtest, socket_enabled):
+    # create a User
+    user = UserFactory.create(with_verified_primary_email=True, clear_pwd="password")
+
+    # /login is an unauthenticated endpoint that accepts a POST
+    login_page = webtest.get("/account/login/", status=HTTPStatus.OK)
+
+    # Get the CSRF token from the form
+    login_form = login_page.forms["login-form"]
+    anonymous_csrf_token = login_form["csrf_token"].value
+
+    body = MultiDict()
+    body.add("username", user.username)
+    body.add("password", "password")
+    body.add("csrf_token", anonymous_csrf_token)
+    # Add multiple duplicate keys to the POST body, doesn't matter what they are
+    body.add("foo", "bar")
+    body.add("foo", "baz")
+
+    webtest.post("/account/login", params=body, status=HTTPStatus.BAD_REQUEST)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -290,6 +290,7 @@ def test_configure(monkeypatch, settings, environment):
         whitenoise_add_manifest=pretend.call_recorder(lambda *a, **kw: None),
         scan=pretend.call_recorder(lambda categories, ignore: None),
         commit=pretend.call_recorder(lambda: None),
+        add_view_deriver=pretend.call_recorder(lambda *a, **kw: None),
     )
     configurator_cls = pretend.call_recorder(lambda settings: configurator_obj)
     monkeypatch.setattr(config, "Configurator", configurator_cls)
@@ -530,6 +531,11 @@ def test_configure(monkeypatch, settings, environment):
     assert configurator_obj.add_renderer.calls == [
         pretend.call("json", json_renderer_obj),
         pretend.call("xmlrpc", xmlrpc_renderer_obj),
+    ]
+    assert configurator_obj.add_view_deriver.calls == [
+        pretend.call(
+            config.reject_duplicate_post_keys_view, under=config.viewderivers.INGRESS
+        )
     ]
 
     assert json_renderer_cls.calls == [

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -893,8 +893,8 @@ def configure(settings=None):
     )
 
     # Sanity check our request and responses.
-    # Note: It is very important that this go last. We need everything else that might
-    #       have added a tween to be registered prior to this.
+    # Note: It is very important that this go last. We need everything else
+    # that might have added a tween to be registered prior to this.
     config.include(".sanity")
 
     # Finally, commit all of our changes

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -12,6 +12,7 @@
 
 import base64
 import enum
+import functools
 import json
 import os
 import secrets
@@ -24,10 +25,11 @@ import orjson
 import platformdirs
 import transaction
 
-from pyramid import renderers
+from pyramid import renderers, viewderivers
 from pyramid.authorization import Allow, Authenticated
 from pyramid.config import Configurator as _Configurator
 from pyramid.exceptions import HTTPForbidden
+from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.settings import asbool
 from pyramid.tweens import EXCVIEW
 from pyramid_rpc.xmlrpc import XMLRPCRenderer
@@ -264,6 +266,29 @@ def maybe_set_redis(settings, name, envvar, coercer=None, default=None, db=None)
 
 def from_base64_encoded_json(configuration):
     return json.loads(base64.urlsafe_b64decode(configuration.encode("ascii")))
+
+
+def reject_duplicate_post_keys_view(view, info):
+    if not info.options.get("permit_duplicate_post_keys"):
+
+        @functools.wraps(view)
+        def wrapped(context, request):
+            if request.POST:
+                # Attempt to cast to a dict to catch duplicate keys
+                try:
+                    dict(**request.POST)
+                except TypeError:
+                    return HTTPBadRequest("POST body may not contain duplicate keys")
+
+            # Casting succeeded, so just return the regular view
+            return view(context, request)
+
+        return wrapped
+
+    return view
+
+
+reject_duplicate_post_keys_view.options = {"permit_duplicate_post_keys"}  # type: ignore
 
 
 def configure(settings=None):
@@ -816,6 +841,9 @@ def configure(settings=None):
             EXCVIEW,
         ],
     )
+
+    # Reject requests with duplicate POST keys
+    config.add_view_deriver(reject_duplicate_post_keys_view, under=viewderivers.INGRESS)
 
     # Enable Warehouse to serve our static files
     prevent_http_cache = config.get_settings().get("pyramid.prevent_http_cache", False)

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -487,6 +487,7 @@ def _sort_releases(request: Request, project: Project):
     require_csrf=False,
     require_methods=["POST"],
     has_translations=True,
+    permit_duplicate_post_keys=True,
 )
 def file_upload(request):
     # This is a list of warnings that we'll emit *IF* the request is successful.

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:569 warehouse/manage/views/__init__.py:870
+#: warehouse/accounts/views.py:569 warehouse/manage/views/__init__.py:865
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -285,7 +285,7 @@ msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
 #: warehouse/accounts/views.py:1548 warehouse/accounts/views.py:1791
-#: warehouse/manage/views/__init__.py:1249
+#: warehouse/manage/views/__init__.py:1242
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
@@ -305,19 +305,19 @@ msgstr ""
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1614 warehouse/manage/views/__init__.py:1304
-#: warehouse/manage/views/__init__.py:1417
-#: warehouse/manage/views/__init__.py:1529
-#: warehouse/manage/views/__init__.py:1639
+#: warehouse/accounts/views.py:1614 warehouse/manage/views/__init__.py:1297
+#: warehouse/manage/views/__init__.py:1410
+#: warehouse/manage/views/__init__.py:1522
+#: warehouse/manage/views/__init__.py:1632
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1625 warehouse/manage/views/__init__.py:1318
-#: warehouse/manage/views/__init__.py:1431
-#: warehouse/manage/views/__init__.py:1543
-#: warehouse/manage/views/__init__.py:1653
+#: warehouse/accounts/views.py:1625 warehouse/manage/views/__init__.py:1311
+#: warehouse/manage/views/__init__.py:1424
+#: warehouse/manage/views/__init__.py:1536
+#: warehouse/manage/views/__init__.py:1646
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
@@ -427,130 +427,130 @@ msgstr ""
 msgid "This team name has already been used. Choose a different team name."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:282
+#: warehouse/manage/views/__init__.py:281
 msgid "Account details updated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:312
+#: warehouse/manage/views/__init__.py:311
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:818
+#: warehouse/manage/views/__init__.py:813
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:819
+#: warehouse/manage/views/__init__.py:814
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:928
+#: warehouse/manage/views/__init__.py:923
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1028
+#: warehouse/manage/views/__init__.py:1021
 msgid "API Token does not exist."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1060
+#: warehouse/manage/views/__init__.py:1053
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1285
+#: warehouse/manage/views/__init__.py:1278
 msgid ""
 "GitHub-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1398
+#: warehouse/manage/views/__init__.py:1391
 msgid ""
 "GitLab-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1510
+#: warehouse/manage/views/__init__.py:1503
 msgid ""
 "Google-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1619
+#: warehouse/manage/views/__init__.py:1612
 msgid ""
 "ActiveState-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1854
-#: warehouse/manage/views/__init__.py:2155
-#: warehouse/manage/views/__init__.py:2263
+#: warehouse/manage/views/__init__.py:1847
+#: warehouse/manage/views/__init__.py:2148
+#: warehouse/manage/views/__init__.py:2256
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1986
-#: warehouse/manage/views/__init__.py:2071
-#: warehouse/manage/views/__init__.py:2172
-#: warehouse/manage/views/__init__.py:2272
+#: warehouse/manage/views/__init__.py:1979
+#: warehouse/manage/views/__init__.py:2064
+#: warehouse/manage/views/__init__.py:2165
+#: warehouse/manage/views/__init__.py:2265
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1998
+#: warehouse/manage/views/__init__.py:1991
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2083
+#: warehouse/manage/views/__init__.py:2076
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2184
+#: warehouse/manage/views/__init__.py:2177
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2284
+#: warehouse/manage/views/__init__.py:2277
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2288
+#: warehouse/manage/views/__init__.py:2281
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2438
+#: warehouse/manage/views/__init__.py:2431
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2545
+#: warehouse/manage/views/__init__.py:2538
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2612
+#: warehouse/manage/views/__init__.py:2605
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2644
+#: warehouse/manage/views/__init__.py:2637
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2657
+#: warehouse/manage/views/__init__.py:2650
 #: warehouse/manage/views/organizations.py:878
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2722
+#: warehouse/manage/views/__init__.py:2715
 #: warehouse/manage/views/organizations.py:943
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2755
+#: warehouse/manage/views/__init__.py:2748
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2766
+#: warehouse/manage/views/__init__.py:2759
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2798
+#: warehouse/manage/views/__init__.py:2791
 #: warehouse/manage/views/organizations.py:1130
 msgid "Invitation revoked from '${username}'."
 msgstr ""

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -29,7 +29,6 @@ from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import joinedload
 from venusian import lift
 from webauthn.helpers import bytes_to_base64url
-from webob.multidict import MultiDict
 
 import warehouse.utils.otp as otp
 
@@ -413,7 +412,7 @@ class ManageVerifiedAccountViews(ManageAccountMixin):
     @view_config(request_method="POST", request_param=ChangePasswordForm.__params__)
     def change_password(self):
         form = ChangePasswordForm(
-            MultiDict(**self.request.POST),
+            self.request.POST,
             request=self.request,
             username=self.request.user.username,
             full_name=self.request.user.name,
@@ -452,12 +451,10 @@ class ManageVerifiedAccountViews(ManageAccountMixin):
             return self.default_response
 
         form = ConfirmPasswordForm(
-            formdata=MultiDict(
-                {
-                    "password": confirm_password,
-                    "username": self.request.user.username,
-                }
-            ),
+            formdata={
+                "password": confirm_password,
+                "username": self.request.user.username,
+            },
             request=self.request,
             user_service=self.user_service,
         )
@@ -584,7 +581,7 @@ class ProvisionTOTPViews:
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
         form = ProvisionTOTPForm(
-            MultiDict(**self.request.POST),
+            self.request.POST,
             totp_secret=self.request.session.get_totp_secret(),
         )
 
@@ -634,12 +631,10 @@ class ProvisionTOTPViews:
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
         form = DeleteTOTPForm(
-            formdata=MultiDict(
-                {
-                    "password": self.request.POST["confirm_password"],
-                    "username": self.request.user.username,
-                }
-            ),
+            formdata={
+                "password": self.request.POST["confirm_password"],
+                "username": self.request.user.username,
+            },
             request=self.request,
             user_service=self.user_service,
         )
@@ -711,7 +706,7 @@ class ProvisionWebAuthnViews:
     )
     def validate_webauthn_provision(self):
         form = ProvisionWebAuthnForm(
-            MultiDict(**self.request.POST),
+            self.request.POST,
             user_service=self.user_service,
             user_id=self.request.user.id,
             challenge=self.request.session.get_webauthn_challenge(),
@@ -769,7 +764,7 @@ class ProvisionWebAuthnViews:
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
         form = DeleteWebAuthnForm(
-            MultiDict(**self.request.POST),
+            self.request.POST,
             username=self.request.user.username,
             user_service=self.user_service,
             user_id=self.request.user.id,
@@ -931,7 +926,7 @@ class ProvisionMacaroonViews:
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
         form = CreateMacaroonForm(
-            MultiDict(**self.request.POST),
+            self.request.POST,
             user_id=self.request.user.id,
             macaroon_service=self.macaroon_service,
             project_names=self.project_names,
@@ -1008,13 +1003,11 @@ class ProvisionMacaroonViews:
     )
     def delete_macaroon(self):
         form = DeleteMacaroonForm(
-            formdata=MultiDict(
-                {
-                    "password": self.request.POST["confirm_password"],
-                    "username": self.request.user.username,
-                    "macaroon_id": self.request.POST["macaroon_id"],
-                }
-            ),
+            formdata={
+                "password": self.request.POST["confirm_password"],
+                "username": self.request.user.username,
+                "macaroon_id": self.request.POST["macaroon_id"],
+            },
             request=self.request,
             macaroon_service=self.macaroon_service,
             user_service=self.user_service,

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -29,7 +29,7 @@
     <div class="site-container">
       <h1 class="page-title">{% trans title=title %}Log in to {{ title }}{% endtrans %}</h1>
 
-      <form method="POST" action="{{ request.current_route_path() }}">
+      <form method="POST" action="{{ request.current_route_path() }}" id="login-form">
         <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
 
         {% if redirect.data %}

--- a/warehouse/templates/accounts/reset-password.html
+++ b/warehouse/templates/accounts/reset-password.html
@@ -22,7 +22,7 @@
   <div class="horizontal-section">
     <div class="site-container">
       <h1 class="page-title">{% trans %}Reset your password{% endtrans %}</h1>
-      <form data-controller="password password-match password-strength-gauge" method="POST" action="{{ request.current_route_path() }}">
+      <form data-controller="password password-match password-strength-gauge" method="POST" action="{{ request.current_route_path() }}" id="reset-password-form">
         <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
         {% if form.errors.__all__ %}
           <ul class="errors">

--- a/warehouse/templates/accounts/two-factor.html
+++ b/warehouse/templates/accounts/two-factor.html
@@ -80,7 +80,7 @@
 
       {% if totp_form %}
       <div class="twofa-login__method {% if has_webauthn %}twofa-login__method--padded{% endif %}">
-        <form method="POST" action="{{ request.current_route_path() }}">
+        <form method="POST" action="{{ request.current_route_path() }}" id="totp-auth-form">
           <h2>{% trans %}Authenticate with an app{% endtrans %}</h2>
 
           <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -375,7 +375,7 @@
   <section id="change-password">
     <h2 class="sub-title">{% trans %}Change password{% endtrans %}</h2>
     {{ form_error_anchor(change_password_form) }}
-    <form data-controller="password password-match password-strength-gauge" method="POST" action="#errors">
+    <form data-controller="password password-match password-strength-gauge" method="POST" action="#errors" id="change-password-form">
       <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
       {{ form_errors(change_password_form) }}
       <div class="form-group">


### PR DESCRIPTION
Fixes https://python-software-foundation.sentry.io/share/issue/40756e6481274d3babdc620efac508a9/

Generally, duplicate `POST` keys in a request are an error for us. Rather than sanity-checking this everywhere we use `request.POST`, this PR adds a view deriver that returns an error if duplicate keys are present.