### PR TITLE
oidc: Refactor lookup strategies into single functions

### DIFF
--- a/tests/unit/oidc/models/test_activestate.py
+++ b/tests/unit/oidc/models/test_activestate.py
@@ -37,14 +37,6 @@ INGREDIENT = "fakeingredientname"
 SUBJECT = f"org:{ORG_URL_NAME}:project:{PROJECT_NAME}"
 
 
-def test_lookup_strategies():
-    assert (
-        len(ActiveStatePublisher.__lookup_strategies__)
-        == len(PendingActiveStatePublisher.__lookup_strategies__)
-        == 1
-    )
-
-
 def new_signed_claims(
     sub: str = SUBJECT,
     actor: str = ACTOR,
@@ -380,6 +372,13 @@ class TestActiveStatePublisher:
             db_request.db.flush()
 
         assert publisher.exists(db_request.db) == exists_in_db
+
+    def test_lookup_no_matching_publishers(self, db_request):
+        signed_claims = new_signed_claims(actor_id="my_id")
+
+        with pytest.raises(InvalidPublisherError) as e:
+            ActiveStatePublisher.lookup_by_claims(db_request.db, signed_claims)
+        assert str(e.value) == "Publisher with matching claims was not found"
 
 
 class TestPendingActiveStatePublisher:

--- a/tests/unit/oidc/models/test_core.py
+++ b/tests/unit/oidc/models/test_core.py
@@ -43,9 +43,8 @@ def test_check_claim_invariant():
 
 class TestOIDCPublisher:
     def test_lookup_by_claims_raises(self):
-        with pytest.raises(errors.InvalidPublisherError) as e:
+        with pytest.raises(NotImplementedError):
             _core.OIDCPublisher.lookup_by_claims(pretend.stub(), pretend.stub())
-        assert str(e.value) == "All lookup strategies exhausted"
 
     def test_oidc_publisher_not_default_verifiable(self):
         publisher = _core.OIDCPublisher(projects=[])

--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -96,13 +96,6 @@ def test_check_sub(claim):
 
 
 class TestGitHubPublisher:
-    def test_lookup_strategies(self):
-        assert (
-            len(github.GitHubPublisher.__lookup_strategies__)
-            == len(github.PendingGitHubPublisher.__lookup_strategies__)
-            == 2
-        )
-
     @pytest.mark.parametrize("environment", [None, "some_environment"])
     def test_lookup_fails_invalid_workflow_ref(self, environment):
         signed_claims = {
@@ -116,7 +109,8 @@ class TestGitHubPublisher:
 
         # The `job_workflow_ref` is malformed, so no queries are performed.
         with pytest.raises(
-            errors.InvalidPublisherError, match="All lookup strategies exhausted"
+            errors.InvalidPublisherError,
+            match="Could not job extract workflow filename from OIDC claims",
         ):
             github.GitHubPublisher.lookup_by_claims(pretend.stub(), signed_claims)
 
@@ -164,6 +158,28 @@ class TestGitHubPublisher:
                 ).workflow_filename
                 == workflow
             )
+
+    def test_lookup_no_matching_publishers(self, db_request):
+        GitHubPublisherFactory(
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            repository_owner="foo",
+            repository_name="bar",
+            repository_owner_id="1234",
+            workflow_filename="release.yml",
+            environment="environment",
+        )
+        signed_claims = {
+            "repository": "foo/bar",
+            "job_workflow_ref": (
+                "foo/bar/.github/workflows/release.yml@refs/heads/main"
+            ),
+            "repository_owner_id": "1234",
+            "environment": "another_environment",
+        }
+
+        with pytest.raises(errors.InvalidPublisherError) as e:
+            github.GitHubPublisher.lookup_by_claims(db_request.db, signed_claims)
+        assert str(e.value) == "Publisher with matching claims was not found"
 
     def test_github_publisher_all_known_claims(self):
         assert github.GitHubPublisher.all_known_claims() == {

--- a/tests/unit/oidc/models/test_gitlab.py
+++ b/tests/unit/oidc/models/test_gitlab.py
@@ -64,13 +64,6 @@ def test_check_sub(claim):
 
 
 class TestGitLabPublisher:
-    def test_lookup_strategies(self):
-        assert (
-            len(gitlab.GitLabPublisher.__lookup_strategies__)
-            == len(gitlab.PendingGitLabPublisher.__lookup_strategies__)
-            == 2
-        )
-
     @pytest.mark.parametrize("environment", [None, "some_environment"])
     def test_lookup_fails_invalid_ci_config_ref_uri(self, environment):
         signed_claims = {
@@ -83,7 +76,8 @@ class TestGitLabPublisher:
 
         # The `ci_config_ref_uri` is malformed, so no queries are performed.
         with pytest.raises(
-            errors.InvalidPublisherError, match="All lookup strategies exhausted"
+            errors.InvalidPublisherError,
+            match="Could not extract workflow filename from OIDC claims",
         ):
             gitlab.GitLabPublisher.lookup_by_claims(pretend.stub(), signed_claims)
 
@@ -130,6 +124,15 @@ class TestGitLabPublisher:
                 ).workflow_filepath
                 == workflow_filepath
             )
