### PR TITLE
Remove `UnbustableError`

### DIFF
--- a/tests/unit/utils/test_static.py
+++ b/tests/unit/utils/test_static.py
@@ -10,9 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-from warehouse.utils.static import ManifestCacheBuster, UnbustableError
+from warehouse.utils.static import ManifestCacheBuster
 
 
 class TestManifestCacheBuster:
@@ -27,12 +25,11 @@ class TestManifestCacheBuster:
 
         assert result == ("/the/busted/path/style.css", {"keyword": "arg"})
 
-    def test_raises_when_invalid(self, monkeypatch):
+    def test_passes_when_invalid(self, monkeypatch):
         monkeypatch.setattr(ManifestCacheBuster, "get_manifest", lambda x: {})
         cb = ManifestCacheBuster("warehouse:static/dist/manifest.json")
 
-        with pytest.raises(UnbustableError):
-            cb(None, "/the/path/style.css", {"keyword": "arg"})
+        cb(None, "/the/path/style.css", {"keyword": "arg"})
 
     def test_returns_when_invalid_and_not_strict(self, monkeypatch):
         monkeypatch.setattr(ManifestCacheBuster, "get_manifest", lambda x: {})

--- a/warehouse/utils/static.py
+++ b/warehouse/utils/static.py
@@ -14,10 +14,6 @@
 from pyramid.static import ManifestCacheBuster as _ManifestCacheBuster
 
 
-class UnbustableError(ValueError):
-    pass
-
-
 class ManifestCacheBuster(_ManifestCacheBuster):
     def __init__(self, *args, strict=True, **kwargs):
         super().__init__(*args, **kwargs)
@@ -32,12 +28,3 @@ class ManifestCacheBuster(_ManifestCacheBuster):
             # just fall back to the un-cachebusted path.
             if not self.strict:
                 return subpath, kw
-
-            # We raise an error here even though the one from Pyramid does not.
-            # This is done because we want to be strict that all static files
-            # must be cache busted otherwise it is likely an error of some kind
-            # and should be remedied and without a loud error it's unlikely to
-            # be noticed.
-            raise UnbustableError(
-                f"{subpath} is not able to be cache busted."
-            ) from None


### PR DESCRIPTION
This has proven to be annoying when users attempt to access static assets that don't exist.

Fixes [WAREHOUSE-PRODUCTION-25S](https://python-software-foundation.sentry.io/issues/6325264272/).