### PR TITLE
Simplify archive/unarchive UI buttons

### DIFF
--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -613,20 +613,23 @@
   </div>
 
   <div class="card-footer">
-    {% set can_be_archived = not project.lifecycle_status or project.lifecycle_status == "quarantine-exit" %}
-    {% set can_be_unarchived = project.lifecycle_status == "archived" %}
-    <form method="POST" action="{{ request.route_path('admin.project.unarchive', project_name=project.name) }}">
-      <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-      <div class="float-right">
-        <button type="submit" class="btn btn-primary" title="{{ 'Unarchiving requires superuser privileges' if not request.has_permission(Permissions.AdminProjectsWrite) }}" {{ "disabled" if not request.has_permission(Permissions.AdminProjectsWrite) or not can_be_unarchived }}>Unarchive</button>
-      </div>
-    </form>
-    <form method="POST" action="{{ request.route_path('admin.project.archive', project_name=project.name) }}">
-      <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-      <div class="float-right">
-        <button type="submit" class="btn btn-primary" title="{{ 'Archiving requires superuser privileges' if not request.has_permission(Permissions.AdminProjectsWrite) }}" {{ "disabled" if not request.has_permission(Permissions.AdminProjectsWrite) or not can_be_archived}}>Archive</button>
-      </div>
-    </form>
+    <div class="float-right">
+      {% if project.lifecycle_status == "archived" %}
+        <form method="POST" action="{{ request.route_path('admin.project.unarchive', project_name=project.name) }}">
+          <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+          <button type="submit" class="btn btn-primary" title="{{ 'Unarchiving requires superuser privileges' if not request.has_permission(Permissions.AdminProjectsWrite) }}" {{ "disabled" if not request.has_permission(Permissions.AdminProjectsWrite) }}>
+            Unarchive project
+          </button>
+        </form>
+      {% else %}
+        <form method="POST" action="{{ request.route_path('admin.project.archive', project_name=project.name) }}">
+          <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+          <button type="submit" class="btn btn-primary {{ 'btn-disabled' if project.lifecycle_status == 'quarantine' }}" title="{{ 'Archiving requires superuser privileges' if not request.has_permission(Permissions.AdminProjectsWrite) }}" {{ "disabled" if not request.has_permission(Permissions.AdminProjectsWrite) }}>
+            Archive project
+          </button>
+        </form>
+      {% endif %}
+    </div>
   </div>
 </div>
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1150,7 +1150,7 @@ msgstr ""
 #: warehouse/templates/manage/project/release.html:182
 #: warehouse/templates/manage/project/settings.html:87
 #: warehouse/templates/manage/project/settings.html:136
-#: warehouse/templates/manage/project/settings.html:394
+#: warehouse/templates/manage/project/settings.html:393
 #: warehouse/templates/manage/team/settings.html:84
 msgid "Warning"
 msgstr ""
@@ -6715,7 +6715,7 @@ msgstr ""
 
 #: warehouse/templates/manage/project/settings.html:108
 #: warehouse/templates/manage/project/settings.html:179
-#: warehouse/templates/manage/project/settings.html:432
+#: warehouse/templates/manage/project/settings.html:431
 msgid "Project Name"
 msgstr ""
 
@@ -6861,12 +6861,12 @@ msgid "Description of the purpose or content of the alternate repository."
 msgstr ""
 
 #: warehouse/templates/manage/project/settings.html:354
-#: warehouse/templates/manage/project/settings.html:371
 #: warehouse/templates/manage/project/settings.html:379
+#: warehouse/templates/manage/project/settings.html:383
 msgid "Archive project"
 msgstr ""
 
-#: warehouse/templates/manage/project/settings.html:359
+#: warehouse/templates/manage/project/settings.html:357
 #, python-format
 msgid ""
 "Archiving a project will prevent any new uploads. Before doing so, we "
@@ -6878,29 +6878,29 @@ msgid ""
 "update the project's description by editing the README file."
 msgstr ""
 
+#: warehouse/templates/manage/project/settings.html:370
 #: warehouse/templates/manage/project/settings.html:374
-#: warehouse/templates/manage/project/settings.html:385
 msgid "Unarchive project"
 msgstr ""
 
-#: warehouse/templates/manage/project/settings.html:380
-msgid "Archiving a project will block any new file uploads"
+#: warehouse/templates/manage/project/settings.html:375
+msgid "Unarchiving a project will allow new file uploads."
 msgstr ""
 
-#: warehouse/templates/manage/project/settings.html:386
-msgid "Unarchiving a project will allow new file uploads"
+#: warehouse/templates/manage/project/settings.html:384
+msgid "Archiving a project will block any new file uploads."
 msgstr ""
 
