### PR TITLE
Don't skip normal locale negotiation if `Accept-Language` is set

### DIFF
--- a/tests/unit/i18n/test_init.py
+++ b/tests/unit/i18n/test_init.py
@@ -150,6 +150,13 @@ def test_when_locale_is_missing(monkeypatch):
             ),
             "he",
         ),
+        (
+            pretend.stub(
+                _LOCALE_="garbage",
+                accept_language=AcceptLanguageValidHeader(header_value="xx"),
+            ),
+            None,
+        ),
     ],
 )
 def test_negotiate_locale(monkeypatch, req, expected):

--- a/tests/unit/i18n/test_init.py
+++ b/tests/unit/i18n/test_init.py
@@ -15,6 +15,7 @@ import pytest
 
 from pyramid import viewderivers
 from pyramid.i18n import Localizer
+from webob.acceptparse import AcceptLanguageValidHeader
 
 from warehouse import i18n
 from warehouse.i18n.extensions import FallbackInternationalizationExtension
@@ -143,6 +144,13 @@ def test_when_locale_is_missing(monkeypatch):
                 params={}, cookies={"_LOCALE_": "garbage"}, accept_language=None
             ),
             None,
+        ),
+        (
+            pretend.stub(
+                _LOCALE_="he",
+                accept_language=AcceptLanguageValidHeader(header_value="eo"),
+            ),
+            "he",
         ),
     ],
 )

--- a/tests/unit/i18n/test_init.py
+++ b/tests/unit/i18n/test_init.py
@@ -121,11 +121,9 @@ def test_when_locale_is_missing(monkeypatch):
             pretend.stub(
                 params={},
                 cookies={},
-                accept_language=pretend.stub(
-                    best_match=lambda *a, **kw: "fake-locale-best-match"
-                ),
+                accept_language=AcceptLanguageValidHeader(header_value="eo"),
             ),
-            "fake-locale-best-match",
+            "eo",
         ),
         (
             pretend.stub(

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -80,11 +80,11 @@ def _locale(request):
 
 
 def _negotiate_locale(request):
-    if not request.accept_language:
-        locale_name = default_locale_negotiator(request)
-        if locale_name in KNOWN_LOCALES:
-            return locale_name
-    else:
+    locale_name = default_locale_negotiator(request)
+    if locale_name in KNOWN_LOCALES:
+        return locale_name
+
+    if request.accept_language:
         return request.accept_language.best_match(
             tuple(KNOWN_LOCALES.keys()),
             default_match=default_locale_negotiator(request),

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -85,10 +85,7 @@ def _negotiate_locale(request):
         return locale_name
 
     if request.accept_language:
-        return request.accept_language.best_match(
-            tuple(KNOWN_LOCALES.keys()),
-            default_match=default_locale_negotiator(request),
-        )
+        return request.accept_language.best_match(tuple(KNOWN_LOCALES.keys()))
 
     return None
 


### PR DESCRIPTION
This PR fixes #17965 by ensuring that the presence of `Accept-Language` doesn't potentially bypass normal local negotiation. (a119f48bb736701f736e76a97c4410103224c837).

This brings the locale negotiation pattern more in line with https://github.com/pypi/infra/blob/d5374e6e92f5a09729d649a0a587935d19f2d76f/terraform/warehouse/vcl/main.vcl#L160-L174

It also fixes another potential avenue for a user-submitted 'garbage' locale being used that was missed in #17947 (351d78f99e47963eeccf712f68c62337b3348c78).