### PR TITLE
feat(dev): add traefik in front of services

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -27,7 +27,7 @@ SESSION_SECRET="an insecure development secret"
 BILLING_BACKEND=warehouse.subscriptions.services.MockStripeBillingService api_base=http://stripe:12111 api_version=2020-08-27 domain=localhost
 # BILLING_BACKEND=warehouse.subscriptions.services.StripeBillingService api_version=2020-08-27 publishable_key=pk_test_123 secret_key=sk_test_123 webhook_key=whsec_123 domain=localhost
 
-CAMO_URL={request.scheme}://{request.domain}:9000/
+CAMO_URL={request.scheme}://camo.localhost/
 CAMO_KEY=insecurecamokey
 
 # Example of a Live Reload URL for remote development
@@ -37,9 +37,9 @@ HIBP_API_KEY="something-not-real"
 
 DOCS_URL="https://pythonhosted.org/{project}/"
 
-FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://localhost:9001/packages/{path}
-ARCHIVE_FILES_BACKEND=warehouse.packaging.services.LocalArchiveFileStorage path=/var/opt/warehouse/packages-archive/ url=http://localhost:9001/packages-archive/{path}
-SIMPLE_BACKEND=warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://localhost:9001/simple/{path}
+FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files.localhost/packages/{path}
+ARCHIVE_FILES_BACKEND=warehouse.packaging.services.LocalArchiveFileStorage path=/var/opt/warehouse/packages-archive/ url=http://files.localhost/packages-archive/{path}
+SIMPLE_BACKEND=warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://files.localhost/simple/{path}
 DOCS_BACKEND=warehouse.packaging.services.LocalDocsStorage path=/var/opt/warehouse/docs/
 SPONSORLOGOS_BACKEND=warehouse.admin.services.LocalSponsorLogoStorage path=/var/opt/warehouse/sponsorlogos/
 ORIGIN_CACHE=warehouse.cache.origin.fastly.NullFastlyCache api_key=some_api_key service_id=some_service_id

--- a/dev/environment
+++ b/dev/environment
@@ -27,7 +27,7 @@ SESSION_SECRET="an insecure development secret"
 BILLING_BACKEND=warehouse.subscriptions.services.MockStripeBillingService api_base=http://stripe:12111 api_version=2020-08-27 domain=localhost
 # BILLING_BACKEND=warehouse.subscriptions.services.StripeBillingService api_version=2020-08-27 publishable_key=pk_test_123 secret_key=sk_test_123 webhook_key=whsec_123 domain=localhost
 
-CAMO_URL={request.scheme}://camo.localhost/
+CAMO_URL={request.scheme}://localhost:9000/
 CAMO_KEY=insecurecamokey
 
 # Example of a Live Reload URL for remote development
@@ -37,9 +37,9 @@ HIBP_API_KEY="something-not-real"
 
 DOCS_URL="https://pythonhosted.org/{project}/"
 
-FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files.localhost/packages/{path}
-ARCHIVE_FILES_BACKEND=warehouse.packaging.services.LocalArchiveFileStorage path=/var/opt/warehouse/packages-archive/ url=http://files.localhost/packages-archive/{path}
-SIMPLE_BACKEND=warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://files.localhost/simple/{path}
+FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://localhost:9001/packages/{path}
+ARCHIVE_FILES_BACKEND=warehouse.packaging.services.LocalArchiveFileStorage path=/var/opt/warehouse/packages-archive/ url=http://localhost:9001/packages-archive/{path}
+SIMPLE_BACKEND=warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://localhost:9001/simple/{path}
 DOCS_BACKEND=warehouse.packaging.services.LocalDocsStorage path=/var/opt/warehouse/docs/
 SPONSORLOGOS_BACKEND=warehouse.admin.services.LocalSponsorLogoStorage path=/var/opt/warehouse/sponsorlogos/
 ORIGIN_CACHE=warehouse.cache.origin.fastly.NullFastlyCache api_key=some_api_key service_id=some_service_id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,25 @@ volumes:
   cachedata:
 
 services:
+  traefik:
+    image: traefik:v3.6
+    command:
+      - "--api.insecure=true"  # enables dashboard on 8080 with no routing rules
+      - "--providers.docker=true"
+      - "--providers.docker.exposedByDefault=false"
+      - "--entrypoints.web.address=:80"  # port mapping to `web` service, not host-facing
+      # TODO: Is this too noisy, duplicating the web logs?
+      # - "--accesslog=true"
+      # - "--accesslog.format=json"
+    ports:
+      - "${WEB_PORT:-80}:80"
+      - "${TRAEFIK_DASHBOARD_PORT:-8080}:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      web:
+        condition: service_started  # no healthcheck yet
+
   db:
     image: postgres:17.5
     ports:
