### PR TITLE
Turn keywords back into a string when passing metadata to BigQuery

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -1309,7 +1309,7 @@ class TestFileUpload:
                     "license": None,
                     "license_expression": "MIT OR Apache-2.0",
                     "license_files": ["LICENSE.APACHE", "LICENSE.MIT"],
-                    "keywords": ["keyword1", "keyword2"],
+                    "keywords": "keyword1, keyword2",
                     "classifiers": ["Environment :: Other Environment"],
                     "platform": None,
                     "home_page": None,

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1471,7 +1471,7 @@ def file_upload(request):
         "license": meta.license,
         "license_expression": meta.license_expression,
         "license_files": meta.license_files,
-        "keywords": meta.keywords,
+        "keywords": ", ".join(meta.keywords) if meta.keywords else None,
         "classifiers": meta.classifiers,
         "platform": meta.platforms[0] if meta.platforms else None,
         "home_page": meta.home_page,


### PR DESCRIPTION
Towards fixing #16008.