### PR TITLE
Make migration version 24aa37164e72 apply immediately

### DIFF
--- a/warehouse/migrations/versions/24aa37164e72_update_dynamicfieldsenum_to_include_all_.py
+++ b/warehouse/migrations/versions/24aa37164e72_update_dynamicfieldsenum_to_include_all_.py
@@ -25,46 +25,14 @@ down_revision = "ed4cc2ef6b0f"
 
 
 def upgrade():
-    op.sync_enum_values(
-        enum_schema="public",
-        enum_name="release_dynamic_fields",
-        new_values=[
-            "Platform",
-            "Supported-Platform",
-            "Summary",
-            "Description",
-            "Description-Content-Type",
-            "Keywords",
-            "Author",
-            "Author-Email",
-            "Maintainer",
-            "Maintainer-Email",
-            "License",
-            "License-Expression",
-            "License-File",
-            "Classifier",
-            "Requires-Dist",
-            "Requires-Python",
-            "Requires-External",
-            "Project-Url",
-            "Provides-Extra",
-            "Provides-Dist",
-            "Obsoletes-Dist",
-            "Home-Page",
-            "Download-Url",
-            "Requires",
-            "Provides",
-            "Obsoletes",
-        ],
-        affected_columns=[
-            TableReference(
-                table_schema="public",
-                table_name="releases",
-                column_name="dynamic",
-                column_type=ColumnType.ARRAY,
-            )
-        ],
-        enum_values_to_rename=[],
+    op.execute(
+        "ALTER TYPE public.release_dynamic_fields ADD VALUE IF NOT EXISTS 'Requires'"
+    )
+    op.execute(
+        "ALTER TYPE public.release_dynamic_fields ADD VALUE IF NOT EXISTS 'Provides'"
+    )
+    op.execute(
+        "ALTER TYPE public.release_dynamic_fields ADD VALUE IF NOT EXISTS 'Obseletes'"
     )
 
 

--- a/warehouse/migrations/versions/24aa37164e72_update_dynamicfieldsenum_to_include_all_.py
+++ b/warehouse/migrations/versions/24aa37164e72_update_dynamicfieldsenum_to_include_all_.py
@@ -32,7 +32,7 @@ def upgrade():
         "ALTER TYPE public.release_dynamic_fields ADD VALUE IF NOT EXISTS 'Provides'"
     )
     op.execute(
-        "ALTER TYPE public.release_dynamic_fields ADD VALUE IF NOT EXISTS 'Obseletes'"
+        "ALTER TYPE public.release_dynamic_fields ADD VALUE IF NOT EXISTS 'Obsoletes'"
     )
 
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -547,6 +547,8 @@ DynamicFieldsEnum = ENUM(
     "Description",
     "Description-Content-Type",
     "Keywords",
+    "Home-Page",  # Deprecated, but technically permitted by PEP 643
+    "Download-Url",  # Deprecated, but technically permitted by PEP 643
     "Author",
     "Author-Email",
     "Maintainer",
@@ -565,8 +567,6 @@ DynamicFieldsEnum = ENUM(
     # Although the following are deprecated fields, they are technically
     # permitted as dynamic by PEP 643
     # https://github.com/pypa/setuptools/issues/4797#issuecomment-2589514950
-    "Home-Page",
-    "Download-Url",
     "Requires",
     "Provides",
     "Obsoletes",


### PR DESCRIPTION
The `sync_enum_values` operator creates the following SQL:

```
-- Running upgrade ed4cc2ef6b0f -> 24aa37164e72

ALTER TYPE public.release_dynamic_fields RENAME TO release_dynamic_fields_old;

CREATE TYPE public.release_dynamic_fields AS ENUM('Platform', 'Supported-Platform', 'Summary', 'Description', 'Description-Content-Type', 'Keywords', 'Author', 'Author-Email', 'Maintainer', 'Maintainer-Email', 'License', 'License-Expression', 'License-File', 'Classifier', 'Requires-Dist', 'Requires-Python', 'Requires-External', 'Project-Url', 'Provides-Extra', 'Provides-Dist', 'Obsoletes-Dist', 'Home-Page', 'Download-Url', 'Requires', 'Provides', 'Obsoletes');

CREATE FUNCTION new_old_not_equals(
                new_enum_val public.release_dynamic_fields, old_enum_val public.release_dynamic_fields_old
            )
            RETURNS boolean AS $$
                SELECT new_enum_val::text != old_enum_val::text;
            $$ LANGUAGE SQL IMMUTABLE;

CREATE OPERATOR != (
            leftarg = public.release_dynamic_fields,
            rightarg = public.release_dynamic_fields_old,
            procedure = new_old_not_equals
        );

CREATE FUNCTION new_old_equals(
                new_enum_val public.release_dynamic_fields, old_enum_val public.release_dynamic_fields_old
            )
            RETURNS boolean AS $$
                SELECT new_enum_val::text = old_enum_val::text;
            $$ LANGUAGE SQL IMMUTABLE;

CREATE OPERATOR = (
            leftarg = public.release_dynamic_fields,
            rightarg = public.release_dynamic_fields_old,
            procedure = new_old_equals
        );

ALTER TABLE public."releases" 
            ALTER COLUMN dynamic TYPE public.release_dynamic_fields[]
            USING dynamic::text[]::public.release_dynamic_fields[];

DROP FUNCTION new_old_not_equals(
            new_enum_val public.release_dynamic_fields, old_enum_val public.release_dynamic_fields_old
        ) CASCADE;

DROP FUNCTION new_old_equals(
            new_enum_val public.release_dynamic_fields, old_enum_val public.release_dynamic_fields_old
        ) CASCADE;

DROP TYPE public.release_dynamic_fields_old;

UPDATE alembic_version SET version_num='24aa37164e72' WHERE alembic_version.version_num = 'ed4cc2ef6b0f';
```

Which creates an all new enum to update the values, then swaps the type on the column. This is unnecessarily disruptive for adding a new value other than the enum.

This updated migration results in:

```
-- Running upgrade ed4cc2ef6b0f -> 24aa37164e72

ALTER TYPE public.release_dynamic_fields ADD VALUE IF NOT EXISTS 'Requires';

ALTER TYPE public.release_dynamic_fields ADD VALUE IF NOT EXISTS 'Provides';

ALTER TYPE public.release_dynamic_fields ADD VALUE IF NOT EXISTS 'Obseletes';

UPDATE alembic_version SET version_num='24aa37164e72' WHERE alembic_version.version_num = 'ed4cc2ef6b0f';
```

and will run extremely quickly.