### PR TITLE
Titlize language names

### DIFF
--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -365,7 +365,7 @@
               {% endif %}
               name="locale_id" value="{{ identifier }}" type="submit"
             >
-              {{ locale.display_name }}
+              {{ locale.display_name.title() }}
             </button>
           </li>
           {% endfor %}


### PR DESCRIPTION
Aligned the case styles of the language names displayed on the language switch buttons.

|||
|-|-|
|[Before](https://pypi.org/)|![localhost_ (2)](https://github.com/user-attachments/assets/3f33f335-3bc0-4dbf-9065-931c52df0fa7)|
|[After](http://localhost:80)|![localhost_ (1)](https://github.com/user-attachments/assets/a46eea50-9727-4f67-a94b-859c0ec524c8)|

---

```py
langs = ["English", "español", "français", "日本語", "português (Brasil)", "українська", "Ελληνικά", "Deutsch", "中文 (简体)", "中文 (繁體)", "русский", "עברית ", "Esperanto"]
for lang in langs: print(lang, "=>", lang.title())
```

```
English => English
español => Español
français => Français
日本語 => 日本語
português (Brasil) => Português (Brasil)
українська => Українська
Ελληνικά => Ελληνικά
Deutsch => Deutsch
中文 (简体) => 中文 (简体)
中文 (繁體) => 中文 (繁體)
русский => Русский
עברית  => עברית
Esperanto => Esperanto
```