### PR TITLE
chore: upgrade eslint from v8 to v9

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,37 @@
+const path = require("path");
+
+module.exports = [
+  {
+    ignores: [
+      "warehouse/static/js/vendor/**",
+      "node_modules/**",
+      "**/node_modules/**",
+      "dist/**",
+      "coverage/**",
+    ],
+  },
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        browser: true,
+        es6: true,
+        amd: true,
+        jquery: true,
+        node: true,
+      },
+    },
+    plugins: {
+      "@stylistic/js": require("@stylistic/eslint-plugin-js"),
+    },
+    rules: {
+      "@stylistic/js/comma-dangle": ["error", "always-multiline"],
+      "@stylistic/js/indent": ["error", 2],
+      "@stylistic/js/linebreak-style": ["error", "unix"],
+      "@stylistic/js/quotes": ["error", "double"],
+      "@stylistic/js/semi": ["error", "always"],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.0",
-    "eslint": "^8.36.0",
+    "eslint": "^9.0.0",
     "gettext-parser": "^8.0.0",
     "image-minimizer-webpack-plugin": "^4.0.2",
     "jest": "^30.2.0",
@@ -75,43 +75,5 @@
     "webpack-livereload-plugin": "^3.0.2",
     "webpack-manifest-plugin": "^5.0.0",
     "webpack-remove-empty-scripts": "^1.0.3"
-  },
-  "eslintConfig": {
-    "env": {
-      "browser": true,
-      "es6": true,
-      "amd": true,
-      "jquery": true
-    },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-      "ecmaVersion": "latest",
-      "sourceType": "module"
-    },
-    "plugins": [
-      "@stylistic/js"
-    ],
-    "rules": {
-      "@stylistic/js/comma-dangle": [
-        "error",
-        "always-multiline"
-      ],
-      "@stylistic/js/indent": [
-        "error",
-        2
-      ],
-      "@stylistic/js/linebreak-style": [
-        "error",
-        "unix"
-      ],
-      "@stylistic/js/quotes": [
-        "error",
-        "double"
-      ],
-      "@stylistic/js/semi": [
-        "error",
-        "always"
-      ]
-    }
   }
 }


### PR DESCRIPTION
This PR upgrades ESLint from version 8 to version 9, addressing issue #17444.

Changes:
1. Updated eslint from ^8.36.0 to ^9.0.0
2. Migrated config to eslint.config.js (flat config)
3. Configured @stylistic/js plugin for flat config