### PR TITLE
attestations: remove double states, simplify tests

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -64,7 +64,6 @@ redis>=2.8.0,<6.0.0
 rfc3986
 sentry-sdk
 setuptools
-sigstore~=3.5.1
 pypi-attestations==0.0.16
 sqlalchemy[asyncio]>=2.0,<3.0
 stdlib-list

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -2084,9 +2084,7 @@ sentry-sdk==2.18.0 \
 sigstore==3.5.1 \
     --hash=sha256:88f73c8edf1662ff9b86ef6fe0870bb6af4ac99ff808b84995e6a41957b7b3d2 \
     --hash=sha256:e7023aef4e574120712c16c6bb151f4caee55791c4677fe30c92ef4e50800204
-    # via
-    #   -r requirements/main.in
-    #   pypi-attestations
+    # via pypi-attestations
 sigstore-protobuf-specs==0.3.2 \
     --hash=sha256:50c99fa6747a3a9c5c562a43602cf76df0b199af28f0e9d4319b6775630425ea \
     --hash=sha256:cae041b40502600b8a633f43c257695d0222a94efa1e5110a7ec7ada78c39d99

--- a/tests/unit/attestations/test_models.py
+++ b/tests/unit/attestations/test_models.py
@@ -10,19 +10,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pretend
 import pypi_attestations
 
+from tests.common.db.oidc import GitHubPublisherFactory
 from tests.common.db.packaging import FileFactory
 
 
 def test_provenance_as_model(db_request, integrity_service, dummy_attestation):
