### PR TITLE
Try to optimize xmlrpc further

### DIFF
--- a/warehouse/legacy/api/xmlrpc/cache/derivers.py
+++ b/warehouse/legacy/api/xmlrpc/cache/derivers.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
+import orjson
 
 from warehouse.legacy.api.xmlrpc.cache import interfaces
 
@@ -31,7 +31,7 @@ def cached_return_view(view, info):
             except LookupError:
                 return view(context, request)
             try:
-                key = json.dumps(request.rpc_args[slice_obj])
+                key = orjson.dumps(request.rpc_args[slice_obj])
                 _tag = tag
                 if arg_index is not None:
                     _tag = tag % (tag_processor(str(request.rpc_args[arg_index])))

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -269,8 +269,8 @@ def changelog_since_serial(request, serial: StrictInt):
 
 @xmlrpc_cache_all_projects(method="list_packages_with_serial")
 def list_packages_with_serial(request):
-    serials = request.db.query(Project.name, Project.last_serial).all()
-    return {serial[0]: serial[1] for serial in serials}
+    package_serial_tuples = request.db.query(Project.name, Project.last_serial).all()
+    return dict(package_serial_tuples)
 
 
 # Package querying methods


### PR DESCRIPTION
Couple things to try to shave some time off of the xmlrpc endpoints:

- Caching: migrate from `json` to `orjson` for serialization/deserialization of cache keys/data
- Refactor `list_packages_with_serial` to remove dictionary comprehension... probably no perf gain but it is more readable!