### PR TITLE
oidc: fix bug when matching GitLab environment claims

### DIFF
--- a/warehouse/oidc/models/gitlab.py
+++ b/warehouse/oidc/models/gitlab.py
@@ -188,7 +188,7 @@ class GitLabPublisherMixin:
     ) -> Self | None:
         if environment:
             if specific_publisher := first_true(
-                publishers, pred=lambda p: p.environment == environment.lower()
+                publishers, pred=lambda p: p.environment == environment
             ):
                 return specific_publisher
 


### PR DESCRIPTION
Bug reported here: https://github.com/pypi/warehouse/issues/18330

The OIDC publisher lookup refactor in https://github.com/pypi/warehouse/pull/18169 introduced a bug where we normalize the incoming environment claim (making it lowercase) when doing the DB lookup for matching GitLab publishers.

This means that the lookup would incorrectly fail when the environment was capitalized (e.g: `SomeEnvironment`), since it would be lowercased before searching the DB (which contained the correct capitalized version).

Inversely, a lookup would incorrectly succeed when the incoming environment claim was capitalized but the environment configured in the Publisher was not. These are different environments (since GitLab's environments are case-sensitive), but by lowercasing the incoming claim, we would match against the publisher with a different (lowercase) claim.

Luckily this second scenario does not result in successful authentication, since this buggy lookup logic is separate from the "claim checking" logic, which happens after a publisher is found, and [does not contain the bug](https://github.com/pypi/warehouse/blob/256248f6ae18aa5fb45d5001f85af30c675421bf/warehouse/oidc/models/gitlab.py#L89-L105).

This PR removes the incorrect `.lower()` call, and adds tests for the two scenarios mentioned above

This fixes https://github.com/pypi/warehouse/issues/18330

cc @di @miketheman 