### PR TITLE
Remove potentially confusing callout when setting up 2FA

### DIFF
--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -177,7 +177,7 @@
     {% endif %}
 
     {% set disabled = not user.has_burned_recovery_codes or not user.has_primary_verified_email %}
-    {% if not user.has_two_factor %}
+    {% if not disabled and not user.has_two_factor %}
      <div class="callout-block">
         <p>
         {% trans %}


### PR DESCRIPTION
This removes an unnecessary and duplicate warning callout that can be distracting from what we actually want the user to do when setting up 2FA.

| Before | After |
|--------|--------|
| <img width="868" alt="Screenshot 2025-01-08 at 12 13 01 PM" src="https://github.com/user-attachments/assets/5205adb0-d6c2-4534-bddd-3edb6e949d4c" /> | <img width="868" alt="Screenshot 2025-01-08 at 12 15 45 PM" src="https://github.com/user-attachments/assets/dcb7bd60-f744-47b1-8ce3-7685e1d57b47" /> | 

The callout is only shown when the user is actually able to begin setting up 2FA:

<img width="868" alt="Screenshot 2025-01-08 at 12 21 17 PM" src="https://github.com/user-attachments/assets/7458a035-f8ba-4c4c-9e47-8391d329e9bf" />

Helps to alleviate confusion raised in #17370.