### PR TITLE
xmlrpc: don't call xmlrpc methods twice!

### DIFF
--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -212,7 +212,7 @@ class XMLRPCWrappedError(xmlrpc.client.Fault):
 class TypedMapplyViewMapper(MapplyViewMapper):
     def mapply(self, fn, args, kwargs):
         try:
-            validate_call(fn)(*args, **kwargs)
+            return validate_call(fn)(*args, **kwargs)
         except ValidationError as exc:
             raise XMLRPCInvalidParamTypes(
                 "; ".join(
@@ -229,8 +229,6 @@ class TypedMapplyViewMapper(MapplyViewMapper):
                     ]
                 )
             )
-
-        return super().mapply(fn, args, kwargs)
 
 
 @view_config(route_name="xmlrpc.pypi", context=Exception, renderer="xmlrpc")


### PR DESCRIPTION
While looking at https://github.com/pypa/bandersnatch/issues/1897, I did some basic checking on XMLRPC performance and checked on opportunities for optimization of the remaining routes.

I noticed specifically for `list_packages_with_serial` we were running the rather expensive query + dictionary build *twice*.

Turns out it was a misunderstanding of pydantic's validate_call introduced in #14361. validate_call *actually* calls the thing, so we should just return that rather than throwing it away and running it again.