### PR TITLE
implement some basic guards on our /search endpoint

### DIFF
--- a/tests/unit/search/test_init.py
+++ b/tests/unit/search/test_init.py
@@ -14,6 +14,7 @@ import opensearchpy
 import pretend
 
 from warehouse import search
+from warehouse.rate_limiting import IRateLimiter, RateLimit
 
 from ...common.db.packaging import ProjectFactory, ReleaseFactory
 
@@ -118,11 +119,15 @@ def test_includeme(monkeypatch):
                 "aws.key_id": "AAAAAAAAAAAA",
                 "aws.secret_key": "deadbeefdeadbeefdeadbeef",
                 "opensearch.url": opensearch_url,
+                "warehouse.search.ratelimit_string": "10 per second",
             },
             __setitem__=registry.__setitem__,
         ),
         add_request_method=pretend.call_recorder(lambda *a, **kw: None),
         add_periodic_task=pretend.call_recorder(lambda *a, **kw: None),
+        register_service_factory=pretend.call_recorder(
+            lambda factory, iface, name=None: None
+        ),
     )
 
     search.includeme(config)
@@ -132,7 +137,7 @@ def test_includeme(monkeypatch):
     ]
     assert len(opensearch_client_init.calls) == 1
     assert opensearch_client_init.calls[0].kwargs["hosts"] == ["https://some.url"]
-    assert opensearch_client_init.calls[0].kwargs["timeout"] == 2
+    assert opensearch_client_init.calls[0].kwargs["timeout"] == 0.5
     assert opensearch_client_init.calls[0].kwargs["retry_on_timeout"] is False
     assert (
         opensearch_client_init.calls[0].kwargs["connection_class"]
@@ -146,4 +151,8 @@ def test_includeme(monkeypatch):
     assert registry["opensearch.replicas"] == 0
     assert config.add_request_method.calls == [
         pretend.call(search.opensearch, name="opensearch", reify=True)
+    ]
+
+    assert config.register_service_factory.calls == [
+        pretend.call(RateLimit("10 per second"), IRateLimiter, name="search")
     ]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -333,6 +333,7 @@ def test_configure(monkeypatch, settings, environment):
         "warehouse.manage.oidc.ip_registration_ratelimit_string": "100 per day",
         "warehouse.packaging.project_create_user_ratelimit_string": "20 per hour",
         "warehouse.packaging.project_create_ip_ratelimit_string": "40 per hour",
+        "warehouse.search.ratelimit_string": "5 per second",
         "oidc.backend": "warehouse.oidc.services.OIDCPublisherService",
         "integrity.backend": "warehouse.attestations.services.IntegrityService",
         "warehouse.organizations.max_undecided_organization_applications": 3,

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -671,7 +671,7 @@ class TestSearch:
             search(db_request)
 
         assert metrics.increment.calls == [
-            pretend.call("warehouse.search.ratelimiter.hit", tags=[]),
+            pretend.call("warehouse.search.ratelimiter.hit"),
             pretend.call("warehouse.views.search.error", tags=["error:query_too_long"]),
         ]
 
@@ -705,7 +705,7 @@ class TestSearch:
 
         assert url_maker_factory.calls == [pretend.call(db_request)]
         assert metrics.increment.calls == [
-            pretend.call("warehouse.search.ratelimiter.hit", tags=[]),
+            pretend.call("warehouse.search.ratelimiter.hit"),
             pretend.call("warehouse.views.search.error"),
         ]
         assert metrics.histogram.calls == []
@@ -742,7 +742,7 @@ class TestSearch:
 
         assert exc_info.value.args[0] == message
         assert metrics.increment.calls == [
-            pretend.call("warehouse.search.ratelimiter.exceeded", tags=[])
+            pretend.call("warehouse.search.ratelimiter.exceeded")
         ]
 
 

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -556,6 +556,12 @@ def configure(settings=None):
         "PROJECT_CREATE_IP_RATELIMIT_STRING",
         default="40 per hour",
     )
+    maybe_set(
+        settings,
+        "warehouse.search.ratelimit_string",
+        "SEARCH_RATELIMIT_STRING",
+        default="5 per second",
+    )
 
     # OIDC feature flags and settings
     maybe_set(settings, "warehouse.oidc.audience", "OIDC_AUDIENCE")

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1,16 +1,16 @@
-#: warehouse/views.py:147
+#: warehouse/views.py:149
 msgid ""
 "You must verify your **primary** email address before you can perform "
 "this action."
 msgstr ""
 
