### PR TITLE
Prevent user-submitted garbage in locale fields

### DIFF
--- a/tests/unit/i18n/test_init.py
+++ b/tests/unit/i18n/test_init.py
@@ -126,6 +126,24 @@ def test_when_locale_is_missing(monkeypatch):
             ),
             "fake-locale-best-match",
         ),
+        (
+            pretend.stub(
+                params={}, cookies={}, _LOCALE_="garbage", accept_language=None
+            ),
+            None,
+        ),
+        (
+            pretend.stub(
+                params={"_LOCALE_": "garbage"}, cookies={}, accept_language=None
+            ),
+            None,
+        ),
+        (
+            pretend.stub(
+                params={}, cookies={"_LOCALE_": "garbage"}, accept_language=None
+            ),
+            None,
+        ),
     ],
 )
 def test_negotiate_locale(monkeypatch, req, expected):

--- a/tests/unit/i18n/test_init.py
+++ b/tests/unit/i18n/test_init.py
@@ -106,29 +106,30 @@ def test_when_locale_is_missing(monkeypatch):
     assert i18n._locale(request) is locale_obj
 
 
-def test_negotiate_locale(monkeypatch):
-    request = pretend.stub(_LOCALE_="fake-locale-attr")
-    assert i18n._negotiate_locale(request) == "fake-locale-attr"
-
-    request = pretend.stub(params={"_LOCALE_": "fake-locale-param"})
-    assert i18n._negotiate_locale(request) == "fake-locale-param"
-
-    request = pretend.stub(params={}, cookies={"_LOCALE_": "fake-locale-cookie"})
-    assert i18n._negotiate_locale(request) == "fake-locale-cookie"
-
-    request = pretend.stub(params={}, cookies={}, accept_language=None)
-    default_locale_negotiator = pretend.call_recorder(lambda r: "fake-locale-default")
-    monkeypatch.setattr(i18n, "default_locale_negotiator", default_locale_negotiator)
-    assert i18n._negotiate_locale(request) == "fake-locale-default"
-
-    request = pretend.stub(
-        params={},
-        cookies={},
-        accept_language=pretend.stub(
-            best_match=pretend.call_recorder(lambda *a, **kw: "fake-locale-best-match")
+@pytest.mark.parametrize(
+    ("req", "expected"),
+    [
+        (pretend.stub(_LOCALE_="eo", accept_language=None), "eo"),
+        (pretend.stub(params={"_LOCALE_": "eo"}, accept_language=None), "eo"),
+        (
+            pretend.stub(params={}, cookies={"_LOCALE_": "eo"}, accept_language=None),
+            "eo",
         ),
-    )
-    assert i18n._negotiate_locale(request) == "fake-locale-best-match"
+        (pretend.stub(params={}, cookies={}, accept_language=None), None),
+        (
+            pretend.stub(
+                params={},
+                cookies={},
+                accept_language=pretend.stub(
+                    best_match=lambda *a, **kw: "fake-locale-best-match"
+                ),
+            ),
+            "fake-locale-best-match",
+        ),
+    ],
+)
+def test_negotiate_locale(monkeypatch, req, expected):
+    assert i18n._negotiate_locale(req) == expected
 
 
 def test_localize(monkeypatch):

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -80,24 +80,17 @@ def _locale(request):
 
 
 def _negotiate_locale(request):
-    locale_name = getattr(request, LOCALE_ATTR, None)
-    if locale_name is not None:
-        return locale_name
-
-    locale_name = request.params.get(LOCALE_ATTR)
-    if locale_name is not None:
-        return locale_name
-
-    locale_name = request.cookies.get(LOCALE_ATTR)
-    if locale_name is not None:
-        return locale_name
-
     if not request.accept_language:
-        return default_locale_negotiator(request)
+        locale_name = default_locale_negotiator(request)
+        if locale_name in KNOWN_LOCALES:
+            return locale_name
+    else:
+        return request.accept_language.best_match(
+            tuple(KNOWN_LOCALES.keys()),
+            default_match=default_locale_negotiator(request),
+        )
 
-    return request.accept_language.best_match(
-        tuple(KNOWN_LOCALES.keys()), default_match=default_locale_negotiator(request)
-    )
+    return None
 
 
 def _localize(request, message, **kwargs):


### PR DESCRIPTION
This PR ensures we only negotiate _known_ locales, and don't ever try to use a user-submitted locale that doesn't match a known locale.

It also simplifies local negotiation, since we were doing the same thing as the default locale negotiator: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/i18n.html#default-locale-negotiator 

Fixes [WAREHOUSE-PRODUCTION-272](https://python-software-foundation.sentry.io/issues/6494130756/events/3420895ff2b14e1c93baa305291e6ddc/).