+
+    def test_lookup_no_matching_publisher(self, db_request):
+        signed_claims = {
+            "project_path": "foo/bar",
+            "ci_config_ref_uri": ("gitlab.com/foo/bar//.gitlab-ci.yml@refs/heads/main"),
+        }
+        with pytest.raises(errors.InvalidPublisherError) as e:
+            gitlab.GitLabPublisher.lookup_by_claims(db_request.db, signed_claims)
+        assert str(e.value) == "Publisher with matching claims was not found"
 
     def test_gitlab_publisher_all_known_claims(self):
         assert gitlab.GitLabPublisher.all_known_claims() == {

--- a/tests/unit/oidc/models/test_google.py
+++ b/tests/unit/oidc/models/test_google.py
@@ -19,14 +19,6 @@ from warehouse.oidc import errors
 from warehouse.oidc.models import _core, google
 
 
-def test_lookup_strategies():
-    assert (
-        len(google.GooglePublisher.__lookup_strategies__)
-        == len(google.PendingGooglePublisher.__lookup_strategies__)
-        == 2
-    )
-
-
 class TestGooglePublisher:
     def test_publisher_name(self):
         publisher = google.GooglePublisher(email="fake@example.com")
@@ -195,6 +187,16 @@ class TestGooglePublisher:
                     signed_claims=signed_claims, publisher_service=pretend.stub()
                 )
             assert str(e.value) == "Check failed for optional claim 'sub'"
+
+    def test_lookup_no_matching_publishers(self, db_request):
+        signed_claims = {
+            "email": "fake@example.com",
+            "email_verified": True,
+        }
+
+        with pytest.raises(errors.InvalidPublisherError) as e:
+            google.GooglePublisher.lookup_by_claims(db_request.db, signed_claims)
+        assert str(e.value) == "Publisher with matching claims was not found"
 
     @pytest.mark.parametrize("exists_in_db", [True, False])
     def test_exists(self, db_request, exists_in_db):

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -13,7 +13,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, Unpack
+from typing import TYPE_CHECKING, Any, Self, TypedDict, TypeVar, Unpack
 
 import rfc3986
 import sentry_sdk
@@ -174,20 +174,10 @@ class OIDCPublisherMixin:
     # but there are a few problems: those claim sets don't map to their
     # "equivalent" column (only to an instantiated property), and may not
     # even have an "equivalent" column.
-    __lookup_strategies__: list = []
 
     @classmethod
-    def lookup_by_claims(cls, session, signed_claims: SignedClaims):
-        for lookup in cls.__lookup_strategies__:
-            query = lookup(cls, signed_claims)
-            if not query:
-                # We might not build a query if we know the claim set can't
-                # satisfy it. If that's the case, then we skip.
-                continue
-
-            if publisher := query.with_session(session).one_or_none():
-                return publisher
-        raise InvalidPublisherError("All lookup strategies exhausted")
+    def lookup_by_claims(cls, session, signed_claims: SignedClaims) -> Self:
+        raise NotImplementedError
 
     @classmethod
     def all_known_claims(cls) -> set[str]:

--- a/warehouse/oidc/models/activestate.py
+++ b/warehouse/oidc/models/activestate.py
@@ -13,7 +13,7 @@
 
 import urllib
 
-from typing import Any
+from typing import Any, Self
 
 from sqlalchemy import ForeignKey, String, UniqueConstraint, and_, exists
 from sqlalchemy.dialects.postgresql import UUID
@@ -92,18 +92,6 @@ class ActiveStatePublisherMixin:
         "project_visibility",
     }
 
-    @staticmethod
-    def __lookup_all__(klass, signed_claims: SignedClaims):
-        return Query(klass).filter_by(
-            organization=signed_claims["organization"],
-            activestate_project_name=signed_claims["project"],
-            actor_id=signed_claims["actor_id"],
-        )
-
-    __lookup_strategies__ = [
-        __lookup_all__,
-    ]
-
     @property
     def sub(self) -> str:
         return f"org:{self.organization}:project:{self.activestate_project_name}"
