### PR TITLE
feat: add warehouse.task.start metric

### DIFF
--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -244,7 +244,7 @@ class TestWarehouseTask:
         ]
         assert metrics.increment.calls == [
             pretend.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
-            pretend.call("warehouse.task.complete", tags=["task:warehouse.test.task"])
+            pretend.call("warehouse.task.complete", tags=["task:warehouse.test.task"]),
         ]
 
     def test_run_retries_failed_transaction(self, metrics):

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -243,6 +243,7 @@ class TestWarehouseTask:
             pretend.call("warehouse.task.run", tags=["task:warehouse.test.task"])
         ]
         assert metrics.increment.calls == [
+            pretend.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
             pretend.call("warehouse.task.complete", tags=["task:warehouse.test.task"])
         ]
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -290,7 +290,7 @@ class TestWarehouseTask:
         ]
         assert metrics.increment.calls == [
             pretend.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
-            pretend.call("warehouse.task.retried", tags=["task:warehouse.test.task"])
+            pretend.call("warehouse.task.retried", tags=["task:warehouse.test.task"]),
         ]
 
     def test_run_doesnt_retries_failed_transaction(self, metrics):
@@ -329,7 +329,7 @@ class TestWarehouseTask:
         ]
         assert metrics.increment.calls == [
             pretend.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
-            pretend.call("warehouse.task.failed", tags=["task:warehouse.test.task"])
+            pretend.call("warehouse.task.failed", tags=["task:warehouse.test.task"]),
         ]
 
     def test_after_return_without_pyramid_env(self):

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -289,6 +289,7 @@ class TestWarehouseTask:
             pretend.call("warehouse.task.run", tags=["task:warehouse.test.task"])
         ]
         assert metrics.increment.calls == [
+            pretend.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
             pretend.call("warehouse.task.retried", tags=["task:warehouse.test.task"])
         ]
 
@@ -327,6 +328,7 @@ class TestWarehouseTask:
             pretend.call("warehouse.task.run", tags=["task:warehouse.test.task"])
         ]
         assert metrics.increment.calls == [
+            pretend.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
             pretend.call("warehouse.task.failed", tags=["task:warehouse.test.task"])
         ]
 

--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -72,8 +72,8 @@ class WarehouseTask(celery.Task):
             metric_tags = [f"task:{obj.name}"]
 
             with request.tm, metrics.timed("warehouse.task.run", tags=metric_tags):
+                metrics.increment("warehouse.task.start", tags=metric_tags)
                 try:
-                    metrics.increment("warehouse.task.start", tags=metric_tags)
                     result = original_run(*args, **kwargs)
                     metrics.increment("warehouse.task.complete", tags=metric_tags)
                     return result

--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -73,6 +73,7 @@ class WarehouseTask(celery.Task):
 
             with request.tm, metrics.timed("warehouse.task.run", tags=metric_tags):
                 try:
+                    metrics.increment("warehouse.task.start", tags=metric_tags)
                     result = original_run(*args, **kwargs)
                     metrics.increment("warehouse.task.complete", tags=metric_tags)
                     return result


### PR DESCRIPTION
Tracks when we start a warehouse task for troubleshooting noisy tasks later