### PR TITLE
style(admin): allow long lines in reports to scroll

### DIFF
--- a/warehouse/admin/static/css/admin.scss
+++ b/warehouse/admin/static/css/admin.scss
@@ -50,6 +50,11 @@
   }
 }
 
+/* Timeline */
+.timeline-body dl dd {
+  overflow-inline: auto; /* Prevent long lines in malware report bodies from breaking the layout */
+}
+
 /* Dashboard utilization cards */
 .utilization-card {
   .info-icon {


### PR DESCRIPTION
Prevents breaking modal pop up locations. Felt more critically on smaller screens.