### PR TITLE
feat(dev): add names for persistent volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ volumes:
   policies:
   caches:
   rstuf-metadata:
+  pgdata:
+  cachedata:
 
 services:
   db:
@@ -21,6 +23,7 @@ services:
       interval: 1s
       start_period: 10s
     volumes:
+      - pgdata:/var/lib/postgresql/data
       - ./dev/db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:z
       - ./dev/example.sql.xz:/example.sql.xz:z
       - ./dev/db/post-migrations.sql:/post-migrations.sql:z
@@ -33,6 +36,8 @@ services:
 
   redis:
     image: redis:7.0
+    volumes:
+      - cachedata:/data
 
   opensearch:
     build:


### PR DESCRIPTION
Helps with identifying which volume is associated with which service. Instead of a random hash, volumes will now appear with the project name as a prefix, like so:

    $ docker volume ls
    ...
    local     warehouse_cachedata
    ...
    local     warehouse_pgdata
    ...