### PR TITLE
lint: enable unreachable code detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ known_first_party = ['warehouse', 'tests']
 
 [tool.mypy]
 python_version = "3.12"
+warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 plugins = ["mypy_zope:plugin"]

--- a/warehouse/macaroons/models.py
+++ b/warehouse/macaroons/models.py
@@ -106,7 +106,7 @@ class Macaroon(db.Model):
 
     # Intentionally not using a back references here, since we express
     # relationships in terms of the "other" side of the relationship.
-    user: Mapped["User"] = orm.relationship(lazy=True, viewonly=True)
+    user: Mapped[User | None] = orm.relationship(lazy=True, viewonly=True)
     # TODO: Can't annotate this as "OIDCPublisher" because that would create a
     #  circular import.
     oidc_publisher = orm.relationship("OIDCPublisher", lazy=True, viewonly=True)


### PR DESCRIPTION
Having mypy check for unreachable code during linting can prevent accidental inclusion of code that cannot be reached, and that coverage may not report.

This specific fix was surfaced by a check for `dm.user is None:` in `macaroon/services.py` and since the type declaration for the `user` column did not allow for None, the warning was raised as unreachable.

Since the database column `user_id` is allowed to have nulls, the associated relationship may not always return a User, set it to match.