### PR TITLE
Restyle org request page

### DIFF
--- a/warehouse/admin/templates/admin/organization_applications/detail.html
+++ b/warehouse/admin/templates/admin/organization_applications/detail.html
@@ -336,7 +336,7 @@
       </div>
     </div>
 
-    {% set information_requests = organization_application.information_requests %}
+    {% set information_requests = organization_application.information_requests|reverse %}
     {% set outstanding_information_requests = organization_application.information_requests|selectattr("additional", "defined")|map(attribute="additional")|selectattr("response", "undefined")|list %}
     <div class="col-md-7 col-lg-6">
       <div class="card">
@@ -490,7 +490,7 @@
         </div>
         <div class="card-body">
         {% for information_request in information_requests %}
-        <div class="card {% if information_request.additional.response %}card-neutral{% else %}card-warning{% endif %} card-outline direct-chat direct-chat-primary"</div>
+        <div class="card {% if information_request.additional.response %}card-neutral{% else %}card-warning{% endif %} direct-chat direct-chat-primary"</div>
           <div class="card-body">
             <div class="direct-chat-messages unset-height">
               <div class="direct-chat-msg">

--- a/warehouse/static/sass/blocks/_callout-block.scss
+++ b/warehouse/static/sass/blocks/_callout-block.scss
@@ -22,9 +22,11 @@
   </div>
 
   Modifiers:
+    - neutral: Makes border grey
     - danger: Makes border red
     - warning: Makes border brown
     - success: Makes border green
+    - message: Custom styles for messaging UI
     - bottom-margin: Adds extra margin below the callout
 
   // Collapsible
@@ -48,7 +50,6 @@
   margin: 15px 0;
   position: relative;
   border-radius: 4px;
-  display: inline-block;
 
   &__dismiss {
     @include dismiss-button;
@@ -96,18 +97,6 @@
       height: calc(100% + 2px);
       border-radius: 0 3px 3px 0;
     }
-  }
-
-  &--full-width {
-    width: 100%;
-  }
-
-  &--bottom-margin {
-    margin-bottom: $half-spacing-unit;
-  }
-
-  &--dismissed {
-    display: none;
   }
 
   &--neutral {
@@ -180,5 +169,23 @@
     .callout-block__dismiss {
       @include link-focus-state($success-color);
     }
+  }
+
+  &--message {
+    display: inline-block;
+    max-width: 75%;
+    margin: 10px 0;
+
+    @media only screen and (max-width: $mobile) {
+     max-width: 85%;
+    }
+  }
+
+  &--bottom-margin {
+    margin-bottom: $half-spacing-unit;
+  }
+
+  &--dismissed {
+    display: none;
   }
 }

