### PR TITLE
chore(ci): address overly broad permissions scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:  # generally only for the "combine-prs" workflow
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -18,7 +20,6 @@ jobs:
       buildId: ${{ steps.build.outputs.build-id}}
     permissions:
       id-token: write
-      contents: read
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -63,7 +64,6 @@ jobs:
         BILLING_BACKEND: warehouse.subscriptions.services.MockStripeBillingService api_base=http://stripe:12111 api_version=2020-08-27
     permissions:
       id-token: write
-      contents: read
     services:
       postgres:
         image: ${{ (matrix.name == 'Tests') && 'postgres:16.1' || '' }}
@@ -107,7 +107,6 @@ jobs:
       image: registry.depot.dev/rltf7cln5v:${{ needs.build.outputs.buildId }}
     permissions:
       id-token: write
-      contents: read
     services:
       postgres:
         image: postgres:16.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:  # generally only for the "combine-prs" workflow
-permissions:
-  id-token: write
-  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -19,9 +16,14 @@ jobs:
     runs-on: depot-ubuntu-22.04-arm
     outputs:
       buildId: ${{ steps.build.outputs.build-id}}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
       - name: Build image
@@ -59,6 +61,9 @@ jobs:
       image: registry.depot.dev/rltf7cln5v:${{ needs.build.outputs.buildId }}
       env:
         BILLING_BACKEND: warehouse.subscriptions.services.MockStripeBillingService api_base=http://stripe:12111 api_version=2020-08-27
+    permissions:
+      id-token: write
+      contents: read
     services:
       postgres:
         image: ${{ (matrix.name == 'Tests') && 'postgres:16.1' || '' }}
@@ -81,6 +86,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Cache mypy results
         if: ${{ (matrix.name == 'Lint') }}
         uses: actions/cache@v4
@@ -98,6 +105,9 @@ jobs:
     continue-on-error: true
     container:
       image: registry.depot.dev/rltf7cln5v:${{ needs.build.outputs.buildId }}
+    permissions:
+      id-token: write
+      contents: read
     services:
       postgres:
         image: postgres:16.1
@@ -112,6 +122,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Dotenv Action
         # We need to load the environment variables to run the CLI
         id: dotenv

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       if: matrix.language == 'python'

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -11,17 +11,16 @@ on:
         required: true
         default: 'blocked'
 
-# https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
-permissions:
-  contents: write
-  pull-requests: write
-  checks: read
-  actions: write
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "combine-prs"
   combine-prs:
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      actions: write
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/dev-env-test.yml
+++ b/.github/workflows/dev-env-test.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - run: make build
       - run: docker compose up -d
       - run: docker compose ps

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+            persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 23.1.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+# https://github.com/woodruffw/zizmor
+name: GitHub Actions Security Analysis with Zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Zizmor latest via Cargo
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Get zizmor
+        run: cargo install zizmor
+      - name: Run zizmor
+        run: zizmor --format sarif . > results.sarif
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: results.sarif
+          # Optional category for the results
+          # Used to differentiate multiple results for one commit
+          category: zizmor


### PR DESCRIPTION
- inform checkout to not persist credentials
- move permissions from workflow to job scope

Thanks, Dr. Zizmor!
Refs: https://github.com/woodruffw/zizmor