### PR TITLE
feat: add a favicon route on the root

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -77,6 +77,7 @@ def test_routes(warehouse):
         pretend.call("force-status", r"/_force-status/{status:[45]\d\d}/"),
         pretend.call("index", "/", domain=warehouse),
         pretend.call("locale", "/locale/", domain=warehouse),
+        pretend.call("favicon.ico", "/favicon.ico", domain=warehouse),
         pretend.call("robots.txt", "/robots.txt", domain=warehouse),
         pretend.call("opensearch.xml", "/opensearch.xml", domain=warehouse),
         pretend.call("index.sitemap.xml", "/sitemap.xml", domain=warehouse),

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1,16 +1,16 @@
-#: warehouse/views.py:149
+#: warehouse/views.py:157
 msgid ""
 "You must verify your **primary** email address before you can perform "
 "this action."
 msgstr ""
 
-#: warehouse/views.py:165
+#: warehouse/views.py:173
 msgid ""
 "Two-factor authentication must be enabled on your account to perform this"
 " action."
 msgstr ""
 
-#: warehouse/views.py:301
+#: warehouse/views.py:332
 msgid "Locale updated"
 msgstr ""
 

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -28,6 +28,7 @@ def includeme(config):
     # Basic global routes
     config.add_route("index", "/", domain=warehouse)
     config.add_route("locale", "/locale/", domain=warehouse)
+    config.add_route("favicon.ico", "/favicon.ico", domain=warehouse)
     config.add_route("robots.txt", "/robots.txt", domain=warehouse)
     config.add_route("opensearch.xml", "/opensearch.xml", domain=warehouse)
     config.add_route("index.sitemap.xml", "/sitemap.xml", domain=warehouse)

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -10,9 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 import collections
 import re
+import typing
+
+from pathlib import Path
 
 import opensearchpy
 
@@ -32,6 +36,7 @@ from pyramid.httpexceptions import (
 from pyramid.i18n import make_localizer
 from pyramid.interfaces import ITranslationDirectories
 from pyramid.renderers import render_to_response
+from pyramid.response import FileResponse
 from pyramid.view import (
     exception_view_config,
     forbidden_view_config,
@@ -67,6 +72,9 @@ from warehouse.utils.cors import _CORS_HEADERS
 from warehouse.utils.http import is_safe_url
 from warehouse.utils.paginate import OpenSearchPage, paginate_url_factory
 from warehouse.utils.row_counter import RowCount
+
+if typing.TYPE_CHECKING:
+    from pyramid.request import Request
 
 JSON_REGEX = r"^/pypi/([^\/]+)\/?([^\/]+)?/json\/?$"
 json_path = re.compile(JSON_REGEX)
@@ -201,6 +209,29 @@ def forbidden_api(exc, request):
 @view_config(context=DatabaseNotAvailableError)
 def service_unavailable(exc, request):
     return httpexception_view(HTTPServiceUnavailable(), request)
+
+
+@view_config(
+    route_name="favicon.ico",
+    decorator=[
+        cache_control(365 * 24 * 60 * 60),  # 1 year
+    ],
+)
+def favicon(request: Request) -> FileResponse:
+    """
+    Return static favicon.ico file
+
+    The favicon path is not known, static files are compressed into a dist/ directory.
+    """
+    favicon_filename = Path(
+        request.static_path("warehouse:static/dist/images/favicon.ico")
+    ).name
+    favicon_path = (
+        Path(__file__).parent / "static" / "dist" / "images" / favicon_filename
+    )
+
+    request.response.content_type = "image/x-icon"
+    return FileResponse(favicon_path, request=request)
 
 
 @view_config(


### PR DESCRIPTION
Many browsers may not respect the inline HTML directive on where to find a favicon file, so add a route to serve it directly and not respond with a 404 Not Found.

Refs: #970