@@ -60,9 +79,12 @@ services:
 
   camo:
     image: pypa/warehouse-camo:2.0.0
-    command: "/bin/go-camo --listen=0.0.0.0:9000 --header 'Access-Control-Allow-Origin: http://localhost'"
-    ports:
-      - "9000:9000"
+    command: "/bin/go-camo --listen=0.0.0.0:9000 --header 'Access-Control-Allow-Origin: *'"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.camo.rule=Host(`camo.localhost`)"
+      - "traefik.http.routers.camo.entrypoints=web"
+      - "traefik.http.services.camo.loadbalancer.server.port=9000"
     environment:
       GOCAMO_HMAC: "insecurecamokey"
       GOCAMO_MAXSIZE: 10000
@@ -111,8 +133,12 @@ services:
     env_file: dev/environment
     pull_policy: never
     volumes: *base_volumes
-    ports:
-      - "${WEB_PORT:-80}:8000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.web.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.web.priority=1"
+      - "traefik.http.routers.web.entrypoints=web"
+      - "traefik.http.services.web.loadbalancer.server.port=8000"
     depends_on:
       db:
         condition: service_healthy
@@ -149,8 +175,11 @@ services:
       - sponsorlogos:/var/opt/warehouse/sponsorlogos
       - simple:/var/opt/warehouse/simple
       - rstuf-metadata:/var/opt/warehouse/tuf-metadata
-    ports:
-      - "9001:9001"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.files.rule=Host(`files.localhost`)"
+      - "traefik.http.routers.files.entrypoints=web"
+      - "traefik.http.services.files.loadbalancer.server.port=9001"
 
   worker:
     image: warehouse:docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,25 @@ volumes:
   mailpit_data:
 
 services:
+  traefik:
+    image: traefik:v3.6
+    command:
+      - "--api.insecure=true"  # enables dashboard on 8080 with no routing rules
+      - "--providers.docker=true"
+      - "--providers.docker.exposedByDefault=false"
+      - "--entrypoints.web.address=:80"  # port mapping to `web` service, not host-facing
+      # TODO: Is this too noisy, duplicating the web logs?
+      # - "--accesslog=true"
+      # - "--accesslog.format=json"
+    ports:
+      - "${WEB_PORT:-80}:80"
+      - "${TRAEFIK_DASHBOARD_PORT:-8080}:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      web:
+        condition: service_started  # no healthcheck yet
+
   db:
     image: postgres:17.5
     ports:
@@ -62,9 +81,12 @@ services:
 
   camo:
     image: pypa/warehouse-camo:2.0.0
-    command: "/bin/go-camo --listen=0.0.0.0:9000 --header 'Access-Control-Allow-Origin: http://localhost'"
-    ports:
-      - "9000:9000"
+    command: "/bin/go-camo --listen=0.0.0.0:9000 --header 'Access-Control-Allow-Origin: *'"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.camo.rule=Host(`camo.localhost`)"
+      - "traefik.http.routers.camo.entrypoints=web"
+      - "traefik.http.services.camo.loadbalancer.server.port=9000"
     environment:
       GOCAMO_HMAC: "insecurecamokey"
       GOCAMO_MAXSIZE: 10000
@@ -99,8 +121,12 @@ services:
     env_file: dev/environment
     pull_policy: never
     volumes: *base_volumes
-    ports:
-      - "${WEB_PORT:-80}:8000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.web.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.web.priority=1"
+      - "traefik.http.routers.web.entrypoints=web"
+      - "traefik.http.services.web.loadbalancer.server.port=8000"
     depends_on:
       db:
         condition: service_healthy
@@ -137,8 +163,11 @@ services:
       - sponsorlogos:/var/opt/warehouse/sponsorlogos
       - simple:/var/opt/warehouse/simple
       - rstuf-metadata:/var/opt/warehouse/tuf-metadata
-    ports:
-      - "9001:9001"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.files.rule=Host(`files.localhost`)"
+      - "traefik.http.routers.files.entrypoints=web"
+      - "traefik.http.services.files.loadbalancer.server.port=9001"
 
   worker:
     image: warehouse:docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,18 +13,22 @@ volumes:
 
 services:
   traefik:
