### PR TITLE
test: add pytest-mock

### DIFF
--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -4,6 +4,7 @@ freezegun
 pretend
 pytest>=3.0.0
 pytest-icdiff
+pytest-mock
 pytest-postgresql>=3.1.3,<8.0.0
 pytest-randomly
 pytest-socket

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -252,6 +252,7 @@ pytest==8.3.5 \
     # via
     #   -r requirements/tests.in
     #   pytest-icdiff
+    #   pytest-mock
     #   pytest-postgresql
     #   pytest-randomly
     #   pytest-socket
@@ -260,6 +261,10 @@ pytest==8.3.5 \
 pytest-icdiff==0.9 \
     --hash=sha256:13aede616202e57fcc882568b64589002ef85438046f012ac30a8d959dac8b75 \
     --hash=sha256:efee0da3bd1b24ef2d923751c5c547fbb8df0a46795553fba08ef57c3ca03d82
+    # via -r requirements/tests.in
+pytest-mock==3.14.0 \
+    --hash=sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f \
+    --hash=sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0
     # via -r requirements/tests.in
 pytest-postgresql==7.0.1 \
     --hash=sha256:7723dfbfc57ea6f6f9876c2828e7b36f8b0e60b6cb040b1ddd444a60eed06e0a \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -550,8 +550,10 @@ def search_service():
 
 
 @pytest.fixture
-def domain_status_service():
-    return account_services.NullDomainStatusService()
+def domain_status_service(mocker):
+    service = account_services.NullDomainStatusService()
+    mocker.spy(service, "get_domain_status")
+    return service
 
 
 class QueryRecorder:

--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -1542,7 +1542,7 @@ class TestUserBurnRecoveryCodes:
 
 
 class TestUserEmailDomainCheck:
-    def test_user_email_domain_check(self, db_request):
+    def test_user_email_domain_check(self, db_request, domain_status_service):
         user = UserFactory.create(with_verified_primary_email=True)
         db_request.POST["email_address"] = user.primary_email.email
         db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/foobar")
@@ -1562,3 +1562,12 @@ class TestUserEmailDomainCheck:
         ]
         assert user.primary_email.domain_last_checked is not None
         assert user.primary_email.domain_last_status == ["active"]
+
+        # Total calls
+        assert domain_status_service.get_domain_status.call_count == 1
+        # most recent return value
+        assert domain_status_service.get_domain_status.spy_return == ["active"]
+        # all return values
+        assert domain_status_service.get_domain_status.spy_return_list == [["active"]]
+        # most recent exception
+        assert domain_status_service.get_domain_status.spy_exception is None


### PR DESCRIPTION
See https://pytest-mock.readthedocs.io/

Example of using `mocker` fixture to add a `mocker.spy` for a single function and asserting its calls in the test.