### PR TITLE
Send PEP 625 warning emails

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -6112,3 +6112,109 @@ class TestTrustedPublisherEmails:
                 },
             ),
         ]
+
+    @pytest.mark.parametrize(
+        ("fn", "template_name", "extra_kwargs"),
+        [
+            (email.send_pep625_extension_email, "pep625-extension-email", {}),
+            (
+                email.send_pep625_name_email,
+                "pep625-name-email",
+                {"normalized_name": "something_else"},
+            ),
+            (
+                email.send_pep625_version_email,
+                "pep625-version-email",
+                {"normalized_version": "1.0.0.post1"},
+            ),
+        ],
+    )
+    def test_pep625_emails(
+        self,
+        pyramid_request,
+        pyramid_config,
+        monkeypatch,
+        fn,
+        template_name,
+        extra_kwargs,
+    ):
+        stub_user = pretend.stub(
+            id="id",
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+        )
+        subject_renderer = pyramid_config.testing_add_renderer(
+            f"email/{template_name}/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            f"email/{template_name}/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            f"email/{template_name}/body.html"
+        )
+        html_renderer.string_response = "Email HTML Body"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        pyramid_request.db = pretend.stub(
+            query=lambda a: pretend.stub(
+                filter=lambda *a: pretend.stub(
+                    one=lambda: pretend.stub(user_id=stub_user.id)
+                )
+            ),
+        )
+        pyramid_request.user = stub_user
+        pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
+
+        project_name = "test_project"
+        filename = "test-project-1.0-post1.zip"
+
+        result = fn(
+            pyramid_request,
+            stub_user,
+            project_name=project_name,
+            filename=filename,
+            **extra_kwargs,
+        )
+
+        assert result == {
+            "project_name": project_name,
+            "filename": filename,
+            **extra_kwargs,
+        }
+        subject_renderer.assert_(project_name=project_name)
+        body_renderer.assert_(project_name=project_name)
+        html_renderer.assert_(project_name=project_name)
+        assert pyramid_request.task.calls == [pretend.call(send_email)]
+        assert send_email.delay.calls == [
+            pretend.call(
+                f"{stub_user.username} <{stub_user.email}>",
+                {
+                    "sender": None,
+                    "subject": "Email Subject",
+                    "body_text": "Email Body",
+                    "body_html": (
+                        "<html>\n<head></head>\n"
+                        "<body><p>Email HTML Body</p></body>\n</html>\n"
+                    ),
+                },
+                {
+                    "tag": "account:email:sent",
+                    "user_id": stub_user.id,
+                    "additional": {
+                        "from_": "noreply@example.com",
+                        "to": stub_user.email,
+                        "subject": "Email Subject",
+                        "redact_ip": False,
+                    },
+                },
+            )
+        ]

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -358,7 +358,9 @@ class TestIsDuplicateFile:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
         file_content = io.BytesIO(_TAR_GZ_PKG_TESTDATA)
         file_value = file_content.getvalue()
 
@@ -389,8 +391,12 @@ class TestIsDuplicateFile:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
-        requested_file_name = f"{project.name}-{release.version}-1.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
+        requested_file_name = "{}-{}.post1.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
         file_content = io.BytesIO(_TAR_GZ_PKG_TESTDATA)
         file_value = file_content.getvalue()
 
@@ -426,8 +432,12 @@ class TestIsDuplicateFile:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
-        requested_file_name = f"{project.name}-{release.version}-1.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
+        requested_file_name = "{}-{}.post1.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
         file_content = io.BytesIO(_TAR_GZ_PKG_TESTDATA)
         file_value = file_content.getvalue()
 
@@ -461,7 +471,9 @@ class TestIsDuplicateFile:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
         file_content = io.BytesIO(_TAR_GZ_PKG_TESTDATA)
         file_value = file_content.getvalue()
 
@@ -1097,7 +1109,9 @@ class TestFileUpload:
 
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.user = user
         user_context = UserContext(
@@ -1273,7 +1287,9 @@ class TestFileUpload:
 
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1309,7 +1325,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1347,7 +1365,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.bz2"
+        filename = "{}-{}.tar.bz2".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1390,7 +1410,9 @@ class TestFileUpload:
         )
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.zip"
+        filename = "{}-{}.zip".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1424,7 +1446,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1489,7 +1513,9 @@ class TestFileUpload:
         )
         monkeypatch.setattr(metadata, "deprecated_classifiers", deprecated_classifiers)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1560,7 +1586,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1597,7 +1625,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.zip"
