### PR TITLE
chore: remove setuptools/wheel installation in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,12 +65,9 @@ RUN set -x \
 # our $PATH to refer to it first.
 ENV PATH="/opt/warehouse/bin:${PATH}"
 
-# Next, we want to update pip, setuptools, and wheel inside of this virtual
+# Next, we want to update pip and wheel inside of this virtual
 # environment to ensure that we have the latest versions of them.
-# TODO: We use --require-hashes in our requirements files, but not here, making
-#       the ones in the requirements files kind of a moot point. We should
-#       probably pin these too, and update them as we do anything else.
-RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip setuptools wheel
+RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip wheel
 
 # We copy this into the docker container prior to copying in the rest of our
 # application so that we can skip installing requirements if the only thing
@@ -149,12 +146,9 @@ RUN set -x \
 # our $PATH to refer to it first.
 ENV PATH="/opt/warehouse/bin:${PATH}"
 
-# Next, we want to update pip, setuptools, and wheel inside of this virtual
+# Next, we want to update pip and wheel inside of this virtual
 # environment to ensure that we have the latest versions of them.
-# TODO: We use --require-hashes in our requirements files, but not here, making
-#       the ones in the requirements files kind of a moot point. We should
-#       probably pin these too, and update them as we do anything else.
-RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip setuptools wheel
+RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip wheel
 
 # We copy this into the docker container prior to copying in the rest of our
 # application so that we can skip installing requirements if the only thing

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,9 @@ RUN set -x \
 # our $PATH to refer to it first.
 ENV PATH="/opt/warehouse/bin:${PATH}"
 
-# Next, we want to update pip and wheel inside of this virtual
-# environment to ensure that we have the latest versions of them.
-RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip wheel
+# Next, we want to update pip inside of this virtual
+# environment to ensure that we have the latest version.
+RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip
 
 # We copy this into the docker container prior to copying in the rest of our
 # application so that we can skip installing requirements if the only thing
@@ -146,9 +146,9 @@ RUN set -x \
 # our $PATH to refer to it first.
 ENV PATH="/opt/warehouse/bin:${PATH}"
 
-# Next, we want to update pip and wheel inside of this virtual
-# environment to ensure that we have the latest versions of them.
-RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip wheel
+# Next, we want to update pip inside of this virtual
+# environment to ensure that we have the latest version.
+RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip
 
 # We copy this into the docker container prior to copying in the rest of our
 # application so that we can skip installing requirements if the only thing


### PR DESCRIPTION
As `setuptools` isn't needed during the installation and image building, we can remove the step that automatically upgrades it, along with the TODO about pinning.

The requirements files control the version of `setuptools`, removing one step of uninstalling the updated version during the build.