### PR TITLE
chore(dev): replace redis with valkey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
           POSTGRES_INITDB_ARGS: '--no-sync --set fsync=off --set full_page_writes=off'
         # Set health checks to wait until postgres has started
         options: --health-cmd "pg_isready --username=postgres --dbname=postgres" --health-interval 10s --health-timeout 5s --health-retries 5
-      redis:
-        image: ${{ (matrix.name == 'Tests') && 'redis:7.0' || '' }}
+      cache:
+        image: ${{ (matrix.name == 'Tests') && 'valkey/valkey:8-alpine' || '' }}
         ports:
           - 6379:6379
       stripe:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
           POSTGRES_INITDB_ARGS: '--no-sync --set fsync=off --set full_page_writes=off'
         # Set health checks to wait until postgres has started
         options: --health-cmd "pg_isready --username=postgres --dbname=postgres" --health-interval 10s --health-timeout 5s --health-retries 5
-      redis:
-        image: ${{ (matrix.name == 'Tests') && 'redis:7.0' || '' }}
+      cache:
+        image: ${{ (matrix.name == 'Tests') && 'valkey/valkey:9-alpine' || '' }}
         ports:
           - 6379:6379
       stripe:

--- a/dev/environment
+++ b/dev/environment
@@ -16,7 +16,7 @@ DATABASE_URL=postgresql+psycopg://postgres@db/warehouse
 
 OPENSEARCH_URL=http://opensearch:9200/development
 
-REDIS_URL=redis://redis:6379
+REDIS_URL=redis://cache:6379
 
 SESSION_SECRET="an insecure development secret"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,8 @@ services:
     ports:
       - "12111:12111"
 
-  redis:
-    image: redis:7.0
-    volumes:
-      - cachedata:/data
+  cache:
+    image: valkey/valkey:8-alpine
 
   opensearch:
     build:
@@ -122,7 +120,7 @@ services:
         condition: service_healthy
       opensearch:
         condition: service_started
-      redis:
+      cache:
         condition: service_started
       stripe:
         condition: service_started
@@ -136,7 +134,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
+      cache:
         condition: service_started
       stripe:
         condition: service_started
@@ -173,7 +171,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
+      cache:
         condition: service_started
 
   rstuf-api:
@@ -182,12 +180,12 @@ services:
       - 8001:80
     stop_signal: SIGKILL
     environment:
-      - RSTUF_BROKER_SERVER=redis://redis/1
-      - RSTUF_REDIS_SERVER=redis://redis
+      - RSTUF_BROKER_SERVER=redis://cache/1
+      - RSTUF_REDIS_SERVER=redis://cache
       - RSTUF_REDIS_SERVER_DB_RESULT=1
       - RSTUF_REDIS_SERVER_DB_REPO_SETTINGS=2
     depends_on:
-      redis:
+      cache:
         condition: service_started
 
   rstuf-worker:
@@ -200,15 +198,15 @@ services:
       - RSTUF_STORAGE_BACKEND=LocalStorage
       - RSTUF_ONLINE_KEY_DIR=/keyvault
       - RSTUF_LOCAL_STORAGE_BACKEND_PATH=/var/opt/repository-service-tuf/storage
-      - RSTUF_BROKER_SERVER=redis://redis/1
-      - RSTUF_REDIS_SERVER=redis://redis
+      - RSTUF_BROKER_SERVER=redis://cache/1
+      - RSTUF_REDIS_SERVER=redis://cache
       - RSTUF_REDIS_SERVER_DB_RESULT=1
       - RSTUF_REDIS_SERVER_DB_REPO_SETTINGS=2
       - RSTUF_SQL_SERVER=postgresql://postgres@db:5432/rstuf
     depends_on:
       db:
         condition: service_healthy
-      redis:
+      cache:
         condition: service_started
 
   static:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,8 @@ services:
     ports:
       - "12111:12111"
 
-  redis:
-    image: redis:7.0
-    volumes:
-      - cachedata:/data
+  cache:
+    image: valkey/valkey:9-alpine
 
   opensearch:
     build:
@@ -106,7 +104,7 @@ services:
         condition: service_healthy
       opensearch:
         condition: service_started
-      redis:
+      cache:
         condition: service_started
       stripe:
         condition: service_started
@@ -120,7 +118,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
+      cache:
         condition: service_started
       stripe:
         condition: service_started
@@ -159,7 +157,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
+      cache:
         condition: service_started
 
   rstuf-api:
