### PR TITLE
add rust toolchain to build and dev containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
-        build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev libcurl4-openssl-dev libssl-dev \
+        build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev libcurl4-openssl-dev libssl-dev rust-all \
         $(if [ "$DEVEL" = "yes" ]; then echo 'libjpeg-dev'; fi)
 
 # We create an /opt directory with a virtual environment in it to store our
@@ -223,7 +223,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         libpq5 libxml2 libxslt1.1 libcurl4  \
-        $(if [ "$DEVEL" = "yes" ]; then echo 'bash libjpeg62 postgresql-client build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev libcurl4-openssl-dev libssl-dev vim oathtool'; fi) \
+        $(if [ "$DEVEL" = "yes" ]; then echo 'bash libjpeg62 postgresql-client build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev libcurl4-openssl-dev libssl-dev vim oathtool rust-all'; fi) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
a [release of orjson](https://pypi.org/project/orjson/3.10.15/) caused `make deps` to start [failing unexpectedly](https://github.com/pypi/warehouse/actions/runs/12845424159/job/35819512078?pr=17451) with:

```
+ pip-compile --upgrade -o /tmp/tmp.VM3uXJx64Y/main.txt requirements/main.in
    error: subprocess-exited-with-error

    × Preparing metadata (pyproject.toml) did not run successfully.
    │ exit code: 1
    ╰─> [6 lines of output]
        Checking for Rust toolchain....

        Cargo, the Rust package manager, is not installed or is not on PATH.
        This package requires Rust and Cargo to compile extensions. Install it through
        the system's package manager or via https://rustup.rs/

        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
```

This adds the rust toolchain to our build intermediate container, and development container so that builds and dependency resolution can utilize it.