### PR TITLE
resolve degenerate n+1 query in manage.project.releases

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -572,6 +572,18 @@ class TestProject:
             == 0
         )
 
+    def test_active_and_yanked_releases(self, db_session):
+        project = DBProjectFactory.create()
+        active_release0 = DBReleaseFactory.create(project=project)
+        active_release1 = DBReleaseFactory.create(project=project)
+        yanked_release0 = DBReleaseFactory.create(project=project, yanked=True)
+
+        assert len(project.active_releases) == len([active_release0, active_release1])
+        assert len(project.yanked_releases) == len([yanked_release0])
+        assert len(project.releases) == len(
+            [active_release0, active_release1, yanked_release0]
+        )
+
 
 class TestDependency:
     def test_repr(self, db_session):

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -474,6 +474,26 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
             .first()
         )
 
+    @property
+    def active_releases(self):
+        return (
+            orm.object_session(self)
+            .query(Release)
+            .filter(Release.project == self, Release.yanked.is_(False))
+            .order_by(Release._pypi_ordering.desc())
+            .all()
+        )
+
+    @property
+    def yanked_releases(self):
+        return (
+            orm.object_session(self)
+            .query(Release)
+            .filter(Release.project == self, Release.yanked.is_(True))
+            .order_by(Release._pypi_ordering.desc())
+            .all()
+        )
+
 
 class DependencyKind(enum.IntEnum):
     requires = 1

--- a/warehouse/templates/includes/manage/manage-project-menu.html
+++ b/warehouse/templates/includes/manage/manage-project-menu.html
@@ -17,7 +17,7 @@
       <a href="{{ request.route_path('manage.project.releases', project_name=project.normalized_name)}}" class="vertical-tabs__tab vertical-tabs__tab--with-icon {% if active_tab == 'releases' %}vertical-tabs__tab--is-active{% endif %} {% if mode == 'mobile' %}vertical-tabs__tab--mobile{% endif %}" {% if active_tab == 'releases' %}aria-selected="true"{% endif %}>
         <i class="fa fa-cube" aria-hidden="true"></i>
         {% trans %}Releases{% endtrans %}
-        <span class="badge badge--neutral">{{ project.releases|rejectattr("yanked")|list|length }}</span>
+        <span class="badge badge--neutral">{{ project.active_releases|length }}</span>
       </a>
     </li>
     <li>

--- a/warehouse/templates/manage/project/release.html
+++ b/warehouse/templates/manage/project/release.html
@@ -33,11 +33,11 @@
   <div class="heading-wsubtitle heading-wsubtitle--in-content">
     <h2 class="heading-wsubtitle__heading">
       {% if not release.yanked %}
-      {% set releases = project.releases|rejectattr("yanked")|list %}
+      {% set releases = project.active_releases %}
       <a href="{{ request.route_path('manage.project.releases', project_name=project.normalized_name)}}">{% trans %}Releases{% endtrans %}</a>
       <span class="badge badge--neutral">{{ releases|length }}</span>
       {% else %}
-      {% set yanked_releases = project.releases|selectattr("yanked")|list %}
+      {% set yanked_releases = project.yanked_releases %}
       <a href="{{ request.route_path('manage.project.releases', project_name=project.normalized_name)}}">{% trans %}Yanked releases{% endtrans %}</a>
       <span class="badge badge--neutral">{{ yanked_releases|length }}</span>
       {% endif %}

--- a/warehouse/templates/manage/project/releases.html
+++ b/warehouse/templates/manage/project/releases.html
@@ -151,7 +151,7 @@
 {% block title %}{% trans project_name=project.name %}Manage '{{ project_name }}' releases{% endtrans %}{% endblock %}
 
 {% block main %}
-{% set releases = project.releases|rejectattr("yanked")|list %}
+{% set releases = project.active_releases %}
   {% if releases %}
   <h2>
     {% trans %}Releases{% endtrans %}
@@ -160,7 +160,7 @@
   {{ release_table(releases) }}
   {% endif %}
 
-  {% set yanked_releases = project.releases|selectattr("yanked")|list %}
+  {% set yanked_releases = project.yanked_releases %}
   {% if yanked_releases %}
   <h2>
     {% trans %}Yanked releases{% endtrans %}


### PR DESCRIPTION
adds helpers for getting all active/yanked releases in one shot, uses that in favor of selectattr/rejectattr in the templates

for worst case I could find in dev db (cs18-sidecar):

Before:

<img width="910" alt="Screenshot 2025-02-05 at 11 16 16 AM" src="https://github.com/user-attachments/assets/44c6cdf1-14e7-4f53-9b5b-f9cfb80d5187" />


After:

<img width="742" alt="Screenshot 2025-02-05 at 11 11 05 AM" src="https://github.com/user-attachments/assets/011c1ffc-011d-4334-afc2-a50d74413d5c" />