### PR TITLE
docs(attestations): fix example for GitLab CI/CD

### DIFF
--- a/docs/user/attestations/producing-attestations.md
+++ b/docs/user/attestations/producing-attestations.md
@@ -181,7 +181,7 @@ information.
         - python -m pip install -U twine id
 
         # Retrieve the OIDC token from GitLab CI/CD, and exchange it for a PyPI API token
-        - oidc_token=$(python -m id PYPI)
+        - oidc_token=$(python -m id pypi)
         # Replace "https://pypi.org/*" with "https://test.pypi.org/*" if uploading to TestPyPI
         - resp=$(curl -X POST https://pypi.org/_/oidc/mint-token -d "{\"token\":\"${oidc_token}\"}")
         - api_token=$(jq --raw-output '.token' <<< "${resp}")

--- a/docs/user/attestations/producing-attestations.md
+++ b/docs/user/attestations/producing-attestations.md
@@ -188,7 +188,7 @@ information.
 
         # Upload to PyPI authenticating via the newly-minted token, including the generated attestations
         # Add "--repository testpypi" if uploading to TestPyPI
-        - twine --verbose --attestations upload -u __token__ -p "${api_token}" python_pkg/dist/*
+        - twine upload --verbose --attestations -u __token__ -p "${api_token}" python_pkg/dist/*
     ```
 
     Note how, compared with the [Trusted Publishing workflow][GitLab Trusted Publishing], it has the


### PR DESCRIPTION
I was setting up attestations on gitlab.com and had to go through a bit of trial and error, this is just a tiny typo fix to get a working example, as the options should follow the subcommand.

Here's a (condensed) example config that worked for me and the job uploading the attestations:
https://gitlab.com/marge-org/marge-bot/-/blob/main/.gitlab-ci.yml?ref_type=heads#L179-207
https://gitlab.com/marge-org/marge-bot/-/jobs/8456428455