@@ -146,6 +134,17 @@ class ActiveStatePublisherMixin:
                 )
             )
         ).scalar()
+
+    @classmethod
+    def lookup_by_claims(cls, session, signed_claims: SignedClaims) -> Self:
+        query: Query = Query(cls).filter_by(
+            organization=signed_claims["organization"],
+            activestate_project_name=signed_claims["project"],
+            actor_id=signed_claims["actor_id"],
+        )
+        if publisher := query.with_session(session).one_or_none():
+            return publisher
+        raise InvalidPublisherError("Publisher with matching claims was not found")
 
 
 class ActiveStatePublisher(ActiveStatePublisherMixin, OIDCPublisher):

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -12,7 +12,7 @@
 
 import re
 
-from typing import Any
+from typing import Any, Self
 
 from pypi_attestations import GitHubPublisher as GitHubIdentity, Publisher
 from sqlalchemy import ForeignKey, String, UniqueConstraint, and_, exists
@@ -192,49 +192,50 @@ class GitHubPublisherMixin:
         "ref_protected",
     }
 
-    @staticmethod
-    def __lookup_all__(klass, signed_claims: SignedClaims) -> Query | None:
-        # This lookup requires the environment claim to be present;
-        # if it isn't, bail out early.
-        if not (environment := signed_claims.get("environment")):
-            return None
+    # Get the most specific publisher from a list of publishers,
+    # where publishers constrained with an environment are more
+    # specific than publishers not constrained on environment.
+    @classmethod
+    def _get_publisher_for_environment(
+        cls, publishers: list[Self], environment: str | None
+    ) -> Self | None:
+        if environment:
+            specific_publishers = [
+                p for p in publishers if p.environment == environment.lower()
+            ]
+            if specific_publishers:
+                return specific_publishers[0]
 
+        general_publishers = [p for p in publishers if p.environment == ""]
+        if general_publishers:
+            return general_publishers[0]
+
+        return None
+
+    @classmethod
+    def lookup_by_claims(cls, session, signed_claims: SignedClaims) -> Self:
         repository = signed_claims["repository"]
         repository_owner, repository_name = repository.split("/", 1)
-        workflow_ref = signed_claims["job_workflow_ref"]
+        job_workflow_ref = signed_claims["job_workflow_ref"]
+        environment = signed_claims.get("environment")
 
-        if not (workflow_filename := _extract_workflow_filename(workflow_ref)):
-            return None
+        if not (job_workflow_filename := _extract_workflow_filename(job_workflow_ref)):
+            raise InvalidPublisherError(
+                "Could not job extract workflow filename from OIDC claims"
+            )
 
-        return Query(klass).filter_by(
+        query: Query = Query(cls).filter_by(
             repository_name=repository_name,
             repository_owner=repository_owner,
             repository_owner_id=signed_claims["repository_owner_id"],
-            environment=environment.lower(),
-            workflow_filename=workflow_filename,
+            workflow_filename=job_workflow_filename,
         )
+        publishers = query.with_session(session).all()
 
-    @staticmethod
-    def __lookup_no_environment__(klass, signed_claims: SignedClaims) -> Query | None:
-        repository = signed_claims["repository"]
-        repository_owner, repository_name = repository.split("/", 1)
-        workflow_ref = signed_claims["job_workflow_ref"]
-
-        if not (workflow_filename := _extract_workflow_filename(workflow_ref)):
-            return None
-
-        return Query(klass).filter_by(
-            repository_name=repository_name,
-            repository_owner=repository_owner,
-            repository_owner_id=signed_claims["repository_owner_id"],
-            environment="",
-            workflow_filename=workflow_filename,
-        )
-
-    __lookup_strategies__ = [
-        __lookup_all__,
-        __lookup_no_environment__,
-    ]
+        if publisher := cls._get_publisher_for_environment(publishers, environment):
+            return publisher
+        else:
+            raise InvalidPublisherError("Publisher with matching claims was not found")
 
     @property
     def _workflow_slug(self):

--- a/warehouse/oidc/models/gitlab.py
+++ b/warehouse/oidc/models/gitlab.py
@@ -12,7 +12,7 @@
 
 import re
 
-from typing import Any
+from typing import Any, Self
 
 from pypi_attestations import GitLabPublisher as GitLabIdentity, Publisher
 from sqlalchemy import ForeignKey, String, UniqueConstraint, and_, exists
@@ -188,47 +188,48 @@ class GitLabPublisherMixin:
         "groups_direct",
     }
 
