### PR TITLE
docs: re-enable search for user-facing docs

### DIFF
--- a/docs/mkdocs-user-docs.yml
+++ b/docs/mkdocs-user-docs.yml
@@ -2,6 +2,7 @@ site_name: PyPI Docs
 docs_dir: user
 site_dir: user-site
 plugins:
+  - search
   - macros:
       module_name: user/main
       j2_block_start_string: "<!--[[%"


### PR DESCRIPTION
With mkdocs once you configure plugins you have to explicitly enable the `search` plugin as well or it gets skipped. I'm not sure if it was intentional but when https://github.com/pypi/warehouse/pull/13202/files#diff-d75d62239cf1cddb23c129000bba023160dfa9e10a88fb5c9c7dd6ae6ae740b7R4 was added, the PR doesn't seem to address it so I assume it might be accidental, especially as the blog has it enabled.

I think with the docs now growing and more user-facing pages for publishing & attestation this might be useful.

This adds the search back so it's consistent with the blog site as well (and probably the user site before that commit, but not sure). If this was intentional though, feel free to close the PR :)

https://docspypiorg--17167.org.readthedocs.build/

Example:

![image](https://github.com/user-attachments/assets/71b86871-fff5-424a-9d98-c7dd85c5bce6)
