### PR TITLE
oidc/gitlab: Support single-character workflow filenames

### DIFF
--- a/tests/unit/oidc/models/test_gitlab.py
+++ b/tests/unit/oidc/models/test_gitlab.py
@@ -36,6 +36,8 @@ NAMESPACE = "project_owner"
             "gitlab.com/foo/bar//@.yml.foo.yml@bar.yml@/some/ref",
             "@.yml.foo.yml@bar.yml",
         ),
+        ("gitlab.com/foo/bar//a.yml@/some/ref", "a.yml"),
+        ("gitlab.com/foo/bar//a/b.yml@/some/ref", "a/b.yml"),
         # Malformed `ci_config_ref_uri`s.
         ("gitlab.com/foo/bar//notnested.wrongsuffix@/some/ref", None),
         ("gitlab.com/foo/bar//@/some/ref", None),

--- a/warehouse/oidc/models/gitlab.py
+++ b/warehouse/oidc/models/gitlab.py
@@ -33,8 +33,8 @@ _WORKFLOW_FILEPATH_RE = re.compile(
                       # component of the claim.
 
     (                 # our capture group
-        .+            # match one or more of any character, including slashes
-        [^/]          # match at least one non-slash character, to prevent
+        .*            # match zero or more of any character, including slashes
+        [^/]          # match exactly one non-slash character, to prevent
                       # empty basenames (e.g. `foo/.yml`)
         \.(yml|yaml)  # match the literal suffix `.yml` or `.yaml`
     )


### PR DESCRIPTION
I'm currently working on GitLab support for the Trusted Publishing implementation of crates.io and noticed that the regular expression that PyPI uses does not accept single character workflow filenames like `a.yml`.

This PR should hopefully fix the problem if CI confirms it... 🤞 