### PR TITLE
chore(dev,deps): remove specific ipython transitive deps

### DIFF
--- a/requirements/ipython.txt
+++ b/requirements/ipython.txt
@@ -1,12 +1,1 @@
-decorator>=4.1.2
-ipython>=6.2.1
-ipython-genutils>=0.2.0
-jedi>=0.11.0
-parso>=0.1.0
-pexpect>=4.3.1
-pickleshare>=0.7.4
-prompt-toolkit>=1.0.15
-ptyprocess>=0.5.2
-simplegeneric>=0.8.1
-traitlets>=4.3.2
-wcwidth>=0.1.7
+ipython>=9.2.0


### PR DESCRIPTION
When #2702 introduced the list of dependencies, ipython was more in flux with other dependencies than it is today.

Allowing pip to resolve the necessary versions is preferable, especially as ipython changes over time.
For example, `ipython-genutils` and `pickleshare` are no longer needed.