### PR TITLE
feat(admin): add modal to delete an email address

### DIFF
--- a/tests/unit/admin/test_routes.py
+++ b/tests/unit/admin/test_routes.py
@@ -102,6 +102,13 @@ def test_includeme():
             traverse="/{username}",
         ),
         pretend.call(
+            "admin.user.delete_email",
+            "/admin/users/{username}/delete_email/",
+            domain=warehouse,
+            factory="warehouse.accounts.models:UserFactory",
+            traverse="/{username}",
+        ),
+        pretend.call(
             "admin.user.delete",
             "/admin/users/{username}/delete/",
             domain=warehouse,

--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -1600,23 +1600,3 @@ class TestUserEmailDelete:
         assert db_request.session.flash.calls == [
             pretend.call("Email not found", queue="error")
         ]
-
-    def test_user_email_not_associated_with_user_fails(self, db_request):
-        user = UserFactory.create(with_verified_primary_email=True)
-        email = EmailFactory.create(user=user, primary=False, verified=False)
-        other_user = UserFactory.create()
-
-        db_request.POST["email_address"] = email.email
-        db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/foobar")
-        db_request.session = pretend.stub(
-            flash=pretend.call_recorder(lambda *a, **kw: None)
-        )
-
-        result = views.user_email_delete(other_user, db_request)
-
-        assert isinstance(result, HTTPSeeOther)
-        assert result.headers["Location"] == "/foobar"
-        assert db_request.session.flash.calls == [
-            pretend.call("Email not associated with user", queue="error")
-        ]
-        assert email in user.emails

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -100,6 +100,13 @@ def includeme(config):
         traverse="/{username}",
     )
     config.add_route(
+        "admin.user.delete_email",
+        "/admin/users/{username}/delete_email/",
+        domain=warehouse,
+        factory="warehouse.accounts.models:UserFactory",
+        traverse="/{username}",
+    )
+    config.add_route(
         "admin.user.delete",
         "/admin/users/{username}/delete/",
         domain=warehouse,

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -556,6 +556,12 @@
                             <i class="fa fa-times text-red"></i> Unverify Reason: {{ field.unverify_reason.data.value }}
                           </div>
                         {% endif %}
+                        <button type="button"
+                                class="btn btn-sm btn-danger"
+                                data-toggle="modal"
+                                data-target="#deleteEmail-{{ field.email.id }}">
+                          <i class="fa fa-trash"></i>
+                        </button>
                       </div>
                       <div class="row">
                         <div class="col-sm">Domain Status: {{ field.domain_last_status.data }}</div>
@@ -1091,5 +1097,38 @@
         </div>
       </form>
     </div>
+
+    <div class="modal fade"
+         id="deleteEmail-{{ email.id }}-email"
+          tabindex="-1"
+          role="dialog">
+      <form method="POST"
+            action="{{ request.route_path('admin.user.delete_email', username=user.username, email_address=email.email.data) }}">
+        <input name="csrf_token"
+               type="hidden"
+               value="{{ request.session.get_csrf_token() }}">
+        <input name="email_address" type="hidden" value="{{ email.email.data }}">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title" id="deleteEmailModalLabel">Delete email?</h4>
+              <button type="button" class="close" data-dismiss="modal">
+                <span>&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p>Are you sure you want to delete this email address?</p>
+              <p>Email address:</p>
+              <code>{{ email.email.data }}</code>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+              <button type="submit" class="btn btn-danger">Delete</button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+
   {% endfor %}
 {% endblock %}

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -317,16 +317,12 @@ def user_add_email(user, request):
 )
 def user_email_delete(user: User, request: Request) -> HTTPSeeOther:
     email = request.db.scalar(
-        select(Email).where(Email.email == request.POST.get("email_address"))
+        select(Email).where(
+            Email.email == request.POST.get("email_address"), Email.user == user
+        )
     )
     if not email:
         request.session.flash("Email not found", queue="error")
-        return HTTPSeeOther(
-            request.route_path("admin.user.detail", username=user.username)
-        )
-
-    if email not in user.emails:
-        request.session.flash("Email not associated with user", queue="error")
         return HTTPSeeOther(
             request.route_path("admin.user.detail", username=user.username)
         )


### PR DESCRIPTION
In some cases, removing an email address is desirable, such as when the user has already added a correct second address to their account, and editing the existing invalid one would be a duplicate record.