### PR TITLE
fix: add non-breaking space to error codes in 403, 404, 410, and search result templates

### DIFF
--- a/warehouse/templates/403.html
+++ b/warehouse/templates/403.html
@@ -6,4 +6,4 @@
 {% block error_heading %}
   {% trans %}You don't have permission to view this page{% endtrans %}
 {% endblock %}
-{% block error_code %}403{% endblock %}
+{% block error_code %}&nbsp;403{% endblock %}

--- a/warehouse/templates/404.html
+++ b/warehouse/templates/404.html
@@ -6,7 +6,7 @@
 {% block error_heading %}
   {% trans %}We looked everywhere but couldn't find this page{% endtrans %}
 {% endblock %}
-{% block error_code %}404{% endblock %}
+{% block error_code %}&nbsp;404{% endblock %}
 {% block extra_css %}<link href="https://fonts.googleapis.com/css?family=Ewert" rel="stylesheet">{% endblock %}
 {% block easter_egg %}
   <div class="viewport-section viewport-section--ee">

--- a/warehouse/templates/410.html
+++ b/warehouse/templates/410.html
@@ -6,4 +6,4 @@
 {% block error_heading %}
   {% trans %}The page you are looking for has been removed{% endtrans %}
 {% endblock %}
-{% block error_code %}410{% endblock %}
+{% block error_code %}&nbsp;410{% endblock %}

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -141,7 +141,7 @@
                 {% trans count=page.item_count, count_display=item_count_display %}
                 <strong>{{ count_display }}</strong> project
               {% pluralize %}
-                <strong>{{ count_display }}</strong> projects
+                <strong>{{ count_display }}</strong> projects&nbsp;
               {% endtrans %}
               {% if term %}
                 {% trans term=term %}for "{{ term }}"{% endtrans %}

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -139,7 +139,7 @@
                   {% set item_count_display = page.item_count|format_number %}
                 {% endif %}
                 {% trans count=page.item_count, count_display=item_count_display %}
-                <strong>{{ count_display }}</strong> project
+                <strong>{{ count_display }}</strong> project&nbsp;
               {% pluralize %}
                 <strong>{{ count_display }}</strong> projects&nbsp;
               {% endtrans %}


### PR DESCRIPTION
Still a draft; feedback very welcome 🙂

Closes #18552