### PR TITLE
chore(docs): add social links for Mastodon and Bluesky

### DIFF
--- a/docs/mkdocs-user-docs.yml
+++ b/docs/mkdocs-user-docs.yml
@@ -61,6 +61,10 @@ extra:
       link: https://github.com/pypi
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/pypi
+    - icon: fontawesome/brands/mastodon
+      link: https://fosstodon.org/@pypi
+    - icon: fontawesome/brands/bluesky
+      link: https://bsky.app/profile/pypi.org
 repo_url: https://github.com/pypi/warehouse
 edit_uri: blob/main/docs/user/
 


### PR DESCRIPTION
Noticed that these were present on the blog's MkDocs but not the user docs 🙂 