### PR TITLE
chore: disallow password resets to unverified email

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,6 +228,7 @@ def pyramid_request(pyramid_services, jinja):
     dummy_request.log = pretend.stub(
         bind=pretend.call_recorder(lambda *args, **kwargs: dummy_request.log),
         info=pretend.call_recorder(lambda *args, **kwargs: None),
+        warning=pretend.call_recorder(lambda *args, **kwargs: None),
         error=pretend.call_recorder(lambda *args, **kwargs: None),
     )
 

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -1906,7 +1906,7 @@ class TestRequestPasswordReset:
         stub_user = pretend.stub(
             id=uuid.uuid4(),
             email="foo@example.com",
-            emails=[pretend.stub(email="foo@example.com")],
+            emails=[pretend.stub(email="foo@example.com", verified=True)],
             can_reset_password=True,
             record_event=pretend.call_recorder(lambda *a, **kw: None),
         )
@@ -1977,8 +1977,8 @@ class TestRequestPasswordReset:
             id=uuid.uuid4(),
             email="foo@example.com",
             emails=[
-                pretend.stub(email="foo@example.com"),
-                pretend.stub(email="other@example.com"),
+                pretend.stub(email="foo@example.com", verified=True),
+                pretend.stub(email="other@example.com", verified=True),
             ],
             can_reset_password=True,
             record_event=pretend.call_recorder(lambda *a, **kw: None),
@@ -2055,7 +2055,7 @@ class TestRequestPasswordReset:
         stub_user = pretend.stub(
             id=uuid.uuid4(),
             email="foo@example.com",
-            emails=[pretend.stub(email="foo@example.com")],
+            emails=[pretend.stub(email="foo@example.com", verified=True)],
             can_reset_password=True,
             record_event=pretend.call_recorder(lambda *a, **kw: None),
         )

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -677,12 +677,10 @@ class TestSendPasswordResetEmail:
             db_request, (unverified_email.user, unverified_email)
         )
 
-        assert result == {
-            "email": unverified_email,
-        }
+        assert result == {}
         subject_renderer.assert_()
-        body_renderer.assert_(email=unverified_email)
-        html_renderer.assert_(email=unverified_email)
+        body_renderer.assert_()
+        html_renderer.assert_()
 
 
 class TestEmailVerificationEmail:

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -657,6 +657,33 @@ class TestSendPasswordResetEmail:
             )
         ]
 
