### PR TITLE
attestations: provenance added metric

### DIFF
--- a/tests/unit/attestations/test_services.py
+++ b/tests/unit/attestations/test_services.py
@@ -261,10 +261,10 @@ class TestIntegrityService:
         assert attestations == [dummy_attestation]
 
     def test_build_provenance_fails_unsupported_publisher(
-        self, db_request, dummy_attestation
+        self, metrics, db_request, dummy_attestation
     ):
         integrity_service = services.IntegrityService(
-            metrics=pretend.stub(),
+            metrics=metrics,
             session=db_request.db,
         )
 
@@ -277,6 +277,8 @@ class TestIntegrityService:
         # If building provenance fails, nothing is stored or associated with the file
         assert not file.provenance
 
+        assert metrics.increment.calls == []
+
     @pytest.mark.parametrize(
         "publisher_factory",
         [
@@ -285,12 +287,12 @@ class TestIntegrityService:
         ],
     )
     def test_build_provenance_succeeds(
-        self, db_request, publisher_factory, dummy_attestation
+        self, metrics, db_request, publisher_factory, dummy_attestation
     ):
         db_request.oidc_publisher = publisher_factory.create()
 
         integrity_service = services.IntegrityService(
-            metrics=pretend.stub(),
+            metrics=metrics,
             session=db_request.db,
         )
 
@@ -304,6 +306,10 @@ class TestIntegrityService:
 
         model = Provenance.model_validate(provenance.provenance)
         assert model.attestation_bundles[0].attestations == [dummy_attestation]
+
+        assert metrics.increment.calls == [
+            pretend.call("warehouse.attestations.build_provenance.ok")
+        ]
 
 
 def test_publisher_from_oidc_publisher_succeeds_github(db_request):

--- a/warehouse/attestations/services.py
+++ b/warehouse/attestations/services.py
@@ -242,4 +242,6 @@ class IntegrityService:
     def build_provenance(
         self, request: Request, file: File, attestations: list[Attestation]
     ) -> DatabaseProvenance:
-        return _build_provenance(request, file, attestations)
+        provenance = _build_provenance(request, file, attestations)
+        self.metrics.increment("warehouse.attestations.build_provenance.ok")
+        return provenance


### PR DESCRIPTION
Adds `warehouse.attestations.build_provenance.ok`
to signal when a provenance object is persisted to DB.