### PR TITLE
Add JSON user API

### DIFF
--- a/docs/user/api/json.md
+++ b/docs/user/api/json.md
@@ -482,6 +482,44 @@ For example, here is what a withdrawn vulnerability might look like:
 }
 ```
 
+### Get a user
+
+Route: `GET /user/<username>/json`
+
+Returns the same information found in the HTML profile page (`/user/<username>`), but in a JSON format. 
+It contains the time of account creation, the username, the name (or null), and a list of the user's projects.
+
+Status codes:
+
+* `200 OK` - no error
+* `404 Not Found` - User was not found
+
+Example request:
+```
+GET /user/someuser/json HTTP/1.1
+Host: pypi.org
+Accept: application/json
+```
+
+??? "Example JSON response"
+
+    ```http
+    HTTP/1.1 200 OK
+    Content-Type: application/json; charset="UTF-8"
+
+    {
+        "joined_at": "2025-01-01T06:35:12",
+        "name": "Some User",
+        "projects": [
+            {
+                "last_released": "2025-01-04T08:47:36",
+                "name": "sampleproject",
+                "summary": "sample project"
+            }
+        ],
+        "username": "someuser"
+    }
+    ```
 
 [Index API]: ./index-api.md
 [known vulnerabilities]: https://github.com/pypa/advisory-database

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -623,6 +623,18 @@ def test_routes(warehouse):
             factory="warehouse.legacy.api.json.release_factory",
             domain=warehouse,
         ),
+        pretend.call(
+            "legacy.api.json.user",
+            "/user/{username}/json",
+            factory="warehouse.legacy.api.json.user_factory",
+            domain=warehouse,
+        ),
+        pretend.call(
+            "legacy.api.json.user_slash",
+            "/user/{username}/json/",
+            factory="warehouse.legacy.api.json.user_factory",
+            domain=warehouse,
+        ),
         pretend.call("legacy.docs", docs_route_url),
     ]
 

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -16,6 +16,7 @@ from pyramid.view import view_config
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.orm import Load, contains_eager, joinedload
 
+from warehouse.accounts.models import User
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import (
@@ -310,6 +311,17 @@ def release_factory(request):
         return HTTPNotFound(headers=_CORS_HEADERS)
 
     return release
+
+
+def user_factory(request):
+    username = request.matchdict["username"]
+
+    try:
+        user = request.db.query(User).filter(User.username == username).one()
+    except NoResultFound:
+        return HTTPNotFound(headers=_CORS_HEADERS)
+
+    return user
 
 
 @view_config(

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -357,3 +357,42 @@ def json_release(release, request):
 )
 def json_release_slash(release, request):
     return json_release(release, request)
+
+
+@view_config(
+    route_name="legacy.api.json.user",
+    context=User,
+    renderer="json",
+)
+def json_user(user, request):
+    projects = []
+    for project in user.projects:
+        latest_release = max(project.releases, key=lambda r: r.created, default=None)
+        if latest_release:
+            projects.append(
+                {
+                    "name": project.name,
+                    "last_released": latest_release.created.strftime(
+                        "%Y-%m-%dT%H:%M:%S"
+                    ),
+                    "summary": latest_release.summary,
+                }
+            )
+
+    # Apply CORS headers.
+    request.response.headers.update(_CORS_HEADERS)
+    return {
+        "username": user.username,
+        "name": user.name or None,
+        "joined_at": user.date_joined.strftime("%Y-%m-%dT%H:%M:%S"),
+        "projects": projects,
+    }
+
+
+@view_config(
+    route_name="legacy.api.json.user_slash",
+    context=User,
+    renderer="json",
+)
+def json_user_slash(user, request):
+    return json_user(user, request)

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -640,6 +640,20 @@ def includeme(config):
         domain=warehouse,
     )
 
+    config.add_route(
+        "legacy.api.json.user",
+        "/user/{username}/json",
+        factory="warehouse.legacy.api.json.user_factory",
+        domain=warehouse,
+    )
+
+    config.add_route(
+        "legacy.api.json.user_slash",
+        "/user/{username}/json/",
+        factory="warehouse.legacy.api.json.user_factory",
+        domain=warehouse,
+    )
+
     # Legacy Action URLs
     # TODO: We should probably add Warehouse routes for these that just error
     #       and direct people to use upload.pypi.org


### PR DESCRIPTION
Closes #15769 

Some points of discussion:
- Is this added in the right place? Feels strange adding to the legacy JSON API but at the same time it seems to fit in
- Data model: should we stay faithful to exactly what's returned in the HTML page for `/user/{username}`? Or should we return other stuff as well? 