### PR TITLE
Capture sentry message when `_exc_with_message` is called without a message

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -113,6 +113,19 @@ class TestExcWithMessage:
         assert exc.status_code == 400
         assert exc.status == "400 look at these wild chars: ?Ã¤â??"
 
+    def test_exc_with_missing_message(self, monkeypatch):
+        sentry_sdk = pretend.stub(
+            capture_message=pretend.call_recorder(lambda message: None)
+        )
+        monkeypatch.setattr(legacy, "sentry_sdk", sentry_sdk)
+        exc = legacy._exc_with_message(HTTPBadRequest, "")
+        assert isinstance(exc, HTTPBadRequest)
+        assert exc.status_code == 400
+        assert exc.status == "400 Bad Request"
+        assert sentry_sdk.capture_message.calls == [
+            pretend.call("Attempting to _exc_with_message without a message")
+        ]
+
 
 def test_construct_dependencies():
     types = {"requires": DependencyKind.requires, "provides": DependencyKind.provides}

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -189,6 +189,9 @@ _dist_file_re = re.compile(r".+?(?P<extension>\.(tar\.gz|zip|whl))$", re.I)
 
 
 def _exc_with_message(exc, message, **kwargs):
+    if not message:
+        sentry_sdk.capture_message("Attempting to _exc_with_message without a message")
+
     # The crappy old API that PyPI offered uses the status to pass down
     # messages to the client. So this function will make that easier to do.
     resp = exc(detail=message, **kwargs)


### PR DESCRIPTION
In https://github.com/pypa/gh-action-pypi-publish/issues/303 we saw an error message being returned from the Upload API without a custom message, which is confusing for the end user. Since we sometimes return messages that come from third-party libraries (like pypa/packaging) this will notify us if we start returning "bare" error messages, while still allowing the original exception to be returned.