### PR TITLE
Add an admin UI to burn leaked recovery codes

### DIFF
--- a/tests/unit/admin/test_routes.py
+++ b/tests/unit/admin/test_routes.py
@@ -119,6 +119,13 @@ def test_includeme():
             traverse="/{username}",
         ),
         pretend.call(
+            "admin.user.burn_recovery_codes",
+            "/admin/users/{username}/burn_recovery_codes/",
+            domain=warehouse,
+            factory="warehouse.accounts.models:UserFactory",
+            traverse="/{username}",
+        ),
+        pretend.call(
             "admin.macaroon.decode_token", "/admin/token/decode", domain=warehouse
         ),
         pretend.call(

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -116,6 +116,13 @@ def includeme(config):
         factory="warehouse.accounts.models:UserFactory",
         traverse="/{username}",
     )
+    config.add_route(
+        "admin.user.burn_recovery_codes",
+        "/admin/users/{username}/burn_recovery_codes/",
+        domain=warehouse,
+        factory="warehouse.accounts.models:UserFactory",
+        traverse="/{username}",
+    )
 
     # Macaroon related Admin pages
     config.add_route(

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -647,25 +647,44 @@
           </div>
         </div>
         {% endif %}
-        {% if user.has_recovery_codes %}
-        <div>
-          <div class="card-header with-border">
-            <h3 class="card-title">Recovery codes</h3>
-          </div>
-          <div class="card-body">
-            <table class="table table-hover">
-              <tr>
-                <th>Generated</th>
-                <th>Remaining</th>
-              </tr>
-              <tr>
-                <td>{{ user.recovery_codes[0].generated }}</td>
-                <td>{{ user.recovery_codes.filter_by(burned=None).all()|length }}</td>
-              </tr>
-            </table>
-          </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header with-border">
+          <h3 class="card-title">Recovery codes</h3>
         </div>
-        {% endif %}
+        <div class="card-body">
+          {% if user.has_recovery_codes %}
+          <table class="table table-hover">
+            <tr>
+              <th>Generated</th>
+              <th>Remaining</th>
+            </tr>
+            <tr>
+              <td>{{ user.recovery_codes[0].generated }}</td>
+              <td>{{ user.recovery_codes.filter_by(burned=None).all()|length }}</td>
+            </tr>
+          </table>
+          <form method="POST" action="{{ request.route_path('admin.user.burn_recovery_codes', username=user.username) }}">
+            <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+            <div class="card">
+              <div class="card-header with-border">
+                <h3 class="card-title">Burn leaked recovery codes</h3>
+              </div>
+              <textarea name="to_burn" placeholder="One or more leaked recovery codes for this user, separated by whitespace or newlines"></textarea>
+              <div class="card-footer">
+                <div class="form-group">
+                  <div class="col-sm-offset-10 col-sm-2">
+                    <button type="submit" class="btn btn-danger" title="{{ 'Submitting requires superuser privileges' if not perms_admin_users_email_write }}" {{ "disabled" if not perms_admin_users_email_write }}>Submit</button>
+                  </div>
+                </div>
+              </div> <!-- .card-footer -->
+            </div> <!-- .card -->
+          </form>
+          {% else %}
+          No recovery codes configured.
+          {% endif %}
+        </div> <!-- .card-body -->
       </div> <!-- .card -->
 
       <div class="card">

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -562,10 +562,10 @@
             </div>
           </form>
 
-          <div class="card-header with-border">
-            <h3 class="card-title">Add a new email</h3>
-          </div>
           <div class="card">
+            <div class="card-header with-border">
+              <h3 class="card-title">Add a new email</h3>
+            </div>
             <form class="form-horizontal" method="POST" action="{{ request.route_path('admin.user.add_email', username=user.username) }}">
               <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
 
@@ -598,10 +598,10 @@
                     <button type="submit" class="btn btn-danger" title="{{ 'Submitting requires superuser privileges' if not perms_admin_users_email_write }}" {{ "disabled" if not perms_admin_users_email_write }}>Submit</button>
                   </div>
                 </div>
-              </div>
+              </div> <!-- .card-footer -->
             </form>
           </div>
-        </div>
+        </div> <!-- .card -->
       </div> <!-- .card -->
 
       <div class="card">
@@ -693,6 +693,7 @@
         </div>
 
         <div class="card-body">
+          {% if user.macaroons %}
           <table id="api-tokens" class="table table-hover">
             <thead>
               <tr>
@@ -721,6 +722,9 @@
               {% endfor %}
             </tbody>
           </table>
+          {% else %}
+          No API tokens configured.
+          {% endif %}
         </div>
       </div> <!-- .card -->
 
@@ -756,6 +760,7 @@
         </div>
 
         <div class="card-body">
+          {% if roles %}
           <table class="table table-hover" id="projects">
             <thead>
               <tr>
@@ -774,6 +779,9 @@
             {% endfor %}
             </tbody>
           </table>
+          {% else %}
+          No roles available.
+          {% endif %}
         </div>
       </div> <!-- .card -->
 

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -27,10 +27,10 @@ from sqlalchemy import or_, select
 from sqlalchemy.orm import joinedload
 
 from warehouse.accounts.interfaces import (
-    IEmailBreachedService,
-    IUserService,
     BurnedRecoveryCode,
+    IEmailBreachedService,
     InvalidRecoveryCode,
+    IUserService,
 )
 from warehouse.accounts.models import (
     DisableReason,

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -619,8 +619,8 @@ def user_burn_recovery_codes(user, request):
 
         for code in codes:
             try:
-                if user_service.check_recovery_code(user.id, code):
-                    n_burned += 1
+                user_service.check_recovery_code(user.id, code)
+                n_burned += 1
             except (BurnedRecoveryCode, InvalidRecoveryCode):
                 pass
 


### PR DESCRIPTION
Adds an admin UI to burn provided recovery codes (if they are valid). Fixes #17301.

<img width="792" alt="image" src="https://github.com/user-attachments/assets/b6990ea8-8b08-46d4-8175-8b75e2c0b974" />
