### PR TITLE
More fixes for project details sidebar

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2821,7 +2821,7 @@ msgid "These details have been <a href=\"%(href)s\">verified by PyPI</a>"
 msgstr ""
 
 #: warehouse/templates/includes/packaging/project-data.html:23
-#: warehouse/templates/includes/packaging/project-data.html:139
+#: warehouse/templates/includes/packaging/project-data.html:137
 msgid "Project links"
 msgstr ""
 
@@ -2858,48 +2858,48 @@ msgid "Avatar for {username} from gravatar.com"
 msgstr ""
 
 #: warehouse/templates/includes/packaging/project-data.html:112
-#: warehouse/templates/includes/packaging/project-data.html:155
+#: warehouse/templates/includes/packaging/project-data.html:153
 msgid "Meta"
 msgstr ""
 
 #: warehouse/templates/includes/packaging/project-data.html:117
-#: warehouse/templates/includes/packaging/project-data.html:167
-#: warehouse/templates/includes/packaging/project-data.html:173
+#: warehouse/templates/includes/packaging/project-data.html:165
+#: warehouse/templates/includes/packaging/project-data.html:171
 msgid "Author:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:125
-#: warehouse/templates/includes/packaging/project-data.html:180
-#: warehouse/templates/includes/packaging/project-data.html:186
+#: warehouse/templates/includes/packaging/project-data.html:124
+#: warehouse/templates/includes/packaging/project-data.html:178
+#: warehouse/templates/includes/packaging/project-data.html:184
 #: warehouse/templates/pages/help.html:620
 msgid "Maintainer:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:136
+#: warehouse/templates/includes/packaging/project-data.html:134
 msgid "Unverified details"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:137
+#: warehouse/templates/includes/packaging/project-data.html:135
 msgid "These details have <b>not</b> been verified by PyPI"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:160
+#: warehouse/templates/includes/packaging/project-data.html:158
 msgid "License:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:194
+#: warehouse/templates/includes/packaging/project-data.html:192
 msgid "Tags"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:206
+#: warehouse/templates/includes/packaging/project-data.html:204
 msgid "Requires:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:213
+#: warehouse/templates/includes/packaging/project-data.html:211
 msgid "Provides-Extra:"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/project-data.html:223
+#: warehouse/templates/includes/packaging/project-data.html:221
 #: warehouse/templates/pages/classifiers.html:16
 #: warehouse/templates/pages/classifiers.html:21
 #: warehouse/templates/pages/sitemap.html:39

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -113,17 +113,15 @@
     <ul>
     {% if release.author_email and release.author_email_verified %}
       <li>
-        <span class="vertical-tabs__tab vertical-tabs__tab--condensed">
+        <span>
           <strong>{% trans %}Author:{% endtrans %}</strong> <a href="mailto:{{ release.author_email|format_email|last }}">{{ release.author or release.author_email|format_email|first }}</a>
-          <i class="fa fa-circle-check check" title="Email verified by PyPI"></i>
         </span>
       </li>
     {% endif %}
     {% if release.maintainer_email and release.maintainer_email_verified%}
       <li>
-        <span class="vertical-tabs__tab vertical-tabs__tab--condensed">
+        <span>
           <strong>{% trans %}Maintainer:{% endtrans %}</strong> <a href="mailto:{{ release.maintainer_email|format_email|last }}">{{ release.maintainer or release.maintainer_email|format_email|first }}</a>
-          <i class="fa fa-circle-check check" title="Email verified by PyPI"></i>
         </span>
       </li>
     {% endif %}
@@ -209,7 +207,7 @@
   {% endif %}
   {% if release.provides_extra %}
   <li>
-    <span class="vertical-tabs__tab vertical-tabs__tab--condensed">
+    <span>
       <strong>{% trans %}Provides-Extra:{% endtrans %}</strong> {% for extra in release.provides_extra %}<code>{{ extra }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
     </span>
   </li>


### PR DESCRIPTION
Missed in ##16746, resulting in a slightly mis-rendered 'Meta' section:

<img width="321" alt="image" src="https://github.com/user-attachments/assets/9cb0cd6b-1505-4d01-a1e6-40032b72cd64">


