### PR TITLE
blog: add bluesky to footer

### DIFF
--- a/docs/mkdocs-blog.yml
+++ b/docs/mkdocs-blog.yml
@@ -76,6 +76,8 @@ extra:
       link: https://github.com/pypi
     - icon: fontawesome/brands/mastodon
       link: https://fosstodon.org/@pypi
+    - icon: fontawesome/brands/bluesky
+      link: https://bsky.app/profile/pypi.org
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/pypi
     - icon: material/rss


### PR DESCRIPTION
Looks like:
![image](https://github.com/user-attachments/assets/90950e55-3db4-4643-bf54-c6dfc9d4c786)
