### PR TITLE
Fix heading hierarchy for accessibility

### DIFF
--- a/warehouse/static/sass/blocks/_verified.scss
+++ b/warehouse/static/sass/blocks/_verified.scss
@@ -15,7 +15,8 @@
     padding-bottom: 0;
   }
 
-  h6 {
+  h4 {
+    font-size: 1rem;
     padding-bottom: 5px;
     padding-top: 15px;
   }

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -19,7 +19,7 @@
   </h3>
   <small><i>{% trans href="https://docs.pypi.org/project_metadata/#verified-details" %}These details have been <a href="{{ href }}">verified by PyPI</a>{% endtrans %}</i></small>
   {% if release.urls_by_verify_status(verified=True).values() | contains_valid_uris %}
-    <h6>{% trans %}Project links{% endtrans %}</h6>
+    <h4>{% trans %}Project links{% endtrans %}</h4>
     <ul class="vertical-tabs__list">
       {% for name, url in release.urls_by_verify_status(verified=True).items() %}
         {% if is_valid_uri(url) %}
@@ -33,7 +33,7 @@
     </ul>
   {% endif %}
   {% if project.organization %}
-    <h6>Owner</h6>
+    <h4>Owner</h4>
     <ul class="vertical-tabs__list">
       <li>
         <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed"
@@ -46,7 +46,7 @@
     </ul>
   {% endif %}
   {% if release.verified_github_repo_info_url and release.verified_github_open_issue_info_url %}
-    <h6>{% trans %}GitHub Statistics{% endtrans %}</h6>
+    <h4>{% trans %}GitHub Statistics{% endtrans %}</h4>
     <div class="hidden github-repo-info" data-controller="github-repo-info">
       <ul class="vertical-tabs__list">
         <li>
@@ -97,7 +97,7 @@
     </div>
   {% endif %}
   {% if release.verified_gitlab_repository %}
-    <h6>{% trans %}GitLab Statistics{% endtrans %}</h6>
+    <h4>{% trans %}GitLab Statistics{% endtrans %}</h4>
     <div class="hidden gitlab-repo-info" data-controller="gitlab-repo-info">
       <ul class="vertical-tabs__list">
         <li>
@@ -148,7 +148,7 @@
     </div>
   {% endif %}
   {% if maintainers %}
-    <h6>{% trans %}Maintainers{% endtrans %}</h6>
+    <h4>{% trans %}Maintainers{% endtrans %}</h4>
     {% for maintainer in maintainers %}
       {% set alt = gettext("Avatar for {username} from gravatar.com").format(username=maintainer.username) %}
       <span class="sidebar-section__maintainer">
@@ -168,7 +168,7 @@
   {% endif %}
   {% if release.has_meta and (release.author_email_verified or release.maintainer_email_verified) %}
     <div class="sidebar-section verified">
-      <h6>{% trans %}Meta{% endtrans %}</h6>
+      <h4>{% trans %}Meta{% endtrans %}</h4>
       <ul>
         {% if release.author_email and release.author_email_verified %}
           <li>
@@ -192,7 +192,7 @@
   <h3 class="sidebar-section__title">{% trans %}Unverified details{% endtrans %}</h3>
   <small><i>{% trans %}These details have <b>not</b> been verified by PyPI{% endtrans %}</i></small>
   {% if release.urls_by_verify_status(verified=False).values() | contains_valid_uris %}
-    <h6>{% trans %}Project links{% endtrans %}</h6>
+    <h4>{% trans %}Project links{% endtrans %}</h4>
     <ul class="vertical-tabs__list">
       {% for name, url in release.urls_by_verify_status(verified=False).items() %}
         {% if is_valid_uri(url) %}
@@ -207,7 +207,7 @@
   {% endif %}
   {% if release.has_meta %}
     <div class="sidebar-section unverified">
-      <h6>{% trans %}Meta{% endtrans %}</h6>
+      <h4>{% trans %}Meta{% endtrans %}</h4>
       <ul>
         {% if release.license_expression %}
           <li>
@@ -293,7 +293,7 @@
   {% endif %}
   {% if release.classifiers %}
     <div class="sidebar-section unverified">
-      <h6 class="sidebar-section__title">{% trans %}Classifiers{% endtrans %}</h6>
+      <h4 class="sidebar-section__title">{% trans %}Classifiers{% endtrans %}</h4>
       <ul class="sidebar-section__classifiers">
         {% for classifier_head, classifier_tails in (release.classifiers|format_classifiers()).items() %}
           <li>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -213,7 +213,7 @@
     <div class="vertical-tabs">
       <div class="vertical-tabs__tabs">
         <div class="sidebar-section">
-          <h3 class="sidebar-section__title">{% trans %}Navigation{% endtrans %}</h3>
+          <h2 class="sidebar-section__title">{% trans %}Navigation{% endtrans %}</h2>
           <nav aria-label="{% trans project=release.project.name %}Navigation for {{ project }}{% endtrans %}">
             <ul class="vertical-tabs__list" role="tablist">
               <li role="tab">


### PR DESCRIPTION
## Summary

Fixes #18162 — corrects the heading structure on the package detail page to follow proper HTML semantic hierarchy, improving accessibility for screen readers and assistive technologies.

### Changes

- **Navigation heading** (`detail.html`): Changed from `<h3>` to `<h2>` — as a top-level section under the `<h1>` project name, it should be `<h2>`
- **Subsection headings** (`project-data.html`): Changed all `<h6>` to `<h4>` — these headings (Project links, Owner, GitHub/GitLab Statistics, Maintainers, Meta, Classifiers) sit under `<h3>` (Verified/Unverified details) and were incorrectly skipping heading levels 4 and 5
- **Stylesheet** (`_verified.scss`): Updated the selector from `h6` to `h4` and explicitly set `font-size: 1rem` to preserve the existing visual appearance

### Before
```
h1: Project Name
  h3: Navigation          ← skips h2
    h3: Verified details
      h6: Project links   ← skips h4, h5
      h6: Meta
    h3: Unverified details
      h6: Project links
      h6: Meta
```

### After
```
h1: Project Name
  h2: Navigation          ← correct level
    h3: Verified details
      h4: Project links   ← correct level
      h4: Meta
    h3: Unverified details
      h4: Project links
      h4: Meta
```

### Visual Impact

The `.sidebar-section__title` class already controls the Navigation heading's font size (1.1rem), so the `h3→h2` change has no visual effect. For the `h6→h4` change, `font-size: 1rem` is explicitly set in the updated CSS rule to match the previous `h6` base style, preventing any visual regression.

### Testing

- Verified heading hierarchy follows semantic HTML structure (h1 → h2 → h3 → h4)
- Confirmed CSS preserves existing visual appearance through explicit font-size override