### PR TITLE
lint: narrow types to ensure correct usage

### DIFF
--- a/warehouse/admin/views/organizations.py
+++ b/warehouse/admin/views/organizations.py
@@ -49,7 +49,7 @@ def organization_list(request):
     )
 
     if q:
-        filters = []
+        filters: list = []
         for term in terms:
             # Examples:
             # - search individual words or "whole phrase" in any field
@@ -223,7 +223,7 @@ def organization_applications_list(request):
     ).order_by(OrganizationApplication.normalized_name)
 
     if q:
-        filters = []
+        filters: list = []
         for term in terms:
             # Examples:
             # - search individual words or "whole phrase" in any field

--- a/warehouse/admin/views/prohibited_project_names.py
+++ b/warehouse/admin/views/prohibited_project_names.py
@@ -57,7 +57,7 @@ def prohibited_project_names(request):
     if q:
         terms = shlex.split(q)
 
-        filters = []
+        filters: list = []
         for term in terms:
             filters.append(
                 ProhibitedProjectName.name.ilike(func.normalize_pep426_name(term))

--- a/warehouse/cli/sponsors.py
+++ b/warehouse/cli/sponsors.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import cast
+
 import click
 
 from warehouse.cli import warehouse
@@ -569,10 +571,12 @@ def populate_db(config):
         img = params.pop("image")
         params["is_active"] = True
         params["link_url"] = params.pop("url")
-        params["activity_markdown"] = "\n\n".join(params.pop("activity", [])).strip()
-        params["color_logo_url"] = BLACK_BASE_URL + img
+        params["activity_markdown"] = "\n\n".join(
+            cast(list, params.pop("activity", []))
+        ).strip()
+        params["color_logo_url"] = BLACK_BASE_URL + str(img)
         if params["footer"] or params["infra_sponsor"]:
-            params["white_logo_url"] = WHITE_BASE_URL + img
+            params["white_logo_url"] = WHITE_BASE_URL + str(img)
 
         sponsor = Sponsor(**params)
         try:

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -461,7 +461,7 @@ def file_upload(request):
     request.metrics.increment("warehouse.upload.attempt")
 
     # This is a list of warnings that we'll emit *IF* the request is successful.
-    warnings = []
+    warnings: list[str] = []
 
     # If we're in read-only mode, let upload clients know
     if request.flags.enabled(AdminFlagValue.READ_ONLY):
@@ -618,7 +618,7 @@ def file_upload(request):
         meta = metadata.parse(None, form_data=request.POST)
     except* metadata.InvalidMetadata as exc:
         # Turn our list of errors into a mapping of errors, keyed by the field
-        errors = {}
+        errors: dict = {}
         for error in exc.exceptions:
             errors.setdefault(error.field, []).append(error)
 

--- a/warehouse/integrations/__init__.py
+++ b/warehouse/integrations/__init__.py
@@ -13,10 +13,12 @@
 import base64
 import time
 
+from typing import cast
+
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric.ec import ECDSA
+from cryptography.hazmat.primitives.asymmetric.ec import ECDSA, EllipticCurvePublicKey
 from cryptography.hazmat.primitives.hashes import SHA256
 
 
@@ -124,6 +126,8 @@ class PayloadVerifier:
             loaded_public_key = serialization.load_pem_public_key(
                 data=public_key.encode("utf-8"), backend=default_backend()
             )
+            # Use Type Narrowing to confirm the loaded_public_key is the correct type
+            loaded_public_key = cast(EllipticCurvePublicKey, loaded_public_key)
             loaded_public_key.verify(
                 signature=base64.b64decode(signature),
                 data=payload,

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -85,9 +85,9 @@ def _json_data(request, project, release, *, all_releases):
 
     # Map our releases + files into a dictionary that maps each release to a
     # list of all its files.
-    releases = {}
+    releases_and_files: dict[Release, list[File]] = {}
     for r, file_ in release_files:
-        files = releases.setdefault(r, [])
+        files = releases_and_files.setdefault(r, [])
         if file_ is not None:
             files.append(file_)
 
@@ -122,7 +122,7 @@ def _json_data(request, project, release, *, all_releases):
             }
             for f in fs
         ]
-        for r, fs in releases.items()
+        for r, fs in releases_and_files.items()
     }
 
     # Serialize a list of vulnerabilities for this release

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -297,7 +297,7 @@ msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
 #: warehouse/accounts/views.py:1593 warehouse/accounts/views.py:1836
