### PR TITLE
allow outsized headers on the upload endpoint

### DIFF
--- a/gunicorn-uploads.conf.py
+++ b/gunicorn-uploads.conf.py
@@ -6,6 +6,9 @@ preload_app = True
 max_requests = 32
 max_requests_jitter = 8
 
+# Allow large macaroons in Authorization header, default is 8190
+limit_request_field_size = 8190 * 4
+
 worker_connections = 256
 timeout = 240
 keepalive = 2


### PR DESCRIPTION
because macaroons