### PR TITLE
oidc: move reusable_worfklow_used field to the correct event

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3401,7 +3401,6 @@ class TestFileUpload:
                 if not test_with_user
                 else None
             ),
-            "reusable_worfklow_used": False,  # This is tested in oidc.test_views
             "uploaded_via_trusted_publisher": not test_with_user,
         }
 

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -630,6 +630,7 @@ def test_mint_token_no_pending_publisher_ok(
                 "expires": 900,
                 "publisher_name": "GitHub",
                 "publisher_url": "https://fake/url",
+                "reusable_workflow_used": False,
             },
         )
     ]

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -56,7 +56,6 @@ from warehouse.forklift import metadata
 from warehouse.forklift.forms import UploadForm, _filetype_extension_mapping
 from warehouse.macaroons.models import Macaroon
 from warehouse.metrics import IMetricsService
-from warehouse.oidc.views import is_from_reusable_workflow
 from warehouse.packaging.interfaces import IFileStorage, IProjectService
 from warehouse.packaging.metadata_verification import verify_email, verify_url
 from warehouse.packaging.models import (
@@ -897,13 +896,6 @@ def file_upload(request):
                     if request.oidc_publisher
                     else None
                 ),
-                # NOTE(ww, 2024-10-21): This unfortunately typo'd event field
-                # was always incorrect, since the `file_upload` endpoint isn't
-                # itself aware of the kind of workflow that minted its API
-                # token. The correctly named datapoint is now under the
-                # `account:short_lived_api_token:added` event which, despite
-                # its name, is actually a project event.
-                "reusable_worfklow_used": False,
                 "uploaded_via_trusted_publisher": bool(request.oidc_publisher),
             },
         )

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -897,13 +897,13 @@ def file_upload(request):
                     if request.oidc_publisher
                     else None
                 ),
-                "reusable_worfklow_used": (
-                    is_from_reusable_workflow(
-                        request.oidc_publisher, request.oidc_claims
-                    )
-                    if request.oidc_publisher
-                    else False
-                ),
+                # NOTE(ww, 2024-10-21): This unfortunately typo'd event field
+                # was always incorrect, since the `file_upload` endpoint isn't
+                # itself aware of the kind of workflow that minted its API
+                # token. The correctly named datapoint is now under the
+                # `account:short_lived_api_token:added` event which, despite
+                # its name, is actually a project event.
+                "reusable_worfklow_used": False,
                 "uploaded_via_trusted_publisher": bool(request.oidc_publisher),
             },
         )

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -11,13 +11,11 @@
 # limitations under the License.
 
 import time
-
 from datetime import datetime
 from typing import TypedDict, cast
 
 import jwt
 import sentry_sdk
-
 from pydantic import BaseModel, StrictStr, ValidationError
 from pyramid.httpexceptions import HTTPException, HTTPForbidden
 from pyramid.request import Request
@@ -300,6 +298,7 @@ def mint_token(
                 "expires": expires_at,
                 "publisher_name": publisher.publisher_name,
                 "publisher_url": publisher.publisher_url(),
+                "reusable_workflow_used": is_from_reusable_workflow(publisher, claims),
             },
         )
 

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -11,11 +11,13 @@
 # limitations under the License.
 
 import time
+
 from datetime import datetime
 from typing import TypedDict, cast
 
 import jwt
 import sentry_sdk
+
 from pydantic import BaseModel, StrictStr, ValidationError
 from pyramid.httpexceptions import HTTPException, HTTPForbidden
 from pyramid.request import Request


### PR DESCRIPTION
This _should_ fix the `reusable_workflow_used` data quality issues we're seeing, which stem from us originally trying to get it at `file_upload` time, where the request has only a limited view into the original minted token's OIDC claims.

We instead now collect this field during `mint_token`, where the full set of OIDC claims is available to us.

h/t @miketheman for pointing this out, cc @facutuesca 