### PR TITLE
fix: make event relationship order explicit

### DIFF
--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -198,6 +198,7 @@ class HasEvents:
             passive_deletes=True,
             lazy="dynamic",
             back_populates="source",
+            order_by=f"desc({cls.__name__}Event.time)",
         )
 
     def record_event(self, *, tag, request: Request, additional=None):


### PR DESCRIPTION
Without a default order, some pages in Admin may display events in any order at all by traversing the relationship in a template, making it a little confusing as to what is most recent.

Existing test `test_recent_events` uses `desc` order today, so preserve and make explicit.