### PR TITLE
chore: remove unused property

### DIFF
--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -1477,40 +1477,6 @@ class TestHaveIBeenPwnedPasswordBreachedService:
         )
         assert svc.failure_message == expected
 
-    @pytest.mark.parametrize(
-        ("help_url", "expected"),
-        [
-            (
-                None,
-                (
-                    "This password appears in a security breach or has been "
-                    "compromised and cannot be used."
-                ),
-            ),
-            (
-                "http://localhost/help/#compromised-password",
-                (
-                    "This password appears in a security breach or has been "
-                    "compromised and cannot be used. See the FAQ entry at "
-                    "http://localhost/help/#compromised-password for more information."
-                ),
-            ),
-        ],
-    )
-    def test_failure_message_plain(self, help_url, expected):
-        context = pretend.stub()
-        request = pretend.stub(
-            http=pretend.stub(),
-            find_service=lambda iface, context: {
-                (IMetricsService, None): NullMetrics()
-            }[(iface, context)],
-            help_url=lambda _anchor=None: help_url,
-        )
-        svc = services.HaveIBeenPwnedPasswordBreachedService.create_service(
-            context, request
-        )
-        assert svc.failure_message_plain == expected
-
 
 class TestNullPasswordBreachedService:
     def test_verify_service(self):

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -269,9 +269,6 @@ class ITokenService(Interface):
 
 class IPasswordBreachedService(Interface):
     failure_message = Attribute("The message to describe the failure that occurred")
-    failure_message_plain = Attribute(
-        "The message to describe the failure that occurred in plain text"
-    )
 
     def check_password(password, *, tags=None):
         """

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -815,13 +815,6 @@ class HaveIBeenPwnedPasswordBreachedService:
             )
         return message
 
-    @property
-    def failure_message_plain(self):
-        message = self._failure_message_preamble
-        if self._help_url:
-            message += f" See the FAQ entry at {self._help_url} for more information."
-        return message
-
     def _metrics_increment(self, *args, **kwargs):
         self._metrics.increment(*args, **kwargs)
 
@@ -890,7 +883,6 @@ class HaveIBeenPwnedPasswordBreachedService:
 @implementer(IPasswordBreachedService)
 class NullPasswordBreachedService:
     failure_message = "This password appears in a breach."
-    failure_message_plain = "This password appears in a breach."
 
     @classmethod
     def create_service(cls, context, request):


### PR DESCRIPTION
Callers of the `plain` variant were removed as part of the Basic authentication scheme cleanup in #15182 and were left orphaned.