### PR TITLE
Properly validate & normalize GitHub environment names.

### DIFF
--- a/tests/unit/oidc/forms/test_github.py
+++ b/tests/unit/oidc/forms/test_github.py
@@ -412,7 +412,7 @@ class TestGitHubPublisherForm:
             ("\n", "Environment name must not contain non-printable characters"),
         ],
     )
-    def test_validate_environment(self, environment, expected, monkeypatch):
+    def test_validate_environment_raises(self, environment, expected, monkeypatch):
         request = pretend.stub(
             localizer=pretend.stub(translate=pretend.call_recorder(lambda ts: ts))
         )
@@ -426,6 +426,13 @@ class TestGitHubPublisherForm:
             form.validate_environment(field)
 
         assert str(e.value).startswith(expected)
+
+    @pytest.mark.parametrize("environment", ["", None])
+    def test_validate_environment_passes(self, environment):
+        field = pretend.stub(data=environment)
+        form = github.GitHubPublisherForm(api_token=pretend.stub())
+
+        assert form.validate_environment(field) is None
 
     @pytest.mark.parametrize(
         ("data", "expected"),

--- a/tests/unit/oidc/forms/test_github.py
+++ b/tests/unit/oidc/forms/test_github.py
@@ -430,12 +430,11 @@ class TestGitHubPublisherForm:
     @pytest.mark.parametrize(
         ("data", "expected"),
         [
-            ("wu-tang", "wu-tang"),
-            ("WU-TANG", "wu-tang"),
-            ("", ""),
-            ("  ", ""),
-            ("\t\r\n", ""),
-            (None, ""),
+            ("wu-tang", "wu-tang"),  # Non-alpha characters are preserved
+            ("WU-TANG", "wu-tang"),  # Alpha characters are lowercased
+            ("Foo   Bar", "foo   bar"),  # Whitespace is preserved
+            ("", ""),  # Empty string is empty string
+            (None, ""),  # None and empty string are equivalent
         ],
     )
     def test_normalized_environment(self, data, expected):

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -739,52 +739,70 @@ msgstr ""
 msgid "ActiveState actor not found"
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:32
+#: warehouse/oidc/forms/github.py:33
 msgid "Specify GitHub repository owner (username or organization)"
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:39
+#: warehouse/oidc/forms/github.py:40
 msgid "Specify repository name"
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:41
+#: warehouse/oidc/forms/github.py:42
 msgid "Invalid repository name"
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:48
+#: warehouse/oidc/forms/github.py:49
 msgid "Specify workflow filename"
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:83
+#: warehouse/oidc/forms/github.py:84
 msgid "Unknown GitHub user or organization."
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:94
+#: warehouse/oidc/forms/github.py:95
 msgid "GitHub has rate-limited this action. Try again in a few minutes."
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:103
+#: warehouse/oidc/forms/github.py:104
 msgid "Unexpected error from GitHub. Try again."
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:111
+#: warehouse/oidc/forms/github.py:112
 msgid "Unexpected connection error from GitHub. Try again in a few minutes."
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:120
+#: warehouse/oidc/forms/github.py:121
 msgid "Unexpected timeout from GitHub. Try again in a few minutes."
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:132
+#: warehouse/oidc/forms/github.py:133
 msgid "Invalid GitHub user or organization name."
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:148
+#: warehouse/oidc/forms/github.py:149
 msgid "Workflow name must end with .yml or .yaml"
 msgstr ""
 
-#: warehouse/oidc/forms/github.py:153
+#: warehouse/oidc/forms/github.py:154
 msgid "Workflow filename must be a filename only, without directories"
+msgstr ""
+
+#: warehouse/oidc/forms/github.py:165
+msgid "Environment name is too long (maximum is 255 characters)"
+msgstr ""
+
+#: warehouse/oidc/forms/github.py:170
+msgid "Environment name may not start with whitespace"
+msgstr ""
+
+#: warehouse/oidc/forms/github.py:175
+msgid "Environment name may not end with whitespace"
+msgstr ""
+
+#: warehouse/oidc/forms/github.py:181
+msgid ""
+"Environment name must not contain non-printable characters or the "
+"characters \"'\", \"\"\", \"`\", \",\", \";\", \"\\\""
 msgstr ""
 
 #: warehouse/oidc/forms/gitlab.py:32

--- a/warehouse/oidc/forms/github.py
+++ b/warehouse/oidc/forms/github.py
@@ -21,6 +21,7 @@ from warehouse.oidc.forms._core import PendingPublisherMixin
 
 _VALID_GITHUB_REPO = re.compile(r"^[a-zA-Z0-9-_.]+$")
 _VALID_GITHUB_OWNER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$")
+_INVALID_ENVIRONMENT_CHARS = re.compile(r'[\x00-\x1F\x7F\'"`,;\\]', re.UNICODE)
 
 
 class GitHubPublisherBase(wtforms.Form):
@@ -151,6 +152,35 @@ class GitHubPublisherBase(wtforms.Form):
         if "/" in workflow_filename:
             raise wtforms.validators.ValidationError(
                 _("Workflow filename must be a filename only, without directories")
+            )
+
+    def validate_environment(self, field):
+        environment = field.data
+
+        if not environment:
+            return
+
+        if len(environment) > 255:
+            raise wtforms.validators.ValidationError(
+                _("Environment name is too long (maximum is 255 characters)")
+            )
+
+        if environment.startswith(" "):
+            raise wtforms.validators.ValidationError(
+                _("Environment name may not start with whitespace")
+            )
+
+        if environment.endswith(" "):
+            raise wtforms.validators.ValidationError(
+                _("Environment name may not end with whitespace")
+            )
+
+        if _INVALID_ENVIRONMENT_CHARS.search(environment):
+            raise wtforms.validators.ValidationError(
+                _(
+                    "Environment name must not contain non-printable characters "
+                    'or the characters "\'", """, "`", ",", ";", "\\"'
+                )
             )
 
     @property

--- a/warehouse/oidc/forms/github.py
+++ b/warehouse/oidc/forms/github.py
@@ -185,14 +185,11 @@ class GitHubPublisherBase(wtforms.Form):
 
     @property
     def normalized_environment(self):
+        # The only normalization is due to case-insensitivity.
+        #
         # NOTE: We explicitly do not compare `self.environment.data` to None,
-        # since it might also be falsey via an empty string (or might be
-        # only whitespace, which we also treat as a None case).
-        return (
-            self.environment.data.lower()
-            if self.environment.data and not self.environment.data.isspace()
-            else ""
-        )
+        # since it might also be falsey via an empty string.
+        return self.environment.data.lower() if self.environment.data else ""
 
 
 class PendingGitHubPublisherForm(GitHubPublisherBase, PendingPublisherMixin):


### PR DESCRIPTION
Fixes #17689 by adding several more validators for GitHub environment names.

Also fixes an inconsistency with our environment name normalization, which was not preserving whitespace within the environment name when normalizing them.