### PR TITLE
style: wrap the yanked reason to prevent overflow

### DIFF
--- a/warehouse/static/sass/blocks/_release.scss
+++ b/warehouse/static/sass/blocks/_release.scss
@@ -99,10 +99,14 @@
     padding-bottom: 2px;
   }
 
-  &__yanked-reason p {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  &__yanked-reason {
+    display: block;
+
+    p {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 
   &--current {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-/* global module, __dirname */
+/* global module, process, __dirname */
 
 // This is the main configuration file for webpack.
 // See: https://webpack.js.org/configuration/
@@ -372,6 +372,8 @@ module.exports = [
         path: path.resolve(__dirname, "warehouse/static/dist"),
       },
       dependencies: ["warehouse"],
+      // Emit fewer stats-per-language in non-production builds.
+      stats: (process.env.NODE_ENV === "production") ? undefined : "errors-warnings",
     };
   }),
 ];


### PR DESCRIPTION
Add a top-level directive to override `.callout-block` attribute and
trigger the ellipsis behavior on wrap.

Fixes #18186

Signed-off-by: Mike Fiedler <miketheman@gmail.com>