### PR TITLE
attestations: allow upload of SLSA provenances

### DIFF
--- a/warehouse/attestations/services.py
+++ b/warehouse/attestations/services.py
@@ -39,6 +39,12 @@ if typing.TYPE_CHECKING:
     from warehouse.packaging.models import File
 
 
+SUPPORTED_ATTESTATION_TYPES = {
+    AttestationType.PYPI_PUBLISH_V1,
+    AttestationType.SLSA_PROVENANCE_V1,
+}
+
+
 def _extract_attestations_from_request(request: Request) -> list[Attestation]:
     """
     Extract well-formed attestation objects from the given request's payload.
@@ -177,7 +183,7 @@ class IntegrityService:
                     f"Unknown error while trying to verify included attestations: {e}",
                 )
 
-            if predicate_type != AttestationType.PYPI_PUBLISH_V1:
+            if predicate_type not in SUPPORTED_ATTESTATION_TYPES:
                 self.metrics.increment(
                     "warehouse.upload.attestations.failed_unsupported_predicate_type"
                 )


### PR DESCRIPTION
PEP 740 [allows](https://peps.python.org/pep-0740/#attestation-statement-and-signature-generation) for two `predicateType` values:
>* The following `predicateType` values are supported:
>   * SLSA Provenance: https://slsa.dev/provenance/v1
>   * PyPI Publish Attestation: https://docs.pypi.org/attestations/publish/v1

This PR enables support for the first one (the second one was already enabled).

<img width="774" alt="image" src="https://github.com/user-attachments/assets/cbd72adc-712a-463a-9487-9980646ececb">

Part of https://github.com/pypi/warehouse/issues/17001

cc @woodruffw @di 