### PR TITLE
feat(admin): set Help Scout URL on malware report

### DIFF
--- a/tests/unit/admin/test_routes.py
+++ b/tests/unit/admin/test_routes.py
@@ -386,6 +386,11 @@ def test_includeme():
             domain=warehouse,
         ),
         pretend.call(
+            "admin.malware_reports.detail.add_helpscout_conversation",
+            "/admin/malware_reports/{observation_id}/add_helpscout_conversation/",
+            domain=warehouse,
+        ),
+        pretend.call(
             "admin.malware_reports.detail.verdict_not_malware",
             "/admin/malware_reports/{observation_id}/not_malware/",
             domain=warehouse,

--- a/tests/unit/admin/views/test_malware_reports.py
+++ b/tests/unit/admin/views/test_malware_reports.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 import pretend
+import pytest
 
 from pyramid.httpexceptions import HTTPSeeOther
 
@@ -333,3 +334,57 @@ class TestMalwareReportsDetail:
                 queue="success",
             ),
         ]
+
+    @pytest.mark.parametrize(
+        "input_url",
+        [
+            "https://secure.helpscout.net/conversation/123456789/987654321",
+            "https://secure.helpscout.net/conversation/123456789/23711?viewId=7857079#thread-9203145731"  # noqa: E501
+            "https://api.helpscout.net/v2/conversations/123456789",
+        ],
+    )
+    def test_add_helpscout_conversation_valid_url(self, db_request, input_url):
+        report = ProjectObservationFactory.create(kind="is_malware")
+
+        db_request.matchdict["observation_id"] = str(report.id)
+        db_request.POST["helpscout_conversation_url"] = input_url
+        db_request.route_path = lambda r, **kw: f"/admin/malware_reports/{report.id}"
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+
+        result = views.add_helpscout_conversation(db_request)
+
+        assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Location"] == f"/admin/malware_reports/{report.id}"
+        assert db_request.session.flash.calls == [
+            pretend.call(
+                f"HelpScout Conversation URL added to report for {report.related.name}",
+                queue="success",
+            )
+        ]
+        assert report.additional["helpscout_conversation_url"] == (
+            "https://api.helpscout.net/v2/conversations/123456789"
+        )
+
+    def test_add_helpscout_conversation_invalid_url(self, db_request):
+        report = ProjectObservationFactory.create(kind="is_malware")
+
+        db_request.matchdict["observation_id"] = str(report.id)
+        db_request.POST["helpscout_conversation_url"] = "invalid-url"
+        db_request.route_path = lambda r, **kw: f"/admin/malware_reports/{report.id}"
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+
+        result = views.add_helpscout_conversation(db_request)
+
+        assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Location"] == f"/admin/malware_reports/{report.id}"
+        assert db_request.session.flash.calls == [
+            pretend.call(
+                "Please provide a valid HelpScout Conversation URL.",
+                queue="error",
+            )
+        ]
+        assert "helpscout_conversation_url" not in report.additional

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -396,6 +396,11 @@ def includeme(config):
         domain=warehouse,
     )
     config.add_route(
+        "admin.malware_reports.detail.add_helpscout_conversation",
+        "/admin/malware_reports/{observation_id}/add_helpscout_conversation/",
+        domain=warehouse,
+    )
+    config.add_route(
         "admin.malware_reports.detail.verdict_not_malware",
         "/admin/malware_reports/{observation_id}/not_malware/",
         domain=warehouse,

--- a/warehouse/admin/templates/admin/malware_reports/detail.html
+++ b/warehouse/admin/templates/admin/malware_reports/detail.html
@@ -48,6 +48,25 @@
         <dd class="col-sm-10">
           {{ report.summary }}
         </dd>
+        <dt class="col-sm-2" title="Help Scout Conversation">HS Convo</dt>
+        <dd class="col-sm-10">
+          {% if report.additional.get("helpscout_conversation_url") %}
+            {% set hs_url = report.additional.helpscout_conversation_url %}
+            {% set conversation_id = hs_url.rstrip('/').split('/')[-1] %}
+            <a href="https://secure.helpscout.net/conversation/{{ conversation_id }}" target="_blank">
+              HelpScout Conversation #{{ conversation_id }}
+            </a>
+            <button type="button"
+                    class="btn btn-sm btn-outline-primary"
+                    data-toggle="modal"
+                    data-target="#modal-add-helpscout-conversation">Update</button>
+          {% else %}
+            <button type="button"
+                    class="btn btn-sm btn-outline-primary"
+                    data-toggle="modal"
+                    data-target="#modal-add-helpscout-conversation">Add HelpScout Conversation</button>
+          {% endif %}
+        </dd>
         {# TODO: Decide how to pretty this up when we have more data #}
         {% if report.actions %}
           <dt class="col-sm-2">Actions</dt>
@@ -215,6 +234,49 @@
           <div class="modal-footer justify-content-between">
             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
             <button type="submit" class="btn btn-danger">Verdict: Remove Malware</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+  <!-- /.modal -->
+  <div class="modal fade" id="modal-add-helpscout-conversation">
+    <div class="modal-dialog modal-add-helpscout-conversation">
+      <form id="add-helpscout-conversation"
+            action="{{ request.route_path('admin.malware_reports.detail.add_helpscout_conversation', observation_id=report.id) }}"
+            method="post">
+        <input name="csrf_token"
+               type="hidden"
+               value="{{ request.session.get_csrf_token() }}">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title">Add HelpScout Conversation</h4>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">×</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>
+              Add a HelpScout conversation URL to this Malware Report.
+              This will allow you to track the conversation related to this report.
+            </p>
+            <p>
+              Paste either the API URL or the web URL.
+            </p>
+            <div class="form-group">
+              <label for="helpscout_conversation_url">HelpScout Conversation URL</label>
+              <input name="helpscout_conversation_url"
+                     id="helpscout_conversation_url"
+                     class="form-control"
+                     type="url"
+                     placeholder="Enter HelpScout Conversation URL"
+                     value="{{ report.additional.get('helpscout_conversation_url', '') }}"
+                     required>
+            </div>
+          </div>
+          <div class="modal-footer justify-content-between">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            <button type="submit" class="btn btn-primary">Save</button>
           </div>
         </div>
       </form>

--- a/warehouse/admin/views/malware_reports.py
+++ b/warehouse/admin/views/malware_reports.py
@@ -3,6 +3,8 @@
 """Admin Views related to Observations"""
 from __future__ import annotations
 
+import re
+
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -213,6 +215,55 @@ def malware_reports_detail(request):
     observation = request.db.get(Observation, observation_id)
 
     return {"report": observation}
+
+
+@view_config(
+    route_name="admin.malware_reports.detail.add_helpscout_conversation",
+    permission=Permissions.AdminObservationsWrite,
+    uses_session=True,
+    require_csrf=True,
+    require_methods=["POST"],
+)
+def add_helpscout_conversation(request):
+    """
+    Add a HelpScout Conversation URL to an Observation.
+    """
+    observation_id = request.matchdict.get("observation_id")
+    observation = request.db.get(Observation, observation_id)
+
+    helpscout_conversation_url = request.POST.get("helpscout_conversation_url")
+
+    # Allow the user to paste any kind of Help Scout URL, parse out the conversation ID.
+    match = re.match(
+        r"https://(?:secure|api)\.helpscout\.net/(?:conversation|v2/conversations)/(\d+)",  # noqa: E501
+        helpscout_conversation_url,
+    )
+    if not match:
+        request.session.flash(
+            "Please provide a valid HelpScout Conversation URL.",
+            queue="error",
+        )
+        return HTTPSeeOther(
+            request.route_path(
+                "admin.malware_reports.detail", observation_id=observation_id
+            )
+        )
+
+    conversation_id = match.group(1)
+    observation.additional["helpscout_conversation_url"] = (
+        f"https://api.helpscout.net/v2/conversations/{conversation_id}"
+    )
+
+    request.session.flash(
+        f"HelpScout Conversation URL added to report for {observation.related.name}",
+        queue="success",
+    )
+
+    return HTTPSeeOther(
+        request.route_path(
+            "admin.malware_reports.detail", observation_id=observation_id
+        )
+    )
 
 
 @view_config(


### PR DESCRIPTION
Some observations may not receive a helpscout URL for some reason. Surface the URL in Admin UI if it exists, and allow Admin to set one.