### PR TITLE
feat(db): pass flag to emit migration as SQL

### DIFF
--- a/tests/unit/cli/test_db.py
+++ b/tests/unit/cli/test_db.py
@@ -281,7 +281,7 @@ def test_stamp_command(monkeypatch, cli, pyramid_config):
 
 
 def test_upgrade_command(monkeypatch, cli, pyramid_config):
-    alembic_upgrade = pretend.call_recorder(lambda config, revision: None)
+    alembic_upgrade = pretend.call_recorder(lambda config, revision, sql: None)
     monkeypatch.setattr(alembic.command, "upgrade", alembic_upgrade)
 
     alembic_config = pretend.stub(attributes={})
@@ -297,7 +297,7 @@ def test_upgrade_command(monkeypatch, cli, pyramid_config):
 
     result = cli.invoke(upgrade, ["foo"], obj=pyramid_config)
     assert result.exit_code == 0
-    assert alembic_upgrade.calls == [pretend.call(alembic_config, "foo")]
+    assert alembic_upgrade.calls == [pretend.call(alembic_config, "foo", sql=False)]
 
 
 def test_check_command(monkeypatch, cli, pyramid_config):

--- a/warehouse/cli/db/upgrade.py
+++ b/warehouse/cli/db/upgrade.py
@@ -18,9 +18,12 @@ from warehouse.cli.db import db
 
 @db.command()
 @click.argument("revision", required=True)
+@click.option(
+    "--sql", is_flag=True, help="Generate SQL script instead of applying the upgrade."
+)
 @click.pass_obj
-def upgrade(config, revision, **kwargs):
+def upgrade(config, revision, sql, **kwargs):
     """
     Upgrade database.
     """
-    alembic.command.upgrade(config.alembic_config(), revision, **kwargs)
+    alembic.command.upgrade(config.alembic_config(), revision, sql=sql, **kwargs)

--- a/warehouse/migrations/env.py
+++ b/warehouse/migrations/env.py
@@ -30,7 +30,8 @@ def run_migrations_offline():
     Calls to context.execute() here emit the given string to the
     script output.
     """
-    url = context.config.get_main_option("sqlalchemy.url")
+    options = context.config.get_section(context.config.config_ini_section)
+    url = options.pop("url")
     context.configure(url=url, compare_server_default=True)
 
     with context.begin_transaction():


### PR DESCRIPTION
Was missing the correct current way to get the DB URL, corrected.

Refs: https://alembic.sqlalchemy.org/en/latest/offline.html