-    @staticmethod
-    def __lookup_all__(klass, signed_claims: SignedClaims) -> Query | None:
-        # This lookup requires the environment claim to be present;
-        # if it isn't, bail out early.
-        if not (environment := signed_claims.get("environment")):
-            return None
+    # Get the most specific publisher from a list of publishers,
+    # where publishers constrained with an environment are more
+    # specific than publishers not constrained on environment.
+    @classmethod
+    def _get_publisher_for_environment(
+        cls, publishers: list[Self], environment: str | None
+    ) -> Self | None:
+        if environment:
+            specific_publishers = [
+                p for p in publishers if p.environment == environment.lower()
+            ]
+            if specific_publishers:
+                return specific_publishers[0]
 
+        general_publishers = [p for p in publishers if p.environment == ""]
+        if general_publishers:
+            return general_publishers[0]
+
+        return None
+
+    @classmethod
+    def lookup_by_claims(cls, session, signed_claims: SignedClaims) -> Self:
         project_path = signed_claims["project_path"]
         ci_config_ref_uri = signed_claims["ci_config_ref_uri"]
         namespace, project = project_path.rsplit("/", 1)
+        environment = signed_claims.get("environment")
 
         if not (workflow_filepath := _extract_workflow_filepath(ci_config_ref_uri)):
-            return None
+            raise InvalidPublisherError(
+                "Could not extract workflow filename from OIDC claims"
+            )
 
-        return Query(klass).filter_by(
+        query: Query = Query(cls).filter_by(
             namespace=namespace,
             project=project,
-            environment=environment,
             workflow_filepath=workflow_filepath,
         )
+        publishers = query.with_session(session).all()
+        if publisher := cls._get_publisher_for_environment(publishers, environment):
+            return publisher
 
-    @staticmethod
-    def __lookup_no_environment__(klass, signed_claims: SignedClaims) -> Query | None:
-        project_path = signed_claims["project_path"]
-        ci_config_ref_uri = signed_claims["ci_config_ref_uri"]
-        namespace, project = project_path.rsplit("/", 1)
-
-        if not (workflow_filepath := _extract_workflow_filepath(ci_config_ref_uri)):
-            return None
-
-        return Query(klass).filter_by(
-            namespace=namespace,
-            project=project,
-            environment="",
-            workflow_filepath=workflow_filepath,
-        )
-
-    __lookup_strategies__ = [
-        __lookup_all__,
-        __lookup_no_environment__,
-    ]
+        raise InvalidPublisherError("Publisher with matching claims was not found")
 
     @property
     def project_path(self):


### PR DESCRIPTION
This PR refactors the Trusted Publishing "lookup strategies" pattern into a single `lookup_by_claims()` method for each of the publishers.

## Context
A strategy is a way of, given a set of OIDC claims, query the database for a matching Trusted Publisher. Concretely, a strategy is a function that takes a set of claims and returns a `Query` object. Each publisher has a list of these strategies, ordered from specific to general. When trying to find a Trusted Publisher, the more specific strategies are tried first, and if they fail the more general ones are tried.

For example, for the given set of claims for a GitHub OIDC token:
```json
{
    "repository": "foo/bar",
    "job_workflow_ref": "foo/bar/.github/workflows/release.yml@refs/heads/main",
    "environment": "my_environment",
}
```

first we ran a strategy that tried to find publishers with exactly those values (in particular, `environment==my_environment`). If that strategy failed, we tried the second strategy, where we tried to find publishers with `environment==None` (that is, allowing any environment).
The "specific to general" order in this case meant going from "Publishers that only allow `my_environment` as an environment" to "Publishers that allow any environment".

## New implementation
This PR changes the above approach to a single function per provider called `lookup_by_claims()` which takes a set of claims and returns a Publisher.

The multiple strategies are collapsed into a single query: we query for all publishers where the non-optional fields match the claims. In the example above, this means our single query looks for all publishers that match `repository` and `job_workflow_ref`, ignoring the `environment` value.

We then look at the resulting Python Publisher objects, and select the most specific one. 

## Rationale
The reasons for this change are:
- Removing the multiple lookup strategies, which are unnecessary since a single (general) query is enough
- Preparing for adding support for GitHub reusable workflows (as sketched in https://github.com/pypi/warehouse/issues/11096#issuecomment-2895081700). 

cc @woodruffw @miketheman @di 


