### PR TITLE
requirements: bump pypi-attestations to 0.0.12

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -65,7 +65,7 @@ rfc8785
 sentry-sdk
 setuptools
 sigstore~=3.2.0
-pypi-attestations==0.0.11
+pypi-attestations==0.0.12
 sqlalchemy[asyncio]>=2.0,<3.0
 stdlib-list
 stripe

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1799,9 +1799,9 @@ pyparsing==3.1.4 \
     --hash=sha256:a6a7ee4235a3f944aa1fa2249307708f893fe5717dc603503c6c7969c070fb7c \
     --hash=sha256:f86ec8d1a83f11977c9a6ea7598e8c27fc5cddfa5b07ea2241edbbde1d7bc032
     # via linehaul
-pypi-attestations==0.0.11 \
-    --hash=sha256:b730e6b23874d94da0f3817b1f9dd3ecb6a80d685f62a18ad96e5b0396149ded \
-    --hash=sha256:e74329074f049568591e300373e12fcd46a35e21723110856546e33bf2949efa
+pypi-attestations==0.0.12 \
+    --hash=sha256:b1b2d5e700def138a214869f65835ff20e5f2e524acca841d5280ea89c2d2c46 \
+    --hash=sha256:d4a901121993ff8693ef9fd99e83f506ce79b5f799c36fcf8ddcdb38f4f8960b
     # via -r requirements/main.in
 pyqrcode==1.2.1 \
     --hash=sha256:1b2812775fa6ff5c527977c4cd2ccb07051ca7d0bc0aecf937a43864abe5eff6 \

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import hashlib
 import io
 import re
@@ -2478,11 +2479,12 @@ class TestFileUpload:
         attestation = Attestation(
             version=1,
             verification_material=VerificationMaterial(
-                certificate="some_cert", transparency_entries=[dict()]
+                certificate=base64.b64encode(b"some_cert"),
+                transparency_entries=[dict()],
             ),
             envelope=Envelope(
-                statement="somebase64string",
-                signature="somebase64string",
+                statement=base64.b64encode(b"somebase64string"),
+                signature=base64.b64encode(b"somebase64string"),
             ),
         )
 


### PR DESCRIPTION
This bumps `pypi-attestations` to 0.0.12 to fix a bug we discovered in the previous series (https://github.com/trailofbits/pypi-attestations/pull/48). The TL;DR is that Pydantic's default Base64 encode/decode behavior isn't what we expected (it injects newlines into the encoded value), resulting in the generation of attestations that aren't consistent with PEP740. 

This could have been much worse had we begun to persist and serve attestations, but that fortunately hasn't happened yet 🙂.

See https://github.com/pypa/gh-action-pypi-publish/pull/262 for additional context.