### PR TITLE
requirements: bump pypi-attestations

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -65,7 +65,7 @@ rfc3986
 sentry-sdk
 setuptools
 sigstore~=3.5.1
-pypi-attestations==0.0.13
+pypi-attestations==0.0.15
 sqlalchemy[asyncio]>=2.0,<3.0
 stdlib-list
 stripe

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1779,9 +1779,9 @@ pyparsing==3.2.0 \
     --hash=sha256:93d9577b88da0bbea8cc8334ee8b918ed014968fd2ec383e868fb8afb1ccef84 \
     --hash=sha256:cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c
     # via linehaul
-pypi-attestations==0.0.13 \
-    --hash=sha256:2f61f3ba81d836b54359096f43f19d7ddb15fa13542d3236b9caf92bd8b3af65 \
-    --hash=sha256:cc4213c2aab3b9d06d54c353ed7f23febf92b2409b0bb4ce5d8ade0aadcbd6ed
+pypi-attestations==0.0.15 \
+    --hash=sha256:79d974fc162676383c531eb04c2197876dc09c1983ba915ebd09c7c18d626aed \
+    --hash=sha256:892de82329ccbc88f0866aa3cbf7b2a071a6ff22bcb03b7fd44bd002709ad481
     # via -r requirements/main.in
 pyqrcode==1.2.1 \
     --hash=sha256:1b2812775fa6ff5c527977c4cd2ccb07051ca7d0bc0aecf937a43864abe5eff6 \


### PR DESCRIPTION
This bumps `pypi-attestations`, following a bugfix for `.zip` sdists in https://github.com/trailofbits/pypi-attestations/pull/68. 

This has a corresponding bump in `gh-action-pypi-publish`, since they hit the same distribution name validation pathway: https://github.com/pypa/gh-action-pypi-publish/pull/297