### PR TITLE
Skip ratelimits for admin recovery code burns

### DIFF
--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -606,13 +606,14 @@ class DatabaseUserService:
 
         return recovery_codes
 
-    def check_recovery_code(self, user_id, code):
+    def check_recovery_code(self, user_id, code, skip_ratelimits=False):
         self._metrics.increment("warehouse.authentication.recovery_code.start")
 
-        self._check_ratelimits(
-            userid=user_id,
-            tags=["mechanism:check_recovery_code"],
-        )
+        if not skip_ratelimits:
+            self._check_ratelimits(
+                userid=user_id,
+                tags=["mechanism:check_recovery_code"],
+            )
 
         user = self.get_user(user_id)
         stored_recovery_code = self.get_recovery_code(user.id, code)

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -619,7 +619,7 @@ def user_burn_recovery_codes(user, request):
 
         for code in codes:
             try:
-                user_service.check_recovery_code(user.id, code)
+                user_service.check_recovery_code(user.id, code, skip_ratelimits=True)
                 n_burned += 1
             except (BurnedRecoveryCode, InvalidRecoveryCode):
                 pass


### PR DESCRIPTION
We don't actually need ratelimits when admins are checking recovery codes.