### PR TITLE
Catch a generic `CaptchaError` and make captcha service usage more generic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,6 +346,7 @@ def get_app_config(database, nondefaults=None):
         "oidc.jwk_cache_url": "redis://localhost:0/",
         "warehouse.oidc.audience": "pypi",
         "oidc.backend": "warehouse.oidc.services.NullOIDCPublisherService",
+        "captcha.backend": "warehouse.captcha.hcaptcha.Service",
     }
 
     if nondefaults:

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -648,7 +648,7 @@ class TestRegistrationForm:
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
         assert not form.validate()
-        assert form.captcha_response.errors.pop() == "Recaptcha error."
+        assert form.captcha_response.errors.pop() == "Captcha error."
 
     def test_recaptcha_error(self):
         form = forms.RegistrationForm(
@@ -662,7 +662,7 @@ class TestRegistrationForm:
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
         assert not form.validate()
-        assert form.captcha_response.errors.pop() == "Recaptcha error."
+        assert form.captcha_response.errors.pop() == "Captcha error."
 
     def test_username_exists(self, pyramid_config):
         form = forms.RegistrationForm(

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -433,7 +433,7 @@ class TestRegistrationForm:
                     "new_password": "mysupersecurepassword1!",
                     "password_confirm": "mysupersecurepassword1!",
                     "email": "foo@bar.com",
-                    "g_recaptcha_reponse": "",
+                    "captcha_reponse": "",
                 }
             ),
             user_service=user_service,
@@ -634,12 +634,12 @@ class TestRegistrationForm:
         assert not form.validate()
         # there shouldn't be any errors for the recaptcha field if it's
         # disabled