+        filename = "{}-{}.zip".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1675,7 +1705,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1720,7 +1752,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1772,7 +1806,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -1826,7 +1862,7 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = "{}-{}.tar.gz".format("example", "1.0")
+        filename = "example-1.0.tar.gz"
 
         db_request.POST = MultiDict(
             {
@@ -1908,7 +1944,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
         file_content = io.BytesIO(_TAR_GZ_PKG_TESTDATA)
 
         db_request.POST = MultiDict(
@@ -1952,7 +1990,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
         file_content = io.BytesIO(_TAR_GZ_PKG_TESTDATA)
 
         db_request.POST = MultiDict(
@@ -1999,7 +2039,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
         file_content = io.BytesIO(_TAR_GZ_PKG_TESTDATA)
 
         db_request.POST = MultiDict(
@@ -2056,7 +2098,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.gz"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
         file_content = io.BytesIO(_TAR_GZ_PKG_TESTDATA)
 
         db_request.POST = MultiDict(
@@ -2250,7 +2294,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}{extension}"
+        filename = "{}-{}{}".format(
+            project.normalized_name.replace("-", "_"), release.version, extension
+        )
 
         db_request.POST = MultiDict(
             {
@@ -2293,7 +2339,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.wat"
+        filename = "{}-{}.tar.wat".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -2334,7 +2382,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{character + project.name}-{release.version}.tar.wat"
+        filename = "{}{}-{}.tar.gz".format(
+            character, project.normalized_name.replace("-", "_"), release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -2371,7 +2421,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = f"{project.name}{character}-{release.version}.tar.wat"
+        filename = "{}{}-{}.tar.wat".format(
+            project.normalized_name.replace("-", "_"), character, release.version
+        )
 
         db_request.POST = MultiDict(
             {
@@ -2408,7 +2460,9 @@ class TestFileUpload:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user1, project=project)
 
-        filename = f"{project.name}-{release.version}.tar.wat"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         pyramid_config.testing_securitypolicy(identity=user2, permissive=False)
         db_request.user = user2
@@ -2450,7 +2504,9 @@ class TestFileUpload:
 
         publisher = GitHubPublisherFactory.create(projects=[project])
 
-        filename = f"{project.name}-{release.version}.tar.wat"
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
 
         pyramid_config.testing_securitypolicy(identity=publisher, permissive=False)
         db_request.user = None
@@ -2509,7 +2565,9 @@ class TestFileUpload:
         )
         identity = UserContext(maintainer, macaroon)
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
         attestation = Attestation(
             version=1,
             verification_material=VerificationMaterial(
@@ -3249,7 +3307,8 @@ class TestFileUpload:
         RoleFactory.create(user=user, project=project)
 
         new_project_name = "package_name"
-        filename = "{}-{}.tar.gz".format(new_project_name, "1.1")
+        new_project_version = "1.1"
+        filename = f"{new_project_name}-{new_project_version}.tar.gz"
 
         pyramid_config.testing_securitypolicy(identity=user)
         db_request.user = user
@@ -3258,7 +3317,7 @@ class TestFileUpload:
             {
                 "metadata_version": "1.1",
                 "name": new_project_name,
-                "version": "1.1",
+                "version": new_project_version,
                 "summary": "This is my summary!",
                 "filetype": "sdist",
                 "md5_digest": _TAR_GZ_PKG_MD5,
@@ -3289,7 +3348,9 @@ class TestFileUpload:
         # Ensure that a Release object has been created.
         release = (
             db_request.db.query(Release)
-            .filter((Release.project == project) & (Release.version == "1.1"))
+            .filter(
+                (Release.project == project) & (Release.version == new_project_version)
+            )
             .one()
         )
 
@@ -3337,7 +3398,9 @@ class TestFileUpload:
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
         db_request.db.add(Classifier(classifier="Programming Language :: Python"))
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
 
         pyramid_config.testing_securitypolicy(identity=identity)
         db_request.user = identity if test_with_user else None
@@ -3504,7 +3567,9 @@ class TestFileUpload:
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
         db_request.db.add(Classifier(classifier="Programming Language :: Python"))
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
         attestation = Attestation(
             version=1,
             verification_material=VerificationMaterial(
@@ -3607,7 +3672,9 @@ class TestFileUpload:
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
         db_request.db.add(Classifier(classifier="Programming Language :: Python"))
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
 
         pyramid_config.testing_securitypolicy(identity=identity)
         db_request.user = None
@@ -3667,7 +3734,9 @@ class TestFileUpload:
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
         db_request.db.add(Classifier(classifier="Programming Language :: Python"))
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
 
         pyramid_config.testing_securitypolicy(identity=identity)
         db_request.user_agent = "warehouse-tests/6.6.6"
@@ -3736,7 +3805,9 @@ class TestFileUpload:
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
         db_request.db.add(Classifier(classifier="Programming Language :: Python"))
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
 
         pyramid_config.testing_securitypolicy(identity=identity)
         db_request.user_agent = "warehouse-tests/6.6.6"
@@ -3826,7 +3897,9 @@ class TestFileUpload:
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
         db_request.db.add(Classifier(classifier="Programming Language :: Python"))
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
 
         pyramid_config.testing_securitypolicy(identity=identity)
         db_request.user_agent = "warehouse-tests/6.6.6"
@@ -3913,7 +3986,9 @@ class TestFileUpload:
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
         db_request.db.add(Classifier(classifier="Programming Language :: Python"))
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
 
         pyramid_config.testing_securitypolicy(identity=identity)
         db_request.user_agent = "warehouse-tests/6.6.6"
@@ -3976,7 +4051,9 @@ class TestFileUpload:
         db_request.db.add(Classifier(classifier="Environment :: Other Environment"))
         db_request.db.add(Classifier(classifier="Programming Language :: Python"))
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
 
         pyramid_config.testing_securitypolicy(identity=user)
         db_request.user = user
@@ -4109,7 +4186,9 @@ class TestFileUpload:
                 "filetype": "sdist",
                 "md5_digest": _TAR_GZ_PKG_MD5,
                 "content": pretend.stub(
-                    filename="{}-{}.tar.gz".format(project.name, "1.0.0"),
+                    filename="{}-{}.tar.gz".format(
+                        project.normalized_name.replace("-", "_"), "1.0.0"
+                    ),
                     file=io.BytesIO(_TAR_GZ_PKG_TESTDATA),
                     type="application/tar",
                 ),
@@ -4157,7 +4236,9 @@ class TestFileUpload:
                 "filetype": "sdist",
                 "md5_digest": _TAR_GZ_PKG_MD5,
                 "content": pretend.stub(
-                    filename="{}-{}.tar.gz".format(project.name, "1.0.0"),
+                    filename="{}-{}.tar.gz".format(
+                        project.normalized_name.replace("-", "_"), "1.0.0"
+                    ),
                     file=io.BytesIO(_TAR_GZ_PKG_TESTDATA),
                     type="application/tar",
                 ),
@@ -4670,7 +4751,9 @@ class TestFileUpload:
                 )
             )
 
-        filename = "{}-{}.tar.gz".format(project.name, "1.0")
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), "1.0"
+        )
 
         pyramid_config.testing_securitypolicy(identity=identity)
         db_request.POST = MultiDict(
@@ -4844,11 +4927,15 @@ class TestFileUpload:
 
         if filetype == "sdist":
             if mimetype == "application/tar":
-                filename = "{}-{}.tar.gz".format(project.name, "1.0")
+                filename = "{}-{}.tar.gz".format(
+                    project.normalized_name.replace("-", "_"), "1.0"
+                )
                 digest = _TAR_GZ_PKG_MD5
                 data = _TAR_GZ_PKG_TESTDATA
             elif mimetype == "application/zip":
-                filename = "{}-{}.zip".format(project.name, "1.0")
+                filename = "{}-{}.zip".format(
+                    project.normalized_name.replace("-", "_"), "1.0"
+                )
                 digest = _ZIP_PKG_MD5
                 data = _ZIP_PKG_TESTDATA
         elif filetype == "bdist_wheel":
@@ -4954,11 +5041,15 @@ class TestFileUpload:
 
         if filetype == "sdist":
             if mimetype == "application/tar":
-                filename = "{}-{}.tar.gz".format(project.name, "1.0")
+                filename = "{}-{}.tar.gz".format(
+                    project.normalized_name.replace("-", "_"), "1.0"
+                )
                 digest = _TAR_GZ_PKG_MD5
                 data = _TAR_GZ_PKG_TESTDATA
             elif mimetype == "application/zip":
-                filename = "{}-{}.zip".format(project.name, "1.0")
+                filename = "{}-{}.zip".format(
+                    project.normalized_name.replace("-", "_"), "1.0"
+                )
                 digest = _ZIP_PKG_MD5
                 data = _ZIP_PKG_TESTDATA
             license_filename = "LICENSE"

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -1065,6 +1065,34 @@ def send_api_token_used_in_trusted_publisher_project_email(
     }
 
 
+@_email("pep625-extension-email")
+def send_pep625_extension_email(request, users, project_name, filename):
+    return {
+        "project_name": project_name,
+        "filename": filename,
+    }
+
+
+@_email("pep625-name-email")
+def send_pep625_name_email(request, users, project_name, filename, normalized_name):
+    return {
+        "project_name": project_name,
+        "filename": filename,
+        "normalized_name": normalized_name,
+    }
+
+
+@_email("pep625-version-email")
+def send_pep625_version_email(
+    request, users, project_name, filename, normalized_version
+):
+    return {
+        "project_name": project_name,
+        "filename": filename,
+        "normalized_version": normalized_version,
+    }
+
+
 def includeme(config):
     email_sending_class = config.maybe_dotted(config.registry.settings["mail.backend"])
     config.register_service_factory(email_sending_class.create_service, IEmailSender)

--- a/warehouse/templates/email/pep625-extension-email/body.html
+++ b/warehouse/templates/email/pep625-extension-email/body.html
@@ -1,0 +1,44 @@
+{#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+{% set domain = request.registry.settings.get('warehouse.domain') %}
+
+{% block content %}
+  <p>
+    This email is notifying you of an upcoming deprecation that we have
+    determined may affect you as a result of your recent upload to
+    '{{ project_name }}'.
+  </p>
+  <p>
+    In the future, PyPI will require all newly uploaded source distribution
+    filenames to comply with <a href="https://peps.python.org/pep-0625/">PEP
+    625</a>. Any source distributions already uploaded will remain in place
+    as-is and do not need to be updated.
+  </p>
+  <p>
+    Specifically, your recent upload of {{ filename }} is incompatible with PEP
+    625 because it uses the .zip file extension.
+  </p>
+  <p>
+    In most cases, this can be resolved by upgrading the version of your build
+    tooling to a later version that supports PEP 625 and produces compliant
+    filenames.
+  </p>
+  <p>
+    If you have questions, you can email
+    <a href="mailto:admin@pypi.org">admin@pypi.org</a> to communicate with the PyPI
+    admin@pypi.org to communicate with the PyPI administrators.
+  </p>
+{% endblock %}

--- a/warehouse/templates/email/pep625-extension-email/body.txt
+++ b/warehouse/templates/email/pep625-extension-email/body.txt
@@ -1,0 +1,28 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+
+This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to '{{ project_name }}'.
+
+In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625 (https://peps.python.org/pep-0625/). Any source distributions already uploaded will remain in place as-is and do not need to be updated.
+
+Specifically, your recent upload of {{ filename }} is incompatible with PEP 625 because it uses the .zip extension.
+
+In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames.
+
+If you have questions, you can email admin@pypi.org to communicate with the PyPI administrators.
+
+{% endblock %}

--- a/warehouse/templates/email/pep625-extension-email/subject.txt
+++ b/warehouse/templates/email/pep625-extension-email/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}Deprecation notice for recent source distribution upload to '{{ project_name }}'{% endblock %}

--- a/warehouse/templates/email/pep625-name-email/body.html
+++ b/warehouse/templates/email/pep625-name-email/body.html
@@ -1,0 +1,45 @@
+{#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+{% set domain = request.registry.settings.get('warehouse.domain') %}
+
+{% block content %}
+  <p>
+    This email is notifying you of an upcoming deprecation that we have
+    determined may affect you as a result of your recent upload to
+    '{{ project_name }}'.
+  </p>
+  <p>
+    In the future, PyPI will require all newly uploaded source distribution
+    filenames to comply with <a href="https://peps.python.org/pep-0625/">PEP
+    625</a>. Any source distributions already uploaded will remain in place
+    as-is and do not need to be updated.
+  </p>
+  <p>
+    Specifically, your recent upload of {{ filename }} is incompatible with PEP
+    625 because it does not contains the normalized project name
+    '{{ normalized_name }}'.
+  </p>
+  <p>
+    In most cases, this can be resolved by upgrading the version of your build
+    tooling to a later version that supports PEP 625 and produces compliant
+    filenames.
+  </p>
+  <p>
+    If you have questions, you can email
+    <a href="mailto:admin@pypi.org">admin@pypi.org</a> to communicate with the PyPI
+    admin@pypi.org to communicate with the PyPI administrators.
+  </p>
+{% endblock %}

--- a/warehouse/templates/email/pep625-name-email/body.txt
+++ b/warehouse/templates/email/pep625-name-email/body.txt
@@ -1,0 +1,28 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+
+This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to '{{ project_name }}'.
+
+In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625 (https://peps.python.org/pep-0625/). Any source distributions already uploaded will remain in place as-is and do not need to be updated.
+
+Specifically, your recent upload of {{ filename }} is incompatible with PEP 625 because it does not contain the normalized project name '{{ normalized_name }}'.
+
+In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames.
+
+If you have questions, you can email admin@pypi.org to communicate with the PyPI administrators.
+
+{% endblock %}

--- a/warehouse/templates/email/pep625-name-email/subject.txt
+++ b/warehouse/templates/email/pep625-name-email/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}Deprecation notice for recent source distribution upload to '{{ project_name }}'{% endblock %}

--- a/warehouse/templates/email/pep625-version-email/body.html
+++ b/warehouse/templates/email/pep625-version-email/body.html
@@ -1,0 +1,45 @@
+{#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+{% set domain = request.registry.settings.get('warehouse.domain') %}
+
+{% block content %}
+  <p>
+    This email is notifying you of an upcoming deprecation that we have
+    determined may affect you as a result of your recent upload to
+    '{{ project_name }}'.
+  </p>
+  <p>
+    In the future, PyPI will require all newly uploaded source distribution
+    filenames to comply with <a href="https://peps.python.org/pep-0625/">PEP
+    625</a>. Any source distributions already uploaded will remain in place
+    as-is and do not need to be updated.
+  </p>
+  <p>
+    Specifically, your recent upload of {{ filename }} is incompatible with PEP
+    625 because it does not contain the normalized project version
+    '{{ normalized_version }}'.
+  </p>
+  <p>
+    In most cases, this can be resolved by upgrading the version of your build
+    tooling to a later version that supports PEP 625 and produces compliant
+    filenames.
+  </p>
+  <p>
+    If you have questions, you can email
+    <a href="mailto:admin@pypi.org">admin@pypi.org</a> to communicate with the PyPI
+    admin@pypi.org to communicate with the PyPI administrators.
+  </p>
+{% endblock %}

--- a/warehouse/templates/email/pep625-version-email/body.txt
+++ b/warehouse/templates/email/pep625-version-email/body.txt
@@ -1,0 +1,28 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+
+This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to '{{ project_name }}'.
+
+In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625 (https://peps.python.org/pep-0625/). Any source distributions already uploaded will remain in place as-is and do not need to be updated.
+
+Specifically, your recent upload of {{ filename }} is incompatible with PEP 625 because it does not contain contain the normalized project version '{{ normalized_version }}'.
+
+In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames.
+
+If you have questions, you can email admin@pypi.org to communicate with the PyPI administrators.
+
+{% endblock %}

--- a/warehouse/templates/email/pep625-version-email/subject.txt
+++ b/warehouse/templates/email/pep625-version-email/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}Deprecation notice for recent source distribution upload to '{{ project_name }}'{% endblock %}


### PR DESCRIPTION
Towards #12245.

This also updates many tests which were using non-PEP 625 compliant sdist filenames.