### PR TITLE
feat(admin): surface projects in quarantine

### DIFF
--- a/tests/unit/admin/test_routes.py
+++ b/tests/unit/admin/test_routes.py
@@ -376,6 +376,7 @@ def test_includeme():
             "/admin/observations/",
             domain=warehouse,
         ),
+        pretend.call("admin.quarantine.list", "/admin/quarantine/", domain=warehouse),
         pretend.call(
             "admin.malware_reports.list",
             "/admin/malware_reports/",

--- a/tests/unit/admin/views/test_quarantine.py
+++ b/tests/unit/admin/views/test_quarantine.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from warehouse.admin.views import quarantine
+from warehouse.packaging.models import LifecycleStatus
+
+from ....common.db.packaging import ProjectFactory
+
+
+class TestQuarantineList:
+    def test_quarantine_list_no_projects(self, db_request):
+        """Test quarantine list view when no projects are quarantined"""
+        result = quarantine.quarantine_list(db_request)
+        assert result == {"quarantined_projects": []}
+
+    def test_quarantine_list_with_projects(self, db_request):
+        """Test quarantine list view with quarantined projects"""
+        # Create some projects in different states
+        normal_project = ProjectFactory.create()
+        archived_project = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.Archived
+        )
+        quarantined_project_1 = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+            lifecycle_status_note="Test quarantine reason 1",
+        )
+        quarantined_project_2 = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+            lifecycle_status_note="Test quarantine reason 2",
+        )
+
+        result = quarantine.quarantine_list(db_request)
+
+        # Should only return quarantined projects
+        assert len(result["quarantined_projects"]) == 2
+        project_names = [p.name for p in result["quarantined_projects"]]
+        assert quarantined_project_1.name in project_names
+        assert quarantined_project_2.name in project_names
+        assert normal_project.name not in project_names
+        assert archived_project.name not in project_names
+
+    def test_quarantine_list_ordered_by_date(self, db_request):
+        """Quarantined projects are ordered by quarantine date (oldest first)"""
+        from datetime import datetime, timedelta, timezone
+
+        # Create projects with different quarantine dates
+        base_time = datetime.now(timezone.utc)
+
+        newer_project = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+            lifecycle_status_changed=base_time,
+            lifecycle_status_note="Newer quarantine",
+        )
+        older_project = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+            lifecycle_status_changed=base_time - timedelta(days=5),
+            lifecycle_status_note="Older quarantine",
+        )
+
+        result = quarantine.quarantine_list(db_request)
+
+        # Should be ordered oldest first
+        assert len(result["quarantined_projects"]) == 2
+        assert result["quarantined_projects"][0].name == older_project.name
+        assert result["quarantined_projects"][1].name == newer_project.name
+
+    def test_quarantine_list_handles_null_date(self, db_request):
+        """Projects with null `lifecycle_status_changed` are handled gracefully"""
+        # Create a project with no lifecycle_status_changed
+        quarantined_project = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+            lifecycle_status_changed=None,
+            lifecycle_status_note="No date quarantine",
+        )
+
+        result = quarantine.quarantine_list(db_request)
+
+        # Should still return the project
+        assert len(result["quarantined_projects"]) == 1
+        assert result["quarantined_projects"][0].name == quarantined_project.name
+
+    def test_quarantine_list_with_exit_status(self, db_request):
+        """Test that projects with quarantine-exit status are not included"""
+        # Create projects with different quarantine statuses
+        entering_quarantine = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+            lifecycle_status_note="Entering quarantine",
+        )
+        ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineExit,
+            lifecycle_status_note="Exiting quarantine",
+        )
+
+        result = quarantine.quarantine_list(db_request)
+
+        # Should only return projects entering quarantine
+        assert len(result["quarantined_projects"]) == 1
+        assert result["quarantined_projects"][0].name == entering_quarantine.name

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -386,6 +386,7 @@ def includeme(config):
     config.add_route(
         "admin.observations.list", "/admin/observations/", domain=warehouse
     )
