### PR TITLE
Add `_uploaded_via` and `_trusted_publishing` to json api

### DIFF
--- a/tests/unit/packaging/test_utils.py
+++ b/tests/unit/packaging/test_utils.py
@@ -12,7 +12,69 @@ from warehouse.packaging.utils import (
     render_simple_detail,
 )
 
-from ...common.db.packaging import FileFactory, ProjectFactory, ReleaseFactory
+from ...common.db.packaging import (
+    FileEventFactory,
+    FileFactory,
+    ProjectFactory,
+    ReleaseFactory,
+)
+
+
+def test_simple_detail_uploaded_via_none(db_request):
+    project = ProjectFactory.create()
+    release = ReleaseFactory.create(project=project, version="1.0")
+    FileFactory.create(release=release, uploaded_via=None)
+
+    db_request.route_url = lambda *a, **kw: "the-url"
+    result = _simple_detail(project, db_request)
+
+    assert result["files"][0]["_uploaded_via"] is None
+    assert result["files"][0]["_trusted_publishing"] is False
+
+
+def test_simple_detail_uploaded_via_set(db_request):
+    project = ProjectFactory.create()
+    release = ReleaseFactory.create(project=project, version="1.0")
+    FileFactory.create(release=release, uploaded_via="twine/6.2.0 CPython/3.14.4")
+
+    db_request.route_url = lambda *a, **kw: "the-url"
+    result = _simple_detail(project, db_request)
+
+    assert result["files"][0]["_uploaded_via"] == "twine/6.2.0 CPython/3.14.4"
+    assert result["files"][0]["_trusted_publishing"] is False
+
+
+def test_simple_detail_trusted_publishing_via_publisher_url(db_request):
+    project = ProjectFactory.create()
+    release = ReleaseFactory.create(project=project, version="1.0")
+    f = FileFactory.create(release=release, uploaded_via="twine/6.2.0 CPython/3.14.4")
+    FileEventFactory.create(
+        source=f,
+        tag="fake:event",
+        additional={"publisher_url": "https://github.com/actions/upload"},
+    )
+
+    db_request.route_url = lambda *a, **kw: "the-url"
+    result = _simple_detail(project, db_request)
+
+    assert result["files"][0]["_uploaded_via"] == "twine/6.2.0 CPython/3.14.4"
+    assert result["files"][0]["_trusted_publishing"] is True
+
+
+def test_simple_detail_trusted_publishing_via_flag(db_request):
+    project = ProjectFactory.create()
+    release = ReleaseFactory.create(project=project, version="1.0")
+    f = FileFactory.create(release=release)
+    FileEventFactory.create(
+        source=f,
+        tag="fake:event",
+        additional={"uploaded_via_trusted_publisher": True, "publisher_url": None},
+    )
+
+    db_request.route_url = lambda *a, **kw: "the-url"
+    result = _simple_detail(project, db_request)
+
+    assert result["files"][0]["_trusted_publishing"] is True
 
 
 def test_simple_detail_empty_string(db_request):

--- a/tests/unit/packaging/test_utils.py
+++ b/tests/unit/packaging/test_utils.py
@@ -77,6 +77,37 @@ def test_simple_detail_trusted_publishing_via_flag(db_request):
     assert result["files"][0]["_trusted_publishing"] is True
 
 
+def test_simple_detail_trusted_publishing_costs_one_query(db_request, query_recorder):
+    """
+    Trusted-publishing status comes back in the same query as the files.
+
+    `_trusted_publishing` used to call a per-file property that issued its
+    own `COUNT` query, so a project with many files across many releases
+    cost one query per file. Confirm that no longer happens: however many
+    files a project has, listing them costs the same one query.
+    """
+    project = ProjectFactory.create()
+    for i in range(5):
+        release = ReleaseFactory.create(project=project, version=f"{i}.0")
+        f = FileFactory.create(release=release)
+        FileEventFactory.create(
+            source=f,
+            tag="fake:event",
+            additional={"uploaded_via_trusted_publisher": True, "publisher_url": None},
+        )
+
+    db_request.route_url = lambda *a, **kw: "the-url"
+    assert project.lifecycle_status is None  # load the project row before counting
+
+    query_recorder.clear()
+    with query_recorder:
+        result = _simple_detail(project, db_request)
+
+    assert len(result["files"]) == 5
+    assert all(f["_trusted_publishing"] is True for f in result["files"])
+    assert len(query_recorder.queries) == 1, query_recorder.queries
+
+
 def test_simple_detail_empty_string(db_request):
     project = ProjectFactory.create()
     release = ReleaseFactory.create(project=project, version="1.0", requires_python="")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -28,6 +28,7 @@ from sqlalchemy import (
     UniqueConstraint,
     cast,
     event,
+    exists,
     func,
     or_,
     orm,
@@ -1235,19 +1236,25 @@ class File(HasEvents, db.Model):
         passive_deletes=True,
     )
 
