### PR TITLE
chore: allow one retry for search timeouts

### DIFF
--- a/tests/unit/search/test_init.py
+++ b/tests/unit/search/test_init.py
@@ -138,7 +138,8 @@ def test_includeme(monkeypatch):
     assert len(opensearch_client_init.calls) == 1
     assert opensearch_client_init.calls[0].kwargs["hosts"] == ["https://some.url"]
     assert opensearch_client_init.calls[0].kwargs["timeout"] == 0.5
-    assert opensearch_client_init.calls[0].kwargs["retry_on_timeout"] is False
+    assert opensearch_client_init.calls[0].kwargs["retry_on_timeout"] is True
+    assert opensearch_client_init.calls[0].kwargs["max_retries"] == 1
     assert (
         opensearch_client_init.calls[0].kwargs["connection_class"]
         == opensearchpy.connection.http_requests.RequestsHttpConnection

--- a/warehouse/search/__init__.py
+++ b/warehouse/search/__init__.py
@@ -92,7 +92,7 @@ def includeme(config):
         "verify_certs": True,
         "ca_certs": certifi.where(),
         "timeout": 0.5,
-        "retry_on_timeout": False,
+        "retry_on_timeout": True,
         "serializer": opensearchpy.serializer.serializer,
         "max_retries": 1,
     }


### PR DESCRIPTION
Following an uptick in errors once the time was reduced from 2s to 0.5s in #16812, allow for one more retry for those that timeout.