--- a/warehouse/static/sass/blocks/_form-group.scss
+++ b/warehouse/static/sass/blocks/_form-group.scss
@@ -15,12 +15,12 @@
 */
 
 .form-group {
-  margin-bottom: $half-spacing-unit;
+  margin-bottom: $spacing-unit;
   max-width: 350px;
 
   &__label {
     display: block;
-    font-weight: bold;
+    font-weight: $bold-font-weight;
   }
 
   &__label:not(:first-child) {
@@ -32,9 +32,10 @@
     font-weight: normal;
   }
 
-  &__wide {
+  &--wide {
     margin-bottom: $half-spacing-unit;
     max-width: unset;
+    width: 100%;
   }
 
 :where(
@@ -62,6 +63,10 @@
     width: 350px;
     margin-top: 4px;
     max-width: 100%;
+
+    &--full-width {
+      width: 100%;
+    }
   }
 
   &__text {

--- a/warehouse/static/sass/blocks/_table.scss
+++ b/warehouse/static/sass/blocks/_table.scss
@@ -29,6 +29,7 @@
     - Use a th and add 'scope="row"' for row headings
 
    Modifiers:
+     - information: table for displaying table data - ideally with row level headings
      - downloads: specific styles for downloads table on project detail page
      - releases: specific styles for releases table on manage project page
      - files: specific styles for files table on releases tab
@@ -122,6 +123,10 @@
     padding: 10px;
   }
 
+  tbody tr th {
+    font-weight: $bold-font-weight;
+  }
+
   th,
   td {
     border-bottom: 1px solid $base-grey;
@@ -154,12 +159,29 @@
     text-align: right;
   }
 
+
   &__mobile-label {
     display: none;
     font-weight: $bold-font-weight;
   }
 
   // Custom table styles
+
+  &--information {
+    th {
+      width: 1%; 
+      white-space: nowrap; 
+    }
+
+    td,
+    th {
+      vertical-align: baseline;
+    }
+
+    @media only screen and (max-width: $mobile) {
+      @include mobile-friendly-table;
+    }
+  }
 
   &--downloads {
     word-wrap: break-word;

--- a/warehouse/static/sass/layout-helpers/_containers.scss
+++ b/warehouse/static/sass/layout-helpers/_containers.scss
@@ -34,3 +34,12 @@
     padding: 0 $half-spacing-unit;
   }
 }
+
+/*
+  Reduce the size of the content to a single column:
+  <div class="single-column"></div>
+*/
+
+.single-column {
+  max-width: $site-container / 2;
+}

--- a/warehouse/static/sass/layout-helpers/_floats.scss
+++ b/warehouse/static/sass/layout-helpers/_floats.scss
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.float-left {
+    float: left;
+}
+
+.float-right {
+    float: right;
+}
+
+.clearfix {
+    @include clearfix;
+}

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -42,6 +42,7 @@
 @import "layout-helpers/banner";
 @import "layout-helpers/columns";
 @import "layout-helpers/containers";
+@import "layout-helpers/floats";
 @import "layout-helpers/left-layout";
 @import "layout-helpers/split-layout";
 @import "layout-helpers/stick-to-top";

--- a/warehouse/templates/manage/organization/activate_subscription.html
+++ b/warehouse/templates/manage/organization/activate_subscription.html
@@ -7,7 +7,7 @@
   <h2>{% trans %}Activate Subscription{% endtrans %}</h2>
   <form method="post"
         data-controller="organization-terms-of-service-accepted">
-    <div class="form-group__wide">
+    <div class="form-group form-group--wide">
       <p class="form-group__text">
         {% trans %}Company accounts require an active subscription. Please enter up-to-date billing information to enable the account.{% endtrans %}
       </p>
@@ -16,7 +16,7 @@
            type="hidden"
            value="{{ request.session.get_csrf_token() }}">
     {{ form_errors(form) }}
-    <div class="form-group__wide">
+    <div class="form-group form-group--wide">
       <label for="terms_of_service_agreement" class="form-group__label">
         {% trans %}Terms of Service{% endtrans %}
         <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
@@ -36,7 +36,7 @@
       {% endif %}
     </div>
   </div>
-  <div class="form-group__wide">
+  <div class="form-group form-group--wide">
     <a href="{{ request.route_path('manage.organizations') }}"
        class="button">{% trans %}Cancel{% endtrans %}</a>
     <input value="{% trans %}Activate Subscription{% endtrans %}"

--- a/warehouse/templates/manage/organization/application.html
+++ b/warehouse/templates/manage/organization/application.html
@@ -6,79 +6,114 @@
   {% trans organization_application_name=organization_application.name %}Manage '{{ organization_application_name }}' Organization Request{% endtrans %}
 {% endblock %}
 {% block main %}
-  <h2>{% trans %}Organization request{% endtrans %}</h2>
-  <section id="organization-details">
-    <div class="form-group">
-      <span class="form-group__label">{% trans %}Organization account name{% endtrans %}</span>
-      <p class="form-group__text">{{ organization_application.name }}</p>
-    </div>
-    <div class="form-group">
-      <span class="form-group__label">{% trans %}Organization display name{% endtrans %}</span>
-      <p class="form-group__text">{{ organization_application.display_name }}</p>
-    </div>
-    <div class="form-group">
-      <span class="form-group__label">{% trans %}️Organization URL{% endtrans %}</span>
-      <p class="form-group__text">{{ organization_application.link_url }}</p>
-    </div>
-    <div class="form-group">
-      <span class="form-group__label">{% trans %}️Organization description{% endtrans %}</span>
-      <p class="form-group__text">{{ organization_application.description }}</p>
-    </div>
-    <div class="form-group">
-      <span class="form-group__label">{% trans %}️Organization type{% endtrans %}</span>
-      <p class="form-group__text">{{ organization_application.orgtype.value }}</p>
-    </div>
-    <div class="form-group">
-      <span class="form-group__label">{% trans %}️Organization membership size{% endtrans %}</span>
-      <p class="form-group__text">
-        {{ organization_application.membership_size.value if organization_application.membership_size else "" }}
-      </p>
-    </div>
-    <div class="form-group">
-      <span class="form-group__label">{% trans %}️Anticipated usage{% endtrans %}</span>
-      <p class="form-group__text">{{ organization_application.usage if organization_application.usage else "" }}</p>
-    </div>
-    <div class="form-group">
-      <span class="form-group__label">{% trans %}Date submitted{% endtrans %}</span>
-      <p class="form-group__text">{{ humanize(organization_application.submitted) }}</p>
-    </div>
+  <h2>
+    {% trans org_name=organization_application.display_name %}Organization request for {{ org_name }}{% endtrans %}
+  </h2>
+  <section id="organization-details" class="margin-bottom--large">
+    <table class="table table--information">
+      <caption class="sr-only">Organization request details</caption>
+      <tbody>
+        <tr>
+          <th scope="row">{% trans %}Request status{% endtrans %}</th>
+          <td>
+            {% if organization_application.status == 'declined' %}
+              <strong>{% trans %}Declined{% endtrans %}:</strong>
+              <br />
+              {% trans %}This organization request has been declined{% endtrans %}
+            {% elif organization_application.status == 'moreinformationneeded' %}
+              <strong>{% trans %}More information needed{% endtrans %}:</strong>
+              <br />
+              {% trans %}Please provide more information below{% endtrans %}
+            {% else %}
+              <strong>{% trans %}Request submitted{% endtrans %}:</strong>
+              <br />
+              {% trans %}You will receive an email when the organization has been approved{% endtrans %}
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {% trans %}Organization account name{% endtrans %}
+          </td>
+          <td>{{ organization_application.name }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {% trans %}Organization display name{% endtrans %}
+          </td>
+          <td>{{ organization_application.display_name }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {% trans %}️Organization URL{% endtrans %}
+          </td>
+          <td>{{ organization_application.link_url }}</td>
+        </tr>
+        <tr>
+          <th scope="row">{% trans %}️Organization description{% endtrans %}</th>
+          <td>{{ organization_application.description }}</td>
+        </tr>
+        <tr>
+          <th scope="row">{% trans %}️Organization type{% endtrans %}</th>
+          <td>{{ organization_application.orgtype.value }}</td>
+        </tr>
+        <tr>
+          <th scope="row">{% trans %}️Organization membership size{% endtrans %}</th>
+          <td>{{ organization_application.membership_size.value if organization_application.membership_size else "" }}</td>
+        </tr>
+        <tr>
+          <th scope="row">{% trans %}️Anticipated usage{% endtrans %}</th>
+          <td>{{ organization_application.usage if organization_application.usage else "" }}</td>
+        </tr>
+        <tr>
+          <th scope="row">{% trans %}Date submitted{% endtrans %}</th>
+          <td>{{ humanize(organization_application.submitted) }}</td>
+        </tr>
+      </tbody>
+    </table>
   </section>
   {% if information_requests %}
-    <section>
-      <h3>Information Requests</h3>
-      {% for information_request in information_requests %}
-        <div class="callout-block callout-block--full-width {% if information_request.additional.response %}callout-block--neutral{% endif %}">
-          <div class="preserve-line-breaks">{{ information_request.payload.message }}</div>
-          <small>From PyPI Staff - {{ humanize(information_request.created) }}</small>
-          <br>
-          <br>
-          {% if information_request.additional.response %}
-            <div class="callout-block callout-block__right callout-block--full-width callout-block--neutral">
-              <div class="preserve-line-breaks">{{ information_request.additional.response }}</div>
-              <small>Your Response {{ humanize(information_request.additional.response_time|parse_isoformat) }}</small>
-            </div>
-          {% elif information_request.id in response_forms %}
-            <form method="post">
-              <input hidden name="response_form-id" value="{{ information_request.id }}">
-              <input name="csrf_token"
-                     type="hidden"
-                     value="{{ request.session.get_csrf_token() }}">
-              <div class="form-group">
-                <label class="form-group__label" for="public_email">{% trans %}️Your Response{% endtrans %}</label>
-                <p class="form-group__text">
-                  {{ response_forms[information_request.id].response(id="response_form-" + information_request.id.__str__() + "-response",
-                  class_="form-group__field",
-                  aria_describedby="response_form-" + information_request.id.__str__() + "-errors",
-                  ) }}
-                </p>
-                <div id="response_form-{{ information_request.id }}-errors">
-                  {{ field_errors(response_forms[information_request.id].response) }}
-                </div>
-              </div>
-              <button type="submit" class="button" title="{% trans %}Submit{% endtrans %}">{% trans %}Submit{% endtrans %}</button>
-            </form>
-          {% endif %}
+    <hr />
+    <section class="single-column">
+      <h3>Information requests</h3>
+      {% for information_request in information_requests|reverse %}
+        <div class="clearfix">
+          <div class="callout-block callout-block--message callout-block--neutral">
+            <strong>{% trans %}️PyPI Staff{% endtrans %}</strong>
+            <div class="preserve-line-breaks">{{ information_request.payload.message }}</div>
+            <small>{{ humanize(information_request.created) }}</small>
+          </div>
         </div>
+        {% if information_request.additional.response %}
+          <div class="clearfix">
+            <div class="callout-block callout-block--message float-right">
+              <strong>{% trans %}️Your response{% endtrans %}</strong>
+              <div class="preserve-line-breaks">{{ information_request.additional.response }}</div>
+              <small>{{ humanize(information_request.additional.response_time|parse_isoformat) }}</small>
+            </div>
+          </div>
+        {% elif information_request.id in response_forms and loop.last %}
+          <form method="post" class="clearfix margin-top--large margin-bottom--large">
+            <input hidden name="response_form-id" value="{{ information_request.id }}">
+            <input name="csrf_token"
+                   type="hidden"
+                   value="{{ request.session.get_csrf_token() }}">
+            <div class="form-group form-group--wide">
+              <label class="form-group__label" for="public_email">{% trans %}️Your response{% endtrans %}</label>
+              {{ response_forms[information_request.id].response(id="response_form-" + information_request.id.__str__() + "-response",
+              class_="form-group__field form-group__field--full-width",
+              rows="4",
+              aria_describedby="response_form-" + information_request.id.__str__() + "-errors",
+              ) }}
+              <div id="response_form-{{ information_request.id }}-errors">
+                {{ field_errors(response_forms[information_request.id].response) }}
+              </div>
+            </div>
+            <button type="submit"
+                    class="button button--primary"
+                    title="{% trans %}Submit{% endtrans %}">{% trans %}Submit{% endtrans %}</button>
+          </form>
+        {% endif %}
       {% endfor %}
     </section>
   {% endif %}


### PR DESCRIPTION
**Behaviour change:**

- If the PyPI admin has sent several information requests, the user now only sees a response form under the last message. This makes it appear as though the conversation is a single thread.
- Show information requests as a single conversation thread in the PyPI admin

**Screenshots:**

<img width="1900" height="4208" alt="localhost_manage_organizations_application_fbd5ea4d-82e8-453c-bfeb-87fdc72f9033_ (2)" src="https://github.com/user-attachments/assets/5a3c4633-574e-4d6f-945e-bc12a7703193" />

<img width="1900" height="3041" alt="localhost_admin_organization_applications_fbd5ea4d-82e8-453c-bfeb-87fdc72f9033_" src="https://github.com/user-attachments/assets/c6f3f56d-24d0-4858-8bfc-8d60bd7ec6a6" />