-        assert not form.g_recaptcha_response.errors
+        assert not form.captcha_response.errors
 
     def test_recaptcha_required_error(self):
         form = forms.RegistrationForm(
             request=pretend.stub(),
-            formdata=MultiDict({"g_recaptcha_response": ""}),
+            formdata=MultiDict({"captcha_response": ""}),
             user_service=pretend.stub(),
             captcha_service=pretend.stub(
                 enabled=True,
@@ -648,12 +648,12 @@ class TestRegistrationForm:
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
         assert not form.validate()
-        assert form.g_recaptcha_response.errors.pop() == "Recaptcha error."
+        assert form.captcha_response.errors.pop() == "Recaptcha error."
 
     def test_recaptcha_error(self):
         form = forms.RegistrationForm(
             request=pretend.stub(),
-            formdata=MultiDict({"g_recaptcha_response": "asd"}),
+            formdata=MultiDict({"captcha_response": "asd"}),
             user_service=pretend.stub(),
             captcha_service=pretend.stub(
                 verify_response=pretend.raiser(recaptcha.RecaptchaError),
@@ -662,7 +662,7 @@ class TestRegistrationForm:
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
         assert not form.validate()
-        assert form.g_recaptcha_response.errors.pop() == "Recaptcha error."
+        assert form.captcha_response.errors.pop() == "Recaptcha error."
 
     def test_username_exists(self, pyramid_config):
         form = forms.RegistrationForm(

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -1752,7 +1752,7 @@ class TestRegister:
                 "password_confirm": "MyStr0ng!shP455w0rd",
                 "email": "foo@bar.com",
                 "full_name": "full_name",
-                "g_recaptcha_response": "captchavalue",
+                "captcha_response": "captchavalue",
             }
         )
 

--- a/tests/unit/captcha/test_init.py
+++ b/tests/unit/captcha/test_init.py
@@ -2,26 +2,7 @@
 
 import pretend
 
-from warehouse.captcha import includeme, interfaces, recaptcha
-
-
-def test_includeme_defaults_to_recaptcha():
-    config = pretend.stub(
-        registry=pretend.stub(settings={}),
-        maybe_dotted=lambda i: i,
-        register_service_factory=pretend.call_recorder(
-            lambda factory, iface, name: None
-        ),
-    )
-    includeme(config)
-
-    assert config.register_service_factory.calls == [
-        pretend.call(
-            recaptcha.Service.create_service,
-            interfaces.ICaptchaService,
-            name="captcha",
-        ),
-    ]
+from warehouse.captcha import includeme, interfaces
 
 
 def test_include_with_custom_backend():

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -29,7 +29,7 @@ from warehouse.accounts.interfaces import (
 )
 from warehouse.accounts.models import DisableReason, ProhibitedEmailDomain
 from warehouse.accounts.services import RECOVERY_CODE_BYTES
-from warehouse.captcha import recaptcha
+from warehouse.captcha import CaptchaError
 from warehouse.constants import MAX_PASSWORD_SIZE
 from warehouse.email import (
     send_password_compromised_email_hibp,
@@ -421,7 +421,7 @@ class RegistrationForm(  # type: ignore[misc]
             raise wtforms.validators.ValidationError("Captcha error.")
         try:
             self.captcha_service.verify_response(field.data)
-        except recaptcha.RecaptchaError:
+        except CaptchaError:
             # TODO: log error
             # don't want to provide the user with any detail
             raise wtforms.validators.ValidationError("Captcha error.")

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -418,13 +418,13 @@ class RegistrationForm(  # type: ignore[misc]
     def validate_captcha_response(self, field):
         # do required data validation here due to enabled flag being required
         if self.captcha_service.enabled and not field.data:
-            raise wtforms.validators.ValidationError("Recaptcha error.")
+            raise wtforms.validators.ValidationError("Captcha error.")
         try:
             self.captcha_service.verify_response(field.data)
         except recaptcha.RecaptchaError:
             # TODO: log error
             # don't want to provide the user with any detail
-            raise wtforms.validators.ValidationError("Recaptcha error.")
+            raise wtforms.validators.ValidationError("Captcha error.")
 
 
 class LoginForm(PasswordMixin, UsernameMixin, wtforms.Form):

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -407,7 +407,7 @@ class RegistrationForm(  # type: ignore[misc]
             PreventNullBytesValidator(),
         ]
     )
-    g_recaptcha_response = wtforms.StringField()
+    captcha_response = wtforms.StringField()
 
     def __init__(self, *args, captcha_service, user_service, **kwargs):
         super().__init__(*args, **kwargs)
@@ -415,7 +415,7 @@ class RegistrationForm(  # type: ignore[misc]
         self.user_id = None
         self.captcha_service = captcha_service
 
-    def validate_g_recaptcha_response(self, field):
+    def validate_captcha_response(self, field):
         # do required data validation here due to enabled flag being required
         if self.captcha_service.enabled and not field.data:
             raise wtforms.validators.ValidationError("Recaptcha error.")

--- a/warehouse/captcha/__init__.py
+++ b/warehouse/captcha/__init__.py
@@ -1,14 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .interfaces import ICaptchaService
-from .recaptcha import Service
 
 
 def includeme(config):
     # Register our Captcha service
-    captcha_class = config.maybe_dotted(
-        config.registry.settings.get("captcha.backend", Service)
-    )
+    captcha_class = config.maybe_dotted(config.registry.settings["captcha.backend"])
     config.register_service_factory(
         captcha_class.create_service,
         ICaptchaService,

--- a/warehouse/captcha/__init__.py
+++ b/warehouse/captcha/__init__.py
@@ -3,6 +3,10 @@
 from .interfaces import ICaptchaService
 
 
+class CaptchaError(ValueError):
+    pass
+
+
 def includeme(config):
     # Register our Captcha service
     captcha_class = config.maybe_dotted(config.registry.settings["captcha.backend"])

--- a/warehouse/captcha/hcaptcha.py
+++ b/warehouse/captcha/hcaptcha.py
@@ -8,12 +8,13 @@ from pyramid_retry import RetryableException
 from requests.exceptions import Timeout
 from zope.interface import implementer
 
+from . import CaptchaError
 from .interfaces import ChallengeResponse, ICaptchaService
 
 VERIFY_URL = "https://api.hcaptcha.com/siteverify"
 
 
-class HCaptchaError(ValueError):
+class HCaptchaError(CaptchaError):
     pass
 
 

--- a/warehouse/captcha/recaptcha.py
+++ b/warehouse/captcha/recaptcha.py
@@ -6,12 +6,13 @@ from urllib.parse import urlencode
 
 from zope.interface import implementer
 
+from . import CaptchaError
 from .interfaces import ChallengeResponse, ICaptchaService
 
 VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify"
 
 
-class RecaptchaError(ValueError):
+class RecaptchaError(CaptchaError):
     pass
 
 

--- a/warehouse/templates/includes/input-captcha.html
+++ b/warehouse/templates/includes/input-captcha.html
@@ -4,9 +4,9 @@
   {% if captcha_svc.enabled %}
     <div class="{{ captcha_svc.class_name }}"
          data-sitekey="{{ captcha_svc.site_key }}"></div>
-    {% if form.g_recaptcha_response.errors %}
+    {% if form.captcha_response.errors %}
       <ul class="form-errors">
-        {% for error in form.g_recaptcha_response.errors %}<li>{{ error }}</li>{% endfor %}
+        {% for error in form.captcha_response.errors %}<li>{{ error }}</li>{% endfor %}
       </ul>
     {% endif %}
   {% endif %}


### PR DESCRIPTION
This changes our captcha validation logic to catch a generic `CaptchaError` instead of `recaptcha.RecaptchaError`, which would only be raised when we are using ReCaptcha and not HCaptcha. Additionally, makes our captcha service usage more generic. This was missed in https://github.com/pypi/warehouse/pull/15141.

Fixes [WAREHOUSE-PRODUCTION-262](https://python-software-foundation.sentry.io/issues/6362450005/events/9c91191a9e694510846ad2a422ae08a7/).


