### PR TITLE
lint: check `@view_config.renderer` filenames

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 88
-exclude = *.egg,*/interfaces.py,node_modules,.state
+exclude = *.egg,*/interfaces.py,node_modules,.state,.venv
 ignore = W503,E203,E701
 select = E,W,F,N,P
 per-file-ignores =


### PR DESCRIPTION
Since Pyramid's renderers are only invoked during a webtest-style test,
and not all of those have a functional test today, there exists a
possibility where we only discover a `TemplateNotFound` exception in
production, despite passing the test suite.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>