### PR TITLE
integrity: refine Accept header handling

### DIFF
--- a/tests/unit/api/test_integrity.py
+++ b/tests/unit/api/test_integrity.py
@@ -68,7 +68,7 @@ def test_select_content_type(db_request, accept, expected):
 # Backstop; can be removed/changed once this view supports HTML.
 @pytest.mark.parametrize(
     "content_type",
-    [integrity.MIME_TEXT_HTML, integrity.MIME_PYPI_INTEGRITY_V1_HTML],
+    ["text/html", "application/vnd.pypi.integrity.v1+html"],
 )
 def test_provenance_for_file_bad_accept(db_request, content_type):
     db_request.accept = content_type

--- a/tests/unit/api/test_integrity.py
+++ b/tests/unit/api/test_integrity.py
@@ -16,13 +16,53 @@ import pytest
 from warehouse.api import integrity
 
 
-def test_select_content_type(db_request):
-    db_request.accept = "application/json"
+@pytest.mark.parametrize(
+    ("accept", "expected"),
+    [
+        # Simple cases
+        (
+            "application/vnd.pypi.integrity.v1+json",
+            integrity.MIME_PYPI_INTEGRITY_V1_JSON,
+        ),
+        ("application/json", integrity.MIME_APPLICATION_JSON),
+        # No accept header means we give the user our first offer
+        (None, integrity.MIME_PYPI_INTEGRITY_V1_JSON),
+        # Accept header contains only things we don't offer
+        ("text/xml", None),
+        ("application/octet-stream", None),
+        ("text/xml, application/octet-stream", None),
+        # Accept header contains both things we offer and things we don't;
+        # we pick our matching offer even if the q-value is lower
+        (
+            "text/xml, application/vnd.pypi.integrity.v1+json",
+            integrity.MIME_PYPI_INTEGRITY_V1_JSON,
+        ),
+        (
+            "application/vnd.pypi.integrity.v1+json; q=0.1, text/xml",
+            integrity.MIME_PYPI_INTEGRITY_V1_JSON,
+        ),
+        # Accept header contains multiple things we offer with the same q-value;
+        # we pick our preferred offer
+        (
+            "application/json, application/vnd.pypi.integrity.v1+json",
+            integrity.MIME_PYPI_INTEGRITY_V1_JSON,
+        ),
+        (
+            "application/vnd.pypi.integrity.v1+json; q=0.5, application/json; q=0.5",
+            integrity.MIME_PYPI_INTEGRITY_V1_JSON,
+        ),
+        # Accept header contains multiple things we offer; we pick our
+        # offer based on the q-value
+        (
+            "application/vnd.pypi.integrity.v1+json; q=0.1, application/json",
+            integrity.MIME_APPLICATION_JSON,
+        ),
+    ],
+)
+def test_select_content_type(db_request, accept, expected):
+    db_request.accept = accept
 
-    assert (
-        integrity._select_content_type(db_request)
-        == integrity.MIME_PYPI_INTEGRITY_V1_JSON
-    )
+    assert integrity._select_content_type(db_request) == expected
 
 
 # Backstop; can be removed/changed once this view supports HTML.
@@ -35,6 +75,15 @@ def test_provenance_for_file_bad_accept(db_request, content_type):
     response = integrity.provenance_for_file(pretend.stub(), db_request)
     assert response.status_code == 406
     assert response.json == {"message": "Request not acceptable"}
+
+
+def test_provenance_for_file_accept_multiple(db_request, monkeypatch):
+    db_request.accept = "text/html, application/vnd.pypi.integrity.v1+json; q=0.9"
+    file = pretend.stub(provenance=None, filename="fake-1.2.3.tar.gz")
+
+    response = integrity.provenance_for_file(file, db_request)
+    assert response.status_code == 404
+    assert response.json == {"message": "No provenance available for fake-1.2.3.tar.gz"}
 
 
 def test_provenance_for_file_not_enabled(db_request, monkeypatch):

--- a/warehouse/api/integrity.py
+++ b/warehouse/api/integrity.py
@@ -20,9 +20,7 @@ from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import File
 from warehouse.utils.cors import _CORS_HEADERS
 
-MIME_TEXT_HTML = "text/html"
 MIME_APPLICATION_JSON = "application/json"
-MIME_PYPI_INTEGRITY_V1_HTML = "application/vnd.pypi.integrity.v1+html"
 MIME_PYPI_INTEGRITY_V1_JSON = "application/vnd.pypi.integrity.v1+json"
 
 

--- a/warehouse/api/integrity.py
+++ b/warehouse/api/integrity.py
@@ -32,9 +32,6 @@ def _select_content_type(request: Request) -> str | None:
             # JSON currently has the highest priority.
             MIME_PYPI_INTEGRITY_V1_JSON,
             MIME_APPLICATION_JSON,
-            # Ensures that we fall back to the first offer if
-            # the client does not provide an Accept header.
-            "identity",
         ]
     )
 

--- a/warehouse/api/simple.py
+++ b/warehouse/api/simple.py
@@ -50,7 +50,7 @@ def _select_content_type(request: Request) -> str:
         ]
     )
 
-    # Default case, we want to return whatevr we want to return
+    # Default case, we want to return whatever we want to return
     # by default when there is no Accept header.
     if not offers:
         return MIME_TEXT_HTML


### PR DESCRIPTION
This tweaks the `Accept` handling for this endpoint in the following ways:

1. We no longer accept HTML mimetypes only to reject them later, since this results in a confused state between accept matching and the actual HTTP response
2. We use the `'identity'` marker to ensure an adequate fallback when the user doesn't explicitly specify `Accept`
3. We now accept `application/json`, although this could be removed from the changeset

(NB: The main reason I added `application/json` is to ensure fallbacks/q-factor sorting works as expected.)

I've also added a bunch of parametrized tests to ensure that we handle various combinations/orders/q-values correctly.

See https://github.com/pypi/warehouse/issues/17084.