### PR TITLE
fix: place user reset after new email logic

### DIFF
--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -572,7 +572,6 @@ def user_recover_account_complete(user: User, request):
     user.totp_secret = None
     user.webauthn = []
     user.recovery_codes = []
-    _user_reset_password(user, request)
 
     for account_recovery in user.active_account_recoveries:
         account_recovery.additional["status"] = "completed"
@@ -584,6 +583,8 @@ def user_recover_account_complete(user: User, request):
                 if email.email == override_to_email:
                     email.primary = True
                     email.verified = True
+
+    _user_reset_password(user, request)
 
     request.session.flash(
         (


### PR DESCRIPTION
Since we want the new emails sent out to the user to sent to the new email address, place the action after the changes to the `user` object.

Resolves #16761 