### PR TITLE
Add billing.stripe.com to form-action CSP

### DIFF
--- a/tests/unit/test_csp.py
+++ b/tests/unit/test_csp.py
@@ -250,7 +250,11 @@ def test_includeme():
                     ],
                     "default-src": ["'none'"],
                     "font-src": ["'self'", "fonts.gstatic.com"],
-                    "form-action": ["'self'", "https://checkout.stripe.com"],
+                    "form-action": [
+                        "'self'",
+                        "https://checkout.stripe.com",
+                        "https://billing.stripe.com",
+                    ],
                     "frame-ancestors": ["'none'"],
                     "frame-src": ["'none'"],
                     "img-src": [

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -155,7 +155,11 @@ def includeme(config):
                 "connect-src": _connect_src_settings(config),
                 "default-src": [NONE],
                 "font-src": [SELF, "fonts.gstatic.com"],
-                "form-action": [SELF, "https://checkout.stripe.com"],
+                "form-action": [
+                    SELF,
+                    "https://checkout.stripe.com",
+                    "https://billing.stripe.com",
+                ],
                 "frame-ancestors": [NONE],
                 "frame-src": [NONE],
                 "img-src": [


### PR DESCRIPTION
closes #18315

Allow `https://billing.stripe.com` in form-action CSP.

When an organization's subscription lapses and they are marked as inactive, the POST to /manage/organization/<ORG_SLUG>/subscription/activate reidrects to /manage/organization/<ORG_SLUG>/subscription/ which ultimately redirects to billing.stripe.com since they have an existing customer/subscription. This does not align with CSP.

NEW Organizations/customers are redirected to checkout.stripe.com, which aligns with CSP.

Adding this allows for both states to successfully gain access to the stripe portal.