### PR TITLE
refactor: generate the resulting dict in the db

### DIFF
--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -269,8 +269,15 @@ def changelog_since_serial(request, serial: StrictInt):
 
 @xmlrpc_cache_all_projects(method="list_packages_with_serial")
 def list_packages_with_serial(request):
-    serials = request.db.query(Project.name, Project.last_serial).all()
-    return {serial[0]: serial[1] for serial in serials}
+    # Have PostgreSQL create the dictionary directly
+    query = select(
+        func.jsonb_object_agg(Project.name, Project.last_serial).label(
+            "package_serials"
+        )
+    )
+
+    result = request.db.execute(query).scalar()
+    return result or {}
 
 
 # Package querying methods


### PR DESCRIPTION
Reduces response times for this endpoint by 15-20%

I tested by flipping the [cache flag to False](https://github.com/pypi/warehouse/blob/bdfebbb951129e5338da1187457a62dd191f70d0/warehouse/legacy/api/xmlrpc/views.py#L174) and running a bunch of timing calls to the original and this change.

