### PR TITLE
legacy: ensure invalid attestation error is never empty

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2527,7 +2527,7 @@ class TestFileUpload:
 
         assert resp.status_code == 400
         assert resp.status == (
-            "400 Invalid attestations supplied during upload:"
+            "400 Invalid attestations supplied during upload: "
             "Attestations are only supported when using Trusted Publishing"
         )
 

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2527,7 +2527,8 @@ class TestFileUpload:
 
         assert resp.status_code == 400
         assert resp.status == (
-            "400 Attestations are only supported when using Trusted Publishing"
+            "400 Invalid attestations supplied during upload:"
+            "Attestations are only supported when using Trusted Publishing"
         )
 
     @pytest.mark.parametrize(
@@ -3599,7 +3600,7 @@ class TestFileUpload:
         resp = excinfo.value
 
         assert resp.status_code == 400
-        assert resp.status.startswith("400 Malformed attestations")
+        assert resp.status.startswith("400 Invalid attestations")
 
     @pytest.mark.parametrize(
         ("url", "expected"),

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1245,7 +1245,7 @@ def file_upload(request):
             except AttestationUploadError as e:
                 raise _exc_with_message(
                     HTTPBadRequest,
-                    str(e),
+                    f"Invalid attestations supplied during upload: {e}",
                 )
 
             # Log successful attestation upload


### PR DESCRIPTION
This adds a prefix to ensure that we never emit a fully empty `HTTP 400`. I'll do a follow-up for moving the validation further up as well.

See: https://github.com/pypa/gh-action-pypi-publish/issues/303

CC @di 