-    image: traefik:v3.6
+    image: traefik:v3.7
     command:
       - "--api.insecure=true"  # enables dashboard on 8080 with no routing rules
       - "--providers.docker=true"
       - "--providers.docker.exposedByDefault=false"
-      - "--entrypoints.web.address=:80"  # port mapping to `web` service, not host-facing
+      - "--entrypoints.web.address=:80"  # web application, addressable at http://localhost/
+      - "--entrypoints.camo.address=:9000"  # camo image proxy, addressable at http://localhost:9000/
+      - "--entrypoints.files.address=:9001"  # file server, addressable at http://localhost:9001/
       # TODO: Is this too noisy, duplicating the web logs?
       # - "--accesslog=true"
       # - "--accesslog.format=json"
     ports:
       - "${WEB_PORT:-80}:80"
       - "${TRAEFIK_DASHBOARD_PORT:-8080}:8080"
+      - "9000:9000"
+      - "9001:9001"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
@@ -84,8 +88,8 @@ services:
     command: "/bin/go-camo --listen=0.0.0.0:9000 --header 'Access-Control-Allow-Origin: *'"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.camo.rule=Host(`camo.localhost`)"
-      - "traefik.http.routers.camo.entrypoints=web"
+      - "traefik.http.routers.camo.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.camo.entrypoints=camo"
       - "traefik.http.services.camo.loadbalancer.server.port=9000"
     environment:
       GOCAMO_HMAC: "insecurecamokey"
@@ -165,8 +169,8 @@ services:
       - rstuf-metadata:/var/opt/warehouse/tuf-metadata
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.files.rule=Host(`files.localhost`)"
-      - "traefik.http.routers.files.entrypoints=web"
+      - "traefik.http.routers.files.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.files.entrypoints=files"
       - "traefik.http.services.files.loadbalancer.server.port=9001"
 
   worker:

--- a/docs/dev/development/getting-started.md
+++ b/docs/dev/development/getting-started.md
@@ -247,7 +247,7 @@ TUF trust root for development, and creates the initial set of TUF metadata.
     the TUF metadata repository:
 
     * RSTUF API: http://localhost:8001
-    * TUF Metadata Repository: http://localhost:9001/tuf-metadata/
+    * TUF Metadata Repository: http://files.localhost/tuf-metadata/
 
 ### Resetting the development database
 
@@ -259,8 +259,8 @@ This command will fully reset the development database.
 
 ### Viewing Warehouse in a browser
 
-At this point all the services are up, and web container is listening on port
-80. It's accessible at http://localhost:80/.
+At this point all the services are up, and Traefik is routing traffic on port
+80. The web application is accessible at http://localhost/.
 
 !!! note
     If you are using `docker-machine` on an older version of macOS or
@@ -279,7 +279,7 @@ use that port instead.
 
 ### Logging in to Warehouse
 
-You can log into warehouse at http://localhost:80/account/login/.
+You can log into warehouse at http://localhost/account/login/.
 
 There are 4 accounts ready for you to use:
 
@@ -406,7 +406,7 @@ access your developer environment, you'll:
 make serve
 ```
 
-View Warehouse in the browser at http://localhost:80/.
+View Warehouse in the browser at http://localhost/.
 
 ### Debugging the webserver
 

--- a/docs/dev/development/getting-started.md
+++ b/docs/dev/development/getting-started.md
@@ -247,7 +247,7 @@ TUF trust root for development, and creates the initial set of TUF metadata.
     the TUF metadata repository:
 
     * RSTUF API: http://localhost:8001
-    * TUF Metadata Repository: http://files.localhost/tuf-metadata/
+    * TUF Metadata Repository: http://localhost:9001/tuf-metadata/
 
 ### Resetting the development database
 

--- a/docs/dev/development/reviewing-patches.md
+++ b/docs/dev/development/reviewing-patches.md
@@ -107,7 +107,7 @@ If you are testing Warehouse locally, you may want to use [twine](https://github
 uploading a test package. First, checkout the branch you would like to test.
 Then, start up the development environment (as described in
 [Getting Started](getting-started.md)). Once you have the Warehouse site working on
-`localhost:80`, you can upload a package to the version of Warehouse running
+`localhost`, you can upload a package to the version of Warehouse running
 in your development environment with Twine using the following command:
 
 ```shell


### PR DESCRIPTION
Mirrors production in that we can now expose all of the web-like services via the same machinery.
web, camo, files can all be accessed directly via `localhost` and the appropriate paths.