### PR TITLE
fix(search): limit description for search

### DIFF
--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -41,7 +41,7 @@ class Project(Document):
         obj["name"] = release.name
         obj["normalized_name"] = release.normalized_name
         obj["summary"] = release.summary
-        obj["description"] = release.description
+        obj["description"] = release.description[:5_000_000]
         obj["author"] = release.author
         obj["author_email"] = release.author_email
         obj["maintainer"] = release.maintainer

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -40,7 +40,7 @@ def _project_docs(db, project_name: str | None = None):
     )
     projects_to_index = (
         select(
-            func.left(Description.raw, 5_000_000).label("description"),
+            Description.raw.label("description"),
             Release.author,
             Release.author_email,
             Release.maintainer,


### PR DESCRIPTION
Since the previous change slowed down the query plan, move the
truncation to when we construct the document prior to sending it over
the wire.

This reverts commit ebcb380.