### PR TITLE
address #16743

### DIFF
--- a/warehouse/static/sass/blocks/_verified.scss
+++ b/warehouse/static/sass/blocks/_verified.scss
@@ -26,6 +26,7 @@
   li {
     a {
         display: inline;
+        padding: 0;
     }
   }
 

--- a/warehouse/static/sass/blocks/_vertical-tabs.scss
+++ b/warehouse/static/sass/blocks/_vertical-tabs.scss
@@ -106,18 +106,7 @@
   &__tab {
     display: block;
     padding: $half-spacing-unit;
-    cursor: pointer;
     @include link-without-underline;
-
-    &:hover {
-      color: darken($primary-color, 10);
-    }
-
-    &:active,
-    &:focus {
-      outline: 1px solid $white;
-      box-shadow: 0 0 0 2px $primary-color;
-    }
 
     &--mobile {
       display: none;


### PR DESCRIPTION
Two distinct commits for the issues noted in #16743.

1) explicitly removes extraneous padding on `a` elements in vertical-tabs elements
2) removes cursor/hover behavior for vertical-tabs__tab class, which is predominately used on a elements which have the desired behavior directly.

<img width="321" alt="Screenshot 2024-09-18 at 3 23 52 PM" src="https://github.com/user-attachments/assets/398ae4ef-0243-460e-961d-f67f4cc24055">