+    def test_unverified_email_sends_alt_notice(self, pyramid_config, db_request):
+        unverified_email = EmailFactory.create(verified=False)
+
+        subject_renderer = pyramid_config.testing_add_renderer(
+            "email/password-reset-unverified/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            "email/password-reset-unverified/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            "email/password-reset-unverified/body.html"
+        )
+        html_renderer.string_response = "Email HTML Body"
+
+        result = email.send_password_reset_unverified_email(
+            db_request, (unverified_email.user, unverified_email)
+        )
+
+        assert result == {
+            "email": unverified_email,
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(email=unverified_email)
+        html_renderer.assert_(email=unverified_email)
+
 
 class TestEmailVerificationEmail:
     def test_email_verification_email(

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -535,17 +535,14 @@ class TestSendEmail:
 
 class TestSendPasswordResetEmail:
     @pytest.mark.parametrize(
-        ("verified", "email_addr"),
+        "email_addr",
         [
-            (True, None),
-            (False, None),
-            (True, "other@example.com"),
-            (False, "other@example.com"),
+            None,
+            "other@example.com",
         ],
     )
     def test_send_password_reset_email(
         self,
-        verified,
         email_addr,
         pyramid_request,
         pyramid_config,
@@ -556,7 +553,7 @@ class TestSendPasswordResetEmail:
         stub_user = pretend.stub(
             id="id",
             email="email@example.com",
-            primary_email=pretend.stub(email="email@example.com", verified=verified),
+            primary_email=pretend.stub(email="email@example.com", verified=True),
             username="username_value",
             name="name_value",
             last_login="last_login",
@@ -565,7 +562,7 @@ class TestSendPasswordResetEmail:
         if email_addr is None:
             stub_email = None
         else:
-            stub_email = pretend.stub(email=email_addr, verified=verified)
+            stub_email = pretend.stub(email=email_addr, verified=True)
         pyramid_request.method = "POST"
         token_service.dumps = pretend.call_recorder(lambda a: "TOKEN")
 
@@ -654,7 +651,7 @@ class TestSendPasswordResetEmail:
                 "warehouse.emails.scheduled",
                 tags=[
                     "template_name:password-reset",
-                    "allow_unverified:True",
+                    "allow_unverified:False",
                     "repeat_window:none",
                 ],
             )

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -246,6 +246,20 @@ def send_password_reset_email(request, user_and_email):
     }
 
 
+@_email("password-reset-unverified", allow_unverified=True)
+def send_password_reset_unverified_email(_request, user_and_email):
+    """
+    This email is sent to users who have not verified their email address
+    when they request a password reset. It is sent to the email address
+    they provided, which may not be their primary email address.
+    """
+    user, email = user_and_email
+
+    return {
+        "email": email,
+    }
+
+
 @_email("verify-email", allow_unverified=True)
 def send_email_verification_email(request, user_and_email):
     user, email = user_and_email

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -247,17 +247,14 @@ def send_password_reset_email(request, user_and_email):
 
 
 @_email("password-reset-unverified", allow_unverified=True)
-def send_password_reset_unverified_email(_request, user_and_email):
+def send_password_reset_unverified_email(_request, _user_and_email):
     """
     This email is sent to users who have not verified their email address
     when they request a password reset. It is sent to the email address
     they provided, which may not be their primary email address.
     """
-    user, email = user_and_email
-
-    return {
-        "email": email,
-    }
+    # No params are used in the template, return an empty dict
+    return {}
 
 
 @_email("verify-email", allow_unverified=True)

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -222,7 +222,7 @@ def _email(
     return inner
 
 
-@_email("password-reset", allow_unverified=True)
+@_email("password-reset")
 def send_password_reset_email(request, user_and_email):
     user, _ = user_and_email
     token_service = request.find_service(ITokenService, name="password")

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -168,161 +168,161 @@ msgid ""
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:905
+#: warehouse/accounts/views.py:897
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:907
+#: warehouse/accounts/views.py:899
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:909 warehouse/accounts/views.py:1010
-#: warehouse/accounts/views.py:1114 warehouse/accounts/views.py:1283
+#: warehouse/accounts/views.py:901 warehouse/accounts/views.py:1002
+#: warehouse/accounts/views.py:1106 warehouse/accounts/views.py:1275
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:913
+#: warehouse/accounts/views.py:905
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:918
+#: warehouse/accounts/views.py:910
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:929
+#: warehouse/accounts/views.py:921
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:947
+#: warehouse/accounts/views.py:939
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:978
+#: warehouse/accounts/views.py:970
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:1006
+#: warehouse/accounts/views.py:998
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:1008
+#: warehouse/accounts/views.py:1000
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:1014
+#: warehouse/accounts/views.py:1006
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1023
+#: warehouse/accounts/views.py:1015
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:1026
+#: warehouse/accounts/views.py:1018
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:1044
+#: warehouse/accounts/views.py:1036
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1047
+#: warehouse/accounts/views.py:1039
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1053
+#: warehouse/accounts/views.py:1045
 #, python-brace-format
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:1110
+#: warehouse/accounts/views.py:1102
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1112
+#: warehouse/accounts/views.py:1104
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1118
+#: warehouse/accounts/views.py:1110
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1122
+#: warehouse/accounts/views.py:1114
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1131
+#: warehouse/accounts/views.py:1123
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1183
+#: warehouse/accounts/views.py:1175
 #, python-brace-format
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1246
+#: warehouse/accounts/views.py:1238
 #, python-brace-format
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1279
+#: warehouse/accounts/views.py:1271
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1281
+#: warehouse/accounts/views.py:1273
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1287
+#: warehouse/accounts/views.py:1279
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1291
+#: warehouse/accounts/views.py:1283
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1306
+#: warehouse/accounts/views.py:1298
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1338
+#: warehouse/accounts/views.py:1330
 #, python-brace-format
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1404
+#: warehouse/accounts/views.py:1396
 #, python-brace-format
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1484
+#: warehouse/accounts/views.py:1476
 #, python-brace-format
 msgid "Please review our updated <a href=\"${tos_url}\">Terms of Service</a>."
 msgstr ""
 
-#: warehouse/accounts/views.py:1696 warehouse/accounts/views.py:1938
+#: warehouse/accounts/views.py:1688 warehouse/accounts/views.py:1930
 #: warehouse/manage/views/__init__.py:1419
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1717
+#: warehouse/accounts/views.py:1709
 msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1733
+#: warehouse/accounts/views.py:1725
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1746
+#: warehouse/accounts/views.py:1738
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1761 warehouse/manage/views/__init__.py:1600
+#: warehouse/accounts/views.py:1753 warehouse/manage/views/__init__.py:1600
 #: warehouse/manage/views/__init__.py:1715
 #: warehouse/manage/views/__init__.py:1829
 #: warehouse/manage/views/__init__.py:1941
@@ -331,29 +331,29 @@ msgid ""
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1771 warehouse/manage/views/__init__.py:1613
+#: warehouse/accounts/views.py:1763 warehouse/manage/views/__init__.py:1613
 #: warehouse/manage/views/__init__.py:1728
 #: warehouse/manage/views/__init__.py:1842
 #: warehouse/manage/views/__init__.py:1954
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1786
+#: warehouse/accounts/views.py:1778
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1813
+#: warehouse/accounts/views.py:1805
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1951 warehouse/accounts/views.py:1964
-#: warehouse/accounts/views.py:1971
+#: warehouse/accounts/views.py:1943 warehouse/accounts/views.py:1956
+#: warehouse/accounts/views.py:1963
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1978
+#: warehouse/accounts/views.py:1970
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -2550,7 +2550,7 @@ msgid_plural "This link will expire in %(n_hours)s hours."
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/email/password-reset-unverified/body.html:30
+#: warehouse/templates/email/password-reset-unverified/body.html:33
 #: warehouse/templates/email/password-reset/body.html:24
 #: warehouse/templates/email/verify-email/body.html:24
 msgid "If you did not make this request, you can safely ignore this email."
@@ -2564,18 +2564,24 @@ msgstr ""
 
 #: warehouse/templates/email/password-reset-unverified/body.html:22
 msgid ""
-"However, the email used to make this request is not verified. You must "
-"verify your email address before you can reset your password."
+"However, the email used to make this request is not verified. Your email "
+"address must be verified before you can use it to reset your password."
 msgstr ""
 
 #: warehouse/templates/email/password-reset-unverified/body.html:25
-#, python-format
 msgid ""
-"Follow <a href=\"%(href)s\">account recovery steps</a> for your PyPI "
-"account if you are unable to verify your email address."
+"If you have another verified email address associated with your PyPI "
+"account, try that instead."
 msgstr ""
 
 #: warehouse/templates/email/password-reset-unverified/body.html:28
+#, python-format
+msgid ""
+"If you cannot use another verified email, follow <a "
+"href=\"%(href)s\">account recovery steps</a> for your PyPI account."
+msgstr ""
+
+#: warehouse/templates/email/password-reset-unverified/body.html:31
 #, python-format
 msgid "<a href=\"%(href)s\">Read more about verified emails.</a>"
 msgstr ""

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -122,21 +122,21 @@ msgstr ""
 msgid "The username isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/views.py:118
+#: warehouse/accounts/views.py:119
 #, python-brace-format
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for {}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:139
+#: warehouse/accounts/views.py:140
 #, python-brace-format
 msgid ""
 "Too many emails have been added to this account without verifying them. "
 "Check your inbox and follow the verification links. (IP: ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:151
+#: warehouse/accounts/views.py:152
 #, python-brace-format
 msgid ""
 "Too many password resets have been requested for this account without "
@@ -144,185 +144,185 @@ msgid ""
 " ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:398 warehouse/accounts/views.py:467
-#: warehouse/accounts/views.py:469 warehouse/accounts/views.py:498
-#: warehouse/accounts/views.py:500 warehouse/accounts/views.py:606
+#: warehouse/accounts/views.py:399 warehouse/accounts/views.py:468
+#: warehouse/accounts/views.py:470 warehouse/accounts/views.py:499
+#: warehouse/accounts/views.py:501 warehouse/accounts/views.py:607
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:461
+#: warehouse/accounts/views.py:462
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:541
+#: warehouse/accounts/views.py:542
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:638 warehouse/manage/views/__init__.py:881
+#: warehouse/accounts/views.py:639 warehouse/manage/views/__init__.py:881
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:730
+#: warehouse/accounts/views.py:731
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:872
+#: warehouse/accounts/views.py:905
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:874
+#: warehouse/accounts/views.py:907
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:876 warehouse/accounts/views.py:977
-#: warehouse/accounts/views.py:1081 warehouse/accounts/views.py:1250
+#: warehouse/accounts/views.py:909 warehouse/accounts/views.py:1010
+#: warehouse/accounts/views.py:1114 warehouse/accounts/views.py:1283
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:880
+#: warehouse/accounts/views.py:913
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:885
+#: warehouse/accounts/views.py:918
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:896
+#: warehouse/accounts/views.py:929
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:914
+#: warehouse/accounts/views.py:947
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:945
+#: warehouse/accounts/views.py:978
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:973
+#: warehouse/accounts/views.py:1006
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:975
+#: warehouse/accounts/views.py:1008
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:981
+#: warehouse/accounts/views.py:1014
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:990
+#: warehouse/accounts/views.py:1023
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:993
+#: warehouse/accounts/views.py:1026
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:1011
+#: warehouse/accounts/views.py:1044
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1014
+#: warehouse/accounts/views.py:1047
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1020
+#: warehouse/accounts/views.py:1053
 #, python-brace-format
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:1077
+#: warehouse/accounts/views.py:1110
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1079
+#: warehouse/accounts/views.py:1112
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1085
+#: warehouse/accounts/views.py:1118
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1089
+#: warehouse/accounts/views.py:1122
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1098
+#: warehouse/accounts/views.py:1131
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1150
+#: warehouse/accounts/views.py:1183
 #, python-brace-format
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1213
+#: warehouse/accounts/views.py:1246
 #, python-brace-format
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1246
+#: warehouse/accounts/views.py:1279
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1248
+#: warehouse/accounts/views.py:1281
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1254
+#: warehouse/accounts/views.py:1287
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1258
+#: warehouse/accounts/views.py:1291
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1273
+#: warehouse/accounts/views.py:1306
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1305
+#: warehouse/accounts/views.py:1338
 #, python-brace-format
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1371
+#: warehouse/accounts/views.py:1404
 #, python-brace-format
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1451
+#: warehouse/accounts/views.py:1484
 #, python-brace-format
 msgid "Please review our updated <a href=\"${tos_url}\">Terms of Service</a>."
 msgstr ""
 
-#: warehouse/accounts/views.py:1663 warehouse/accounts/views.py:1905
+#: warehouse/accounts/views.py:1696 warehouse/accounts/views.py:1938
 #: warehouse/manage/views/__init__.py:1419
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1684
+#: warehouse/accounts/views.py:1717
 msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1700
+#: warehouse/accounts/views.py:1733
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1713
+#: warehouse/accounts/views.py:1746
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1728 warehouse/manage/views/__init__.py:1600
+#: warehouse/accounts/views.py:1761 warehouse/manage/views/__init__.py:1600
 #: warehouse/manage/views/__init__.py:1715
 #: warehouse/manage/views/__init__.py:1829
 #: warehouse/manage/views/__init__.py:1941
@@ -331,29 +331,29 @@ msgid ""
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1738 warehouse/manage/views/__init__.py:1613
+#: warehouse/accounts/views.py:1771 warehouse/manage/views/__init__.py:1613
 #: warehouse/manage/views/__init__.py:1728
 #: warehouse/manage/views/__init__.py:1842
 #: warehouse/manage/views/__init__.py:1954
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1753
+#: warehouse/accounts/views.py:1786
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1780
+#: warehouse/accounts/views.py:1813
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1918 warehouse/accounts/views.py:1931
-#: warehouse/accounts/views.py:1938
+#: warehouse/accounts/views.py:1951 warehouse/accounts/views.py:1964
+#: warehouse/accounts/views.py:1971
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1945
+#: warehouse/accounts/views.py:1978
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -1966,8 +1966,8 @@ msgstr ""
 
 #: warehouse/templates/accounts/request-password-reset.html:51
 msgid ""
-"If you submitted a valid username or email address, an email has been "
-"sent to your registered email address."
+"If you submitted a valid username or verified email address, an email has"
+" been sent to your registered email address."
 msgstr ""
 
 #: warehouse/templates/accounts/request-password-reset.html:52
@@ -2550,9 +2550,34 @@ msgid_plural "This link will expire in %(n_hours)s hours."
 msgstr[0] ""
 msgstr[1] ""
 
+#: warehouse/templates/email/password-reset-unverified/body.html:30
 #: warehouse/templates/email/password-reset/body.html:24
 #: warehouse/templates/email/verify-email/body.html:24
 msgid "If you did not make this request, you can safely ignore this email."
+msgstr ""
+
+#: warehouse/templates/email/password-reset-unverified/body.html:19
+msgid ""
+"Someone, perhaps you, has made a password reset request for a PyPI "
+"account associated with this email address."
+msgstr ""
+
+#: warehouse/templates/email/password-reset-unverified/body.html:22
+msgid ""
+"However, the email used to make this request is not verified. You must "
+"verify your email address before you can reset your password."
+msgstr ""
+
+#: warehouse/templates/email/password-reset-unverified/body.html:25
+#, python-format
+msgid ""
+"Follow <a href=\"%(href)s\">account recovery steps</a> for your PyPI "
+"account if you are unable to verify your email address."
+msgstr ""
+
+#: warehouse/templates/email/password-reset-unverified/body.html:28
+#, python-format
+msgid "<a href=\"%(href)s\">Read more about verified emails.</a>"
 msgstr ""
 
 #: warehouse/templates/email/primary-email-change/body.html:18

--- a/warehouse/templates/accounts/request-password-reset.html
+++ b/warehouse/templates/accounts/request-password-reset.html
@@ -48,7 +48,7 @@
       {% else %}
         <div class="callout-block callout-block--success">
           <h2 class="callout-block__heading">{% trans %}Reset email sent{% endtrans %}</h2>
-          <p>{% trans %}If you submitted a valid username or email address, an email has been sent to your registered email address.{% endtrans %}</p>
+          <p>{% trans %}If you submitted a valid username or verified email address, an email has been sent to your registered email address.{% endtrans %}</p>
           <p>{% trans n_hours=n_hours %}The email contains a link to reset your password. This link will expire in {{ n_hours }} hours.{% endtrans %}</p>
         </div>
       {% endif %}

--- a/warehouse/templates/email/password-reset-unverified/body.html
+++ b/warehouse/templates/email/password-reset-unverified/body.html
@@ -1,0 +1,31 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/body.html" %}
+
+{% block content %}
+  <p>
+    {% trans %}Someone, perhaps you, has made a password reset request for a PyPI account associated with this email address.{% endtrans %}
+  </p>
+  <p>
+    {% trans %}However, the email used to make this request is not verified. You must verify your email address before you can reset your password.{% endtrans %}
+  </p>
+  <p>
+    {% trans href=request.route_url('help', _anchor='account-recovery') %}Follow <a href="{{ href }}">account recovery steps</a> for your PyPI account if you are unable to verify your email address.{% endtrans %}
+  </p>
+  <p>
+    {% trans href=request.route_url('help', _anchor='verified-email') %}<a href="{{ href }}">Read more about verified emails.</a>{% endtrans %}
+  </p>
+  <p>{% trans %}If you did not make this request, you can safely ignore this email.{% endtrans %}</p>
+{% endblock content %}

--- a/warehouse/templates/email/password-reset-unverified/body.html
+++ b/warehouse/templates/email/password-reset-unverified/body.html
@@ -19,10 +19,13 @@
     {% trans %}Someone, perhaps you, has made a password reset request for a PyPI account associated with this email address.{% endtrans %}
   </p>
   <p>
-    {% trans %}However, the email used to make this request is not verified. You must verify your email address before you can reset your password.{% endtrans %}
+    {% trans %}However, the email used to make this request is not verified. Your email address must be verified before you can use it to reset your password.{% endtrans %}
   </p>
   <p>
-    {% trans href=request.route_url('help', _anchor='account-recovery') %}Follow <a href="{{ href }}">account recovery steps</a> for your PyPI account if you are unable to verify your email address.{% endtrans %}
+    {% trans %}If you have another verified email address associated with your PyPI account, try that instead.{% endtrans %}
+  </p>
+  <p>
+    {% trans href=request.route_url('help', _anchor='account-recovery') %}If you cannot use another verified email, follow <a href="{{ href }}">account recovery steps</a> for your PyPI account.{% endtrans %}
   </p>
   <p>
     {% trans href=request.route_url('help', _anchor='verified-email') %}<a href="{{ href }}">Read more about verified emails.</a>{% endtrans %}

--- a/warehouse/templates/email/password-reset-unverified/body.txt
+++ b/warehouse/templates/email/password-reset-unverified/body.txt
@@ -1,0 +1,30 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+{% trans %}Someone, perhaps you, has made a password reset request for a PyPI account associated with this email address.{% endtrans %}
+
+{% trans %}However, the email used to make this request is not verified. You must verify your email address before you can reset your password.{% endtrans %}
+
+{% trans %}Follow account recovery steps for your PyPI account if you are unable to verify your email address.{% endtrans %}
+
+    {{ request.route_url('help', _anchor='account-recovery') }}
+
+{% trans %}Read more about verified emails:{% endtrans %}
+
+    {{ request.route_url('help', _anchor='verified-email') }}
+
+{% trans %}If you did not make this request, you can safely ignore this email.{% endtrans %}
+{% endblock %}

--- a/warehouse/templates/email/password-reset-unverified/body.txt
+++ b/warehouse/templates/email/password-reset-unverified/body.txt
@@ -16,9 +16,11 @@
 {% block content %}
 {% trans %}Someone, perhaps you, has made a password reset request for a PyPI account associated with this email address.{% endtrans %}
 
-{% trans %}However, the email used to make this request is not verified. You must verify your email address before you can reset your password.{% endtrans %}
+{% trans %}However, the email used to make this request is not verified. Your email address must be verified before you can use it to reset your password.{% endtrans %}
 
-{% trans %}Follow account recovery steps for your PyPI account if you are unable to verify your email address.{% endtrans %}
+{% trans %}If you have another verified email address associated with your PyPI account, try that instead.{% endtrans %}
+
+{% trans %}If you cannot use another verified email, follow account recovery steps for your PyPI account.{% endtrans %}
 
     {{ request.route_url('help', _anchor='account-recovery') }}
 

--- a/warehouse/templates/email/password-reset-unverified/subject.txt
+++ b/warehouse/templates/email/password-reset-unverified/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}{% trans %}Password reset request{% endtrans %}{% endblock %}

--- a/warehouse/templates/email/password-reset-unverified/subject.txt
+++ b/warehouse/templates/email/password-reset-unverified/subject.txt
@@ -14,4 +14,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}{% trans %}Password reset request{% endtrans %}{% endblock %}
+{% block subject %}{% trans %}Password reset requested for unverified email{% endtrans %}{% endblock %}


### PR DESCRIPTION
Only allow account resets to verified email addresses to prevent account
domain resurrection attacks.

If the user account exists for a given email address, check if the
account is verified. If it's not, reject with a flash message.

Does not disclose the name of a given user account, logs an event/warning for inspection.