### PR TITLE
feat: add index to Provenance.file_id

### DIFF
--- a/warehouse/attestations/models.py
+++ b/warehouse/attestations/models.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 import pypi_attestations
 
-from sqlalchemy import ForeignKey, orm
+from sqlalchemy import ForeignKey, Index, orm
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -51,3 +51,5 @@ class Provenance(db.Model):
     @cached_property
     def as_model(self):
         return pypi_attestations.Provenance.model_validate(self.provenance)
+
+    __table_args__ = (Index("ix_provenance_file_id", file_id),)

--- a/warehouse/migrations/versions/635b80625fc9_add_index_to_provenance_file_id.py
+++ b/warehouse/migrations/versions/635b80625fc9_add_index_to_provenance_file_id.py
@@ -1,0 +1,43 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add index to Provenance.file_id
+
+Revision ID: 635b80625fc9
+Revises: 2f5dbc74c770
+Create Date: 2025-02-28 17:41:58.763011
+"""
+
+from alembic import op
+
+revision = "635b80625fc9"
+down_revision = "2f5dbc74c770"
+
+
+def upgrade():
+    # CREATE INDEX CONCURRENTLY cannot happen inside a transaction. We'll close
+    # our transaction here and issue the statement.
+    op.get_bind().commit()
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_provenance_file_id",
+            "provenance",
+            ["file_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    op.drop_index(
+        "ix_provenance_file_id", table_name="provenance", postgresql_concurrently=True
+    )

--- a/warehouse/migrations/versions/7f0c9f105f44_create_attestations_table.py
+++ b/warehouse/migrations/versions/7f0c9f105f44_create_attestations_table.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 """
 create Attestations table
+
 Revision ID: 7f0c9f105f44
 Revises: 26455e3712a2
 Create Date: 2024-07-25 15:49:01.993869


### PR DESCRIPTION
When used as a JOIN condition in `legacy.api.json.release` for the release's files, the `provenance` table is consulted for any records related to the `file_id`.

Currently unindexed, this is a sequential scan of the table of ~164k rows, and ~87% of the total query cost.

Add an index to what is effectively a primary key to prevent further slowdown as the provenance table grows with more projects publishing.