@@ -168,12 +166,12 @@ services:
       - 8001:80
     stop_signal: SIGKILL
     environment:
-      - RSTUF_BROKER_SERVER=redis://redis/1
-      - RSTUF_REDIS_SERVER=redis://redis
+      - RSTUF_BROKER_SERVER=redis://cache/1
+      - RSTUF_REDIS_SERVER=redis://cache
       - RSTUF_REDIS_SERVER_DB_RESULT=1
       - RSTUF_REDIS_SERVER_DB_REPO_SETTINGS=2
     depends_on:
-      redis:
+      cache:
         condition: service_started
 
   rstuf-worker:
@@ -186,15 +184,15 @@ services:
       - RSTUF_STORAGE_BACKEND=LocalStorage
       - RSTUF_ONLINE_KEY_DIR=/keyvault
       - RSTUF_LOCAL_STORAGE_BACKEND_PATH=/var/opt/repository-service-tuf/storage
-      - RSTUF_BROKER_SERVER=redis://redis/1
-      - RSTUF_REDIS_SERVER=redis://redis
+      - RSTUF_BROKER_SERVER=redis://cache/1
+      - RSTUF_REDIS_SERVER=redis://cache
       - RSTUF_REDIS_SERVER_DB_RESULT=1
       - RSTUF_REDIS_SERVER_DB_REPO_SETTINGS=2
       - RSTUF_SQL_SERVER=postgresql://postgres@db:5432/rstuf
     depends_on:
       db:
         condition: service_healthy
-      redis:
+      cache:
         condition: service_started
 
   static:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ allow-unsafe = true
 
 [tool.pytest]
 addopts = [
-  "--allow-hosts=localhost,::1,stripe,redis",
+  "--allow-hosts=localhost,::1,stripe,cache",
   "--disable-socket",
   "--durations=20",
   "--numprocesses=auto",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ allow-unsafe = true
 
 [tool.pytest]
 addopts = [
-  "--allow-hosts=localhost,::1,stripe,redis",
+  "--allow-hosts=localhost,::1,stripe,cache",
   "--disable-socket",
   "--durations=20",
   "--numprocesses=auto",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -326,7 +326,7 @@ def get_app_config(database, nondefaults=None):
         "database.url": database,
         "docs.url": "http://docs.example.com/",
         "ratelimit.url": "memory://",
-        "db_results_cache.url": "redis://redis:0/",
+        "db_results_cache.url": "redis://cache:0/",
         "opensearch.url": "https://localhost/warehouse",
         "files.backend": "warehouse.packaging.services.LocalFileStorage",
         "archive_files.backend": "warehouse.packaging.services.LocalArchiveFileStorage",
@@ -419,8 +419,8 @@ def app_config_dbsession_from_env(database):
         "breached_passwords.backend": "warehouse.accounts.services.NullPasswordBreachedService",  # noqa: E501
         "token.email.secret": "insecure token",
         "token.two_factor.secret": "insecure token",
-        # A running redis service is required for functional web sessions
-        "sessions.url": "redis://redis:0/",
+        # A running redis-like service is required for functional web sessions
+        "sessions.url": "redis://cache:0/",
     }
 
     return get_app_config(database, nondefaults)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -381,7 +381,7 @@ def get_app_config(database, nondefaults=None):
         "database.url": database,
         "docs.url": "http://docs.example.com/",
         "ratelimit.url": "memory://",
-        "db_results_cache.url": "redis://redis:0/",
+        "db_results_cache.url": "redis://cache:0/",
         "opensearch.url": "https://localhost/warehouse",
         "files.backend": "warehouse.packaging.services.LocalFileStorage",
         "archive_files.backend": "warehouse.packaging.services.LocalArchiveFileStorage",
@@ -474,8 +474,8 @@ def app_config_dbsession_from_env(database):
         "breached_passwords.backend": "warehouse.accounts.services.NullPasswordBreachedService",  # noqa: E501
         "token.email.secret": "insecure token",
         "token.two_factor.secret": "insecure token",
-        # A running redis service is required for functional web sessions
-        "sessions.url": "redis://redis:0/",
+        # A running redis-like service is required for functional web sessions
+        "sessions.url": "redis://cache:0/",
     }
 
     return get_app_config(database, nondefaults)


### PR DESCRIPTION
As part of the changeover, replace most of the references to `redis` as a service concept to `cache` since that is what function it performs.

Refs: https://github.com/pypi/warehouse/issues/17860