+    config.add_route("admin.quarantine.list", "/admin/quarantine/", domain=warehouse)
     config.add_route(
         "admin.malware_reports.list",
         "/admin/malware_reports/",

--- a/warehouse/admin/static/css/admin.scss
+++ b/warehouse/admin/static/css/admin.scss
@@ -28,3 +28,24 @@
 .hidden {
   display: none;
 }
+
+/* Responsive quarantine table */
+.quarantine-table {
+  .project-info {
+    min-width: 200px;
+  }
+
+  .project-name {
+    font-weight: 500;
+  }
+
+  @media (width <= 768px) {
+    td {
+      padding: 0.75rem 0.5rem;
+    }
+
+    .btn .btn-group-vertical {
+      font-size: 0.875rem;
+    }
+  }
+}

--- a/warehouse/admin/templates/admin/base.html
+++ b/warehouse/admin/templates/admin/base.html
@@ -140,7 +140,7 @@
             <a href="#" class="nav-link">
               <i class="nav-icon fa-solid fa-eye"></i>
               <p>
-                Observatory
+                Observations
                 <i class="right fas fa-angle-left"></i>
               </p>
             </a>

--- a/warehouse/admin/templates/admin/base.html
+++ b/warehouse/admin/templates/admin/base.html
@@ -102,11 +102,6 @@
           {# TODO: Is there a cleaner way to show/hide the allowed sections? #}
           {% if request.has_permission(Permissions.AdminDashboardSidebarRead) %}
           <li class="nav-item">
-            <a href="{{ request.route_path('admin.malware_reports.list') }}" class="nav-link">
-              <i class="fa-solid fa-dumpster-fire nav-icon"></i> <p>Malware Reports</p>
-            </a>
-          </li>
-          <li class="nav-item">
             <a href="{{ request.route_path('admin.organization_application.list') }}?q=is%3Asubmitted" class="nav-link">
               <i class="fa fa-sitemap nav-icon"></i> <p>Organization Applications</p>
             </a>
@@ -143,6 +138,34 @@
           </li>
           <li class="nav-item menu-closed">
             <a href="#" class="nav-link">
+              <i class="nav-icon fa-solid fa-eye"></i>
+              <p>
+                Observatory
+                <i class="right fas fa-angle-left"></i>
+              </p>
+            </a>
+            <ul class="nav nav-treeview">
+              <li class="nav-item">
+                <a href="{{ request.route_path('admin.malware_reports.list') }}" class="nav-link">
+                  <i class="nav-icon fa-solid fa-dumpster-fire"></i>
+                  <p>Malware Reports</p>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="{{ request.route_path('admin.quarantine.list') }}" class="nav-link">
+                  <i class="nav-icon fa-solid fa-file-shield"></i> <p>Quarantine</p>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="{{ request.route_path('admin.observations.list') }}" class="nav-link">
+                  <i class="nav-icon fa-solid fa-eye"></i>
+                  <p>All Observations</p>
+                </a>
+              </li>
+            </ul>
+          </li>
+          <li class="nav-item menu-closed">
+            <a href="#" class="nav-link">
               <i class="nav-icon fa fa-ban"></i>
               <p>
                 Prohibition Era
@@ -169,11 +192,6 @@
                 </a>
               </li>
             </ul>
-          </li>
-          <li class="nav-item">
-            <a href="{{ request.route_path('admin.observations.list') }}" class="nav-link">
-              <i class="fa-solid fa-eye nav-icon"></i> <p>Observations</p>
-            </a>
           </li>
           <li class="nav-item">
             <a href="{{ request.route_path('admin.emails.list') }}" class="nav-link">

--- a/warehouse/admin/templates/admin/quarantine/list.html
+++ b/warehouse/admin/templates/admin/quarantine/list.html
@@ -1,0 +1,167 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+
+{% extends "admin/base.html" %}
+
+{% block title %}Quarantine{% endblock %}
+
+{% block breadcrumb %}
+  <li class="breadcrumb-item active">Quarantine</li>
+{% endblock %}
+
+{% block content %}
+  <div class="card">
+    <div class="card-header">
+      <h3 class="card-title">Projects in Quarantine</h3>
+    </div>
+    <div class="card-body">
+      {% if quarantined_projects %}
+        <div class="table-responsive">
+          <table class="table table-striped quarantine-table">
+            <thead>
+              <tr>
+                <th>Project</th>
+                <th class="d-none d-md-table-cell">Days in Quarantine</th>
+                <th class="d-none d-lg-table-cell">Quarantined Date</th>
+                <th class="d-none d-xl-table-cell">Note</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for project in quarantined_projects %}
+                <tr>
+                  <td>
+                    <div class="project-info">
+                      <div class="project-name">
+                        <a href="{{ request.route_path('admin.project.detail', project_name=project.name) }}">
+                          <strong>{{ project.name }}</strong>
+                        </a>
+                      </div>
+                      <!-- Mobile-only information shown under project name -->
+                      <div class="d-md-none text-muted small mt-1">
+                        {% if project.lifecycle_status_changed %}
+                          {% set days_quarantined = (now() - project.lifecycle_status_changed).days %}
+                          <span class="badge badge-{{ 'warning' if days_quarantined > 30 else ('info' if days_quarantined > 7 else 'secondary') }} mr-2">
+                            {{ days_quarantined }} days
+                          </span>
+                          {{ project.lifecycle_status_changed.strftime('%Y-%m-%d') }}
+                        {% else %}
+                          <span class="badge badge-secondary">Unknown</span>
+                        {% endif %}
+                      </div>
+                      {% if project.lifecycle_status_note %}
+                        <div class="d-xl-none text-muted small mt-1">
+                          <strong>Note:</strong> {{ project.lifecycle_status_note }}
+                        </div>
+                      {% endif %}
+                    </div>
+                  </td>
+                  <td class="d-none d-md-table-cell">
+                    {% if project.lifecycle_status_changed %}
+                      {% set days_quarantined = (now() - project.lifecycle_status_changed).days %}
+                      <span class="badge badge-{{ 'warning' if days_quarantined > 30 else ('info' if days_quarantined > 7 else 'secondary') }}">
+                        {{ days_quarantined }} days
+                      </span>
+                    {% else %}
+                      <em>Unknown</em>
+                    {% endif %}
+                  </td>
+                  <td class="d-none d-lg-table-cell">
+                    {% if project.lifecycle_status_changed %}
+                      {{ project.lifecycle_status_changed.strftime('%Y-%m-%d %H:%M:%S UTC') }}
+                    {% else %}
+                      <em>Unknown</em>
+                    {% endif %}
+                  </td>
+                  <td class="d-none d-xl-table-cell">
+                    {% if project.lifecycle_status_note %}
+                      {{ project.lifecycle_status_note }}
+                    {% else %}
+                      <em>No note</em>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <div class="btn-group-vertical d-md-none">
+                      <a href="{{ request.route_path('admin.project.detail', project_name=project.name) }}"
+                         class="btn btn-sm btn-info mb-1" title="View Project Details">
+                        <i class="fa fa-eye"></i> View
+                      </a>
+                      <button type="button"
+                              class="btn btn-sm btn-success"
+                              data-toggle="modal"
+                              data-target="#modal-exit-quarantine-{{ loop.index }}"
+                              title="Clear from Quarantine">
+                        <i class="fa fa-unlock"></i> Release
+                      </button>
+                    </div>
+                    <div class="btn-group d-none d-md-flex" role="group">
+                      <a href="{{ request.route_path('admin.project.detail', project_name=project.name) }}"
+                         class="btn btn-sm btn-info" title="View Project Details">
+                        <i class="fa fa-eye"></i> View
+                      </a>
+                      <button type="button"
+                              class="btn btn-sm btn-success"
+                              data-toggle="modal"
+                              data-target="#modal-exit-quarantine-{{ loop.index }}"
+                              title="Clear from Quarantine">
+                        <i class="fa fa-unlock"></i> Release
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Modals -->
+        {% for project in quarantined_projects %}
+          <div class="modal fade" id="modal-exit-quarantine-{{ loop.index }}">
+            <div class="modal-dialog modal-exit-quarantine">
+              <form id="exit-quarantine-{{ loop.index }}"
+                    action="{{ request.route_path('admin.project.remove_from_quarantine', project_name=project.name) }}"
+                    method="post">
+                <input name="csrf_token"
+                       type="hidden"
+                       value="{{ request.session.get_csrf_token() }}">
+                <div class="modal-content">
+                  <div class="modal-header bg-success">
+                    <h4 class="modal-title">Clear Project from Quarantine</h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">×</span>
+                    </button>
+                  </div>
+                  <div class="modal-body">
+                    <p>
+                      Confirming that <code>{{ project.name }}</code> will no longer be quarantined.
+                    </p>
+                    <p>
+                      This will restore the project to the index for installation.
+                      It will not affect any frozen user accounts - those will need to be handled separately.
+                    </p>
+                  </div>
+                  <div class="modal-footer justify-content-between">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    <button type="submit" class="btn btn-outline-success">Clear from Quarantine</button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        {% endfor %}
+
+        <div class="mt-3">
+          <div class="alert alert-info">
+            <i class="fa fa-info-circle"></i>
+            <strong>{{ quarantined_projects|length }}</strong> project{{ 's' if quarantined_projects|length != 1 else '' }} currently in quarantine.
+            Projects are sorted by quarantine date (oldest first).
+          </div>
+        </div>
+      {% else %}
+        <div class="alert alert-success">
+          <i class="fa fa-check-circle"></i>
+          No projects are currently in quarantine.
+        </div>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/warehouse/admin/views/quarantine.py
+++ b/warehouse/admin/views/quarantine.py
@@ -21,7 +21,6 @@ if typing.TYPE_CHECKING:
     permission=Permissions.AdminProjectsRead,
     request_method="GET",
     uses_session=True,
-    require_csrf=True,
     require_methods=False,
 )
 def quarantine_list(request: Request) -> dict[str, list[Project]]:

