### PR TITLE
Guard our BigQuery release metadata sync against upcoming schema changes

### DIFF
--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -419,6 +419,8 @@ bq_schema = [
     SchemaField("maintainer", "STRING", "NULLABLE"),
     SchemaField("maintainer_email", "STRING", "NULLABLE"),
     SchemaField("license", "STRING", "NULLABLE"),
+    SchemaField("license_expression", "STRING", "NULLABLE"),
+    SchemaField("license_files", "STRING", "REPEATED"),
     SchemaField("keywords", "STRING", "NULLABLE"),
     SchemaField("classifiers", "STRING", "REPEATED"),
     SchemaField("platform", "STRING", "REPEATED"),
@@ -624,6 +626,8 @@ class TestUpdateBigQueryMetadata:
                         "maintainer_email": form_factory["maintainer_email"].data
                         or None,
                         "license": form_factory["license"].data or None,
+                        "license_expression": None,
+                        "license_files": [],
                         "keywords": form_factory["description_content_type"].data
                         or None,
                         "classifiers": form_factory["classifiers"].data or [],
@@ -774,6 +778,8 @@ class TestSyncBigQueryMetadata:
                         "maintainer": release.maintainer or None,
                         "maintainer_email": release.maintainer_email or None,
                         "license": release.license or None,
+                        "license_expression": None,
+                        "license_files": [],
                         "keywords": release.keywords or None,
                         "classifiers": release.classifiers or [],
                         "platform": [release.platform] or [],

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -316,7 +316,7 @@ def update_bigquery_release_files(task, request, dist_metadata):
         # values individually
         json_rows = dict()
         for sch in table_schema:
-            field_data = dist_metadata[sch.name]
+            field_data = dist_metadata.get(sch.name, None)
 
             if isinstance(field_data, datetime.datetime):
                 field_data = field_data.isoformat()


### PR DESCRIPTION
PEP 639 implementation will need the following columns added to the big query schema:

license_expression, STRING, NULLABLE
license_files, STRING, REPEATED

We'll want that done in advance of merging an implementation, but need to have the Big Query public dataset team do that for us... so to avoid the need for coordination, lets guard ourselves against the schema changing underneath us...