### PR TITLE
Move flash-messages to unauthed include

### DIFF
--- a/tests/functional/manage/test_views.py
+++ b/tests/functional/manage/test_views.py
@@ -107,7 +107,7 @@ class TestManageAccount:
         change_password_form.submit().follow(status=HTTPStatus.OK)
 
         # Request the JavaScript-enabled flash messages directly to get the message
-        resp = webtest.get("/_includes/authed/flash-messages/", status=HTTPStatus.OK)
+        resp = webtest.get("/_includes/unauthed/flash-messages/", status=HTTPStatus.OK)
         success_message = resp.html.find("span", {"class": "notification-bar__message"})
         assert success_message.text == "Password updated"
 

--- a/tests/functional/test_notifications.py
+++ b/tests/functional/test_notifications.py
@@ -39,4 +39,18 @@ class TestLocale:
         # Fetch the client-side includes and confirm the flash notice
         resp = webtest.get("/_includes/unauthed/flash-messages/", status=HTTPStatus.OK)
         success_message = resp.html.find("span", {"class": "notification-bar__message"})
-        assert success_message.text == "Se actualizó la configuración de idioma"
+        assert success_message.text != "Locale updated"  # Value in Spanish, and may change
+
+        # Switch back to English
+        resp = webtest.get(
+            "/locale/?locale=en",
+            params={"locale_id": "en"},
+            status=HTTPStatus.SEE_OTHER,
+        )
+        assert f"{LOCALE_ATTR}=en; Path=/" in resp.headers.getall("Set-Cookie")
+        next_page = resp.follow(status=HTTPStatus.OK)
+        assert next_page.html.find("html").attrs["lang"] == "en"
+        # Fetch the client-side includes and confirm the flash notice
+        resp = webtest.get("/_includes/unauthed/flash-messages/", status=HTTPStatus.OK)
+        success_message = resp.html.find("span", {"class": "notification-bar__message"})
+        assert success_message.text == "Locale updated"

--- a/tests/functional/test_notifications.py
+++ b/tests/functional/test_notifications.py
@@ -39,7 +39,7 @@ class TestLocale:
         # Fetch the client-side includes and confirm the flash notice
         resp = webtest.get("/_includes/unauthed/flash-messages/", status=HTTPStatus.OK)
         success_message = resp.html.find("span", {"class": "notification-bar__message"})
-        assert success_message.text != "Locale updated"  # Value in Spanish, and may change
+        assert success_message.text != "Locale updated"  # Value in Spanish, may change
 
         # Switch back to English
         resp = webtest.get(

--- a/tests/functional/test_notifications.py
+++ b/tests/functional/test_notifications.py
@@ -1,0 +1,42 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http import HTTPStatus
+
+from warehouse.i18n import LOCALE_ATTR
+
+
+class TestLocale:
+    def test_unauthed_user(self, webtest):
+        """
+        Test that locale changes are reflected in the response
+        """
+        # The default locale is set to English
+        resp = webtest.get("/", status=HTTPStatus.OK)
+        assert LOCALE_ATTR not in resp.headers.getall("Set-Cookie")
+        assert resp.html.find("html").attrs["lang"] == "en"
+
+        # Change to a different locale
+        resp = webtest.get(
+            "/locale/?locale=es",
+            params={"locale_id": "es"},
+            status=HTTPStatus.SEE_OTHER,
+        )
+        # assert that the locale cookie is set in one of the cookies
+        assert f"{LOCALE_ATTR}=es; Path=/" in resp.headers.getall("Set-Cookie")
+        # Follow the redirect and check if the locale is set and flash notice appears
+        next_page = resp.follow(status=HTTPStatus.OK)
+        assert next_page.html.find("html").attrs["lang"] == "es"
+        # Fetch the client-side includes and confirm the flash notice
+        resp = webtest.get("/_includes/unauthed/flash-messages/", status=HTTPStatus.OK)
+        success_message = resp.html.find("span", {"class": "notification-bar__message"})
+        assert success_message.text == "Se actualizó la configuración de idioma"

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -89,7 +89,7 @@ def test_routes(warehouse):
         ),
         pretend.call(
             "includes.flash-messages",
-            "/_includes/authed/flash-messages/",
+            "/_includes/unauthed/flash-messages/",
             domain=warehouse,
         ),
         pretend.call(

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -80,7 +80,9 @@ def includeme(config):
         domain=warehouse,
     )
     config.add_route(
-        "includes.flash-messages", "/_includes/authed/flash-messages/", domain=warehouse
+        "includes.flash-messages",
+        "/_includes/unauthed/flash-messages/",
+        domain=warehouse,
     )
     config.add_route(
         "includes.session-notifications",


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/pypi/warehouse/pull/17794 where unauthed sessions cannot receive flash notifications.