### PR TITLE
fix: handle errors in the body of the response

### DIFF
--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -1700,6 +1700,32 @@ class TestDomainrDomainStatusService:
             )
         ]
 
+    def test_domainr_response_contains_errors_returns_none(self):
+        response = pretend.stub(
+            json=lambda: {
+                "status": [],
+                "errors": [{
+                    "code": 400,
+                    "detail": "unknown zone: ocm",
+                    "message": "Bad request"
+                }],
+            },
+            raise_for_status=lambda: None,
+        )
+        session = pretend.stub(get=pretend.call_recorder(lambda *a, **kw: response))
+        svc = services.DomainrDomainStatusService(
+            session=session, client_id="some_client_id"
+        )
+
+        assert svc.get_domain_status("example.ocm") is None
+        assert session.get.calls == [
+            pretend.call(
+                "https://api.domainr.com/v2/status",
+                params={"client_id": "some_client_id", "domain": "example.ocm"},
+                timeout=5,
+            )
+        ]
+
     def test_factory(self):
         context = pretend.stub()
         request = pretend.stub(

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -1704,11 +1704,13 @@ class TestDomainrDomainStatusService:
         response = pretend.stub(
             json=lambda: {
                 "status": [],
-                "errors": [{
-                    "code": 400,
-                    "detail": "unknown zone: ocm",
-                    "message": "Bad request"
-                }],
+                "errors": [
+                    {
+                        "code": 400,
+                        "detail": "unknown zone: ocm",
+                        "message": "Bad request",
+                    }
+                ],
             },
             raise_for_status=lambda: None,
         )

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -1008,4 +1008,8 @@ class DomainrDomainStatusService:
             logger.warning("Error contacting Domainr: %r", exc)
             return None
 
+        if errors := resp.json().get("errors"):
+            logger.warning("Error from Domainr: %r", errors)
+            return None
+
         return resp.json()["status"][0]["status"].split()


### PR DESCRIPTION
The request completes with a HTTP 200 response, but provides errors in the body of the response.

Fixes WAREHOUSE-PRODUCTION-27Y