### PR TITLE
Issue 6688: Added project, role and initiator user URLs to email

### DIFF
--- a/warehouse/templates/email/added-as-collaborator/body.html
+++ b/warehouse/templates/email/added-as-collaborator/body.html
@@ -23,3 +23,7 @@
 {% block reason %}
 {% trans initiator_username=initiator_username, site=site %}You are receiving this because you have been added by {{ initiator_username }} to a project on {{ site }}.{% endtrans %}
 {% endblock %}
+
+Project "{{ project_name }}" details: https://pypi.org/project/{{ project_name }}
+Role "{{ role }}" details: https://pypi.org/help/#collaborator-roles
+Added by {{ initiator_username }}: https://pypi.org/user/{{ initiator_username }}

--- a/warehouse/templates/email/added-as-collaborator/body.txt
+++ b/warehouse/templates/email/added-as-collaborator/body.txt
@@ -20,3 +20,7 @@
 {% endblock %}
 
 {% block reason %}{% trans initiator_username=initiator_username, site=site %}You are receiving this because you have been added by {{ initiator_username }} to a project on {{ site }}.{% endtrans %}{% endblock %}
+
+Project "{{ project_name }}" details: https://pypi.org/project/{{ project_name }}
+Role "{{ role }}" details: https://pypi.org/help/#collaborator-roles
+Added by {{ initiator_username }}: https://pypi.org/user/{{ initiator_username }}


### PR DESCRIPTION
fixes: #6688
NOTE:
I'm working on a machine with 4GB RAM, and the `make serve` step failed due to timeout. However, since the patch only involved minor additions to Jinja2 templates, I proceeded with the submission despite not fully testing it. I understand this isn't ideal, but the fix appeared straightforward.