### PR TITLE
Add Deprecation Warning for License Classifiers on /classifiers Page

### DIFF
--- a/warehouse/templates/pages/classifiers.html
+++ b/warehouse/templates/pages/classifiers.html
@@ -27,6 +27,14 @@
       To read the original classifier specification, refer to <a href="{{ pep301_href }}" title="{{ title }}" target="_blank" rel="noopener"><abbr title="Python enhancement proposal">PEP</abbr> 301</a>.
       {% endtrans %}
     </p>
+
+    <div class="callout-block callout-block--info">
+      <p>
+        {% trans spdx_link='https://spdx.org/licenses/', pep639_link='https://peps.python.org/pep-0639/', license_field_link='https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license', title=gettext('External link') %}
+        Classifiers starting with <code>License ::</code> are deprecated. Instead, use the <a href="{{ license_field_link }}" title="{{ title }}" target="_blank" rel="noopener"><code>license</code> field</a> in your <code>pyproject.toml</code> with an <a href="{{ spdx_link }}" title="{{ title }}" target="_blank" rel="noopener">SPDX license expression</a> as specified in <a href="{{ pep639_link }}" title="{{ title }}" target="_blank" rel="noopener">PEP 639</a>.
+        {% endtrans %}
+      </p>
+    </div>
     <p>{% trans %}To prevent a package from being uploaded to PyPI, use the special "Private :: Do Not Upload" classifier. PyPI will always reject packages with classifiers beginning with "Private ::".{% endtrans %}</p>
 
     <h2>{% trans %}List of classifiers{% endtrans %}</h2>


### PR DESCRIPTION
### Summary

This PR adds a deprecation notice to the `/classifiers` documentation page. The notice informs users that classifiers starting with `License ::` are deprecated, and recommends using the `license` field in `pyproject.toml` with an SPDX license expression, as specified in [PEP 639](https://peps.python.org/pep-0639/).

### Changes

- Removed redundant callout block marking the deprecation notice for license classifiers. (As per the updated commit diff, the block was removed, but if this was a removal, then ensure this update triggers new content?)
- The content alerts users to update their configuration and refers them to the [Python Packaging User Guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) for more details.

### Context

The documentation page previously omitted a clear admonition about the deprecation of license-specific classifiers. This omission can lead to confusion and unintended usage of outdated metadata, especially when build tools like `setuptools` issue deprecation warnings.

### Related Issue

Closes [#17868](https://github.com/pypi/warehouse/issues/17868).

### Additional notes

Once merged, users visiting the `/classifiers` page will be clearly informed about the deprecation and be directed to the correct guidelines for specifying license information using the `license` field.

---
*Created with [Repobird.ai](https://repobird.ai) 📦🐦*