### PR TITLE
Add package version support to `/p/` shortlink routing

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -675,6 +675,9 @@ def test_routes(warehouse):
         pretend.call("/u/{username}/", "/user/{username}/", domain=warehouse),
         pretend.call("/2fa/", "/manage/account/two-factor/", domain=warehouse),
         pretend.call("/p/{name}/", "/project/{name}/", domain=warehouse),
+        pretend.call(
+            "/p/{name}/{version}/", "/project/{name}/{version}/", domain=warehouse
+        ),
         pretend.call("/pypi/{name}/", "/project/{name}/", domain=warehouse),
         pretend.call(
             "/pypi/{name}/{version}/", "/project/{name}/{version}/", domain=warehouse

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -517,6 +517,9 @@ def includeme(config):
 
     # Packaging
     config.add_redirect("/p/{name}/", "/project/{name}/", domain=warehouse)
+    config.add_redirect(
+        "/p/{name}/{version}/", "/project/{name}/{version}/", domain=warehouse
+    )
     config.add_route(
         "packaging.project",
         "/project/{name}/",


### PR DESCRIPTION
Does what it says on the tin. I saw +1 from a project member on this simple idea and decided to try making the change myself.

I've made sure that:

- `make tests` still passes
- `make reformat` doesn't make any changes
- Redirection from e.g. `/p/pip/18.0/` -> `/project/pip/18.0/` works correctly in a fresh test instance

Closes #17483.

<details>
<summary>Off-topic: Tooling lament</summary>

This makes me sad all over again that Gitpod is shuttering their fully-hosted cloud IDE product ("Gitpod Classic"). Getting set up for this on that platform took me no time at all; all I had to do was paste a repo URL, type `make build`, and wait a few minutes for `make serve` to spin up so I could test out my patch.

If I want to keep contributing to Warehouse, sadly I will have to find another solution, or figure out getting Docker working on my local (Windows) PC.

</details>