### PR TITLE
make sync_release_files task batch size configurable

### DIFF
--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -171,7 +171,7 @@ def test_includeme(monkeypatch, with_bq_sync):
 
     if with_bq_sync:
         assert (
-            pretend.call(crontab(minute="*/5"), sync_bigquery_release_files)
+            pretend.call(crontab(minute="*"), sync_bigquery_release_files)
             in config.add_periodic_task.calls
         )
         pass

--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -756,7 +756,8 @@ class TestSyncBigQueryMetadata:
 
         db_request.find_service = find_service
         db_request.registry.settings = {
-            "warehouse.release_files_table": release_files_table
+            "warehouse.release_files_table": release_files_table,
+            "sync_release_file_backfill.batch_size": 10,
         }
 
         sync_bigquery_release_files(db_request)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -338,6 +338,7 @@ def test_configure(monkeypatch, settings, environment):
         "warehouse.organizations.max_undecided_organization_applications": 3,
         "reconcile_file_storages.batch_size": 100,
         "metadata_backfill.batch_size": 500,
+        "sync_release_file_backfill.batch_size": 10,
         "gcloud.service_account_info": {},
         "warehouse.forklift.legacy.MAX_FILESIZE_MIB": 100,
         "warehouse.forklift.legacy.MAX_PROJECT_SIZE_GIB": 10,

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -439,6 +439,13 @@ def configure(settings=None):
         coercer=int,
         default=500,
     )
+    maybe_set(
+        settings,
+        "sync_release_file_backfill.batch_size",
+        "SYNC_RELEASE_FILE_BACKFILL_BATCH_SIZE",
+        coercer=int,
+        default=10,
+    )
     maybe_set_compound(settings, "billing", "backend", "BILLING_BACKEND")
     maybe_set_compound(settings, "files", "backend", "FILES_BACKEND")
     maybe_set_compound(settings, "archive_files", "backend", "ARCHIVE_FILES_BACKEND")

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -199,4 +199,4 @@ def includeme(config):
     config.add_periodic_task(crontab(minute="*/5"), compute_packaging_metrics)
 
     if config.get_settings().get("warehouse.release_files_table"):
-        config.add_periodic_task(crontab(minute="*/5"), sync_bigquery_release_files)
+        config.add_periodic_task(crontab(minute="*"), sync_bigquery_release_files)

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -357,6 +357,7 @@ def sync_bigquery_release_files(request):
         return
 
     bq = request.find_service(name="gcloud.bigquery")
+    batch_size = request.registry.settings["sync_release_file_backfill.batch_size"]
 
     # Multiple table names can be specified by separating them with whitespace
     table_names = release_files_table.split()
@@ -364,7 +365,7 @@ def sync_bigquery_release_files(request):
     missing_files = (
         request.db.query(MissingDatasetFile)
         .filter(MissingDatasetFile.processed.is_(None))
-        .limit(10)
+        .limit(batch_size)
         .all()
     )
     for missing_file in missing_files:


### PR DESCRIPTION
Moves this task to every minute, and allows for a configurable batch size.