-    @property
+    @classmethod
+    def _trusted_publisher_event_filter(cls):
+        return or_(
+            cls.Event.additional["uploaded_via_trusted_publisher"].as_boolean(),
+            cls.Event.additional["publisher_url"].as_string().is_not(None),
+        )
+
+    @hybrid_property
     def uploaded_via_trusted_publisher(self) -> bool:
         """Return True if the file was uploaded via a trusted publisher."""
-        return (
-            self.events.where(
-                or_(
-                    self.Event.additional[
-                        "uploaded_via_trusted_publisher"
-                    ].as_boolean(),
-                    self.Event.additional["publisher_url"].as_string().is_not(None),
-                )
-            ).count()
-            > 0
+        return self.events.where(self._trusted_publisher_event_filter()).count() > 0
+
+    @uploaded_via_trusted_publisher.expression  # type: ignore[no-redef]
+    def uploaded_via_trusted_publisher(cls):
+        # A correlated EXISTS, so this can run as a column in the query
+        # that lists a project's files instead of a per-file COUNT query.
+        return exists().where(
+            cls.Event.source_id == cls.id,
+            cls._trusted_publisher_event_filter(),
         )
 
     @hybrid_property

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -120,6 +120,8 @@ def _simple_detail(project, request):
                     if file.provenance
                     else None
                 ),
+                "_uploaded_via": file.uploaded_via or None,
+                "_trusted_publishing": file.uploaded_via_trusted_publisher,
             }
             for file in files
         ],

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -116,6 +116,8 @@ def _simple_detail(project, request):
                     if file.provenance
                     else None
                 ),
+                "_uploaded_via": file.uploaded_via or None,
+                "_trusted_publishing": file.uploaded_via_trusted_publisher,
             }
             for file in files
         ],

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -49,9 +49,14 @@ def _simple_index(request, serial):
 
 
 def _simple_detail(project, request):
-    # Get all of the files for this project.
-    files = sorted(
-        request.db.query(File)
+    # Get all of the files for this project, along with whether each was
+    # uploaded via a trusted publisher. That flag is computed as a
+    # correlated EXISTS column here, rather than via the `File` property of
+    # the same name, so a project with hundreds of files across many
+    # releases costs one query instead of one `COUNT` query per file.
+    trusted_publishing = File.uploaded_via_trusted_publisher.label("trusted_publishing")
+    rows = sorted(
+        request.db.query(File, trusted_publishing)
         .options(joinedload(File.release))
         .join(Release)
         .filter(Release.project == project)
@@ -66,8 +71,12 @@ def _simple_detail(project, request):
             Project.lifecycle_status.is_distinct_from(LifecycleStatus.QuarantineEnter)
         )
         .all(),
-        key=lambda f: (packaging_legacy.version.parse(f.release.version), f.filename),
+        key=lambda row: (
+            packaging_legacy.version.parse(row[0].release.version),
+            row[0].filename,
+        ),
     )
+    files = [file for file, _ in rows]
     versions = sorted(
         {f.release.version for f in files}, key=packaging_legacy.version.parse
     )
@@ -117,9 +126,9 @@ def _simple_detail(project, request):
                     else None
                 ),
                 "_uploaded_via": file.uploaded_via or None,
-                "_trusted_publishing": file.uploaded_via_trusted_publisher,
+                "_trusted_publishing": is_trusted_publisher,
             }
-            for file in files
+            for file, is_trusted_publisher in rows
         ],
     }
 


### PR DESCRIPTION
These are only accessible in the version HTML today, which requires a fastly client challenge to view.  These fields are useful for automation.