### PR TITLE
feat: reduce dev-time warnings with inheritance

### DIFF
--- a/docs/dev/development/patterns.rst
+++ b/docs/dev/development/patterns.rst
@@ -133,6 +133,8 @@ Adding a new service
 3. (Optional) Create other implementations of the interface. For instance, many services in ``warehouse``
    also provide a ``NullService`` version used for development. These Null implementations only
    provide basic functionalities without verifications and reduce the need for stubs in tests.
+   When implementing a warning for using the service, subclass the exception from
+   ``warehouse.utils.exceptions.DevelopmentModeWarning`` to minimize warnings in the test logs.
 
    Any new implementation must implement the complete interface, including all its methods and attributes.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,10 +93,7 @@ markers = [
     'functional: Slower running tests which test the entire system is functioning.',
 ]
 filterwarnings = [
-    'ignore::warehouse.admin.services.InsecureStorageWarning',
-    'ignore::warehouse.utils.exceptions.InsecureIntegrityServiceWarning',
-    'ignore::warehouse.utils.exceptions.InsecureOIDCPublisherWarning',
-    'ignore::warehouse.packaging.services.InsecureStorageWarning',
+    'ignore::warehouse.utils.exceptions.DevelopmentModeWarning',
     'error:SELECT statement has a cartesian product:sqlalchemy.exc.SAWarning',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,16 +50,15 @@ cache_dir = "dev/.mypy_cache"
 [[tool.mypy.overrides]]
 # These modules do not yet have types available.
 module = [
-    "automat.*",
     "bpython.*",  # https://github.com/bpython/bpython/issues/892
     "b2sdk.*",  # https://github.com/Backblaze/b2-sdk-python/issues/148
     "celery.app.backends.*",
     "celery.backends.redis.*",
-    "github_reserved_names.*",
+    "github_reserved_names.*",  # https://github.com/Julian/github-reserved-names/pull/10
     "google.cloud.*",
     "forcediphttpsadapter.*",
     "IPython.*",  # has types, but only installed in dev
-    "packaging_legacy.*",
+    "packaging_legacy.*",  # https://github.com/di/packaging_legacy/pull/5
     "paginate.*",
     "paginate_sqlalchemy.*",
     "premailer.*",
@@ -71,10 +70,11 @@ module = [
     "pyramid_rpc.*",
     "pyqrcode.*",
     "requests_aws4auth.*",  # https://github.com/tedder/requests-aws4auth/issues/53
-    "rfc3986.*",
+    "rfc3986.*",  # https://github.com/python-hyper/rfc3986/issues/122
     "transaction.*",
     "ua_parser.*",  # https://github.com/ua-parser/uap-python/issues/110
     "venusian.*",
+    "whitenoise.*",  # https://github.com/evansd/whitenoise/pull/410
     "zope.sqlalchemy.*",
 ]
 ignore_missing_imports = true

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -996,9 +996,9 @@ limits==3.13.0 \
     --hash=sha256:6571b0c567bfa175a35fed9f8a954c0c92f1c3200804282f1b8f1de4ad98a953 \
     --hash=sha256:9767f7233da4255e9904b79908a728e8ec0984c0b086058b4cbbd309aea553f6
     # via -r requirements/main.in
-linehaul==1.0.1 \
-    --hash=sha256:09d71b1f6a9ab92dd8c763b3d099e4ae05c2845ee783a02d5fe731e6e2a6a997 \
-    --hash=sha256:d19ca669008dad910868dfae7f904dfc5362583729bda344799cf7ea2ad5ef12
+linehaul==1.0.2 \
+    --hash=sha256:4545fee3b54df22c697d204da8668e8fd975afcb28cbb5654865e43491c70ff0 \
+    --hash=sha256:e2f91cda162ed05d3053426ac21e1546313513d4fbaeda74d085b7b54a2cb914
     # via -r requirements/main.in
 logfury==1.0.1 \
     --hash=sha256:130a5daceab9ad534924252ddf70482aa2c96662b3a3825a7d30981d03b76a26 \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ from sqlalchemy import event
 
 import warehouse
 
-from warehouse import admin, config, email, static
+from warehouse import admin, config, static
 from warehouse.accounts import services as account_services
 from warehouse.accounts.interfaces import ITokenService, IUserService
 from warehouse.admin.flags import AdminFlag, AdminFlagValue
@@ -679,7 +679,7 @@ def send_email(pyramid_request, monkeypatch):
         lambda *args, **kwargs: send_email_stub
     )
     pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
-    monkeypatch.setattr(email, "send_email", send_email_stub)
+    monkeypatch.setattr(warehouse.email, "send_email", send_email_stub)
     return send_email_stub
 
 

--- a/warehouse/admin/services.py
+++ b/warehouse/admin/services.py
@@ -18,9 +18,10 @@ import google.api_core.retry
 from zope.interface import implementer
 
 from warehouse.admin.interfaces import ISponsorLogoStorage
+from warehouse.utils.exceptions import DevelopmentModeWarning
 
 
-class InsecureStorageWarning(UserWarning):
+class InsecureStorageWarning(DevelopmentModeWarning):
     pass
 
 

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -222,9 +222,10 @@ class HasEvents:
                     additional = additional or {}
                     additional["user_agent_info"] = {
                         "installer": "Browser",
-                        "device": parsed_user_agent["device"]["family"],
-                        "os": parsed_user_agent["os"]["family"],
-                        "user_agent": parsed_user_agent["user_agent"]["family"],
+                        # See https://github.com/pypi/linehaul-cloud-function/issues/203
+                        "device": parsed_user_agent["device"]["family"],  # type: ignore[index] # noqa: E501
+                        "os": parsed_user_agent["os"]["family"],  # type: ignore[index]
+                        "user_agent": parsed_user_agent["user_agent"]["family"],  # type: ignore[index] # noqa: E501
                     }
                 else:
                     additional = additional or {}

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -53,6 +53,7 @@ from warehouse.packaging.models import (
     Role,
 )
 from warehouse.rate_limiting import DummyRateLimiter, IRateLimiter
+from warehouse.utils.exceptions import DevelopmentModeWarning
 from warehouse.utils.project import PROJECT_NAME_RE
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,7 @@ STDLIB_PROHIBITED = {
 }
 
 
-class InsecureStorageWarning(UserWarning):
+class InsecureStorageWarning(DevelopmentModeWarning):
     pass
 
 

--- a/warehouse/utils/exceptions.py
+++ b/warehouse/utils/exceptions.py
@@ -11,9 +11,13 @@
 # limitations under the License.
 
 
-class InsecureOIDCPublisherWarning(UserWarning):
+class DevelopmentModeWarning(UserWarning):
     pass
 
 
-class InsecureIntegrityServiceWarning(UserWarning):
+class InsecureOIDCPublisherWarning(DevelopmentModeWarning):
+    pass
+
+
+class InsecureIntegrityServiceWarning(DevelopmentModeWarning):
     pass


### PR DESCRIPTION
Also includes cleanups that were not caught before.

- [refactor: resolve circular import for email module](https://github.com/pypi/warehouse/commit/fd10878731c1c3f5733748115ed9ab12bc127b5a) 
Something in `warehouse.email.__init__` is triggering a circular import
when the `filterwarnings` block is updated.
Since we already import `warehouse` as a whole, use that scope instead
to patch instead.

- [chore(deps): update linehaul, restore exclusions](https://github.com/pypi/warehouse/commit/a5b6a16c45d6d11f5b5c495b475de04ebf1621ba) 
GitHub Actions mypy cache was allowing these through, despite not being
available.
Manually removing the cache and re-running a passed check exposes the
error.
    - Update to `linehaul` release includes that type hints
    - Restore `whitenoise` exclusion
    - Add URLs to track