### PR TITLE
Metadata backfill: Remove no-op task

### DIFF
--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -342,8 +342,3 @@ def update_bigquery_release_files(task, request, dist_metadata):
         json_rows = [json_rows]
 
         bq.insert_rows_json(table=table_name, json_rows=json_rows)
-
-
-@tasks.task(ignore_result=True, acks_late=True)
-def sync_bigquery_release_files(request):  # pragma: no cover
-    pass


### PR DESCRIPTION
Follow-on to #17465.