### PR TITLE
fix: false positive on swapped words

### DIFF
--- a/tests/unit/packaging/test_typosnyper.py
+++ b/tests/unit/packaging/test_typosnyper.py
@@ -29,6 +29,7 @@ from warehouse.packaging.typosnyper import typo_check_name
         ("dateutil-python", ("swapped_words", "python-dateutil")),
         ("numpi", ("common_typos", "numpy")),
         ("requestz", ("common_typos", "requests")),
+        ("python-dateutil", None),  # Pass, swapped_words same as original
     ],
 )
 def test_typo_check_name(name, expected):

--- a/warehouse/packaging/typosnyper.py
+++ b/warehouse/packaging/typosnyper.py
@@ -381,7 +381,7 @@ def _swapped_words(project_name: str, corpus: set[str]) -> TypoCheckMatch:
         # Join the words using `-` to create a new name
         reconstructed = "-".join(p)
         # If the new name is in the list of popular names, return it
-        if reconstructed in corpus:
+        if reconstructed != project_name and reconstructed in corpus:
             return "swapped_words", reconstructed
 
     return None


### PR DESCRIPTION
Surfaced false positives in this check with some recent upload testing. Since the permutations can reconstruct the project name to the same as the input, verify that the reconstructed name differs from input.