### PR TITLE
docs: update API links everywhere

### DIFF
--- a/docs/blog/posts/2023-05-24-pypi-was-subpoenaed.md
+++ b/docs/blog/posts/2023-05-24-pypi-was-subpoenaed.md
@@ -232,7 +232,7 @@ These were sourced from our database records and for past projects, are private 
 PyPI does not retain download logs for packages which include IP addresses.
 Download logs are processed by a pipeline which includes GeoIP information reported by our CDN only.
 
-These records were sourced from the [Google BigQuery Public dataset](https://warehouse.pypa.io/api-reference/bigquery-datasets.html) with the following queries:
+These records were sourced from the [Google BigQuery Public dataset](https://docs.pypi.org/api/bigquery/) with the following queries:
 
 ```sql
 SELECT * FROM `bigquery-public-data.pypi.file_downloads`

--- a/docs/dev/application.rst
+++ b/docs/dev/application.rst
@@ -110,7 +110,7 @@ Directories within the repository:
   - `organizations/ <https://github.com/pypi/warehouse/tree/main/warehouse/organizations>`_ - organization accounts
   - `packaging/ <https://github.com/pypi/warehouse/tree/main/warehouse/packaging>`_ - core packaging models (projects, releases, files)
   - `rate_limiting/ <https://github.com/pypi/warehouse/tree/main/warehouse/rate_limiting>`_ - rate limiting to prevent abuse
-  - `rss/ <https://github.com/pypi/warehouse/tree/main/warehouse/rss>`_ - RSS feeds: :doc:`api-reference/feeds`
+  - `rss/ <https://github.com/pypi/warehouse/tree/main/warehouse/rss>`_ - `RSS Feeds <https://docs.pypi.org/api/feeds/>`_
   - `search/ <https://github.com/pypi/warehouse/tree/main/warehouse/search>`_ - utilities for building and querying the search index
   - `sitemap/ <https://github.com/pypi/warehouse/tree/main/warehouse/sitemap>`_ - site maps
   - `sponsors/ <https://github.com/pypi/warehouse/tree/main/warehouse/sponsors>`_ - sponsors management
@@ -156,9 +156,8 @@ may be used to from the legacy site, such as:
 
 - `HTTP access to APIs; now it's HTTPS-only <https://mail.python.org/pipermail/distutils-sig/2017-October/031712.html>`_
 
-- GPG/PGP signatures for packages (still visible in the :doc:`../api-reference/legacy/`
-  per `PEP 503 <https://peps.python.org/pep-0503/>`_, but no
-  longer visible in the web UI)
+- GPG/PGP signatures for packages (no longer visible in the web UI or index, but retrievable
+  by appending an ``.asc`` if the signature exists)
 
 - `OpenID and Google auth login <https://mail.python.org/pipermail/distutils-sig/2018-January/031855.html>`_
   are no longer supported.

--- a/docs/dev/security/index.rst
+++ b/docs/dev/security/index.rst
@@ -18,6 +18,6 @@ directions for submitting security vulnerabilities, please visit
 
 Project and release activity details
 ------------------------------------
-See :doc:`/api-reference/feeds` for how to track new and updated releases on
-PyPI.
+See `RSS Feeds <https://docs.pypi.org/api/feeds/>`_ for how to track new and
+updated releases on PyPI.
 

--- a/docs/user/attestations/producing-attestations.md
+++ b/docs/user/attestations/producing-attestations.md
@@ -231,7 +231,7 @@ Before uploading attestations to the index, please:
 
 [twine]: https://github.com/pypa/twine
 
-[legacy upload API documentation]: https://warehouse.pypa.io/api-reference/legacy.html#upload-api
+[legacy upload API documentation]: /api/upload
 
 [GitLab Trusted Publishing]: /trusted-publishers/using-a-publisher/#gitlab-cicd
 [Linux Foundation Immutable Record notice]: https://lfprojects.org/policies/hosted-project-tools-immutable-records/

--- a/warehouse/api/README.md
+++ b/warehouse/api/README.md
@@ -8,6 +8,6 @@ but do not live under the `/api/*` route namespace.
 They may be refactored to another location at some future point.
 
 We have API endpoints that pre-date the `/api/*` namespace,
-see https://warehouse.pypa.io/api-reference/index.html for more.
+see https://docs.pypi.org/api/ for more.
 
 All APIs under the `/api/*` namespace are JSON-only.

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -564,13 +564,13 @@
         <h2>{% trans %}Integrating{% endtrans %}</h2>
 
         <h3 id="APIs">{{ APIs() }}</h3>
-        <p>{% trans %}Yes, including RSS feeds of new packages and new releases.{% endtrans %} <a href="https://warehouse.pypa.io/api-reference/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}See the API reference.{% endtrans %}</a></p>
+        <p>{% trans %}Yes, including RSS feeds of new packages and new releases.{% endtrans %} <a href="https://docs.pypi.org/api/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}See the API reference.{% endtrans %}</a></p>
 
         <h3 id="mirroring">{{ mirroring() }}</h3>
         <p>{% trans href='https://pypi.org/project/bandersnatch/' %}If you need to run your own mirror of PyPI, the <a href="{{ href }}">bandersnatch project</a> is the recommended solution. Note that the storage requirements for a PyPI mirror would exceed 1 terabyte—and growing!{% endtrans %}</p>
 
         <h3 id="project-release-notifications">{{ project_release_notifications() }}</h3>
-        <p>{% trans href='https://github.com/marketplace?category=dependency-management&query=python', title=gettext('External link'), rss_href='https://warehouse.pypa.io/api-reference/feeds/#project-releases-feed' %}You can subscribe to the <a href="{{ rss_href }}" title="{{ title }}" target="_blank" rel="noopener">project releases RSS feed</a>. Additionally, there are several third-party services that offer comprehensive monitoring and notifications for project releases and vulnerabilities listed as <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">GitHub apps</a>.{% endtrans %}</p>
+        <p>{% trans href='https://github.com/marketplace?category=dependency-management&query=python', title=gettext('External link'), rss_href='https://docs.pypi.org/api/feeds/#project-releases-feed' %}You can subscribe to the <a href="{{ rss_href }}" title="{{ title }}" target="_blank" rel="noopener">project releases RSS feed</a>. Additionally, there are several third-party services that offer comprehensive monitoring and notifications for project releases and vulnerabilities listed as <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">GitHub apps</a>.{% endtrans %}</p>
 
         <h3 id="statistics">{{ statistics() }}</h3>
         <p>{% trans href='https://packaging.python.org/guides/analyzing-pypi-package-downloads/', title=gettext('External link') %}You can analyze PyPI project/package metadata and <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">download usage statistics</a> via our public dataset on Google BigQuery.{% endtrans %}</p>

--- a/warehouse/templates/pages/security-key-giveaway.html
+++ b/warehouse/templates/pages/security-key-giveaway.html
@@ -58,7 +58,7 @@
       <p>
         PyPI determines eligibility based on download counts derived
         from PyPI's <a
-        href="https://warehouse.pypa.io/api-reference/bigquery-datasets.html">public
+        href="https://docs.pypi.org/api/bigquery/">public
       dataset of download statistics</a>. Any project in the top 1% of
     downloads over the prior 6 months is designated as critical.
       </p>

--- a/warehouse/templates/pages/stats.html
+++ b/warehouse/templates/pages/stats.html
@@ -33,7 +33,7 @@
     </p>
     <ul>
       <li>
-        <a href="https://warehouse.pypa.io/api-reference/bigquery-datasets.html">
+        <a href="https://docs.pypi.org/api/bigquery/">
           {% trans %}PyPI provides public datasets, including download statistics and metadata via BigQuery{% endtrans %}
         </a>
       </li>


### PR DESCRIPTION
This is the last piece of https://github.com/pypi/warehouse/issues/16541.

It moves all of the links (*except XML-RPC API links*) over to the new docs.