### PR TITLE
Use zizmor from PyPI

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,10 +27,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version-file: '.python-version'
-      - name: Get zizmor
-        run: python -m pip install zizmor
       - name: Run zizmor
-        run: zizmor --format sarif . > results.sarif
+        run: pipx run zizmor --format sarif . > results.sarif
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -11,7 +11,7 @@ jobs:
   zizmor:
     # Advanced Security is not enabled on private repositories
     if: github.repository == 'pypi/warehouse'
-    name: Zizmor latest via Cargo
+    name: Zizmor
     runs-on: ubuntu-24.04
     permissions:
       security-events: write
@@ -23,10 +23,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: '.python-version'
       - name: Get zizmor
-        run: cargo install zizmor
+        run: python -m pip install zizmor
       - name: Run zizmor
         run: zizmor --format sarif . > results.sarif
       - name: Upload SARIF file


### PR DESCRIPTION
This PR switches the installation of zizmor from `cargo install` to `pip install`.

/cc @woodruffw 