--- a/warehouse/admin/views/quarantine.py
+++ b/warehouse/admin/views/quarantine.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admin Views related to Quarantine"""
+from __future__ import annotations
+
+import typing
+
+from pyramid.view import view_config
+from sqlalchemy import select
+
+from warehouse.authnz import Permissions
+from warehouse.packaging.models import LifecycleStatus, Project
+
+if typing.TYPE_CHECKING:
+    from pyramid.request import Request
+
+
+@view_config(
+    route_name="admin.quarantine.list",
+    renderer="warehouse.admin:templates/admin/quarantine/list.html",
+    permission=Permissions.AdminProjectsRead,
+    request_method="GET",
+    uses_session=True,
+    require_csrf=True,
+    require_methods=False,
+)
+def quarantine_list(request: Request) -> dict[str, list[Project]]:
+    """
+    List all projects currently in quarantine.
+
+    Shows projects with lifecycle_status == 'quarantine-enter',
+    ordered by lifecycle_status_changed (oldest first).
+    """
+    stmt = (
+        select(Project)
+        .where(Project.lifecycle_status == LifecycleStatus.QuarantineEnter)
+        .order_by(Project.lifecycle_status_changed.asc())
+    )
+
+    quarantined_projects = request.db.scalars(stmt).all()
+
+    return {"quarantined_projects": quarantined_projects}


### PR DESCRIPTION
Reorganize the sidebar to group related observation-style stuff. Add a route, view, and template for any quarantined projects

Resolves #18404