### PR TITLE
fix(search): limit description for search

### DIFF
--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -40,7 +40,7 @@ def _project_docs(db, project_name: str | None = None):
     )
     projects_to_index = (
         select(
-            Description.raw.label("description"),
+            func.left(Description.raw, 5_000_000).label("description"),
             Release.author,
             Release.author_email,
             Release.maintainer,


### PR DESCRIPTION
If a release description is larger than the transport size, the indexing will fail, as it cannot pass more than a single 10MB request.

Fixes WAREHOUSE-PRODUCTION-29W