-#: warehouse/manage/views/__init__.py:1417
+#: warehouse/manage/views/__init__.py:1419
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
@@ -317,19 +317,19 @@ msgstr ""
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1659 warehouse/manage/views/__init__.py:1586
-#: warehouse/manage/views/__init__.py:1699
-#: warehouse/manage/views/__init__.py:1811
-#: warehouse/manage/views/__init__.py:1921
+#: warehouse/accounts/views.py:1659 warehouse/manage/views/__init__.py:1588
+#: warehouse/manage/views/__init__.py:1701
+#: warehouse/manage/views/__init__.py:1813
+#: warehouse/manage/views/__init__.py:1923
 msgid ""
 "There have been too many attempted trusted publisher registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1669 warehouse/manage/views/__init__.py:1599
-#: warehouse/manage/views/__init__.py:1712
-#: warehouse/manage/views/__init__.py:1824
-#: warehouse/manage/views/__init__.py:1934
+#: warehouse/accounts/views.py:1669 warehouse/manage/views/__init__.py:1601
+#: warehouse/manage/views/__init__.py:1714
+#: warehouse/manage/views/__init__.py:1826
+#: warehouse/manage/views/__init__.py:1936
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
@@ -478,150 +478,150 @@ msgstr ""
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1038
+#: warehouse/manage/views/__init__.py:1040
 msgid "API Token does not exist."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1070
+#: warehouse/manage/views/__init__.py:1072
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1189
+#: warehouse/manage/views/__init__.py:1191
 msgid "Invalid alternate repository location details"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1227
+#: warehouse/manage/views/__init__.py:1229
 #, python-brace-format
 msgid "Added alternate repository '${name}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1260
-#: warehouse/manage/views/__init__.py:2267
-#: warehouse/manage/views/__init__.py:2352
-#: warehouse/manage/views/__init__.py:2453
-#: warehouse/manage/views/__init__.py:2553
+#: warehouse/manage/views/__init__.py:1262
+#: warehouse/manage/views/__init__.py:2269
+#: warehouse/manage/views/__init__.py:2354
+#: warehouse/manage/views/__init__.py:2455
+#: warehouse/manage/views/__init__.py:2555
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1272
+#: warehouse/manage/views/__init__.py:1274
 msgid "Invalid alternate repository id"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1283
+#: warehouse/manage/views/__init__.py:1285
 msgid "Invalid alternate repository for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1292
+#: warehouse/manage/views/__init__.py:1294
 #, python-brace-format
 msgid ""
 "Could not delete alternate repository - ${confirm} is not the same as "
 "${alt_repo_name}"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1322
+#: warehouse/manage/views/__init__.py:1324
 #, python-brace-format
 msgid "Deleted alternate repository '${name}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1466
+#: warehouse/manage/views/__init__.py:1468
 msgid "The trusted publisher could not be constrained"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1567
+#: warehouse/manage/views/__init__.py:1569
 msgid ""
 "GitHub-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1680
+#: warehouse/manage/views/__init__.py:1682
 msgid ""
 "GitLab-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1792
+#: warehouse/manage/views/__init__.py:1794
 msgid ""
 "Google-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1901
+#: warehouse/manage/views/__init__.py:1903
 msgid ""
 "ActiveState-based trusted publishing is temporarily disabled. See "
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2136
-#: warehouse/manage/views/__init__.py:2437
-#: warehouse/manage/views/__init__.py:2545
+#: warehouse/manage/views/__init__.py:2138
+#: warehouse/manage/views/__init__.py:2439
+#: warehouse/manage/views/__init__.py:2547
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2280
+#: warehouse/manage/views/__init__.py:2282
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2365
+#: warehouse/manage/views/__init__.py:2367
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2466
+#: warehouse/manage/views/__init__.py:2468
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2565
+#: warehouse/manage/views/__init__.py:2567
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2570
+#: warehouse/manage/views/__init__.py:2572
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2720
+#: warehouse/manage/views/__init__.py:2722
 #, python-brace-format
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2827
+#: warehouse/manage/views/__init__.py:2829
 #, python-brace-format
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2894
+#: warehouse/manage/views/__init__.py:2896
 #, python-brace-format
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2926
+#: warehouse/manage/views/__init__.py:2928
 #, python-brace-format
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2939
+#: warehouse/manage/views/__init__.py:2941
 #: warehouse/manage/views/organizations.py:890
 #, python-brace-format
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:3004
+#: warehouse/manage/views/__init__.py:3006
 #: warehouse/manage/views/organizations.py:955
 #, python-brace-format
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:3036
+#: warehouse/manage/views/__init__.py:3038
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:3047
+#: warehouse/manage/views/__init__.py:3049
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:3080
+#: warehouse/manage/views/__init__.py:3082
 #: warehouse/manage/views/organizations.py:1142
 #, python-brace-format
 msgid "Invitation revoked from '${username}'."
