### PR TITLE
Migrate to Redis Broker, take two

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -5,3 +5,4 @@ web-uploads: bin/start-web ddtrace-run python -m gunicorn.app.wsgiapp -c gunicor
 worker: bin/start-worker celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
 worker-beat: bin/start-worker celery -A warehouse beat -S redbeat.RedBeatScheduler -l info
 worker-traced: env DD_SERVICE=warehouse-worker bin/start-worker ddtrace-run celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
+worker-drain-sqs: env BROKER_URL=sqs:///?region=us-east-2&queue_name_prefix=pypi-worker bin/start-worker celery -A warehouse worker -Q default -l info --max-tasks-per-child 32

--- a/dev/environment
+++ b/dev/environment
@@ -7,7 +7,6 @@ WAREHOUSE_IP_SALT="insecure himalayan pink salt"
 
 AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=foo
-BROKER_URL=sqs://localstack:4566/?region=us-east-1&queue_name_prefix=warehouse-dev
 
 DATABASE_URL=postgresql+psycopg://postgres@db/warehouse
 

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -362,6 +362,7 @@ def configure(settings=None):
     )
     maybe_set(settings, "warehouse.downloads_table", "WAREHOUSE_DOWNLOADS_TABLE")
     maybe_set(settings, "celery.broker_url", "BROKER_URL")
+    maybe_set_redis(settings, "celery.broker_redis_url", "REDIS_URL", db=10)
     maybe_set_redis(settings, "celery.result_url", "REDIS_URL", db=12)
     maybe_set_redis(settings, "celery.scheduler_url", "REDIS_URL", db=0)
     maybe_set_redis(settings, "oidc.jwk_cache_url", "REDIS_URL", db=1)

--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -195,7 +195,10 @@ def includeme(config):
 
     broker_transport_options = {}
 
-    broker_url = s["celery.broker_url"]
+    broker_url = s.get("celery.broker_url")
+    if broker_url is None:
+        broker_url = s["celery.broker_redis_url"]
+
     if broker_url.startswith("sqs://"):
         parsed_url = parse_url(broker_url)
         parsed_query = urllib.parse.parse_qs(parsed_url.query)


### PR DESCRIPTION
Temporarily hard-codes a BROKER_URL in a separate worker process.

If not present, REDIS_URL is used for broker.

Cabotage now supports `=` in Procfile envs now: https://github.com/cabotage/cabotage-app/pull/100