-    db_request.oidc_publisher = pretend.stub(
-        publisher_name="GitHub",
-        repository="fake/fake",
-        workflow_filename="fake.yml",
-        environment="fake",
-    )
+    db_request.oidc_publisher = GitHubPublisherFactory.create()
     file = FileFactory.create()
     provenance = integrity_service.build_provenance(
         db_request, file, [dummy_attestation]

--- a/tests/unit/attestations/test_services.py
+++ b/tests/unit/attestations/test_services.py
@@ -183,7 +183,6 @@ class TestIntegrityService:
 
         db_request.oidc_publisher = pretend.stub(
             attestation_identity=pretend.stub(),
-            publisher_verification_policy=pretend.call_recorder(lambda c: None),
         )
         db_request.oidc_claims = {"sha": "somesha"}
         db_request.POST["attestations"] = TypeAdapter(list[Attestation]).dump_json(
@@ -214,7 +213,6 @@ class TestIntegrityService:
         )
         db_request.oidc_publisher = pretend.stub(
             attestation_identity=pretend.stub(),
-            publisher_verification_policy=pretend.call_recorder(lambda c: None),
         )
         db_request.oidc_claims = {"sha": "somesha"}
         db_request.POST["attestations"] = TypeAdapter(list[Attestation]).dump_json(
@@ -250,7 +248,6 @@ class TestIntegrityService:
         )
         db_request.oidc_publisher = pretend.stub(
             attestation_identity=pretend.stub(),
-            publisher_verification_policy=pretend.call_recorder(lambda c: None),
         )
         db_request.oidc_claims = {"sha": "somesha"}
         db_request.POST["attestations"] = TypeAdapter(list[Attestation]).dump_json(

--- a/tests/unit/oidc/models/test_core.py
+++ b/tests/unit/oidc/models/test_core.py
@@ -54,9 +54,9 @@ class TestOIDCPublisher:
             publisher.check_claims_existence(signed_claims={})
         assert str(e.value) == "No required verifiable claims"
 
-    def test_supports_attestations(self):
+    def test_attestation_identity(self):
         publisher = _core.OIDCPublisher(projects=[])
-        assert not publisher.supports_attestations
+        assert not publisher.attestation_identity
 
     @pytest.mark.parametrize(
         ("url", "publisher_url", "expected"),

--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -16,7 +16,6 @@ import sqlalchemy
 
 from tests.common.db.oidc import GitHubPublisherFactory, PendingGitHubPublisherFactory
 from warehouse.oidc import errors
-from warehouse.oidc.errors import InvalidPublisherError
 from warehouse.oidc.models import _core, github
 
 
@@ -651,7 +650,7 @@ class TestGitHubPublisher:
         )
         assert publisher.verify_url(url) == expected
 
-    @pytest.mark.parametrize("environment", ("", "some-env"))
+    @pytest.mark.parametrize("environment", ["", "some-env"])
     def test_github_publisher_attestation_identity(self, environment):
         publisher = github.GitHubPublisher(
             repository_name="repository_name",

--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -651,6 +651,25 @@ class TestGitHubPublisher:
         )
         assert publisher.verify_url(url) == expected
 
+    @pytest.mark.parametrize("environment", ("", "some-env"))
+    def test_github_publisher_attestation_identity(self, environment):
+        publisher = github.GitHubPublisher(
+            repository_name="repository_name",
+            repository_owner="repository_owner",
+            repository_owner_id="666",
+            workflow_filename="workflow_filename.yml",
+            environment=environment,
+        )
+
+        identity = publisher.attestation_identity
+        assert identity.repository == publisher.repository
+        assert identity.workflow == publisher.workflow_filename
+
+        if not environment:
+            assert identity.environment is None
+        else:
+            assert identity.environment == publisher.environment
+
 
 class TestPendingGitHubPublisher:
     def test_reify_does_not_exist_yet(self, db_request):

--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -602,31 +602,6 @@ class TestGitHubPublisher:
         check = github.GitHubPublisher.__optional_verifiable_claims__["environment"]
         assert check(truth, claim, pretend.stub()) is valid
 
-    @pytest.mark.parametrize(
-        ("ref", "sha", "raises"),
-        [
-            ("ref", "sha", False),
-            (None, "sha", False),
-            ("ref", None, False),
-            (None, None, True),
-        ],
-    )
-    def test_github_publisher_verification_policy(self, ref, sha, raises):
-        publisher = github.GitHubPublisher(
-            repository_name="fakerepo",
-            repository_owner="fakeowner",
-            repository_owner_id="fakeid",
-            workflow_filename="fakeworkflow.yml",
-            environment="",
-        )
-        claims = {"ref": ref, "sha": sha}
-
-        if not raises:
-            publisher.publisher_verification_policy(claims)
-        else:
-            with pytest.raises(InvalidPublisherError):
-                publisher.publisher_verification_policy(claims)
-
     def test_github_publisher_duplicates_cant_be_created(self, db_request):
         publisher1 = github.GitHubPublisher(
             repository_name="repository_name",

--- a/warehouse/attestations/services.py
+++ b/warehouse/attestations/services.py
@@ -23,10 +23,7 @@ from pypi_attestations import (
     AttestationBundle,
     AttestationType,
     Distribution,
-    GitHubPublisher,
-    GitLabPublisher,
     Provenance,
-    Publisher,
     VerificationError,
 )
 from pyramid.request import Request
@@ -36,53 +33,17 @@ from warehouse.attestations.errors import AttestationUploadError
 from warehouse.attestations.interfaces import IIntegrityService
 from warehouse.attestations.models import Provenance as DatabaseProvenance
 from warehouse.metrics.interfaces import IMetricsService
-from warehouse.oidc.models import (
-    GitHubPublisher as GitHubOIDCPublisher,
-    GitLabPublisher as GitLabOIDCPublisher,
-    OIDCPublisher,
-)
 from warehouse.utils.exceptions import InsecureIntegrityServiceWarning
 
 if typing.TYPE_CHECKING:
     from warehouse.packaging.models import File
 
 
-def _publisher_from_oidc_publisher(publisher: OIDCPublisher) -> Publisher:
-    """
-    Convert an OIDCPublisher object in a pypi-attestations Publisher.
-    """
-    match publisher.publisher_name:
-        case "GitLab":
-            publisher = typing.cast(GitLabOIDCPublisher, publisher)
-            return GitLabPublisher(
-                repository=publisher.project_path, environment=publisher.environment
-            )
-        case "GitHub":
-            publisher = typing.cast(GitHubOIDCPublisher, publisher)
-            return GitHubPublisher(
-                repository=publisher.repository,
-                workflow=publisher.workflow_filename,
-                environment=publisher.environment,
-            )
-        case _:
-            raise AttestationUploadError(
-                f"Unsupported publisher: {publisher.publisher_name}"
-            )
-
-
 def _build_provenance(
     request: Request, file: File, attestations: list[Attestation]
 ) -> DatabaseProvenance:
-    try:
-        publisher: Publisher = _publisher_from_oidc_publisher(request.oidc_publisher)
-    except AttestationUploadError as exc:
-        sentry_sdk.capture_message(
-            f"Unsupported OIDCPublisher found {request.oidc_publisher.publisher_name}"
-        )
-        raise exc
-
     attestation_bundle = AttestationBundle(
-        publisher=publisher,
+        publisher=request.oidc_publisher.attestation_identity,
         attestations=attestations,
     )
 
@@ -100,15 +61,15 @@ def _extract_attestations_from_request(request: Request) -> list[Attestation]:
     Extract well-formed attestation objects from the given request's payload.
     """
 
-    publisher: OIDCPublisher | None = request.oidc_publisher
-    if not publisher:
+    if not request.oidc_publisher:
         raise AttestationUploadError(
             "Attestations are only supported when using Trusted Publishing"
         )
-    if not publisher.supports_attestations:
+
+    if not request.oidc_publisher.attestation_identity:
         raise AttestationUploadError(
             "Attestations are not currently supported with "
-            f"{publisher.publisher_name} publishers"
+            f"{request.oidc_publisher.publisher_name} publishers"
         )
 
     metrics = request.find_service(IMetricsService, context=None)
@@ -197,16 +158,13 @@ class IntegrityService:
 
         attestations = _extract_attestations_from_request(request)
 
-        # The above attestation extraction guarantees that we have a publisher.
-        publisher: OIDCPublisher = request.oidc_publisher
+        # Sanity-checked above.
+        expected_identity = request.oidc_publisher.attestation_identity
 
-        verification_policy = publisher.publisher_verification_policy(
-            request.oidc_claims
-        )
         for attestation_model in attestations:
             try:
                 predicate_type, _ = attestation_model.verify(
-                    verification_policy,
+                    expected_identity,
                     distribution,
                 )
             except VerificationError as e:

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -29,10 +29,13 @@ from warehouse.oidc.interfaces import SignedClaims
 from warehouse.oidc.urls import verify_url_from_reference
 
 if TYPE_CHECKING:
+    from pypi_attestations import Publisher
+
     from warehouse.accounts.models import User
     from warehouse.macaroons.models import Macaroon
     from warehouse.oidc.services import OIDCPublisherService
     from warehouse.packaging.models import Project
+
 
 C = TypeVar("C")
 
@@ -310,13 +313,14 @@ class OIDCPublisherMixin:
         raise NotImplementedError
 
     @property
-    def supports_attestations(self) -> bool:
+    def attestation_identity(self) -> Publisher | None:
         """
-        Returns whether or not this kind of publisher supports attestations.
+        Returns an appropriate attestation verification identity, if this
+        kind of publisher supports attestations.
 
         Concrete subclasses should override this upon adding attestation support.
         """
-        return False
+        return None
 
     def publisher_verification_policy(
         self, claims: SignedClaims

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, Unpack
 import rfc3986
 import sentry_sdk
 
-from sigstore.verify.policy import VerificationPolicy
 from sqlalchemy import ForeignKey, String, orm
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -322,17 +322,6 @@ class OIDCPublisherMixin:
         """
         return None
 
-    def publisher_verification_policy(
-        self, claims: SignedClaims
-    ) -> VerificationPolicy:  # pragma: no cover
-        """
-        Get the policy used to verify attestations signed with this publisher.
-        NOTE: This is **NOT** a `@property` because we pass `claims` to it.
-        When calling, make sure to use `publisher_verification_policy()`
-        """
-        # Only concrete subclasses are constructed.
-        raise NotImplementedError
-
     def stored_claims(
         self, claims: SignedClaims | None = None
     ) -> dict:  # pragma: no cover

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -15,13 +15,6 @@ import re
 from typing import Any
 
 from pypi_attestations import GitHubPublisher as GitHubIdentity, Publisher
-from sigstore.verify.policy import (
-    AllOf,
-    AnyOf,
-    OIDCBuildConfigURI,
-    OIDCIssuerV2,
-    OIDCSourceRepositoryDigest,
-)
 from sqlalchemy import ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Query, mapped_column

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -14,6 +14,7 @@ import re
 
 from typing import Any
 
+from pypi_attestations import GitHubPublisher as GitHubIdentity, Publisher
 from sigstore.verify.policy import (
     AllOf,
     AnyOf,
@@ -280,8 +281,12 @@ class GitHubPublisherMixin:
         return base
 
     @property
-    def supports_attestations(self) -> bool:
-        return True
+    def attestation_identity(self) -> Publisher | None:
+        return GitHubIdentity(
+            repository=self.repository,
+            workflow=self.workflow_filename,
+            environment=self.environment if self.environment else None,
+        )
 
     def publisher_verification_policy(self, claims):
         """

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -288,41 +288,6 @@ class GitHubPublisherMixin:
             environment=self.environment if self.environment else None,
         )
 
-    def publisher_verification_policy(self, claims):
-        """
-        Get the policy used to verify attestations signed with GitHub Actions.
-
-        This policy checks the certificate in an attestation against the following
-        claims:
-        - OIDCBuildConfigURI (e.g:
-        https://github.com/org/repo/.github/workflows/workflow.yml@REF})
-        - OIDCIssuerV2 (should always be https://token.actions.githubusercontent.com/)
-        - OIDCSourceRepositoryDigest (the commit SHA corresponding to the version of
-        the repo used)
-
-        Note: the Build Config URI might end with either a ref (i.e: refs/heads/main)
-        or with a commit SHA, so we allow either by using the `AnyOf` policy and
-        grouping both possibilities together.
-        """
-        sha = claims.get("sha") if claims else None
-        ref = claims.get("ref") if claims else None
-        if not (ref or sha):
-            raise InvalidPublisherError("The ref and sha claims are empty")
-
-        expected_build_configs = [
-            OIDCBuildConfigURI(f"https://github.com/{self.job_workflow_ref}@{claim}")
-            for claim in [ref, sha]
-            if claim is not None
-        ]
-
-        return AllOf(
-            [
-                OIDCIssuerV2(GITHUB_OIDC_ISSUER_URL),
-                OIDCSourceRepositoryDigest(sha),
-                AnyOf(expected_build_configs),
-            ],
-        )
-
     def stored_claims(self, claims=None):
         claims = claims if claims else {}
         return {"ref": claims.get("ref"), "sha": claims.get("sha")}


### PR DESCRIPTION
This removes some usage of stubs in favor of real models (via factories) where possible, and eliminates some potential sources of double-state/divergence in the original services.

In particular:

* `OIDCPublisherMixin.supports_attestations` is now `attestation_identity`, and returns a `Publisher | None` that can be used directly for verification
* `OIDCPublisherMixin.publisher_verification_policy` is removed, since the `Publisher` now encodes the verification policy
* `_publisher_from_oidc_publisher` is removed, since `attestation_identity` serves the same purpose