### PR TITLE
detail: fix spacing

### DIFF
--- a/warehouse/templates/api/simple/detail.html
+++ b/warehouse/templates/api/simple/detail.html
@@ -23,7 +23,7 @@
   <body>
     <h1>Links for {{ name }}</h1>
     {% for file in files -%}
-    <a href="{{ file.url }}#sha256={{ file.hashes.sha256 }}" {% if file.get('requires-python') %}data-requires-python="{{ file['requires-python'] }}" {% endif %}{% if file.yanked %}data-yanked="{% if file.yanked is string %}{{ file.yanked }}{% endif %}" {% endif %}{% if file['core-metadata'] %}data-dist-info-metadata="sha256={{ file['core-metadata']['sha256'] }}" data-core-metadata="sha256={{ file['core-metadata']['sha256'] }}"{% endif %}{% if file.get('provenance') %}data-provenance="{{ file['provenance'] }}" {% endif %}>{{ file.filename }}</a><br />
+    <a href="{{ file.url }}#sha256={{ file.hashes.sha256 }}" {% if file.get('requires-python') %}data-requires-python="{{ file['requires-python'] }}" {% endif %}{% if file.yanked %}data-yanked="{% if file.yanked is string %}{{ file.yanked }}{% endif %}" {% endif %}{% if file['core-metadata'] %}data-dist-info-metadata="sha256={{ file['core-metadata']['sha256'] }}" data-core-metadata="sha256={{ file['core-metadata']['sha256'] }}"{% endif %}{% if file.get('provenance') %} data-provenance="{{ file['provenance'] }}"{% endif %}>{{ file.filename }}</a><br />
     {% endfor -%}
   </body>
 </html>


### PR DESCRIPTION
This follows the PEP 740 index changes; the current detail render is semantically valid HTML, but this makes the spacing between `data-provenance` and other attributes consistent.

Edit: for context, the current render before this PR has the space at the end instead of the beginning, meaning the attributes appear mashed together:

![image](https://github.com/user-attachments/assets/6a921e6c-93ba-4351-9c2d-1f875faac25c)
