### PR TITLE
add manifest to floss.fund expected location

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://www.python.org/funding.json


### PR DESCRIPTION
`projects[pypi].repositoryUrl.wellKnown` should end in /.well-known/funding-manifest-urls