### PR TITLE
fix: retry observation reporting task

### DIFF
--- a/warehouse/observations/tasks.py
+++ b/warehouse/observations/tasks.py
@@ -17,6 +17,8 @@ import typing
 from base64 import b64encode
 from textwrap import dedent
 
+from requests.exceptions import RequestException
+
 from warehouse import db, tasks
 from warehouse.helpdesk.interfaces import IHelpDeskService
 
@@ -55,7 +57,7 @@ def execute_observation_report(config: Configurator, session: SA_Session):
     bind=True,
     ignore_result=True,
     acks_late=True,
-    autoretry_for=(Exception,),
+    autoretry_for=(RequestException,),
     retry_backoff=True,
 )
 def report_observation_to_helpscout(task, request: Request, model_id: UUID) -> None:

--- a/warehouse/observations/tasks.py
+++ b/warehouse/observations/tasks.py
@@ -51,7 +51,13 @@ def execute_observation_report(config: Configurator, session: SA_Session):
         config.task(report_observation_to_helpscout).delay(obj.id)
 
 
-@tasks.task(bind=True, ignore_result=True, acks_late=True)
+@tasks.task(
+    bind=True,
+    ignore_result=True,
+    acks_late=True,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+)
 def report_observation_to_helpscout(task, request: Request, model_id: UUID) -> None:
     """
     Report an Observation to HelpScout for further tracking.


### PR DESCRIPTION
After seeing the occasional error raised from the upstream service, retry a few times (defaults to 3) with exponential backoff.

Refs: https://docs.celeryq.dev/en/stable/userguide/tasks.html#automatic-retry-for-known-exceptions