### PR TITLE
feat: add periodic task to update domain statuses

### DIFF
--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -4,6 +4,7 @@ freezegun
 pretend
 pytest>=3.0.0
 pytest-icdiff
+pytest-mock
 pytest-postgresql>=3.1.3,<8.0.0
 pytest-randomly
 pytest-socket

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -252,6 +252,7 @@ pytest==8.3.5 \
     # via
     #   -r requirements/tests.in
     #   pytest-icdiff
+    #   pytest-mock
     #   pytest-postgresql
     #   pytest-randomly
     #   pytest-socket
@@ -260,6 +261,10 @@ pytest==8.3.5 \
 pytest-icdiff==0.9 \
     --hash=sha256:13aede616202e57fcc882568b64589002ef85438046f012ac30a8d959dac8b75 \
     --hash=sha256:efee0da3bd1b24ef2d923751c5c547fbb8df0a46795553fba08ef57c3ca03d82
+    # via -r requirements/tests.in
+pytest-mock==3.14.0 \
+    --hash=sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f \
+    --hash=sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0
     # via -r requirements/tests.in
 pytest-postgresql==7.0.1 \
     --hash=sha256:7723dfbfc57ea6f6f9876c2828e7b36f8b0e60b6cb040b1ddd444a60eed06e0a \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -550,8 +550,10 @@ def search_service():
 
 
 @pytest.fixture
-def domain_status_service():
-    return account_services.NullDomainStatusService()
+def domain_status_service(mocker):
+    service = account_services.NullDomainStatusService()
+    mocker.spy(service, "get_domain_status")
+    return service
 
 
 class QueryRecorder:

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -32,7 +32,11 @@ from warehouse.accounts.services import (
     TokenServiceFactory,
     database_login_factory,
 )
-from warehouse.accounts.tasks import compute_user_metrics, notify_users_of_tos_update
+from warehouse.accounts.tasks import (
+    batch_update_email_domain_status,
+    compute_user_metrics,
+    notify_users_of_tos_update,
+)
 from warehouse.accounts.utils import UserContext
 from warehouse.admin.flags import AdminFlagValue
 from warehouse.macaroons.security_policy import MacaroonSecurityPolicy
@@ -215,3 +219,5 @@ def includeme(config):
     # Add a periodic task to generate Account metrics
     config.add_periodic_task(crontab(minute="*/20"), compute_user_metrics)
     config.add_periodic_task(crontab(minute="*"), notify_users_of_tos_update)
+    # TODO: After initial backfill, this can be done less frequently
+    config.add_periodic_task(crontab(minute="*/5"), batch_update_email_domain_status)

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -427,6 +427,7 @@ class Email(db.ModelBase):
     # Domain validation information
     domain_last_checked: Mapped[datetime.datetime | None] = mapped_column(
         comment="Last time domain was checked with the domain validation service.",
+        index=True,
     )
     domain_last_status: Mapped[list[str] | None] = mapped_column(
         ARRAY(String),

--- a/warehouse/accounts/utils.py
+++ b/warehouse/accounts/utils.py
@@ -12,10 +12,17 @@
 
 from __future__ import annotations
 
+import datetime
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from warehouse.accounts.models import Email
+from warehouse.accounts.services import IDomainStatusService
+
 if TYPE_CHECKING:
+    from pyramid.request import Request
+
     from warehouse.accounts.models import User
     from warehouse.macaroons.models import Macaroon
 
@@ -44,3 +51,17 @@ class UserContext:
 
     def __principals__(self) -> list[str]:
         return self.user.__principals__()
+
+
+def update_email_domain_status(email: Email, request: Request) -> None:
+    """
+    Update the domain status of the given email address.
+    """
+    domain_status_service = request.find_service(IDomainStatusService)
+    domain_status = domain_status_service.get_domain_status(email.domain)
+
+    email.domain_last_checked = datetime.datetime.now(datetime.UTC)
+    email.domain_last_status = domain_status
+    request.db.add(email)
+
+    return None

--- a/warehouse/migrations/versions/c8384ca429fc_add_index_to_email_domain_last_checked.py
+++ b/warehouse/migrations/versions/c8384ca429fc_add_index_to_email_domain_last_checked.py
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add Index to Email.domain_last_checked
+
+Revision ID: c8384ca429fc
+Revises: f609b35e981b
+Create Date: 2025-04-22 18:36:03.844860
+"""
+
+from alembic import op
+
+revision = "c8384ca429fc"
+down_revision = "f609b35e981b"
+
+
+def upgrade():
+    op.create_index(
+        op.f("ix_user_emails_domain_last_checked"),
+        "user_emails",
+        ["domain_last_checked"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_user_emails_domain_last_checked"), table_name="user_emails")


### PR DESCRIPTION
Introduces a task to periodically update the domain status of email addresses and includes several supporting changes to the codebase. The most significant updates involve adding a periodic task for batch domain status updates, refactoring domain status update logic into a reusable utility function, and optimizing database queries with a new index.

See each commit message for further details.