### PR TITLE
chore: reduce volume and frequency of batch updates

### DIFF
--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -219,5 +219,6 @@ def includeme(config):
     # Add a periodic task to generate Account metrics
     config.add_periodic_task(crontab(minute="*/20"), compute_user_metrics)
     config.add_periodic_task(crontab(minute="*"), notify_users_of_tos_update)
-    # TODO: After initial backfill, this can be done less frequently
-    config.add_periodic_task(crontab(minute="*/5"), batch_update_email_domain_status)
+    config.add_periodic_task(
+        crontab(minute="0", hour=4), batch_update_email_domain_status
+    )

--- a/warehouse/accounts/tasks.py
+++ b/warehouse/accounts/tasks.py
@@ -159,17 +159,14 @@ def batch_update_email_domain_status(request: Request) -> None:
     stmt = (
         select(Email)
         .where(
-            # TODO: After completely backfilled, remove the `or_` for None
             or_(
                 Email.domain_last_checked.is_(None),
                 Email.domain_last_checked < datetime.now(tz=UTC) - timedelta(days=30),
             )
         )
         .order_by(nullsfirst(Email.domain_last_checked.asc()))
-        .limit(10_000)
+        .limit(1_000)
     )
-    # Run in batches to avoid too much memory usage, API rate limits
-    stmt = stmt.execution_options(yield_per=1_000)
 
     for email in request.db.scalars(stmt):
         update_email_domain_status(email, request)


### PR DESCRIPTION
Now that the backfill is complete, we can slow down to once-per-day.

The original thought of not needing a `None` check was incorrect, as nothing is persisting the status today during registration.