### PR TITLE
docs: add Prerequisites section to attestations

### DIFF
--- a/docs/user/attestations/producing-attestations.md
+++ b/docs/user/attestations/producing-attestations.md
@@ -5,11 +5,21 @@
 PyPI allows attestations to be attached to individual *release files*
 (source and binary distributions within a release) at upload time.
 
-Attestations are currently only supported when uploading with
-[Trusted Publishing], and currently only with GitHub and GitLab-based
-Trusted Publishers. Support for other Trusted Publishers is planned. See
-[#17001](https://github.com/pypi/warehouse/issues/17001) for additional
-information.
+## Prerequisites
+
+Before uploading attestations to the index, please:
+
+* Review the [Linux Foundation Immutable Record notice], which applies to the
+  public transparency log.
+* Set up [Trusted Publishing] with a supported CI/CD provider. Supported
+  providers are listed below with instructions for each.
+
+    !!! note
+
+        Support for other Trusted Publishers is planned.
+        See #17001 for additional information.
+
+## Producing attestations
 
 === "GitHub Actions"
 
@@ -224,3 +234,4 @@ information.
 [legacy upload API documentation]: https://warehouse.pypa.io/api-reference/legacy.html#upload-api
 
 [GitLab Trusted Publishing]: /trusted-publishers/using-a-publisher/#gitlab-cicd
+[Linux Foundation Immutable Record notice]: https://lfprojects.org/policies/hosted-project-tools-immutable-records/


### PR DESCRIPTION
Adds a section based on `npm`'s similar section, but adapted for Trusted Publishing.