### PR TITLE
fix: restrict chunk size to 10MB per quota

### DIFF
--- a/tests/unit/search/test_tasks.py
+++ b/tests/unit/search/test_tasks.py
@@ -243,7 +243,7 @@ class TestReindex:
         class TestError(Exception):
             pass
 
-        def parallel_bulk(client, iterable, index=None):
+        def parallel_bulk(client, iterable, index=None, max_chunk_bytes=None):
             assert client is es_client
             assert iterable is docs
             assert index == "warehouse-cbcbcbcbcb"
@@ -303,7 +303,9 @@ class TestReindex:
         )
         monkeypatch.setattr(warehouse.search.tasks, "SearchLock", NotLock)
 
-        parallel_bulk = pretend.call_recorder(lambda client, iterable, index: [None])
+        parallel_bulk = pretend.call_recorder(
+            lambda client, iterable, index, max_chunk_bytes: [None]
+        )
         monkeypatch.setattr(warehouse.search.tasks, "parallel_bulk", parallel_bulk)
 
         monkeypatch.setattr(os, "urandom", lambda n: b"\xcb" * n)
@@ -311,7 +313,9 @@ class TestReindex:
         reindex(task, db_request)
 
         assert parallel_bulk.calls == [
-            pretend.call(es_client, docs, index="warehouse-cbcbcbcbcb")
+            pretend.call(
+                es_client, docs, index="warehouse-cbcbcbcbcb", max_chunk_bytes=10485760
+            )
         ]
         assert es_client.indices.create.calls == [
             pretend.call(
@@ -367,7 +371,9 @@ class TestReindex:
         )
         monkeypatch.setattr(warehouse.search.tasks, "SearchLock", NotLock)
 
-        parallel_bulk = pretend.call_recorder(lambda client, iterable, index: [None])
+        parallel_bulk = pretend.call_recorder(
+            lambda client, iterable, index, max_chunk_bytes: [None]
+        )
         monkeypatch.setattr(warehouse.search.tasks, "parallel_bulk", parallel_bulk)
 
         monkeypatch.setattr(os, "urandom", lambda n: b"\xcb" * n)
@@ -375,7 +381,9 @@ class TestReindex:
         reindex(task, db_request)
 
         assert parallel_bulk.calls == [
-            pretend.call(es_client, docs, index="warehouse-cbcbcbcbcb")
+            pretend.call(
+                es_client, docs, index="warehouse-cbcbcbcbcb", max_chunk_bytes=10485760
+            )
         ]
         assert es_client.indices.create.calls == [
             pretend.call(
@@ -432,7 +440,9 @@ class TestReindex:
         )
         monkeypatch.setattr(warehouse.search.tasks, "SearchLock", NotLock)
 
-        parallel_bulk = pretend.call_recorder(lambda client, iterable, index: [None])
+        parallel_bulk = pretend.call_recorder(
+            lambda client, iterable, index, max_chunk_bytes: [None]
+        )
         monkeypatch.setattr(warehouse.search.tasks, "parallel_bulk", parallel_bulk)
 
         monkeypatch.setattr(os, "urandom", lambda n: b"\xcb" * n)
@@ -455,7 +465,9 @@ class TestReindex:
         ]
 
         assert parallel_bulk.calls == [
-            pretend.call(es_client, docs, index="warehouse-cbcbcbcbcb")
+            pretend.call(
+                es_client, docs, index="warehouse-cbcbcbcbcb", max_chunk_bytes=10485760
+            )
         ]
         assert es_client.indices.create.calls == [
             pretend.call(

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -165,7 +165,10 @@ def reindex(self, request):
                 request.db.execute(text("SET statement_timeout = '600s'"))
 
                 for _ in parallel_bulk(
-                    client, _project_docs(request.db), index=new_index_name
+                    client,
+                    _project_docs(request.db),
+                    index=new_index_name,
+                    max_chunk_bytes=10 * 1024 * 1024,  # 10MB, per OpenSearch defaults
                 ):
                     pass
             except:  # noqa


### PR DESCRIPTION
The `reindex` task is failing with:

    ...
    File "/opt/warehouse/lib/python3.13/site-packages/opensearchpy/connection/base.py", line 315, in _raise_error
      raise HTTP_EXCEPTIONS.get(status_code, TransportError)(
          status_code, error_message, additional_info
      )
    opensearchpy.exceptions.TransportError: TransportError(413, '{"Message":"Request size exceeded 10485760 bytes"}')

Set the maximum chunk size to reflect the quota of the cluster size.

Refs: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/limits.html#network-limits