### PR TITLE
Expose file events in JSON API

### DIFF
--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -291,6 +291,7 @@ class TestJSONProject:
                         "requires_python": None,
                         "yanked": False,
                         "yanked_reason": None,
+                        "events": [],
                     }
                 ],
                 "2.0": [
@@ -316,6 +317,7 @@ class TestJSONProject:
                         "requires_python": None,
                         "yanked": False,
                         "yanked_reason": None,
+                        "events": [],
                     }
                 ],
                 "3.0": [
@@ -341,6 +343,7 @@ class TestJSONProject:
                         "requires_python": None,
                         "yanked": False,
                         "yanked_reason": None,
+                        "events": [],
                     }
                 ],
             },
@@ -365,6 +368,7 @@ class TestJSONProject:
                     "requires_python": None,
                     "yanked": False,
                     "yanked_reason": None,
+                    "events": [],
                 }
             ],
             "last_serial": je.id,
@@ -613,6 +617,7 @@ class TestJSONRelease:
                     "requires_python": None,
                     "yanked": False,
                     "yanked_reason": None,
+                    "events": [],
                 }
             ],
             "last_serial": je.id,
@@ -707,6 +712,7 @@ class TestJSONRelease:
                     "requires_python": None,
                     "yanked": False,
                     "yanked_reason": None,
+                    "events": [],
                 }
             ],
             "last_serial": je.id,

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -119,6 +119,23 @@ def _json_data(request, project, release, *, all_releases):
                 "requires_python": r.requires_python if r.requires_python else None,
                 "yanked": r.yanked,
                 "yanked_reason": r.yanked_reason or None,
+                "events": [
+                    {
+                        "tag": e.tag,
+                        "time": e.time,
+                        **{
+                            k: v
+                            for k, v in e.additional.items()
+                            if k
+                            in {
+                                "submitted_by",
+                                "publisher_url",
+                                "uploaded_via_trusted_publisher",
+                            }
+                        },
+                    }
+                    for e in f.events
+                ],
             }
             for f in fs
         ]


### PR DESCRIPTION
This PR exposes a subset of the fields on every `File.Event` in `file.events`, specifically:

* `File.Event.tag` (all events)
* `File.Event.time` (all events)
* `File.Event.additional["submitted_by"]` (`file:add` events)
* `File.Event.additional["publisher_url"]` (`file:add` events)
* `File.Event.additional["uploaded_via_trusted_publisher"]` (`file:add` events)

Currently in practice this just exposes the `file:add` event because this is the only `File.Event` that will be available when a file is present, but the implementation will at a minimum expose `File.Event.tag` and `file.Event.time` for any future events that might exist.