### PR TITLE
fix: enable client-side menu post-register

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -392,6 +392,7 @@ class TestLogin:
         assert isinstance(result, HTTPSeeOther)
         assert pyramid_request.route_path.calls == [pretend.call("manage.projects")]
         assert result.headers["Location"] == "/the-redirect"
+        assert result.headers["Set-Cookie"].startswith("user_id__insecure=")
         assert result.headers["foo"] == "bar"
 
         assert form_class.calls == [
@@ -1498,6 +1499,7 @@ class TestRecoveryCode:
             token_expected_data["redirect_to"] = redirect_url
 
         assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Set-Cookie"].startswith("user_id__insecure=")
 
         assert remember.calls == [pretend.call(pyramid_request, str(1))]
         assert pyramid_request.session.invalidate.calls == [pretend.call()]

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -1765,6 +1765,7 @@ class TestRegister:
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/"
+        assert result.headers["Set-Cookie"].startswith("user_id__insecure=")
         assert create_user.calls == [
             pretend.call("username_value", "full_name", "MyStr0ng!shP455w0rd")
         ]

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -344,7 +344,7 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
                 # either where they were trying to go originally, or to the default
                 # view.
                 resp = HTTPSeeOther(redirect_to, headers=dict(headers))
-                _set_userid_cookie(resp, userid)
+                _set_userid_insecure_cookie(resp, userid)
 
             return resp
 
@@ -406,7 +406,7 @@ def two_factor_and_totp_validate(request, _form_class=TOTPAuthenticationForm):
             user_service.update_user(userid, last_totp_value=form.totp_value.data)
 
             resp = HTTPSeeOther(redirect_to)
-            _set_userid_cookie(resp, userid)
+            _set_userid_insecure_cookie(resp, userid)
 
             if not two_factor_state.get("has_recovery_codes", False):
                 send_recovery_code_reminder_email(request, request.user)
@@ -495,7 +495,7 @@ def webauthn_authentication_validate(request):
 
         two_factor_method = "webauthn"
         _login_user(request, userid, two_factor_method, two_factor_label=webauthn.label)
-        _set_userid_cookie(request.response, userid)
+        _set_userid_insecure_cookie(request.response, userid)
 
         if not request.user.has_recovery_codes:
             send_recovery_code_reminder_email(request, request.user)
@@ -512,7 +512,7 @@ def webauthn_authentication_validate(request):
     return {"fail": {"errors": errors}}
 
 
-def _set_userid_cookie(resp, userid):
+def _set_userid_insecure_cookie(resp, userid):
     # We'll use this cookie so that client side javascript can
     # Determine the actual user ID (not username, user ID). This is
     # *not* a security sensitive context and it *MUST* not be used
@@ -602,7 +602,7 @@ def recovery_code(request, _form_class=RecoveryCodeAuthenticationForm):
             _login_user(request, userid, two_factor_method="recovery-code")
 
             resp = HTTPSeeOther(request.route_path("manage.account"))
-            _set_userid_cookie(resp, userid)
+            _set_userid_insecure_cookie(resp, userid)
 
             user = user_service.get_user(userid)
             user.record_event(
@@ -753,7 +753,7 @@ def register(request, _form_class=RegistrationForm):
         resp = HTTPSeeOther(
             request.route_path("index"), headers=dict(_login_user(request, user.id))
         )
-        _set_userid_cookie(resp, user.id)
+        _set_userid_insecure_cookie(resp, user.id)
 
         return resp
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -144,185 +144,185 @@ msgid ""
 " ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:390 warehouse/accounts/views.py:459
-#: warehouse/accounts/views.py:461 warehouse/accounts/views.py:490
-#: warehouse/accounts/views.py:492 warehouse/accounts/views.py:598
+#: warehouse/accounts/views.py:375 warehouse/accounts/views.py:439
+#: warehouse/accounts/views.py:441 warehouse/accounts/views.py:470
+#: warehouse/accounts/views.py:472 warehouse/accounts/views.py:588
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:453
+#: warehouse/accounts/views.py:433
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:533
+#: warehouse/accounts/views.py:507
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:630 warehouse/manage/views/__init__.py:871
+#: warehouse/accounts/views.py:615 warehouse/manage/views/__init__.py:871
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:722
+#: warehouse/accounts/views.py:707
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:888
+#: warehouse/accounts/views.py:876
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:890
+#: warehouse/accounts/views.py:878
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:892 warehouse/accounts/views.py:993
-#: warehouse/accounts/views.py:1099 warehouse/accounts/views.py:1268
+#: warehouse/accounts/views.py:880 warehouse/accounts/views.py:981
+#: warehouse/accounts/views.py:1087 warehouse/accounts/views.py:1256
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:896
+#: warehouse/accounts/views.py:884
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:901
+#: warehouse/accounts/views.py:889
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:912
+#: warehouse/accounts/views.py:900
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:930
+#: warehouse/accounts/views.py:918
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:961
+#: warehouse/accounts/views.py:949
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:989
+#: warehouse/accounts/views.py:977
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:991
+#: warehouse/accounts/views.py:979
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:997
+#: warehouse/accounts/views.py:985
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1006
+#: warehouse/accounts/views.py:994
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:1009
+#: warehouse/accounts/views.py:997
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:1029
+#: warehouse/accounts/views.py:1017
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1032
+#: warehouse/accounts/views.py:1020
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1038
+#: warehouse/accounts/views.py:1026
 #, python-brace-format
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:1095
+#: warehouse/accounts/views.py:1083
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1097
+#: warehouse/accounts/views.py:1085
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1103
+#: warehouse/accounts/views.py:1091
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1107
+#: warehouse/accounts/views.py:1095
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1116
+#: warehouse/accounts/views.py:1104
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1168
+#: warehouse/accounts/views.py:1156
 #, python-brace-format
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1231
+#: warehouse/accounts/views.py:1219
 #, python-brace-format
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1264
+#: warehouse/accounts/views.py:1252
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1266
+#: warehouse/accounts/views.py:1254
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1272
+#: warehouse/accounts/views.py:1260
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1276
+#: warehouse/accounts/views.py:1264
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1291
+#: warehouse/accounts/views.py:1279
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1323
+#: warehouse/accounts/views.py:1311
 #, python-brace-format
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1389
+#: warehouse/accounts/views.py:1377
 #, python-brace-format
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1469
+#: warehouse/accounts/views.py:1457
 #, python-brace-format
 msgid "Please review our updated <a href=\"${tos_url}\">Terms of Service</a>."
 msgstr ""
 
-#: warehouse/accounts/views.py:1681 warehouse/accounts/views.py:1923
+#: warehouse/accounts/views.py:1669 warehouse/accounts/views.py:1911
 #: warehouse/manage/views/__init__.py:1409
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1702
+#: warehouse/accounts/views.py:1690
 msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1718
+#: warehouse/accounts/views.py:1706
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1731
+#: warehouse/accounts/views.py:1719
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1746 warehouse/manage/views/__init__.py:1590
+#: warehouse/accounts/views.py:1734 warehouse/manage/views/__init__.py:1590
 #: warehouse/manage/views/__init__.py:1705
 #: warehouse/manage/views/__init__.py:1819
 #: warehouse/manage/views/__init__.py:1931
@@ -331,29 +331,29 @@ msgid ""
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1756 warehouse/manage/views/__init__.py:1603
+#: warehouse/accounts/views.py:1744 warehouse/manage/views/__init__.py:1603
 #: warehouse/manage/views/__init__.py:1718
 #: warehouse/manage/views/__init__.py:1832
 #: warehouse/manage/views/__init__.py:1944
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1771
+#: warehouse/accounts/views.py:1759
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1798
+#: warehouse/accounts/views.py:1786
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:1936 warehouse/accounts/views.py:1949
-#: warehouse/accounts/views.py:1956
+#: warehouse/accounts/views.py:1924 warehouse/accounts/views.py:1937
+#: warehouse/accounts/views.py:1944
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:1963
+#: warehouse/accounts/views.py:1951
 msgid "Removed trusted publisher for project "
 msgstr ""
 


### PR DESCRIPTION
Once a user has completed registration, the cookie used to determine
what to display in the menu dropdown doesn't yet exist, so it's
confusing as to what to do next.

Includes a refactor commit to consolidate cookie setting logic.