### PR TITLE
feat: list_classifiers endpoint returns all classifiers

### DIFF
--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -4,7 +4,7 @@ import pretend
 import pytest
 
 from pyramid.httpexceptions import HTTPBadRequest, HTTPMovedPermanently, HTTPNotFound
-from trove_classifiers import sorted_classifiers
+from trove_classifiers import all_classifiers
 
 from warehouse.legacy.api import pypi
 
@@ -61,7 +61,7 @@ def test_list_classifiers(db_request):
     resp = pypi.list_classifiers(db_request)
 
     assert resp.status_code == 200
-    assert resp.text == "\n".join(sorted_classifiers)
+    assert resp.text == "\n".join(all_classifiers)
 
 
 def test_search():

--- a/warehouse/legacy/api/pypi.py
+++ b/warehouse/legacy/api/pypi.py
@@ -2,7 +2,7 @@
 
 from pyramid.httpexceptions import HTTPGone, HTTPMovedPermanently, HTTPNotFound, HTTPOk
 from pyramid.view import forbidden_view_config, view_config
-from trove_classifiers import sorted_classifiers
+from trove_classifiers import all_classifiers
 
 from warehouse.classifiers.models import Classifier
 
@@ -65,7 +65,7 @@ def forbidden_legacy(exc, request):
 @view_config(route_name="legacy.api.pypi.list_classifiers")
 def list_classifiers(request):
     return HTTPOk(
-        text="\n".join(sorted_classifiers), content_type="text/plain; charset=utf-8"
+        text="\n".join(all_classifiers), content_type="text/plain; charset=utf-8"
     )
 
 


### PR DESCRIPTION
This is a funky case: the `list_classifiers` API is from legacy PyPI. It used the `sorted_classifiers` API from `trove_classifiers`, but seemingly did so primarily because the concept of a "deprecated" classifier didn't exist at the time.

To accomodate deprecated classifiers, `trove_classifiers` added an `all_classifiers` API. However PyPI never switched to this API _here_, although it _did_ switch to it in the `warehouse classifiers sync` CLI:

https://github.com/pypi/warehouse/blob/bbcabd28a904dc8bc1508be48da4d69a3811a5fa/warehouse/cli/classifiers.py#L5

As a result, there's now a slight discrepancy between what PyPI accepts (all classifiers, including deprecated ones) and what PyPI advertises in this API (only non-deprecated classifiers). 

On a more practical note: I have no idea if this is worth changing/fixing 😅. It solves a very specific niche problem I have, but I think a very reasonable reaction to this PR would be "absolutely not."

CC @dstufft 