### PR TITLE
chore: remove alt text from sponsor images

### DIFF
--- a/tests/unit/sponsors/test_models.py
+++ b/tests/unit/sponsors/test_models.py
@@ -15,10 +15,7 @@ from ...common.db.sponsors import SponsorFactory
 
 def test_sponsor_color_logo_img_tag(db_request):
     sponsor = SponsorFactory.create()
-    expected = (
-        f'<img src="{sponsor.color_logo_url}"'
-        + f' alt="{sponsor.name}" loading="lazy">'
-    )
+    expected = f'<img src="{sponsor.color_logo_url}" alt="" loading="lazy">'
     assert sponsor.color_logo_img == expected
 
 
@@ -26,7 +23,7 @@ def test_sponsor_white_logo_img_tag(db_request):
     sponsor = SponsorFactory.create()
     expected = (
         f'<img class="sponsors__image" src="{sponsor.white_logo_url}"'
-        + f' alt="{sponsor.name}" loading="lazy">'
+        + ' alt="" loading="lazy">'
     )
     assert sponsor.white_logo_img == expected
 

--- a/warehouse/sponsors/models.py
+++ b/warehouse/sponsors/models.py
@@ -48,7 +48,7 @@ class Sponsor(db.Model):
 
     @property
     def color_logo_img(self):
-        return f'<img src="{self.color_logo_url}" alt="{self.name}" loading="lazy">'
+        return f'<img src="{self.color_logo_url}" alt="" loading="lazy">'
 
     @property
     def white_logo_img(self):
@@ -56,7 +56,7 @@ class Sponsor(db.Model):
             return ""
         return (
             '<img class="sponsors__image" '
-            + f'src="{self.white_logo_url}" alt="{self.name}" loading="lazy">'
+            + f'src="{self.white_logo_url}" alt="" loading="lazy">'
         )
 
     @property


### PR DESCRIPTION
WAVE recommends removing duplicate alt text when the image is accompanies by identical text.