### PR TITLE
requirements: drop direct pycurl dep

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -42,7 +42,6 @@ passlib>=1.6.4
 platformdirs>=4.2
 premailer
 psycopg[c]
-pycurl
 pydantic
 pyqrcode
 pyramid>=2.0

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1674,7 +1674,6 @@ pycurl==7.45.3 \
     --hash=sha256:fa7751b614d9aa82d7a0f49ca90924c29c6cedf85a2f8687fb6a772dbfe48711 \
     --hash=sha256:fbd4a6b8654b779089c5a44af1c65c1419c2cd60718780df6d8f354eb35d6d55
     # via
-    #   -r requirements/main.in
     #   celery
     #   kombu
 pydantic[email]==2.10.2 \


### PR DESCRIPTION
This is still in the resolved set since it's a transitive dep of `celery` and `kombu`, but is no longer listed at the top-level (since it doesn't appear anywhere in Warehouse's own code AFAICT).

Closes #17279.