### PR TITLE
Fix header check in secret scanning

### DIFF
--- a/tests/unit/integration/secrets/test_views.py
+++ b/tests/unit/integration/secrets/test_views.py
@@ -35,6 +35,18 @@ class TestDiscloseToken:
                 "token",
             ),
             (
+                config._github_origin,
+                {
+                    "GitHub-Public-Key-Identifier": "foo",
+                    "GitHub-Public-Key-Signature": "bar",
+                },
+                {
+                    "github.token": "token",
+                },
+                "https://api.github.com/meta/public_keys/token_scanning",
+                "token",
+            ),
+            (
                 config._depsdev_origin,
                 {
                     "GOSST-PUBLIC-KEY-IDENTIFIER": "foo",

--- a/tests/unit/integration/secrets/test_views.py
+++ b/tests/unit/integration/secrets/test_views.py
@@ -15,6 +15,8 @@ import json
 import pretend
 import pytest
 
+from webob.headers import EnvironHeaders
+
 from warehouse.integrations.secrets import config, utils, views
 
 
@@ -36,7 +38,7 @@ class TestDiscloseToken:
             ),
             (
                 config._github_origin,
-                {
+                {  # Test for case-insensitivity on header names
                     "GitHub-Public-Key-Identifier": "foo",
                     "GitHub-Public-Key-Signature": "bar",
                 },
@@ -69,7 +71,9 @@ class TestDiscloseToken:
         api_url,
         api_token,
     ):
-        pyramid_request.headers = headers
+        pyramid_request.headers = EnvironHeaders({})
+        for k, v in headers.items():
+            pyramid_request.headers[k] = v
         pyramid_request.body = "[1, 2, 3]"
         pyramid_request.json_body = [1, 2, 3]
         pyramid_request.registry.settings = settings

--- a/warehouse/integrations/secrets/views.py
+++ b/warehouse/integrations/secrets/views.py
@@ -21,7 +21,7 @@ from warehouse.metrics import IMetricsService
 
 def _detect_origin(request):
     for origin in config.origins:
-        if origin.headers.issubset(request.headers.keys()):
+        if all([k in request.headers for k in origin.headers]):
             return origin
 
 


### PR DESCRIPTION
The refactor in https://github.com/pypi/warehouse/pull/17218 caused GitHub requests to the token endpoint to all end up 404ing due to case-sensitivity on the required headers.

Previously the `require_headers` predicate was used which is case-insensitive.

Update the `_detect_origin` function to use the case-insensitive nature of Pyramid/WebOb's request.headers object.