### PR TITLE
db: Make naming of triggers more consistent in prohibited_project_names

### DIFF
--- a/warehouse/migrations/versions/b27b3bb5b4c9_consistent_names_in_prohibited_projects.py
+++ b/warehouse/migrations/versions/b27b3bb5b4c9_consistent_names_in_prohibited_projects.py
@@ -1,0 +1,97 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+consistent names in prohibited projects
+
+Revision ID: b27b3bb5b4c9
+Revises: 6cac7b706953
+Create Date: 2025-02-24 19:31:38.064454
+"""
+
+from alembic import op
+
+revision = "b27b3bb5b4c9"
+down_revision = "6cac7b706953"
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE prohibited_project_names
+        RENAME CONSTRAINT blacklist_name_key TO prohibited_project_names_name_key
+    """)
+
+    op.execute("""
+        ALTER TABLE prohibited_project_names
+        RENAME CONSTRAINT blacklist_pkey TO prohibited_project_names_pkey
+    """)
+
+    op.execute("""
+        ALTER TABLE prohibited_project_names
+        RENAME CONSTRAINT blacklist_blacklisted_by_fkey TO prohibited_project_names_prohibited_by_fkey
+    """)
+
+    op.execute(
+        """ CREATE OR REPLACE FUNCTION ensure_normalized_prohibited_name()
+            RETURNS TRIGGER AS $$
+            BEGIN
+                NEW.name = normalize_pep426_name(NEW.name);
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+        """
+    )
+
+    op.execute("""
+        DROP TRIGGER normalize_blacklist ON prohibited_project_names
+    """)
+
+    op.execute("""
+        CREATE TRIGGER normalize_prohibited_project_name
+        BEFORE INSERT OR UPDATE ON prohibited_project_names
+        FOR EACH ROW EXECUTE FUNCTION public.ensure_normalized_prohibited_name()
+    """)
+
+    op.execute("""
+        DROP FUNCTION IF EXISTS public.ensure_normalized_blacklist()
+    """)
+
+
+def downgrade():
+    # Rename constraints back
+    op.execute("""
+        ALTER TABLE prohibited_project_names
+        RENAME CONSTRAINT prohibited_project_names_name_key TO blacklist_name_key
+    """)
+
+    op.execute("""
+        ALTER TABLE prohibited_project_names
+        RENAME CONSTRAINT prohibited_project_names_pkey TO blacklist_pkey
+    """)
+
+    op.execute("""
+        ALTER TABLE prohibited_project_names
+        RENAME CONSTRAINT prohibited_project_names_prohibited_by_fkey TO blacklist_blacklisted_by_fkey
+    """)
+
+    # Drop new trigger
+    op.execute("""
+        DROP TRIGGER normalize_prohibited_project_name ON prohibited_project_names
+    """)
+
+    # Recreate original trigger using the existing function
+    op.execute("""
+        CREATE TRIGGER normalize_blacklist
+        BEFORE INSERT OR UPDATE ON prohibited_project_names
+        FOR EACH ROW EXECUTE FUNCTION public.ensure_normalized_blacklist()
+    """)
+
+    # Note: We're keeping both functions to avoid breaking anything

--- a/warehouse/migrations/versions/b27b3bb5b4c9_consistent_names_in_prohibited_projects.py
+++ b/warehouse/migrations/versions/b27b3bb5b4c9_consistent_names_in_prohibited_projects.py
@@ -24,20 +24,26 @@ down_revision = "6cac7b706953"
 
 
 def upgrade():
-    op.execute("""
+    op.execute(
+        """
         ALTER TABLE prohibited_project_names
         RENAME CONSTRAINT blacklist_name_key TO prohibited_project_names_name_key
-    """)
+    """
+    )
 
-    op.execute("""
+    op.execute(
+        """
         ALTER TABLE prohibited_project_names
         RENAME CONSTRAINT blacklist_pkey TO prohibited_project_names_pkey
-    """)
+    """
+    )
 
-    op.execute("""
+    op.execute(
+        """
         ALTER TABLE prohibited_project_names
         RENAME CONSTRAINT blacklist_blacklisted_by_fkey TO prohibited_project_names_prohibited_by_fkey
-    """)
+    """
+    )
 
     op.execute(
         """ CREATE OR REPLACE FUNCTION ensure_normalized_prohibited_name()
@@ -50,48 +56,59 @@ def upgrade():
         """
     )
 
-    op.execute("""
+    op.execute(
+        """
         DROP TRIGGER normalize_blacklist ON prohibited_project_names
-    """)
+    """
+    )
 
-    op.execute("""
+    op.execute(
+        """
         CREATE TRIGGER normalize_prohibited_project_name
         BEFORE INSERT OR UPDATE ON prohibited_project_names
         FOR EACH ROW EXECUTE FUNCTION public.ensure_normalized_prohibited_name()
-    """)
+    """
+    )
 
-    op.execute("""
+    op.execute(
+        """
         DROP FUNCTION IF EXISTS public.ensure_normalized_blacklist()
-    """)
+    """
+    )
 
 
 def downgrade():
-    # Rename constraints back
-    op.execute("""
+    op.execute(
+        """
         ALTER TABLE prohibited_project_names
         RENAME CONSTRAINT prohibited_project_names_name_key TO blacklist_name_key
-    """)
+    """
+    )
 
-    op.execute("""
+    op.execute(
+        """
         ALTER TABLE prohibited_project_names
         RENAME CONSTRAINT prohibited_project_names_pkey TO blacklist_pkey
-    """)
+    """
+    )
 
-    op.execute("""
+    op.execute(
+        """
         ALTER TABLE prohibited_project_names
         RENAME CONSTRAINT prohibited_project_names_prohibited_by_fkey TO blacklist_blacklisted_by_fkey
-    """)
+    """
+    )
 
-    # Drop new trigger
-    op.execute("""
+    op.execute(
+        """
         DROP TRIGGER normalize_prohibited_project_name ON prohibited_project_names
-    """)
+    """
+    )
 
-    # Recreate original trigger using the existing function
-    op.execute("""
+    op.execute(
+        """
         CREATE TRIGGER normalize_blacklist
         BEFORE INSERT OR UPDATE ON prohibited_project_names
         FOR EACH ROW EXECUTE FUNCTION public.ensure_normalized_blacklist()
-    """)
-
-    # Note: We're keeping both functions to avoid breaking anything
+    """
+    )


### PR DESCRIPTION
As part of #17607, this PR renames some triggers and functions within the database to make their names more consistent with the current implementation.

This dates back from 0e8f7729161a (2020-06) when the table was renamed, but the constraints were not.

/cc @woodruffw 