### PR TITLE
refactor: extract and narrow `orm.object_session()`

### DIFF
--- a/tests/unit/utils/db/test_orm.py
+++ b/tests/unit/utils/db/test_orm.py
@@ -10,7 +10,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from warehouse.utils.db.orm import orm_session_from_obj
-from warehouse.utils.db.query_printer import print_query
+import pytest
 
-__all__ = ["orm_session_from_obj", "print_query"]
+from sqlalchemy.orm import object_session
+
+from warehouse.db import Model
+from warehouse.utils.db.orm import NoSessionError, orm_session_from_obj
+
+
+def test_orm_session_from_obj_raises_with_no_session():
+
+    class FakeObject(Model):
+        __tablename__ = "fake_object"
+
+    obj = FakeObject()
+    # Confirm that the object does not have a session with the built-in
+    assert object_session(obj) is None
+
+    with pytest.raises(NoSessionError):
+        orm_session_from_obj(obj)

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -40,6 +40,7 @@ from warehouse.events.models import HasEvents
 from warehouse.observations.models import HasObservations, HasObservers, ObservationKind
 from warehouse.sitemap.models import SitemapMixin
 from warehouse.utils.attrs import make_repr
+from warehouse.utils.db import orm_session_from_obj
 from warehouse.utils.db.types import TZDateTime, bool_false, datetime_now
 
 if TYPE_CHECKING:
@@ -236,7 +237,7 @@ class User(SitemapMixin, HasObservers, HasObservations, HasEvents, db.Model):
 
     @property
     def recent_events(self):
-        session = orm.object_session(self)
+        session = orm_session_from_obj(self)
         last_ninety = datetime.datetime.now() - datetime.timedelta(days=90)
         return (
             session.query(User.Event)

--- a/warehouse/cache/origin/__init__.py
+++ b/warehouse/cache/origin/__init__.py
@@ -16,11 +16,10 @@ import operator
 
 from itertools import chain
 
-from sqlalchemy.orm.session import Session
-
 from warehouse import db
 from warehouse.cache.origin.derivers import html_cache_deriver
 from warehouse.cache.origin.interfaces import IOriginCache
+from warehouse.utils.db import orm_session_from_obj
 
 
 @db.listens_for(db.Session, "after_flush")
@@ -139,7 +138,7 @@ def register_origin_cache_keys(config, klass, cache_keys=None, purge_keys=None):
 
 def receive_set(attribute, config, target):
     cache_keys = config.registry["cache_keys"]
-    session = Session.object_session(target)
+    session = orm_session_from_obj(target)
     purges = session.info.setdefault("warehouse.cache.origin.purges", set())
     key_maker = cache_keys[attribute]
     keys = key_maker(target).purge

--- a/warehouse/email/ses/models.py
+++ b/warehouse/email/ses/models.py
@@ -20,10 +20,10 @@ from sqlalchemy import Enum, ForeignKey, orm, sql
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy.orm.session import object_session
 
 from warehouse import db
 from warehouse.accounts.models import Email as EmailAddress, UnverifyReasons
+from warehouse.utils.db import orm_session_from_obj
 from warehouse.utils.db.types import bool_false, datetime_now
 
 MAX_TRANSIENT_BOUNCES = 5
@@ -217,9 +217,9 @@ class EmailStatus:
         if self._email_message.missing:
             return
 
-        db = object_session(self._email_message)
+        session = orm_session_from_obj(self._email_message)
         email = (
-            db.query(EmailAddress)
+            session.query(EmailAddress)
             .filter(EmailAddress.email == self._email_message.to)
             .first()
         )

--- a/warehouse/legacy/api/xmlrpc/cache/__init__.py
+++ b/warehouse/legacy/api/xmlrpc/cache/__init__.py
@@ -14,7 +14,6 @@ import collections
 
 from pyramid.exceptions import ConfigurationError
 from sqlalchemy.orm.base import NO_VALUE
-from sqlalchemy.orm.session import Session
 from urllib3.util import parse_url
 
 from warehouse import db
@@ -23,6 +22,7 @@ from warehouse.legacy.api.xmlrpc.cache.derivers import cached_return_view
 from warehouse.legacy.api.xmlrpc.cache.fncache import RedisLru
 from warehouse.legacy.api.xmlrpc.cache.interfaces import IXMLRPCCache
 from warehouse.legacy.api.xmlrpc.cache.services import NullXMLRPCCache, RedisXMLRPCCache
+from warehouse.utils.db import orm_session_from_obj
 
 __all__ = ["RedisLru"]
 
@@ -32,7 +32,7 @@ CacheKeys = collections.namedtuple("CacheKeys", ["cache", "purge"])
 
 def receive_set(attribute, config, target):
     cache_keys = config.registry["cache_keys"]
-    session = Session.object_session(target)
+    session = orm_session_from_obj(target)
     purges = session.info.setdefault("warehouse.legacy.api.xmlrpc.cache.purges", set())
     key_maker = cache_keys[attribute]
     keys = key_maker(target).purge

--- a/warehouse/utils/db/orm.py
+++ b/warehouse/utils/db/orm.py
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ORM utilities."""
+
+from sqlalchemy.orm import Session, object_session
+
+
+class NoSessionError(Exception):
+    """Raised when there is no active SQLAlchemy session"""
+
+
+def orm_session_from_obj(obj) -> Session:
+    """
+    Returns the session from the ORM object.
+
+    Adds guard, but it should never happen.
+    The guard helps with type hinting, as the object_session function
+    returns Optional[Session] type.
+    """
+    session = object_session(obj)
+    if not session:
+        raise NoSessionError("Object does not have a session")
+    return session


### PR DESCRIPTION
Since `object_session(...)` can return `None`, we need to help mypy have confidence that the session is indeed there.

One way to narrow the type is to assert that it's not `None`, and therefore should not alert about `union-attr` problems.

Includes a couple of renames, and variable extraction where relevant.