### PR TITLE
Build with `--only-binary :all:`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ COPY requirements /tmp/requirements
 RUN --mount=type=cache,target=/root/.cache/pip \
     set -x \
     && pip --disable-pip-version-check \
-            install --no-deps \
+            install --no-deps --only-binary :all: \
             -r /tmp/requirements/docs-dev.txt \
             -r /tmp/requirements/docs-user.txt \
             -r /tmp/requirements/docs-blog.txt \
@@ -174,7 +174,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 RUN --mount=type=cache,target=/root/.cache/pip \
     set -x \
     && pip --disable-pip-version-check \
-            install --no-deps \
+            install --no-deps --only-binary :all: \
                     -r /tmp/requirements/deploy.txt \
                     -r /tmp/requirements/main.txt \
                     $(if [ "$DEVEL" = "yes" ]; then echo '-r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt'; fi) \


### PR DESCRIPTION
~Draft release until this is merge-able.~

~Currently this is blocked because the following dependencies must be built from source for the following reasons:~

`main` dependencies:
- [x] [`grpclib`](https://pypi.org/project/grpclib/) - non-pre-releases do not currently provide wheels
  - https://github.com/vmagamedov/grpclib/pull/188
- [x] [`google-crc32c`](https://pypi.org/project/google-crc32c) - the version we currently use does not provide Python 3.13 wheels
- [x] [`lazy-object-proxy`](https://pypi.org/project/lazy-object-proxy/) - the version we currently use does not provide Python 3.13 wheels
- [x] [`psycopg-c`](https://pypi.org/project/psycopg-c/) (via `psycopg[c]`) - seems to intentionally not provide wheels, maybe use `psycopg[binary]` instead?
- [x] [`pyqrcode`](https://pypi.org/project/pyqrcode) - very old (last release in 2016), does not provide wheels, perhaps unmaintainted
  - https://github.com/mnooner256/pyqrcode/issues/52