@@ -814,7 +814,7 @@ msgstr ""
 msgid "Provide an Inspector link to specific lines of code."
 msgstr ""
 
-#: warehouse/packaging/views.py:352
+#: warehouse/packaging/views.py:353
 msgid "Your report has been recorded. Thank you for your help."
 msgstr ""
 

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import datetime
+import typing
 import uuid
 
 import pymacaroons
@@ -170,9 +171,10 @@ class DatabaseMacaroonService:
         # NOTE: This is a bit of a hack: we keep a separate copy of the
         # permissions caveat in the DB, so that we can display scope information
         # in the UI.
-        permissions = {}
+        permissions: dict[str, list[str]] | str = {}
         for caveat in scopes:
             if isinstance(caveat, caveats.ProjectName):
+                permissions = typing.cast(dict[str, list[str]], permissions)
                 projects = permissions.setdefault("projects", [])
                 projects.extend(caveat.normalized_names)
             elif isinstance(caveat, caveats.RequestUser):

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -949,6 +949,8 @@ class ProvisionMacaroonViews:
 
         response = {**self.default_response}
         if form.validate():
+            macaroon_caveats: list[caveats.Caveat]
+
             if form.validated_scope == "user":
                 recorded_caveats = [{"permissions": form.validated_scope, "version": 1}]
                 macaroon_caveats = [
@@ -2219,7 +2221,7 @@ def manage_project_releases(project, request):
     #       }
     #   }
 
-    version_to_file_counts = {}
+    version_to_file_counts: dict[str, dict[str, int]] = {}
     for version, packagetype, count in filecounts:
         packagetype_to_count = version_to_file_counts.setdefault(version, {})
         packagetype_to_count.setdefault("total", 0)

--- a/warehouse/migrations/env.py
+++ b/warehouse/migrations/env.py
@@ -31,6 +31,8 @@ def run_migrations_offline():
     script output.
     """
     options = context.config.get_section(context.config.config_ini_section)
+    if options is None:
+        raise ValueError("No options found in config")
     url = options.pop("url")
     context.configure(url=url, compare_server_default=True)
 
@@ -46,6 +48,8 @@ def run_migrations_online():
     and associate a connection with the context.
     """
     options = context.config.get_section(context.config.config_ini_section)
+    if options is None:
+        raise ValueError("No options found in config")
     url = options.pop("url")
     connectable = create_engine(url, poolclass=pool.NullPool)
 

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -312,7 +312,7 @@ def update_bigquery_release_files(task, request, dist_metadata):
         # Using the schema to populate the data allows us to automatically
         # set the values to their respective fields rather than assigning
         # values individually
-        json_rows = dict()
+        json_rows: dict = {}
         for sch in table_schema:
             field_data = dist_metadata.get(sch.name, None)
 

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -258,6 +258,7 @@ def release_detail(release, request):
     if short_license and len(short_license) > 100 and short_license == release.license:
         short_license = short_license[:100] + "..."
 
+    license: str | None
     if license_classifiers and short_license:
         license = f"{license_classifiers} ({short_license})"
     else:

--- a/warehouse/search/__init__.py
+++ b/warehouse/search/__init__.py
@@ -86,6 +86,7 @@ def includeme(config):
     )
 
     p = parse_url(config.registry.settings["opensearch.url"])
+    assert p.path, "The URL for the OpenSearch instance must include the index name."
     qs = urllib.parse.parse_qs(p.query)
     kwargs = {
         "hosts": [urllib.parse.urlunparse((p.scheme, p.netloc) + ("",) * 4)],

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -434,7 +434,7 @@ def search(request):
         Returns a dictionary, each key being a filter and each value being
         the filter's children.
         """
-        d = {}
+        d: dict[str, dict] = {}
         for list_ in split_list:
             current_level = d
             for part in list_:


### PR DESCRIPTION
TL,DR: use [type narrowing](https://mypy.readthedocs.io/en/stable/type_narrowing.html) on objects of ambiguous nature.


These commits push us closer to being able to run `mypy` with `--check-untyped-defs`, we're not fully there yet, but let's get these out the door.

See each commit message for specifics on why the particular action was taken.

With these changes in place, we're down to:

> Found 115 errors in 30 files (checked 394 source files)