### PR TITLE
feat: capture metrics during email validation

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -45,7 +45,7 @@ if [ "${COVERAGE:-yes}" != "no" ]; then
   python -m coverage run -m pytest --strict-markers "${COMMAND_ARGS[@]}"
   python -m coverage combine
   python -m coverage html --show-contexts
-  python -m coverage report -m --fail-under 100
+  python -m coverage report -m --fail-under 100 --skip-covered
 else
   python -m pytest --strict-markers "${COMMAND_ARGS[@]}"
 fi;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ exclude_lines = [
   "if (typing\\.)?TYPE_CHECKING:",
 ]
 
-# Don't show us anything that's already 100% covered.
-skip_covered = true
-
 [tool.curlylint]
 include = '\.(html|jinja|txt)$'
 # For jinja's i18n extension:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,6 +212,7 @@ def pyramid_request(pyramid_services, jinja, remote_addr, remote_addr_hashed):
     dummy_request._unauthenticated_userid = None
     dummy_request.user = None
     dummy_request.oidc_publisher = None
+    dummy_request.metrics = dummy_request.find_service(IMetricsService)
 
     dummy_request.registry.registerUtility(jinja, IJinja2Environment, name=".jinja2")
 

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -414,7 +414,7 @@ def _no_deliverability_check(monkeypatch):
 
 
 class TestRegistrationForm:
-    def test_validate(self):
+    def test_validate(self, metrics):
         captcha_service = pretend.stub(
             enabled=False,
             verify_response=pretend.call_recorder(lambda _: None),
@@ -432,7 +432,8 @@ class TestRegistrationForm:
 
         form = forms.RegistrationForm(
             request=pretend.stub(
-                db=pretend.stub(query=lambda *a: pretend.stub(scalar=lambda: False))
+                db=pretend.stub(query=lambda *a: pretend.stub(scalar=lambda: False)),
+                metrics=metrics,
             ),
             formdata=MultiDict(
                 {
@@ -538,10 +539,11 @@ class TestRegistrationForm:
             str(form.email.errors.pop()) == "The email address isn't valid. Try again."
         )
 
-    def test_exotic_email_success(self):
+    def test_exotic_email_success(self, metrics):
         form = forms.RegistrationForm(
             request=pretend.stub(
-                db=pretend.stub(query=lambda *a: pretend.stub(scalar=lambda: False))
+                db=pretend.stub(query=lambda *a: pretend.stub(scalar=lambda: False)),
+                metrics=metrics,
             ),
             formdata=MultiDict({"email": "foo@n--tree.net"}),
             user_service=pretend.stub(

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -170,12 +170,13 @@ class TestSaveAccountForm:
 
 
 class TestAddEmailForm:
-    def test_validate(self):
+    def test_validate(self, metrics):
         user_id = pretend.stub()
         user_service = pretend.stub(find_userid_by_email=lambda _: None)
         form = forms.AddEmailForm(
             request=pretend.stub(
-                db=pretend.stub(query=lambda *a: pretend.stub(scalar=lambda: False))
+                db=pretend.stub(query=lambda *a: pretend.stub(scalar=lambda: False)),
+                metrics=metrics,
             ),
             formdata=MultiDict({"email": "foo@bar.com"}),
             user_id=user_id,

--- a/tests/unit/metrics/test_init.py
+++ b/tests/unit/metrics/test_init.py
@@ -89,5 +89,6 @@ def test_include_sets_class():
         pretend.call(_metrics, name="metrics", reify=True)
     ]
 
+
 def test_finds_service(pyramid_request):
     assert _metrics(pyramid_request) == pyramid_request.find_service(IMetricsService)

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -14,7 +14,7 @@ msgstr ""
 msgid "Locale updated"
 msgstr ""
 
-#: warehouse/accounts/forms.py:52 warehouse/accounts/forms.py:286
+#: warehouse/accounts/forms.py:52 warehouse/accounts/forms.py:290
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
@@ -74,47 +74,47 @@ msgstr ""
 msgid "The email address is too long. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:314
+#: warehouse/accounts/forms.py:322
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:325
+#: warehouse/accounts/forms.py:337
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:332
+#: warehouse/accounts/forms.py:348
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:367 warehouse/manage/forms.py:139
+#: warehouse/accounts/forms.py:388 warehouse/manage/forms.py:139
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:374
+#: warehouse/accounts/forms.py:395
 msgid "URLs are not allowed in the name field."
 msgstr ""
 
-#: warehouse/accounts/forms.py:463
+#: warehouse/accounts/forms.py:484
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:480
+#: warehouse/accounts/forms.py:501
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:549
+#: warehouse/accounts/forms.py:570
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:558
+#: warehouse/accounts/forms.py:579
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:588
+#: warehouse/accounts/forms.py:609
 msgid "The username isn't valid. Try again."
 msgstr ""
 

--- a/warehouse/metrics/__init__.py
+++ b/warehouse/metrics/__init__.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from pyramid import events, viewderivers
+from pyramid.request import Request
 from pyramid_retry import IBeforeRetry
 
 from warehouse.metrics import event_handlers
@@ -19,6 +20,10 @@ from warehouse.metrics.services import DataDogMetrics, NullMetrics
 from warehouse.metrics.views import timing_view
 
 __all__ = ["IMetricsService", "NullMetrics", "DataDogMetrics", "includeme"]
+
+
+def _metrics(request: Request) -> IMetricsService:
+    return request.find_service(IMetricsService)
 
 
 def includeme(config):
@@ -38,3 +43,6 @@ def includeme(config):
 
     # Register our view deriver that ensures we get our view timed.
     config.add_view_deriver(timing_view, under=viewderivers.INGRESS)
+
+    # Add the metrics service to the request.
+    config.add_request_method(_metrics, name="metrics", reify=True)


### PR DESCRIPTION
Includes changes to enable `request.metrics.increment(...)` and coverage output.