-#: warehouse/views.py:163
+#: warehouse/views.py:165
 msgid ""
 "Two-factor authentication must be enabled on your account to perform this"
 " action."
 msgstr ""
 
-#: warehouse/views.py:299
+#: warehouse/views.py:301
 msgid "Locale updated"
 msgstr ""
 

--- a/warehouse/search/__init__.py
+++ b/warehouse/search/__init__.py
@@ -21,6 +21,7 @@ from urllib3.util import parse_url
 
 from warehouse import db
 from warehouse.packaging.models import Project, Release
+from warehouse.rate_limiting import IRateLimiter, RateLimit
 from warehouse.search.utils import get_index
 
 
@@ -79,13 +80,18 @@ def opensearch(request):
 
 
 def includeme(config):
+    ratelimit_string = config.registry.settings.get("warehouse.search.ratelimit_string")
+    config.register_service_factory(
+        RateLimit(ratelimit_string), IRateLimiter, name="search"
+    )
+
     p = parse_url(config.registry.settings["opensearch.url"])
     qs = urllib.parse.parse_qs(p.query)
     kwargs = {
         "hosts": [urllib.parse.urlunparse((p.scheme, p.netloc) + ("",) * 4)],
         "verify_certs": True,
         "ca_certs": certifi.where(),
-        "timeout": 2,
+        "timeout": 0.5,
         "retry_on_timeout": False,
         "serializer": opensearchpy.serializer.serializer,
         "max_retries": 1,

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -26,6 +26,7 @@ from pyramid.httpexceptions import (
     HTTPRequestEntityTooLarge,
     HTTPSeeOther,
     HTTPServiceUnavailable,
+    HTTPTooManyRequests,
     exception_response,
 )
 from pyramid.i18n import make_localizer
@@ -60,6 +61,7 @@ from warehouse.packaging.models import (
     Release,
     ReleaseClassifiers,
 )
+from warehouse.rate_limiting import IRateLimiter
 from warehouse.search.queries import SEARCH_FILTER_ORDER, get_opensearch_query
 from warehouse.utils.cors import _CORS_HEADERS
 from warehouse.utils.http import is_safe_url
@@ -322,7 +324,22 @@ def list_classifiers(request):
     has_translations=True,
 )
 def search(request):
+    ratelimiter = request.find_service(IRateLimiter, name="search", context=None)
     metrics = request.find_service(IMetricsService, context=None)
+
+    ratelimiter.hit(request.remote_addr)
+    if not ratelimiter.test(request.remote_addr):
+        metrics.increment("warehouse.search.ratelimiter.exceeded", tags=[])
+        message = (
+            "Your search query could not be performed because there were too "
+            "many requests by the client."
+        )
+        _resets_in = ratelimiter.resets_in(request.remote_addr)
+        if _resets_in is not None:
+            _resets_in = max(1, int(_resets_in.total_seconds()))
+            message += f" Limit may reset in {_resets_in} seconds."
+        raise HTTPTooManyRequests(message)
+    metrics.increment("warehouse.search.ratelimiter.hit", tags=[])
 
     querystring = request.params.get("q", "").replace("'", '"')
     # Bail early for really long queries before ES raises an error

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -329,7 +329,7 @@ def search(request):
 
     ratelimiter.hit(request.remote_addr)
     if not ratelimiter.test(request.remote_addr):
-        metrics.increment("warehouse.search.ratelimiter.exceeded", tags=[])
+        metrics.increment("warehouse.search.ratelimiter.exceeded")
         message = (
             "Your search query could not be performed because there were too "
             "many requests by the client."
@@ -339,7 +339,7 @@ def search(request):
             _resets_in = max(1, int(_resets_in.total_seconds()))
             message += f" Limit may reset in {_resets_in} seconds."
         raise HTTPTooManyRequests(message)
-    metrics.increment("warehouse.search.ratelimiter.hit", tags=[])
+    metrics.increment("warehouse.search.ratelimiter.hit")
 
     querystring = request.params.get("q", "").replace("'", '"')
     # Bail early for really long queries before ES raises an error


### PR DESCRIPTION
- Move OpenSearch client timeout from 2000ms to 500ms
- Add a simple rate limiter to the endpoint by client ip