### PR TITLE
feat: add tags to conversations on removal

### DIFF
--- a/tests/unit/admin/views/test_malware_reports.py
+++ b/tests/unit/admin/views/test_malware_reports.py
@@ -135,7 +135,13 @@ class TestMalwareReportsProjectList:
         owner_user = UserFactory.create(is_frozen=False)
         project = ProjectFactory.create()
         RoleFactory(user=owner_user, project=project, role_name="Owner")
-        report = ProjectObservationFactory.create(kind="is_malware", related=project)
+        report = ProjectObservationFactory.create(
+            kind="is_malware",
+            related=project,
+            additional={
+                "helpscout_conversation_url": "https://example.com/conversation/123"
+            },
+        )
 
         db_request.POST["confirm_project_name"] = project.name
         db_request.route_path = lambda a: "/admin/malware_reports/"
@@ -236,7 +242,13 @@ class TestMalwareReportsDetail:
         owner_user = UserFactory.create(is_frozen=False)
         project = ProjectFactory.create()
         RoleFactory(user=owner_user, project=project, role_name="Owner")
-        report = ProjectObservationFactory.create(kind="is_malware", related=project)
+        report = ProjectObservationFactory.create(
+            kind="is_malware",
+            related=project,
+            additional={
+                "helpscout_conversation_url": "https://example.com/conversation/123"
+            },
+        )
 
         db_request.matchdict["observation_id"] = str(report.id)
         db_request.POST["confirm_project_name"] = project.name
@@ -254,8 +266,7 @@ class TestMalwareReportsDetail:
         assert db_request.session.flash.calls == [
             pretend.call(f"Deleted the project '{project.name}'", queue="success"),
             pretend.call(
-                f"Malware Project {report.related.name} removed.\n"
-                "Please update related Help Scout conversations.",
+                f"Malware Project {report.related.name} removed and report updated",
                 queue="success",
             ),
         ]

--- a/tests/unit/helpdesk/test_services.py
+++ b/tests/unit/helpdesk/test_services.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http
+
 from textwrap import dedent
 
 import pretend
@@ -124,4 +126,71 @@ class TestHelpScoutService:
         )
 
         assert resp == "https://api.helpscout.net/v2/conversations/123"
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_add_tag(self):
+        responses.get(
+            "https://api.helpscout.net/v2/conversations/123",
+            headers={"Content-Type": "application/hal+json"},
+            json={"tags": [{"id": 9150, "color": "#929499", "tag": "existing_tag"}]},
+        )
+        responses.put(
+            "https://api.helpscout.net/v2/conversations/123/tags",
+            match=[
+                responses.matchers.json_params_matcher(
+                    {"tags": ["existing_tag", "added_tag"]}
+                )
+            ],
+            status=http.HTTPStatus.NO_CONTENT,
+        )
+
+        service = HelpScoutService(
+            session=requests.Session(),
+            bearer_token="fake token",
+            mailbox_id="12345",
+        )
+
+        service.add_tag(
+            conversation_url="https://api.helpscout.net/v2/conversations/123",
+            tag="added_tag",
+        )
+
+        assert len(responses.calls) == 2
+        # GET call
+        get_call = responses.calls[0]
+        assert get_call.request.url == "https://api.helpscout.net/v2/conversations/123"
+        assert get_call.request.headers["Authorization"] == "Bearer fake token"
+        assert get_call.response.json() == {
+            "tags": [{"id": 9150, "color": "#929499", "tag": "existing_tag"}]
+        }
+        # PUT call
+        put_call = responses.calls[1]
+        assert (
+            put_call.request.url
+            == "https://api.helpscout.net/v2/conversations/123/tags"
+        )
+        assert put_call.request.headers["Authorization"] == "Bearer fake token"
+        assert put_call.response.status_code == http.HTTPStatus.NO_CONTENT
+
+    @responses.activate
+    def test_add_tag_with_duplicate(self):
+        responses.get(
+            "https://api.helpscout.net/v2/conversations/123",
+            headers={"Content-Type": "application/hal+json"},
+            json={"tags": [{"id": 9150, "color": "#929499", "tag": "existing_tag"}]},
+        )
+
+        service = HelpScoutService(
+            session=requests.Session(),
+            bearer_token="fake token",
+            mailbox_id="12345",
+        )
+
+        service.add_tag(
+            conversation_url="https://api.helpscout.net/v2/conversations/123",
+            tag="existing_tag",
+        )
+
+        # No PUT call should be made
         assert len(responses.calls) == 1

--- a/warehouse/admin/views/malware_reports.py
+++ b/warehouse/admin/views/malware_reports.py
@@ -20,6 +20,7 @@ from pyramid.httpexceptions import HTTPSeeOther
 from pyramid.view import view_config
 
 from warehouse.authnz import Permissions
+from warehouse.helpdesk.interfaces import IHelpDeskService
 from warehouse.observations.models import Observation
 from warehouse.utils.project import (
     confirm_project,
@@ -180,6 +181,13 @@ def malware_reports_project_verdict_remove_malware(project, request):
 
     # prohibit the project
     prohibit_and_remove_project(project, request, comment="malware")
+    # tell helpdesk to add a tag to all related conversations
+    helpdesk_service = request.find_service(IHelpDeskService)
+    for observation in observations:
+        helpdesk_service.add_tag(
+            conversation_url=observation.additional["helpscout_conversation_url"],
+            tag="removed_as_malware_via_admin",
+        )
 
     request.session.flash(
         f"Malware Project {project.name} removed.\n"
@@ -293,9 +301,14 @@ def remove_malware_for_project(request):
 
     prohibit_and_remove_project(project, request, comment="malware")
 
+    helpdesk_service = request.find_service(IHelpDeskService)
+    helpdesk_service.add_tag(
+        conversation_url=observation.additional["helpscout_conversation_url"],
+        tag="removed_as_malware_via_admin",
+    )
+
     request.session.flash(
-        f"Malware Project {project.name} removed.\n"
-        "Please update related Help Scout conversations.",
+        f"Malware Project {project.name} removed and report updated",
         queue="success",
     )
     return HTTPSeeOther(request.route_path("admin.malware_reports.list"))

--- a/warehouse/helpdesk/interfaces.py
+++ b/warehouse/helpdesk/interfaces.py
@@ -25,3 +25,8 @@ class IHelpDeskService(Interface):
         """
         Create a new conversation in the helpdesk service.
         """
+
+    def add_tag(*, conversation_url: str, tag: str) -> None:
+        """
+        Add a tag to a conversation.
+        """


### PR DESCRIPTION
Create `add_tag` to set a tag to a Help Scout conversation.

We can use the added tag to trigger automated workflows.