### PR TITLE
Add archived badges to project's settings page

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1705,7 +1705,7 @@ msgstr ""
 #: warehouse/templates/accounts/profile.html:83
 #: warehouse/templates/manage/organization/projects.html:48
 #: warehouse/templates/manage/projects.html:37
-#: warehouse/templates/manage/projects.html:84
+#: warehouse/templates/manage/projects.html:87
 #: warehouse/templates/manage/team/projects.html:48
 #: warehouse/templates/organizations/profile.html:66
 #, python-format
@@ -3899,8 +3899,8 @@ msgstr ""
 #: warehouse/templates/manage/organizations.html:120
 #: warehouse/templates/manage/organizations.html:125
 #: warehouse/templates/manage/project/releases.html:88
-#: warehouse/templates/manage/projects.html:103
-#: warehouse/templates/manage/projects.html:107
+#: warehouse/templates/manage/projects.html:106
+#: warehouse/templates/manage/projects.html:110
 #: warehouse/templates/manage/team/projects.html:66
 #: warehouse/templates/manage/team/projects.html:70
 msgid "Manage"
@@ -4209,7 +4209,7 @@ msgstr ""
 #: warehouse/templates/manage/organizations.html:35
 #: warehouse/templates/manage/organizations.html:96
 #: warehouse/templates/manage/projects.html:44
-#: warehouse/templates/manage/projects.html:91
+#: warehouse/templates/manage/projects.html:94
 #: warehouse/templates/manage/team/projects.html:55
 #, python-format
 msgid "Created %(creation_date)s"
@@ -4302,8 +4302,8 @@ msgstr ""
 #: warehouse/templates/manage/organization/teams.html:63
 #: warehouse/templates/manage/organizations.html:103
 #: warehouse/templates/manage/project/releases.html:94
-#: warehouse/templates/manage/projects.html:115
 #: warehouse/templates/manage/projects.html:118
+#: warehouse/templates/manage/projects.html:121
 #: warehouse/templates/manage/team/projects.html:78
 #: warehouse/templates/manage/team/projects.html:81
 msgid "View"
@@ -4442,31 +4442,35 @@ msgstr ""
 msgid "Sole owner"
 msgstr ""
 
+#: warehouse/templates/manage/projects.html:82
+msgid "Archived"
+msgstr ""
+
 #: warehouse/templates/manage/organization/projects.html:66
-#: warehouse/templates/manage/projects.html:102
+#: warehouse/templates/manage/projects.html:105
 #: warehouse/templates/manage/team/projects.html:65
 msgid "Manage this project"
 msgstr ""
 
 #: warehouse/templates/manage/organization/projects.html:70
-#: warehouse/templates/manage/projects.html:106
+#: warehouse/templates/manage/projects.html:109
 #: warehouse/templates/manage/team/projects.html:69
 msgid "You are not an owner of this project"
 msgstr ""
 
 #: warehouse/templates/manage/organization/projects.html:78
-#: warehouse/templates/manage/projects.html:114
+#: warehouse/templates/manage/projects.html:117
 #: warehouse/templates/manage/team/projects.html:77
 msgid "View this project's public page"
 msgstr ""
 
 #: warehouse/templates/manage/organization/projects.html:81
-#: warehouse/templates/manage/projects.html:117
+#: warehouse/templates/manage/projects.html:120
 #: warehouse/templates/manage/team/projects.html:80
 msgid "This project has no releases"
 msgstr ""
 
-#: warehouse/templates/manage/projects.html:126
+#: warehouse/templates/manage/projects.html:129
 #, python-format
 msgid ""
 "You have not uploaded any projects to PyPI, yet. To learn how to get "
@@ -6113,6 +6117,11 @@ msgid ""
 "article."
 msgstr ""
 
+#: warehouse/templates/manage/project/manage_project_base.html:86
+#: warehouse/templates/packaging/detail.html:318
+msgid "This project has been archived."
+msgstr ""
+
 #: warehouse/templates/manage/project/publishing.html:26
 msgid ""
 "Some form fields have been autofilled, please double-check their values "
@@ -7117,10 +7126,6 @@ msgstr ""
 #: warehouse/templates/packaging/detail.html:278
 #: warehouse/templates/packaging/detail.html:346
 msgid "Project details"
-msgstr ""
-
-#: warehouse/templates/packaging/detail.html:318
-msgid "This project has been archived."
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:320

--- a/warehouse/templates/manage/project/manage_project_base.html
+++ b/warehouse/templates/manage/project/manage_project_base.html
@@ -81,6 +81,10 @@
                 {% endtrans %}
               </p>
             </div>
+          {% elif project.lifecycle_status == "archived" %}
+            <div class="callout-block callout-block--warning">
+              <p>{% trans %}This project has been archived.{% endtrans %}</p>
+            </div>
           {% endif %}
           {% if request.organization_access and project.organization %}
             <div class="organization-snippet organization-snippet--margin-bottom">

--- a/warehouse/templates/manage/projects.html
+++ b/warehouse/templates/manage/projects.html
@@ -78,6 +78,9 @@
             {% if project.name in projects_sole_owned %}
             <a href="{{ request.route_path('manage.project.roles', project_name=project.normalized_name) }}" class="badge badge--warning">{% trans %}Sole owner{% endtrans %}</a>
             {% endif %}
+            {% if project.lifecycle_status == "archived" %}
+            <a href="{{ request.route_path('manage.project.settings', project_name=project.normalized_name) }}" class="badge badge--warning">{% trans %}Archived{% endtrans %}</a>
+            {% endif %}
           </h3>
           {% if release %}
           <p class="package-snippet__meta">


### PR DESCRIPTION
This PR adds "archived" labels to projects in the `manage/projects` and `manage/project/$PROJECT/*` routes, for better clarity for owners about which projects are archived.

## manage/projects
<img width="600" alt="image" src="https://github.com/user-attachments/assets/be121d57-aa5d-4073-b7dd-43dd8a485c08" />

## manage/project/$PROJECT/*
<img width="600" alt="image" src="https://github.com/user-attachments/assets/e3014889-4918-4fc7-b149-24cfda3d0713" />

---- 

This fixes https://github.com/pypi/warehouse/issues/17437

cc @woodruffw @miketheman 