### PR TITLE
perf: update template renderer paths to use package qualifiers

### DIFF
--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -151,7 +151,7 @@ def incomplete_password_resets(exc, request):
 @view_config(
     route_name="accounts.profile",
     context=User,
-    renderer="accounts/profile.html",
+    renderer="warehouse:templates/accounts/profile.html",
     decorator=[
         origin_cache(1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60)  # 1 day each.
     ],
@@ -228,7 +228,7 @@ def profile(user, request):
 
 @view_config(
     route_name="accounts.search",
-    renderer="api/account_search.html",
+    renderer="warehouse:templates/api/account_search.html",
     uses_session=True,
 )
 def accounts_search(request) -> dict[str, list[User]]:
@@ -266,7 +266,7 @@ def accounts_search(request) -> dict[str, list[User]]:
 
 @view_config(
     route_name="accounts.login",
-    renderer="accounts/login.html",
+    renderer="warehouse:templates/accounts/login.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -370,7 +370,7 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
 
 @view_config(
     route_name="accounts.two-factor",
-    renderer="accounts/two-factor.html",
+    renderer="warehouse:templates/accounts/two-factor.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -580,7 +580,7 @@ def _remember_device(request, response, userid, two_factor_method) -> None:
 
 @view_config(
     route_name="accounts.recovery-code",
-    renderer="accounts/recovery-code.html",
+    renderer="warehouse:templates/accounts/recovery-code.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -640,7 +640,7 @@ def recovery_code(request, _form_class=RecoveryCodeAuthenticationForm):
 
 @view_config(
     route_name="accounts.logout",
-    renderer="accounts/logout.html",
+    renderer="warehouse:templates/accounts/logout.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -701,7 +701,7 @@ def logout(request, redirect_field_name=REDIRECT_FIELD_NAME):
 
 @view_config(
     route_name="accounts.register",
-    renderer="accounts/register.html",
+    renderer="warehouse:templates/accounts/register.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -773,7 +773,7 @@ def register(request, _form_class=RegistrationForm):
 
 @view_config(
     route_name="accounts.request-password-reset",
-    renderer="accounts/request-password-reset.html",
+    renderer="warehouse:templates/accounts/request-password-reset.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -862,7 +862,7 @@ def request_password_reset(request, _form_class=RequestPasswordResetForm):
 
 @view_config(
     route_name="accounts.reset-password",
-    renderer="accounts/reset-password.html",
+    renderer="warehouse:templates/accounts/reset-password.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -1070,7 +1070,7 @@ def _get_two_factor_data(request, _redirect_to="/"):
 
 @view_config(
     route_name="accounts.verify-organization-role",
-    renderer="accounts/organization-invite-confirmation.html",
+    renderer="warehouse:templates/accounts/organization-invite-confirmation.html",
     require_methods=False,
     uses_session=True,
     permission=Permissions.AccountVerifyOrgRole,
@@ -1240,7 +1240,7 @@ def verify_organization_role(request):
 
 @view_config(
     route_name="accounts.verify-project-role",
-    renderer="accounts/invite-confirmation.html",
+    renderer="warehouse:templates/accounts/invite-confirmation.html",
     require_methods=False,
     uses_session=True,
     permission=Permissions.AccountVerifyProjectRole,
@@ -1498,7 +1498,7 @@ def view_terms_of_service(request):
 @view_config(
     route_name="includes.current-user-profile-callout",
     context=User,
-    renderer="includes/accounts/profile-callout.html",
+    renderer="warehouse:templates/includes/accounts/profile-callout.html",
     uses_session=True,
     has_translations=True,
 )
@@ -1509,7 +1509,7 @@ def profile_callout(user, request):
 @view_config(
     route_name="includes.profile-actions",
     context=User,
-    renderer="includes/accounts/profile-actions.html",
+    renderer="warehouse:templates/includes/accounts/profile-actions.html",
     uses_session=True,
     has_translations=True,
 )
@@ -1520,7 +1520,7 @@ def edit_profile_button(user, request):
 @view_config(
     route_name="includes.profile-public-email",
     context=User,
-    renderer="includes/accounts/profile-public-email.html",
+    renderer="warehouse:templates/includes/accounts/profile-public-email.html",
     uses_session=True,
     has_translations=True,
 )
@@ -1578,7 +1578,7 @@ def reauthenticate(request, _form_class=ReAuthenticateForm):
 
 @view_defaults(
     route_name="manage.account.publishing",
-    renderer="manage/account/publishing.html",
+    renderer="warehouse:templates/manage/account/publishing.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,

--- a/warehouse/admin/views/banners.py
+++ b/warehouse/admin/views/banners.py
@@ -13,7 +13,7 @@ from warehouse.forms import URIValidator
 
 @view_config(
     route_name="admin.banner.list",
-    renderer="admin/banners/list.html",
+    renderer="warehouse.admin:templates/admin/banners/list.html",
     permission=Permissions.AdminBannerRead,
     request_method="GET",
     uses_session=True,
@@ -25,7 +25,7 @@ def banner_list(request):
 
 @view_config(
     route_name="admin.banner.edit",
-    renderer="admin/banners/edit.html",
+    renderer="warehouse.admin:templates/admin/banners/edit.html",
     permission=Permissions.AdminBannerRead,
     request_method="GET",
     uses_session=True,
@@ -34,7 +34,7 @@ def banner_list(request):
 )
 @view_config(
     route_name="admin.banner.edit",
-    renderer="admin/banners/edit.html",
+    renderer="warehouse.admin:templates/admin/banners/edit.html",
     permission=Permissions.AdminBannerWrite,
     request_method="POST",
     uses_session=True,
@@ -60,7 +60,7 @@ def edit_banner(request):
 
 @view_config(
     route_name="admin.banner.create",
-    renderer="admin/banners/edit.html",
+    renderer="warehouse.admin:templates/admin/banners/edit.html",
     permission=Permissions.AdminBannerRead,
     request_method="GET",
     uses_session=True,
@@ -69,7 +69,7 @@ def edit_banner(request):
 )
 @view_config(
     route_name="admin.banner.create",
-    renderer="admin/banners/edit.html",
+    renderer="warehouse.admin:templates/admin/banners/edit.html",
     permission=Permissions.AdminBannerWrite,
     request_method="POST",
     uses_session=True,
@@ -124,7 +124,7 @@ def delete_banner(request):
     uses_session=True,
     require_csrf=True,
     has_translations=True,
-    renderer="admin/banners/preview.html",
+    renderer="warehouse.admin:templates/admin/banners/preview.html",
 )
 def preview_banner(request):
     id_ = request.matchdict["banner_id"]

--- a/warehouse/admin/views/core.py
+++ b/warehouse/admin/views/core.py
@@ -16,7 +16,7 @@ from warehouse.subscriptions.models import StripeSubscription, StripeSubscriptio
 
 @view_config(
     route_name="admin.dashboard",
-    renderer="admin/dashboard.html",
+    renderer="warehouse.admin:templates/admin/dashboard.html",
     permission=Permissions.AdminDashboardRead,
     uses_session=True,
 )

--- a/warehouse/admin/views/emails.py
+++ b/warehouse/admin/views/emails.py
@@ -20,7 +20,7 @@ from warehouse.utils.paginate import paginate_url_factory
 
 @view_config(
     route_name="admin.emails.list",
-    renderer="admin/emails/list.html",
+    renderer="warehouse.admin:templates/admin/emails/list.html",
     permission=Permissions.AdminEmailsRead,
     request_method="GET",
     uses_session=True,
@@ -111,7 +111,7 @@ def email_mass(request):
 
 @view_config(
     route_name="admin.emails.detail",
-    renderer="admin/emails/detail.html",
+    renderer="warehouse.admin:templates/admin/emails/detail.html",
     permission=Permissions.AdminEmailsRead,
     request_method="GET",
     uses_session=True,

--- a/warehouse/admin/views/flags.py
+++ b/warehouse/admin/views/flags.py
@@ -9,7 +9,7 @@ from warehouse.authnz import Permissions
 
 @view_config(
     route_name="admin.flags",
-    renderer="admin/flags/index.html",
+    renderer="warehouse.admin:templates/admin/flags/index.html",
     permission=Permissions.AdminFlagsRead,
     request_method="GET",
     uses_session=True,

--- a/warehouse/admin/views/includes.py
+++ b/warehouse/admin/views/includes.py
@@ -9,7 +9,7 @@ from warehouse.packaging.models import ProhibitedProjectName, Project
 
 @view_config(
     route_name="includes.administer-project-include",
-    renderer="includes/admin/administer-project-include.html",
+    renderer="warehouse:templates/includes/admin/administer-project-include.html",
     uses_session=True,
 )
 def administer_project_include(request):
@@ -47,7 +47,7 @@ def administer_project_include(request):
 @view_config(
     route_name="includes.administer-user-include",
     context=User,
-    renderer="includes/admin/administer-user-include.html",
+    renderer="warehouse:templates/includes/admin/administer-user-include.html",
     uses_session=True,
 )
 def administer_user_include(user, request):

--- a/warehouse/admin/views/ip_addresses.py
+++ b/warehouse/admin/views/ip_addresses.py
@@ -19,7 +19,7 @@ if typing.TYPE_CHECKING:
 
 @view_config(
     route_name="admin.ip_address.list",
-    renderer="admin/ip_addresses/list.html",
+    renderer="warehouse.admin:templates/admin/ip_addresses/list.html",
     permission=Permissions.AdminIpAddressesRead,
     uses_session=True,
 )
@@ -46,7 +46,7 @@ def ip_address_list(request: Request) -> dict[str, SQLAlchemyORMPage[IpAddress] 
 
 @view_config(
     route_name="admin.ip_address.detail",
-    renderer="admin/ip_addresses/detail.html",
+    renderer="warehouse.admin:templates/admin/ip_addresses/detail.html",
     permission=Permissions.AdminIpAddressesRead,
     uses_session=True,
 )

--- a/warehouse/admin/views/journals.py
+++ b/warehouse/admin/views/journals.py
@@ -15,7 +15,7 @@ from warehouse.utils.paginate import paginate_url_factory
 
 @view_config(
     route_name="admin.journals.list",
-    renderer="admin/journals/list.html",
+    renderer="warehouse.admin:templates/admin/journals/list.html",
     permission=Permissions.AdminJournalRead,
     uses_session=True,
 )

--- a/warehouse/admin/views/macaroons.py
+++ b/warehouse/admin/views/macaroons.py
@@ -14,7 +14,7 @@ from warehouse.macaroons.services import deserialize_raw_macaroon
 
 @view_config(
     route_name="admin.macaroon.decode_token",
-    renderer="admin/macaroons/decode_token.html",
+    renderer="warehouse.admin:templates/admin/macaroons/decode_token.html",
     permission=Permissions.AdminMacaroonsRead,
     request_method="GET",
     uses_session=True,
@@ -23,7 +23,7 @@ from warehouse.macaroons.services import deserialize_raw_macaroon
 )
 @view_config(
     route_name="admin.macaroon.decode_token",
-    renderer="admin/macaroons/decode_token.html",
+    renderer="warehouse.admin:templates/admin/macaroons/decode_token.html",
     permission=Permissions.AdminMacaroonsRead,
     request_method="POST",
     uses_session=True,
@@ -59,7 +59,7 @@ def macaroon_decode_token(request):
 
 @view_config(
     route_name="admin.macaroon.detail",
-    renderer="admin/macaroons/detail.html",
+    renderer="warehouse.admin:templates/admin/macaroons/detail.html",
     permission=Permissions.AdminMacaroonsRead,
     uses_session=True,
 )

--- a/warehouse/admin/views/malware_reports.py
+++ b/warehouse/admin/views/malware_reports.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 @view_config(
     route_name="admin.malware_reports.list",
-    renderer="admin/malware_reports/list.html",
+    renderer="warehouse.admin:templates/admin/malware_reports/list.html",
     permission=Permissions.AdminObservationsRead,
     request_method="GET",
     uses_session=True,
@@ -56,7 +56,7 @@ def malware_reports_list(request):
 
 @view_config(
     route_name="admin.malware_reports.project.list",
-    renderer="admin/malware_reports/project_list.html",
+    renderer="warehouse.admin:templates/admin/malware_reports/project_list.html",
     permission=Permissions.AdminObservationsRead,
     request_method="GET",
     uses_session=True,
@@ -198,7 +198,7 @@ def malware_reports_project_verdict_remove_malware(project, request):
 
 @view_config(
     route_name="admin.malware_reports.detail",
-    renderer="admin/malware_reports/detail.html",
+    renderer="warehouse.admin:templates/admin/malware_reports/detail.html",
     permission=Permissions.AdminObservationsRead,
     request_method="GET",
     uses_session=True,

--- a/warehouse/admin/views/observations.py
+++ b/warehouse/admin/views/observations.py
@@ -12,7 +12,7 @@ from warehouse.observations.models import Observation
 
 @view_config(
     route_name="admin.observations.list",
-    renderer="admin/observations/list.html",
+    renderer="warehouse.admin:templates/admin/observations/list.html",
     permission=Permissions.AdminObservationsRead,
     request_method="GET",
     uses_session=True,

--- a/warehouse/admin/views/organizations.py
+++ b/warehouse/admin/views/organizations.py
@@ -44,7 +44,7 @@ def _turbo_mode(request):
 
 @view_config(
     route_name="admin.organization.list",
-    renderer="admin/organizations/list.html",
+    renderer="warehouse.admin:templates/admin/organizations/list.html",
     permission=Permissions.AdminOrganizationsRead,
     uses_session=True,
 )
@@ -147,7 +147,7 @@ def organization_list(request):
 @view_config(
     route_name="admin.organization.detail",
     require_methods=False,
-    renderer="admin/organizations/detail.html",
+    renderer="warehouse.admin:templates/admin/organizations/detail.html",
     permission=Permissions.AdminOrganizationsRead,
     has_translations=True,
     uses_session=True,
@@ -207,7 +207,7 @@ def organization_rename(request):
 
 @view_config(
     route_name="admin.organization_application.list",
-    renderer="admin/organization_applications/list.html",
+    renderer="warehouse.admin:templates/admin/organization_applications/list.html",
     permission=Permissions.AdminOrganizationsRead,
     uses_session=True,
 )
@@ -319,7 +319,7 @@ class OrganizationApplicationForm(OrganizationNameMixin, SaveOrganizationForm):
 @view_config(
     route_name="admin.organization_application.detail",
     require_methods=False,
-    renderer="admin/organization_applications/detail.html",
+    renderer="warehouse.admin:templates/admin/organization_applications/detail.html",
     permission=Permissions.AdminOrganizationsRead,
     has_translations=True,
     uses_session=True,

--- a/warehouse/admin/views/prohibited_email_domains.py
+++ b/warehouse/admin/views/prohibited_email_domains.py
@@ -13,7 +13,7 @@ from warehouse.utils.paginate import paginate_url_factory
 
 @view_config(
     route_name="admin.prohibited_email_domains.list",
-    renderer="admin/prohibited_email_domains/list.html",
+    renderer="warehouse.admin:templates/admin/prohibited_email_domains/list.html",
     permission=Permissions.AdminProhibitedEmailDomainsRead,
     request_method="GET",
     uses_session=True,

--- a/warehouse/admin/views/prohibited_project_names.py
+++ b/warehouse/admin/views/prohibited_project_names.py
@@ -27,7 +27,7 @@ from warehouse.utils.project import prohibit_and_remove_project
 
 @view_config(
     route_name="admin.prohibited_project_names.list",
-    renderer="admin/prohibited_project_names/list.html",
+    renderer="warehouse.admin:templates/admin/prohibited_project_names/list.html",
     permission=Permissions.AdminProhibitedProjectsRead,
     request_method="GET",
     uses_session=True,
@@ -70,7 +70,7 @@ def prohibited_project_names(request):
 
 @view_config(
     route_name="admin.prohibited_project_names.add",
-    renderer="admin/prohibited_project_names/confirm.html",
+    renderer="warehouse.admin:templates/admin/prohibited_project_names/confirm.html",
     permission=Permissions.AdminProhibitedProjectsWrite,
     request_method="GET",
     uses_session=True,
@@ -285,7 +285,7 @@ def remove_prohibited_project_names(request):
 
 @view_config(
     route_name="admin.prohibited_project_names.bulk_add",
-    renderer="admin/prohibited_project_names/bulk.html",
+    renderer="warehouse.admin:templates/admin/prohibited_project_names/bulk.html",
     permission=Permissions.AdminProhibitedProjectsWrite,
     uses_session=True,
     require_methods=False,

--- a/warehouse/admin/views/prohibited_user_names.py
+++ b/warehouse/admin/views/prohibited_user_names.py
@@ -13,7 +13,7 @@ from warehouse.utils.paginate import paginate_url_factory
 
 @view_config(
     route_name="admin.prohibited_user_names.list",
-    renderer="admin/prohibited_user_names/list.html",
+    renderer="warehouse.admin:templates/admin/prohibited_user_names/list.html",
     permission=Permissions.AdminProhibitedUsernameRead,
     request_method="GET",
     uses_session=True,
@@ -47,7 +47,7 @@ def prohibited_usernames(request):
 
 @view_config(
     route_name="admin.prohibited_user_names.bulk_add",
-    renderer="admin/prohibited_user_names/bulk.html",
+    renderer="warehouse.admin:templates/admin/prohibited_user_names/bulk.html",
     permission=Permissions.AdminUsersWrite,
     uses_session=True,
     require_methods=False,

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -32,7 +32,7 @@ UPLOAD_LIMIT_CAP = ONE_GIB
 
 @view_config(
     route_name="admin.project.list",
-    renderer="admin/projects/list.html",
+    renderer="warehouse.admin:templates/admin/projects/list.html",
     permission=Permissions.AdminProjectsRead,
     request_method="GET",
     uses_session=True,
@@ -69,7 +69,7 @@ def project_list(request):
 
 @view_config(
     route_name="admin.project.detail",
-    renderer="admin/projects/detail.html",
+    renderer="warehouse.admin:templates/admin/projects/detail.html",
     permission=Permissions.AdminProjectsRead,
     request_method="GET",
     uses_session=True,
@@ -78,7 +78,7 @@ def project_list(request):
 )
 @view_config(
     route_name="admin.project.detail",
-    renderer="admin/projects/detail.html",
+    renderer="warehouse.admin:templates/admin/projects/detail.html",
     permission=Permissions.AdminProjectsWrite,
     request_method="POST",
     uses_session=True,
@@ -148,7 +148,7 @@ def project_detail(project, request):
 
 @view_config(
     route_name="admin.project.observations",
-    renderer="admin/projects/project_observations_list.html",
+    renderer="warehouse.admin:templates/admin/projects/project_observations_list.html",
     permission=Permissions.AdminObservationsRead,
     request_method="GET",
     uses_session=True,
@@ -234,7 +234,7 @@ def add_project_observation(project, request):
 
 @view_config(
     route_name="admin.project.releases",
-    renderer="admin/projects/releases_list.html",
+    renderer="warehouse.admin:templates/admin/projects/releases_list.html",
     permission=Permissions.AdminProjectsRead,
     request_method="GET",
     uses_session=True,
@@ -284,7 +284,7 @@ def releases_list(project, request):
 
 @view_config(
     route_name="admin.project.release",
-    renderer="admin/projects/release_detail.html",
+    renderer="warehouse.admin:templates/admin/projects/release_detail.html",
     permission=Permissions.AdminProjectsRead,
     request_method="GET",
     uses_session=True,
@@ -412,7 +412,7 @@ def release_render(release, request):
 
 @view_config(
     route_name="admin.project.journals",
-    renderer="admin/projects/journals_list.html",
+    renderer="warehouse.admin:templates/admin/projects/journals_list.html",
     permission=Permissions.AdminProjectsRead,
     request_method="GET",
     uses_session=True,

--- a/warehouse/admin/views/sponsors.py
+++ b/warehouse/admin/views/sponsors.py
@@ -73,7 +73,7 @@ class SponsorForm(wtforms.Form):
 
 @view_config(
     route_name="admin.sponsor.list",
-    renderer="admin/sponsors/list.html",
+    renderer="warehouse.admin:templates/admin/sponsors/list.html",
     permission=Permissions.AdminSponsorsRead,
     request_method="GET",
     uses_session=True,
@@ -111,7 +111,7 @@ def _upload_image(image_name, request, form):
 
 @view_config(
     route_name="admin.sponsor.edit",
-    renderer="admin/sponsors/edit.html",
+    renderer="warehouse.admin:templates/admin/sponsors/edit.html",
     permission=Permissions.AdminSponsorsRead,
     request_method="GET",
     uses_session=True,
@@ -120,7 +120,7 @@ def _upload_image(image_name, request, form):
 )
 @view_config(
     route_name="admin.sponsor.edit",
-    renderer="admin/sponsors/edit.html",
+    renderer="warehouse.admin:templates/admin/sponsors/edit.html",
     permission=Permissions.AdminSponsorsWrite,
     request_method="POST",
     uses_session=True,
@@ -151,7 +151,7 @@ def edit_sponsor(request):
 
 @view_config(
     route_name="admin.sponsor.create",
-    renderer="admin/sponsors/edit.html",
+    renderer="warehouse.admin:templates/admin/sponsors/edit.html",
     permission=Permissions.AdminSponsorsRead,
     request_method="GET",
     uses_session=True,
@@ -160,7 +160,7 @@ def edit_sponsor(request):
 )
 @view_config(
     route_name="admin.sponsor.create",
-    renderer="admin/sponsors/edit.html",
+    renderer="warehouse.admin:templates/admin/sponsors/edit.html",
     permission=Permissions.AdminSponsorsWrite,
     request_method="POST",
     uses_session=True,

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -48,7 +48,7 @@ if typing.TYPE_CHECKING:
 
 @view_config(
     route_name="admin.user.list",
-    renderer="admin/users/list.html",
+    renderer="warehouse.admin:templates/admin/users/list.html",
     permission=Permissions.AdminUsersRead,
     uses_session=True,
 )
@@ -130,7 +130,7 @@ class UserForm(wtforms.Form):
 
 @view_config(
     route_name="admin.user.detail",
-    renderer="admin/users/detail.html",
+    renderer="warehouse.admin:templates/admin/users/detail.html",
     permission=Permissions.AdminUsersRead,
     request_method="GET",
     uses_session=True,
@@ -139,7 +139,7 @@ class UserForm(wtforms.Form):
 )
 @view_config(
     route_name="admin.user.detail",
-    renderer="admin/users/detail.html",
+    renderer="warehouse.admin:templates/admin/users/detail.html",
     permission=Permissions.AdminUsersWrite,
     request_method="POST",
     uses_session=True,
@@ -473,7 +473,7 @@ def _get_related_urls(user):
 
 @view_config(
     route_name="admin.user.account_recovery.initiate",
-    renderer="admin/users/account_recovery/initiate.html",
+    renderer="warehouse.admin:templates/admin/users/account_recovery/initiate.html",
     permission=Permissions.AdminUsersAccountRecoveryWrite,
     has_translations=True,
     uses_session=True,

--- a/warehouse/api/simple.py
+++ b/warehouse/api/simple.py
@@ -51,7 +51,7 @@ def _select_content_type(request: Request) -> str:
 
 @view_config(
     route_name="api.simple.index",
-    renderer="api/simple/index.html",
+    renderer="warehouse:templates/api/simple/index.html",
     decorator=[
         add_vary("Accept"),
         cache_control(10 * 60),  # 10 minutes
@@ -83,7 +83,7 @@ def simple_index(request):
 @view_config(
     route_name="api.simple.detail",
     context=Project,
-    renderer="api/simple/detail.html",
+    renderer="warehouse:templates/api/simple/detail.html",
     decorator=[
         add_vary("Accept"),
         cache_control(10 * 60),  # 10 minutes

--- a/warehouse/banners/views.py
+++ b/warehouse/banners/views.py
@@ -9,7 +9,7 @@ from warehouse.banners.models import Banner
 
 @view_config(
     route_name="includes.db-banners",
-    renderer="includes/banner-messages.html",
+    renderer="warehouse:templates/includes/banner-messages.html",
     uses_session=True,
     has_translations=True,
 )

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -204,7 +204,7 @@ class ManageAccountMixin:
 
 @view_defaults(
     route_name="manage.unverified-account",
-    renderer="manage/unverified-account.html",
+    renderer="warehouse:templates/manage/unverified-account.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -224,7 +224,7 @@ class ManageUnverifiedAccountViews(ManageAccountMixin):
 
 @view_defaults(
     route_name="manage.account",
-    renderer="manage/account.html",
+    renderer="warehouse:templates/manage/account.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -501,7 +501,7 @@ class ManageVerifiedAccountViews(ManageAccountMixin):
 
 @view_config(
     route_name="manage.account.two-factor",
-    renderer="manage/account/two-factor.html",
+    renderer="warehouse:templates/manage/account/two-factor.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -515,7 +515,7 @@ def manage_two_factor(request):
 
 @view_defaults(
     route_name="manage.account.totp-provision",
-    renderer="manage/account/totp-provision.html",
+    renderer="warehouse:templates/manage/account/totp-provision.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -681,7 +681,7 @@ class ProvisionWebAuthnViews:
     @view_config(
         request_method="GET",
         route_name="manage.account.webauthn-provision",
-        renderer="manage/account/webauthn-provision.html",
+        renderer="warehouse:templates/manage/account/webauthn-provision.html",
     )
     def webauthn_provision(self):
         if not self.request.user.has_burned_recovery_codes:
@@ -808,7 +808,7 @@ class ProvisionRecoveryCodesViews:
     @view_config(
         request_method="GET",
         route_name="manage.account.recovery-codes.generate",
-        renderer="manage/account/recovery_codes-provision.html",
+        renderer="warehouse:templates/manage/account/recovery_codes-provision.html",
         require_reauth=10,  # 10 seconds
     )
     def recovery_codes_generate(self):
@@ -833,7 +833,7 @@ class ProvisionRecoveryCodesViews:
     @view_config(
         request_method="GET",
         route_name="manage.account.recovery-codes.regenerate",
-        renderer="manage/account/recovery_codes-provision.html",
+        renderer="warehouse:templates/manage/account/recovery_codes-provision.html",
         require_reauth=10,  # 10 seconds
     )
     def recovery_codes_regenerate(self):
@@ -848,7 +848,7 @@ class ProvisionRecoveryCodesViews:
 
     @view_config(
         route_name="manage.account.recovery-codes.burn",
-        renderer="manage/account/recovery_codes-burn.html",
+        renderer="warehouse:templates/manage/account/recovery_codes-burn.html",
     )
     def recovery_codes_burn(self, _form_class=RecoveryCodeAuthenticationForm):
         user = self.user_service.get_user(self.request.user.id)
@@ -882,7 +882,7 @@ class ProvisionRecoveryCodesViews:
     require_csrf=True,
     require_methods=False,
     permission=Permissions.AccountAPITokens,
-    renderer="manage/account/token.html",
+    renderer="warehouse:templates/manage/account/token.html",
     route_name="manage.account.token",
     has_translations=True,
     require_reauth=True,
@@ -1070,7 +1070,7 @@ class ProvisionMacaroonViews:
 
 @view_config(
     route_name="manage.projects",
-    renderer="manage/projects.html",
+    renderer="warehouse:templates/manage/projects.html",
     uses_session=True,
     permission=Permissions.ProjectsRead,
     has_translations=True,
@@ -1113,7 +1113,7 @@ def manage_projects(request):
 @view_defaults(
     route_name="manage.project.settings",
     context=Project,
-    renderer="manage/project/settings.html",
+    renderer="warehouse:templates/manage/project/settings.html",
     uses_session=True,
     permission=Permissions.ProjectsRead,
     has_translations=True,
@@ -1323,7 +1323,7 @@ class ManageProjectSettingsViews:
 @view_defaults(
     context=Project,
     route_name="manage.project.settings.publishing",
-    renderer="manage/project/publishing.html",
+    renderer="warehouse:templates/manage/project/publishing.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -2202,7 +2202,7 @@ def destroy_project_docs(project, request):
 @view_config(
     route_name="manage.project.releases",
     context=Project,
-    renderer="manage/project/releases.html",
+    renderer="warehouse:templates/manage/project/releases.html",
     uses_session=True,
     permission=Permissions.ProjectsRead,
     has_translations=True,
@@ -2244,7 +2244,7 @@ def manage_project_releases(project, request):
 @view_defaults(
     route_name="manage.project.release",
     context=Release,
-    renderer="manage/project/release.html",
+    renderer="warehouse:templates/manage/project/release.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -2641,7 +2641,7 @@ class ManageProjectRelease:
 @view_config(
     route_name="manage.project.roles",
     context=Project,
-    renderer="manage/project/roles.html",
+    renderer="warehouse:templates/manage/project/roles.html",
     uses_session=True,
     require_methods=False,
     permission=Permissions.ProjectsWrite,
@@ -3257,7 +3257,7 @@ def delete_project_role(project, request):
 @view_config(
     route_name="manage.project.history",
     context=Project,
-    renderer="manage/project/history.html",
+    renderer="warehouse:templates/manage/project/history.html",
     uses_session=True,
     permission=Permissions.ProjectsRead,
     has_translations=True,
@@ -3306,7 +3306,7 @@ def manage_project_history(project, request):
 @view_config(
     route_name="manage.project.documentation",
     context=Project,
-    renderer="manage/project/documentation.html",
+    renderer="warehouse:templates/manage/project/documentation.html",
     uses_session=True,
     permission=Permissions.ProjectsRead,
     has_translations=True,

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -119,7 +119,7 @@ def organization_members(request, organization):
 
 @view_defaults(
     route_name="manage.organizations",
-    renderer="manage/organizations.html",
+    renderer="warehouse:templates/manage/organizations.html",
     uses_session=True,
     require_active_organization=False,  # Allow list/create orgs without active org.
     require_csrf=True,
@@ -244,7 +244,7 @@ class ManageOrganizationsViews:
 @view_defaults(
     route_name="manage.organizations.application",
     context=OrganizationApplication,
-    renderer="manage/organization/application.html",
+    renderer="warehouse:templates/manage/organization/application.html",
     uses_session=True,
     require_csrf=True,
     require_methods=False,
@@ -320,7 +320,7 @@ class ManageOrganizationApplicationViews:
 @view_defaults(
     route_name="manage.organization.settings",
     context=Organization,
-    renderer="manage/organization/settings.html",
+    renderer="warehouse:templates/manage/organization/settings.html",
     uses_session=True,
     require_active_organization=True,
     require_csrf=True,
@@ -622,7 +622,7 @@ class ManageOrganizationBillingViews:
 
     @view_config(
         route_name="manage.organization.activate_subscription",
-        renderer="manage/organization/activate_subscription.html",
+        renderer="warehouse:templates/manage/organization/activate_subscription.html",
     )
     def activate_subscription(self):
         form = OrganizationActivateBillingForm(self.request.POST)
@@ -658,7 +658,7 @@ class ManageOrganizationBillingViews:
 @view_defaults(
     route_name="manage.organization.teams",
     context=Organization,
-    renderer="manage/organization/teams.html",
+    renderer="warehouse:templates/manage/organization/teams.html",
     uses_session=True,
     require_active_organization=True,
     require_csrf=True,
@@ -746,7 +746,7 @@ class ManageOrganizationTeamsViews:
 @view_defaults(
     route_name="manage.organization.projects",
     context=Organization,
-    renderer="manage/organization/projects.html",
+    renderer="warehouse:templates/manage/organization/projects.html",
     uses_session=True,
     require_active_organization=True,
     require_csrf=True,
@@ -1034,7 +1034,7 @@ def _send_organization_invitation(request, organization, role_name, user):
 @view_config(
     route_name="manage.organization.roles",
     context=Organization,
-    renderer="manage/organization/roles.html",
+    renderer="warehouse:templates/manage/organization/roles.html",
     uses_session=True,
     require_active_organization=True,
     require_methods=False,
@@ -1393,7 +1393,7 @@ def delete_organization_role(organization, request):
 @view_config(
     route_name="manage.organization.history",
     context=Organization,
-    renderer="manage/organization/history.html",
+    renderer="warehouse:templates/manage/organization/history.html",
     uses_session=True,
     permission=Permissions.OrganizationsManage,
     has_translations=True,

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -47,7 +47,7 @@ from warehouse.utils.paginate import paginate_url_factory
 @view_defaults(
     route_name="manage.team.settings",
     context=Team,
-    renderer="manage/team/settings.html",
+    renderer="warehouse:templates/manage/team/settings.html",
     uses_session=True,
     require_active_organization=True,
     require_csrf=True,
@@ -181,7 +181,7 @@ class ManageTeamSettingsViews:
 @view_defaults(
     route_name="manage.team.projects",
     context=Team,
-    renderer="manage/team/projects.html",
+    renderer="warehouse:templates/manage/team/projects.html",
     uses_session=True,
     require_active_organization=True,
     require_csrf=True,
@@ -225,7 +225,7 @@ class ManageTeamProjectsViews:
 @view_defaults(
     route_name="manage.team.roles",
     context=Team,
-    renderer="manage/team/roles.html",
+    renderer="warehouse:templates/manage/team/roles.html",
     uses_session=True,
     require_active_organization=True,
     require_csrf=True,
@@ -439,7 +439,7 @@ class ManageTeamRolesViews:
 @view_config(
     route_name="manage.team.history",
     context=Team,
-    renderer="manage/team/history.html",
+    renderer="warehouse:templates/manage/team/history.html",
     uses_session=True,
     permission=Permissions.OrganizationTeamsManage,
     has_translations=True,

--- a/warehouse/mock/billing.py
+++ b/warehouse/mock/billing.py
@@ -34,14 +34,14 @@ class MockBillingViews:
 
     @view_config(
         route_name="mock.billing.checkout-session",
-        renderer="mock/billing/checkout-session.html",
+        renderer="warehouse:templates/mock/billing/checkout-session.html",
     )
     def mock_checkout_session(self):
         return {"organization": self.organization}
 
     @view_config(
         route_name="mock.billing.portal-session",
-        renderer="mock/billing/portal-session.html",
+        renderer="warehouse:templates/mock/billing/portal-session.html",
     )
     def mock_portal_session(self):
         return {"organization": self.organization}

--- a/warehouse/organizations/views.py
+++ b/warehouse/organizations/views.py
@@ -10,7 +10,7 @@ from warehouse.organizations.models import Organization
 @view_config(
     route_name="organizations.profile",
     context=Organization,
-    renderer="organizations/profile.html",
+    renderer="warehouse:templates/organizations/profile.html",
     decorator=[
         origin_cache(1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60)  # 1 day each.
     ],

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -154,7 +154,7 @@ class PEP740AttestationViewer:
 @view_config(
     route_name="packaging.project",
     context=Project,
-    renderer="packaging/detail.html",
+    renderer="warehouse:templates/packaging/detail.html",
     decorator=[
         origin_cache(
             1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale
@@ -187,7 +187,7 @@ def project_detail(project, request):
 @view_config(
     route_name="packaging.release",
     context=Release,
-    renderer="packaging/detail.html",
+    renderer="warehouse:templates/packaging/detail.html",
     decorator=[
         origin_cache(
             1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale
@@ -285,7 +285,7 @@ def release_detail(release, request):
 @view_config(
     route_name="includes.edit-project-button",
     context=Project,
-    renderer="includes/manage-project-button.html",
+    renderer="warehouse:templates/includes/manage-project-button.html",
     uses_session=True,
     has_translations=True,
 )
@@ -297,7 +297,7 @@ def edit_project_button(project, request):
     context=Project,
     has_translations=True,
     permission=Permissions.SubmitMalwareObservation,
-    renderer="packaging/submit-malware-observation.html",
+    renderer="warehouse:templates/packaging/submit-malware-observation.html",
     require_csrf=True,
     require_methods=False,
     route_name="packaging.project.submit_malware_observation",

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -35,7 +35,7 @@ def _format_author(release):
 
 @view_config(
     route_name="rss.updates",
-    renderer="rss/updates.xml",
+    renderer="warehouse:templates/rss/updates.xml",
     decorator=[
         origin_cache(
             1 * 24 * 60 * 60,  # 1 day
@@ -62,7 +62,7 @@ def rss_updates(request):
 
 @view_config(
     route_name="rss.packages",
-    renderer="rss/packages.xml",
+    renderer="warehouse:templates/rss/packages.xml",
     decorator=[
         origin_cache(
             1 * 24 * 60 * 60,  # 1 day
@@ -92,7 +92,7 @@ def rss_packages(request):
 @view_config(
     route_name="rss.project.releases",
     context=Project,
-    renderer="rss/project_releases.xml",
+    renderer="warehouse:templates/rss/project_releases.xml",
     decorator=[
         origin_cache(
             1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale

--- a/warehouse/sitemap/views.py
+++ b/warehouse/sitemap/views.py
@@ -25,7 +25,7 @@ class BucketTooSmallError(ValueError):
 
 @view_config(
     route_name="index.sitemap.xml",
-    renderer="sitemap/index.xml",
+    renderer="warehouse:templates/sitemap/index.xml",
     decorator=[
         cache_control(1 * 60 * 60),  # 1 hour
         origin_cache(
@@ -91,7 +91,7 @@ def sitemap_index(request):
 
 @view_config(
     route_name="bucket.sitemap.xml",
-    renderer="sitemap/bucket.xml",
+    renderer="warehouse:templates/sitemap/bucket.xml",
     decorator=[
         cache_control(1 * 60 * 60),  # 1 hour
         origin_cache(

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -226,7 +226,7 @@ def favicon(request: Request) -> FileResponse:
 
 @view_config(
     route_name="robots.txt",
-    renderer="robots.txt",
+    renderer="warehouse:templates/robots.txt",
     decorator=[
         cache_control(1 * 24 * 60 * 60),  # 1 day
         origin_cache(
@@ -243,7 +243,7 @@ def robotstxt(request):
 
 @view_config(
     route_name="opensearch.xml",
-    renderer="opensearch.xml",
+    renderer="warehouse:templates/opensearch.xml",
     decorator=[
         cache_control(1 * 24 * 60 * 60),  # 1 day
         origin_cache(
@@ -260,7 +260,7 @@ def opensearchxml(request):
 
 @view_config(
     route_name="index",
-    renderer="index.html",
+    renderer="warehouse:templates/index.html",
     decorator=[
         origin_cache(
             1 * 60 * 60,  # 1 hour
@@ -326,7 +326,9 @@ def locale(request):
 
 
 @view_config(
-    route_name="classifiers", renderer="pages/classifiers.html", has_translations=True
+    route_name="classifiers",
+    renderer="warehouse:templates/pages/classifiers.html",
+    has_translations=True,
 )
 def list_classifiers(request):
     return {"classifiers": sorted_classifiers}
@@ -334,7 +336,7 @@ def list_classifiers(request):
 
 @view_config(
     route_name="search",
-    renderer="search/results.html",
+    renderer="warehouse:templates/search/results.html",
     decorator=[
         origin_cache(
             1 * 60 * 60,  # 1 hour
@@ -461,7 +463,7 @@ def search(request):
 
 @view_config(
     route_name="stats",
-    renderer="pages/stats.html",
+    renderer="warehouse:templates/pages/stats.html",
     decorator=[
         add_vary("Accept"),
         cache_control(1 * 24 * 60 * 60),  # 1 day
@@ -507,7 +509,7 @@ def stats(request):
 
 @view_defaults(
     route_name="security-key-giveaway",
-    renderer="pages/security-key-giveaway.html",
+    renderer="warehouse:templates/pages/security-key-giveaway.html",
     uses_session=True,
     has_translations=True,
     require_csrf=True,
@@ -528,7 +530,7 @@ class SecurityKeyGiveaway:
 
 @view_config(
     route_name="includes.current-user-indicator",
-    renderer="includes/current-user-indicator.html",
+    renderer="warehouse:templates/includes/current-user-indicator.html",
     uses_session=True,
     has_translations=True,
 )
@@ -538,7 +540,7 @@ def current_user_indicator(request):
 
 @view_config(
     route_name="includes.flash-messages",
-    renderer="includes/flash-messages.html",
+    renderer="warehouse:templates/includes/flash-messages.html",
     uses_session=True,
     has_translations=True,
 )
@@ -548,7 +550,7 @@ def flash_messages(request):
 
 @view_config(
     route_name="includes.session-notifications",
-    renderer="includes/session-notifications.html",
+    renderer="warehouse:templates/includes/session-notifications.html",
     uses_session=True,
     has_translations=True,
 )
@@ -558,7 +560,7 @@ def session_notifications(request):
 
 @view_config(
     route_name="includes.sidebar-sponsor-logo",
-    renderer="includes/sidebar-sponsor-logo.html",
+    renderer="warehouse:templates/includes/sidebar-sponsor-logo.html",
     uses_session=False,
     has_translations=False,
     decorator=[


### PR DESCRIPTION
Avoid unnecessary template lookup failures by specifying full package paths for all template renderers. Previously, for endpoints like /simple/<package>, the template resolver would first attempt to find 'warehouse.api:api/simple/detail.html' which would always fail, then fall back to 'templates/api/simple/detail.html'. By using explicit package qualifiers like 'warehouse:templates/api/simple/detail.html', we skip the initial failed lookup and exception handling.

This provides a small performance optimization by eliminating known failed disk lookups, as well as avoiding exception traceback generation when ddtrace is enabled (for attaching the traceback to the span metadata).

Testing locally, the template load time goes from ~830us to ~80us, and template rendering time goes from ~4ms to ~3.7ms... a small optimization, but an easy win.