### PR TITLE
optimization: only fetch bigquery schemas once per run in sync_bigquery_release_files

### DIFF
--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -375,13 +375,17 @@ def sync_bigquery_release_files(request):
     request.tm.commit()
     request.tm.begin()
 
+    table_schemas = {
+        table_name: bq.get_table(table_name).schema for table_name in table_names
+    }
+
     for missing_file in missing_files:
         # Add the objects back into the new session
         request.db.add(missing_file)
         release_file = missing_file.file
 
         for table_name in table_names:
-            table_schema = bq.get_table(table_name).schema
+            table_schema = table_schemas[table_name]
 
             # Using the schema to populate the data allows us to automatically
             # set the values to their respective fields rather than assigning


### PR DESCRIPTION
Currently we are fetching the schema for _each_ file in the batch, and its consuming ~60% of the actual task run time.
<img width="828" alt="Screenshot 2025-01-18 at 10 56 05 AM" src="https://github.com/user-attachments/assets/6f14dc0a-1212-4417-a8b1-f7beea4ecfdc" />
