### PR TITLE
Use `env-file` to bring dev/environment into tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,8 +127,11 @@ services:
   tests:
     image: warehouse:docker-compose
     pull_policy: never
+    env_file: dev/environment
     environment:
       ENCODING: "C"
+      WAREHOUSE_ENV:
+      REDIS_URL:
     volumes: *base_volumes
     depends_on:
       db:


### PR DESCRIPTION
This makes it easier to change the environment file and have those changes reflected in the running service.