### PR TITLE
allow for overriding cache decorator ttl on response

### DIFF
--- a/tests/unit/cache/origin/test_fastly.py
+++ b/tests/unit/cache/origin/test_fastly.py
@@ -211,6 +211,33 @@ class TestFastlyCache:
             ),
         }
 
+    def test_override_ttl_on_response(self):
+        request = pretend.stub()
+        response = pretend.stub(headers={}, override_ttl=6969)
+
+        cacher = fastly.FastlyCache(
+            api_endpoint=None,
+            api_connect_via=None,
+            api_key=None,
+            service_id=None,
+            purger=None,
+        )
+        cacher.cache(
+            ["abc", "defg"],
+            request,
+            response,
+            seconds=9123,
+            stale_while_revalidate=4567,
+            stale_if_error=2276,
+        )
+
+        assert response.headers == {
+            "Surrogate-Key": "abc defg",
+            "Surrogate-Control": (
+                "max-age=6969, stale-while-revalidate=4567, stale-if-error=2276"
+            ),
+        }
+
     def test_multiple_calls_to_cache_dont_overwrite_surrogate_keys(self):
         request = pretend.stub()
         response = pretend.stub(headers={})

--- a/warehouse/api/simple.py
+++ b/warehouse/api/simple.py
@@ -78,6 +78,7 @@ def simple_index(request):
     # to return the correct content types.
     request.response.content_type = _select_content_type(request)
     if request.response.content_type == MIME_PYPI_SIMPLE_V1_JSON:
+        request.response.override_ttl = 30 * 60  # 30 minutes
         request.override_renderer = "json"
 
     # Apply CORS headers.

--- a/warehouse/cache/origin/fastly.py
+++ b/warehouse/cache/origin/fastly.py
@@ -77,6 +77,10 @@ class FastlyCache:
         stale_while_revalidate=None,
         stale_if_error=None,
     ):
+        override_ttl = None
+        if hasattr(response, "override_ttl"):
+            override_ttl = response.override_ttl
+
         existing_keys = set(response.headers.get("Surrogate-Key", "").split())
 
         response.headers["Surrogate-Key"] = " ".join(sorted(set(keys) | existing_keys))
@@ -84,7 +88,10 @@ class FastlyCache:
         values = []
 
         if seconds is not None:
-            values.append(f"max-age={seconds}")
+            if override_ttl is not None:
+                values.append(f"max-age={override_ttl}")
+            else:
+                values.append(f"max-age={seconds}")
 
         if stale_while_revalidate is not None:
             values.append(f"stale-while-revalidate={stale_while_revalidate}")


### PR DESCRIPTION
This is primarily to support discriminating between HTML and JSON rendered /simple/ index cache times.

In support of https://github.com/pypa/bandersnatch/pull/1898