-#: warehouse/templates/manage/project/settings.html:392
-#: warehouse/templates/manage/project/settings.html:432
+#: warehouse/templates/manage/project/settings.html:391
+#: warehouse/templates/manage/project/settings.html:431
 msgid "Delete project"
 msgstr ""
 
-#: warehouse/templates/manage/project/settings.html:395
+#: warehouse/templates/manage/project/settings.html:394
 msgid "Deleting this project will:"
 msgstr ""
 
-#: warehouse/templates/manage/project/settings.html:400
+#: warehouse/templates/manage/project/settings.html:399
 #, python-format
 msgid ""
 "Irreversibly delete the project along with <a href=\"%(href)s\">%(count)s"
@@ -6911,15 +6911,15 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/project/settings.html:406
+#: warehouse/templates/manage/project/settings.html:405
 msgid "Irreversibly delete the project"
 msgstr ""
 
-#: warehouse/templates/manage/project/settings.html:410
+#: warehouse/templates/manage/project/settings.html:409
 msgid "Make the project name available to <strong>any other PyPI</strong> user"
 msgstr ""
 
-#: warehouse/templates/manage/project/settings.html:412
+#: warehouse/templates/manage/project/settings.html:411
 msgid ""
 "This user will be able to make new releases under this project name, so "
 "long as the distribution filenames do not match filenames from a "

--- a/warehouse/templates/manage/project/settings.html
+++ b/warehouse/templates/manage/project/settings.html
@@ -352,8 +352,6 @@
   <hr>
 
   <h2>{% trans %}Archive project{% endtrans %}</h2>
-  {% set can_be_archived = not project.lifecycle_status or project.lifecycle_status == "quarantine-exit" %}
-  {% set can_be_unarchived = project.lifecycle_status == "archived" %}
   <div class="callout-block callout-block--danger" data-controller="archive-confirm">
   <p>
     {% trans readme_description_href='https://packaging.python.org/guides/making-a-pypi-friendly-readme/'%}
@@ -367,24 +365,25 @@
     {% endtrans %}
   </p>
   </div>
-    <a href="#archive-project" class="button button--primary {{ 'button--disabled' if not can_be_archived }}">
-      {% trans %}Archive project{% endtrans %}
-    </a>
-    <a href="#unarchive-project" class="button button--primary {{ 'button--disabled' if not can_be_unarchived }}">
+  {% if project.lifecycle_status == "archived" %}
+    <a href="#unarchive-project" class="button button--primary">
       {% trans %}Unarchive project{% endtrans %}
     </a>
-
-  {% set action = request.route_path('manage.project.archive', project_name=project.name) %}
-  {% set slug = "archive-project" %}
-  {% set title = gettext("Archive project") %}
-  {% set extra_description = gettext("Archiving a project will block any new file uploads") %}
-  {{ confirm_modal(title=title, label=project.name, slug=slug, extra_description=extra_description, action=action, warning=False) }}
-
-  {% set action = request.route_path('manage.project.unarchive', project_name=project.name) %}
-  {% set slug = "unarchive-project" %}
-  {% set title = gettext("Unarchive project") %}
-  {% set extra_description = gettext("Unarchiving a project will allow new file uploads") %}
-  {{ confirm_modal(title=title, label=project.name, slug=slug, extra_description=extra_description, action=action, warning=False) }}
+    {% set action = request.route_path('manage.project.unarchive', project_name=project.name) %}
+    {% set slug = "unarchive-project" %}
+    {% set title = gettext("Unarchive project") %}
+    {% set extra_description = gettext("Unarchiving a project will allow new file uploads.") %}
+    {{ confirm_modal(title=title, label=project.name, slug=slug, extra_description=extra_description, action=action, warning=False) }}
+  {% else %}
+    <a href="#archive-project" class="button button--primary {{ 'button--disabled' if project.lifecycle_status == 'quarantine' }}">
+      {% trans %}Archive project{% endtrans %}
+    </a>
+    {% set action = request.route_path('manage.project.archive', project_name=project.name) %}
+    {% set slug = "archive-project" %}
+    {% set title = gettext("Archive project") %}
+    {% set extra_description = gettext("Archiving a project will block any new file uploads.") %}
+    {{ confirm_modal(title=title, label=project.name, slug=slug, extra_description=extra_description, action=action, warning=False) }}
+  {% endif %}
 
   <hr>
 


### PR DESCRIPTION
Change the "Archive" and "Unarchive" buttons in the UI (both user and admin) so that they're only a single button. It also adds a missing period to the modal messages (i.e: "will block any new file uploads.")

## Before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/09423c30-e731-4a94-a7aa-a2fe140168b4" />

## After
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f2379f2b-2bc0-48e1-8994-d1da567f72ef" />

cc @woodruffw @miketheman 