### PR TITLE
refactor: use `more_itertools.first_true()`

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -15,7 +15,6 @@ datadog>=0.19.0
 disposable-email-domains
 dnspython
 email-validator
-first
 forcediphttpsadapter
 github-reserved-names>=1.0.0
 google-cloud-bigquery
@@ -29,6 +28,7 @@ kombu[sqs]>=5.4,<5.5  # https://github.com/jazzband/pip-tools/issues/1577
 limits
 linehaul
 lxml
+more-itertools
 msgpack
 natsort
 opensearch-py

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -548,10 +548,6 @@ filelock==3.16.1 \
     --hash=sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0 \
     --hash=sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435
     # via tldextract
-first==2.0.2 \
-    --hash=sha256:8d8e46e115ea8ac652c76123c0865e3ff18372aef6f03c22809ceefcea9dec86 \
-    --hash=sha256:ff285b08c55f8c97ce4ea7012743af2495c9f1291785f163722bd36f6af6d3bf
-    # via -r requirements/main.in
 forcediphttpsadapter==1.1.0 \
     --hash=sha256:0d224cf6e8e50eb788c9f5994a7afa6d389bac6dbe540b7dfd77a32590ad0153 \
     --hash=sha256:5e7662ece61735585332d09b87d94fffe4752469d5c0d3feff48746e5d70744b
@@ -1230,6 +1226,7 @@ more-itertools==10.5.0 \
     --hash=sha256:037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef \
     --hash=sha256:5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6
     # via
+    #   -r requirements/main.in
     #   cssutils
     #   openapi-core
 msgpack==1.1.0 \

--- a/tests/unit/search/test_tasks.py
+++ b/tests/unit/search/test_tasks.py
@@ -20,7 +20,7 @@ import pytest
 import redis
 import redis.lock
 
-from first import first
+from more_itertools import first_true
 
 import warehouse.search.tasks
 
@@ -63,9 +63,11 @@ def test_project_docs(db_session):
                 "created": p.created,
                 "name": p.name,
                 "normalized_name": p.normalized_name,
-                "latest_version": first(prs, key=lambda r: not r.is_prerelease).version,
-                "description": first(
-                    prs, key=lambda r: not r.is_prerelease
+                "latest_version": first_true(
+                    prs, pred=lambda r: not r.is_prerelease
+                ).version,
+                "description": first_true(
+                    prs, pred=lambda r: not r.is_prerelease
                 ).description.raw,
             },
         }
@@ -101,9 +103,11 @@ def test_single_project_doc(db_session):
                 "created": p.created,
                 "name": p.name,
                 "normalized_name": p.normalized_name,
-                "latest_version": first(prs, key=lambda r: not r.is_prerelease).version,
-                "description": first(
-                    prs, key=lambda r: not r.is_prerelease
+                "latest_version": first_true(
+                    prs, pred=lambda r: not r.is_prerelease
+                ).version,
+                "description": first_true(
+                    prs, pred=lambda r: not r.is_prerelease
                 ).description.raw,
             },
         }
@@ -140,9 +144,11 @@ def test_project_docs_empty(db_session):
                 "created": p.created,
                 "name": p.name,
                 "normalized_name": p.normalized_name,
-                "latest_version": first(prs, key=lambda r: not r.is_prerelease).version,
-                "description": first(
-                    prs, key=lambda r: not r.is_prerelease
+                "latest_version": first_true(
+                    prs, pred=lambda r: not r.is_prerelease
+                ).version,
+                "description": first_true(
+                    prs, pred=lambda r: not r.is_prerelease
                 ).description.raw,
             },
         }

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -18,7 +18,7 @@ import uuid
 import humanize
 import pytz
 
-from first import first
+from more_itertools import first_true
 from pyramid.httpexceptions import (
     HTTPBadRequest,
     HTTPMovedPermanently,
@@ -727,8 +727,8 @@ def request_password_reset(request, _form_class=RequestPasswordResetForm):
         if user is None:
             user = user_service.get_user_by_email(form.username_or_email.data)
         if user is not None:
-            email = first(
-                user.emails, key=lambda e: e.email == form.username_or_email.data
+            email = first_true(
+                user.emails, pred=lambda e: e.email == form.username_or_email.data
             )
         else:
             token_service = request.find_service(ITokenService, name="password")

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -19,7 +19,7 @@ import pytz
 import sentry_sdk
 
 from celery.schedules import crontab
-from first import first
+from more_itertools import first_true
 from pyramid_mailer.exceptions import BadHeaders, EncodingError, InvalidMessage
 from sqlalchemy.exc import NoResultFound
 
@@ -36,7 +36,9 @@ from warehouse.metrics.interfaces import IMetricsService
 def _compute_recipient(user, email):
     # We want to try and use the user's name, then their username, and finally
     # nothing to display a "Friendly" name for the recipient.
-    return str(Address(first([user.name, user.username], default=""), addr_spec=email))
+    return str(
+        Address(first_true([user.name, user.username], default=""), addr_spec=email)
+    )
 
 
 def _redact_ip(request, email):

--- a/warehouse/rate_limiting/__init__.py
+++ b/warehouse/rate_limiting/__init__.py
@@ -17,10 +17,10 @@ from datetime import datetime, timezone
 
 import redis
 
-from first import first
 from limits import parse_many
 from limits.storage import storage_from_string
 from limits.strategies import MovingWindowRateLimiter
+from more_itertools import first_true
 from zope.interface import implementer
 
 from warehouse.metrics import IMetricsService
@@ -113,7 +113,7 @@ class RateLimiter:
         # If we have any resets, then we'll go through and find whichever one
         # is going to reset soonest and use that as our hint for when this
         # limit might be available again.
-        return first(sorted(resets))
+        return first_true(sorted(resets))
 
 
 @implementer(IRateLimiter)


### PR DESCRIPTION
Instead of relying `first` to provide the necessary iteration algorithm, use `first_true()` from `more-itertools` that we already ship.

Refs: https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.first_true