### PR TITLE
fix: create a parent for column grids

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3885,7 +3885,7 @@ msgstr ""
 msgid "%(remaining)s unused"
 msgstr ""
 
-#: warehouse/templates/manage/account/recovery_codes-burn.html:49
+#: warehouse/templates/manage/account/recovery_codes-burn.html:50
 #: warehouse/templates/manage/manage_base.html:42
 msgid "Regenerate"
 msgstr ""
@@ -4799,20 +4799,20 @@ msgid ""
 "on your account before adding a new publisher."
 msgstr ""
 
-#: warehouse/templates/manage/account/recovery_codes-burn.html:34
+#: warehouse/templates/manage/account/recovery_codes-burn.html:35
 msgid ""
 "In order to verify that you have safely stored your recovery codes for "
 "use in the event of a lost 2FA device, submit one of your recovery codes "
 "here."
 msgstr ""
 
-#: warehouse/templates/manage/account/recovery_codes-burn.html:39
+#: warehouse/templates/manage/account/recovery_codes-burn.html:40
 msgid ""
 "The recovery code you choose will be considered used and no longer be "
 "available to bypass 2FA."
 msgstr ""
 
-#: warehouse/templates/manage/account/recovery_codes-burn.html:44
+#: warehouse/templates/manage/account/recovery_codes-burn.html:45
 msgid ""
 "<strong>Forgot to safely store your recovery codes?</strong> You'll need "
 "to generate them again."
@@ -4826,20 +4826,20 @@ msgstr ""
 msgid "Regenerate recovery codes"
 msgstr ""
 
-#: warehouse/templates/manage/account/recovery_codes-provision.html:42
+#: warehouse/templates/manage/account/recovery_codes-provision.html:43
 msgid ""
 "If you lose access to your authentication application or security key(s),"
 " you’ll need to use one of these recovery codes to log into your PyPI "
 "account. Each code can only be used <strong>once</strong>."
 msgstr ""
 
-#: warehouse/templates/manage/account/recovery_codes-provision.html:43
+#: warehouse/templates/manage/account/recovery_codes-provision.html:44
 msgid ""
 "These codes should <strong>only</strong> be used for account recovery, "
 "not for typical logins."
 msgstr ""
 
-#: warehouse/templates/manage/account/recovery_codes-provision.html:44
+#: warehouse/templates/manage/account/recovery_codes-provision.html:45
 msgid ""
 "<strong>Keep these somewhere safe</strong>. If you lose your "
 "authentication application or security key(s) and do not have access to "

--- a/warehouse/static/sass/layout-helpers/_columns.scss
+++ b/warehouse/static/sass/layout-helpers/_columns.scss
@@ -14,11 +14,16 @@
 
 /*
   Column that is 50% wide:
-  <div class="col-half"></div>
+  <div class="col-grid">
+    <div class="col-half"></div>
+  </div>
 */
 
-.col-half {
+.col-grid {
   @include grid-container;
+}
+
+.col-half {
   grid-column: span 6;
 
   &:last-of-type {

--- a/warehouse/templates/manage/account/recovery_codes-burn.html
+++ b/warehouse/templates/manage/account/recovery_codes-burn.html
@@ -28,29 +28,29 @@
 {% block content %}
 <div class="horizontal-section">
   <div class="site-container">
-    <div class="col-half">
-      <h1 class="page-title page-title--wsubtitle heading-wsubtitle__heading">{{ title }}</h1>
-      <p>
-      {% trans %}
-        In order to verify that you have safely stored your recovery codes for use in the event of a lost 2FA device, submit one of your recovery codes here.
-      {% endtrans %}
-      </p>
-      <p>
-      {% trans %}
-        The recovery code you choose will be considered used and no longer be available to bypass 2FA.
-      {% endtrans %}
-      </p>
-      <p>
-      {% trans %}
-      <strong>Forgot to safely store your recovery codes?</strong> You'll need to generate them again.
-      {% endtrans %}
-      </p>
-      <a href="{{ request.route_path('manage.account.recovery-codes.regenerate') }}" class="button button--secondary">
-        {% trans %}Regenerate{% endtrans %}
-      </a>
-    </div>
-    <div class="col-half">
-      <div>
+    <div class="col-grid">
+      <div class="col-half">
+        <h1 class="page-title page-title--wsubtitle heading-wsubtitle__heading">{{ title }}</h1>
+        <p>
+        {% trans %}
+          In order to verify that you have safely stored your recovery codes for use in the event of a lost 2FA device, submit one of your recovery codes here.
+        {% endtrans %}
+        </p>
+        <p>
+        {% trans %}
+          The recovery code you choose will be considered used and no longer be available to bypass 2FA.
+        {% endtrans %}
+        </p>
+        <p>
+        {% trans %}
+        <strong>Forgot to safely store your recovery codes?</strong> You'll need to generate them again.
+        {% endtrans %}
+        </p>
+        <a href="{{ request.route_path('manage.account.recovery-codes.regenerate') }}" class="button button--secondary">
+          {% trans %}Regenerate{% endtrans %}
+        </a>
+      </div>
+      <div class="col-half">
         <form method="POST" action="{{ request.current_route_path() }}">
           <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
           <input name="method" type="hidden" value="recovery-code">

--- a/warehouse/templates/manage/account/recovery_codes-provision.html
+++ b/warehouse/templates/manage/account/recovery_codes-provision.html
@@ -37,14 +37,14 @@
       </div>
     </div>
     {% else %}
-    <div class="col-half">
-      <h1 class="page-title page-title--wsubtitle heading-wsubtitle__heading">{{ title }}</h1>
-      <p>{% trans %}If you lose access to your authentication application or security key(s), you’ll need to use one of these recovery codes to log into your PyPI account. Each code can only be used <strong>once</strong>.{% endtrans %}</p>
-      <p>{% trans %}These codes should <strong>only</strong> be used for account recovery, not for typical logins.{% endtrans %}</p>
-      <p>{% trans %}<strong>Keep these somewhere safe</strong>. If you lose your authentication application or security key(s) and do not have access to these recovery codes, you may permanently lose access to your PyPI account!{% endtrans %}</p>
-    </div>
-    <div class="col-half">
-      <div>
+    <div class="col-grid">
+      <div class="col-half">
+        <h1 class="page-title page-title--wsubtitle heading-wsubtitle__heading">{{ title }}</h1>
+        <p>{% trans %}If you lose access to your authentication application or security key(s), you’ll need to use one of these recovery codes to log into your PyPI account. Each code can only be used <strong>once</strong>.{% endtrans %}</p>
+        <p>{% trans %}These codes should <strong>only</strong> be used for account recovery, not for typical logins.{% endtrans %}</p>
+        <p>{% trans %}<strong>Keep these somewhere safe</strong>. If you lose your authentication application or security key(s) and do not have access to these recovery codes, you may permanently lose access to your PyPI account!{% endtrans %}</p>
+      </div>
+      <div class="col-half">
         <h2>{% trans %}Save your recovery codes{% endtrans %}</h2>
         <div class="recovery-codes">
           <div>


### PR DESCRIPTION
`display: grid` needs to be at a parent level, and `col-half` didn't have a container per se, as the previous implementation was a computed column width, not part of a CSS Grid.

Fixes #17233
Refs: #17160