### PR TITLE
Allow burning of TP tokens

### DIFF
--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -483,6 +483,19 @@ class TestDatabaseMacaroonService:
         with pytest.raises(services.InvalidMacaroonError, match="Invalid signature"):
             macaroon_service.verify_signature_only(raw_macaroon)
 
+    def test_verify_signature_only_invalid_identifier(self, macaroon_service):
+        macaroon = pymacaroons.Macaroon(
+            location="fake location",
+            identifier=b"\xff",
+            key=b"fake key",
+            version=pymacaroons.MACAROON_V2,
+        )
+
+        with pytest.raises(
+            services.InvalidMacaroonError, match="malformed macaroon identifier"
+        ):
+            macaroon_service.verify_signature_only(f"pypi-{macaroon.serialize()}")
+
     def test_delete_macaroon(self, user_service, macaroon_service):
         user = UserFactory.create()
         _, macaroon = macaroon_service.create_macaroon(

--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -432,6 +432,57 @@ class TestDatabaseMacaroonService:
             if call.args[0].startswith("warehouse.macaroon.verify.attenuat")
         ]
 
+    def test_verify_signature_only(
+        self,
+        user_macaroon,
+        macaroon_service,
+    ):
+        """
+        We can verify a signature on a macaroon without contextually evaluating its
+        caveats.
+        """
+        raw_macaroon, db_macaroon = user_macaroon
+
+        assert macaroon_service.verify_signature_only(raw_macaroon) == db_macaroon
+
+    def test_verify_signature_only_nonexistent(
+        self,
+        user_macaroon,
+        macaroon_service,
+    ):
+        """
+        Verifying only the signature on a macaroon fails if the macaroon doesn't
+        exist in the DB.
+        """
+
+        raw_macaroon, db_macaroon = user_macaroon
+
+        # Delete the macaroon so that lookup fails.
+        macaroon_service.delete_macaroon(str(db_macaroon.id))
+
+        with pytest.raises(services.InvalidMacaroonError, match="Macaroon not found"):
+            macaroon_service.verify_signature_only(raw_macaroon)
+
+    def test_verify_signature_only_invalid(
+        self,
+        user_macaroon,
+        macaroon_service,
+    ):
+        """
+        Verifying only the signature fails if the signature doesn't match.
+        """
+
+        raw_macaroon, db_macaroon = user_macaroon
+
+        # Sanity check: the signature matches.
+        assert macaroon_service.verify_signature_only(raw_macaroon) == db_macaroon
+
+        # Replace the DB-side key so that the signature cannot possibly match.
+        db_macaroon.key = b"banana"
+
+        with pytest.raises(services.InvalidMacaroonError, match="Invalid signature"):
+            macaroon_service.verify_signature_only(raw_macaroon)
+
     def test_delete_macaroon(self, user_service, macaroon_service):
         user = UserFactory.create()
         _, macaroon = macaroon_service.create_macaroon(

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -1202,7 +1202,8 @@ def test_burn_oidc_issued_token_user_macaroon(metrics, monkeypatch):
 
 
 def test_burn_oidc_issued_token_success(metrics):
-    publisher = pretend.stub(publisher_name="GitHub")
+    projects = [pretend.stub(record_event=pretend.call_recorder(lambda *a, **kw: None))]
+    publisher = pretend.stub(publisher_name="GitHub", projects=projects)
     macaroon = pretend.stub(
         id="fake-macaroon-id",
         oidc_publisher=publisher,
@@ -1238,6 +1239,14 @@ def test_burn_oidc_issued_token_success(metrics):
             "warehouse.oidc.burn_oidc_issued_token",
             tags=["status:success", "publisher_name:GitHub"],
         ),
+    ]
+
+    assert macaroon.oidc_publisher.projects[0].record_event.calls == [
+        pretend.call(
+            tag=EventTag.Project.ShortLivedAPITokenRevoked,
+            request=request,
+            additional={},
+        )
     ]
 
 

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import http
 import json
 
 from datetime import datetime
@@ -96,7 +97,7 @@ def test_mint_token_from_oidc_not_enabled(token, service_name, request):
     )
 
     response = views.mint_token_from_oidc(request)
-    assert request.response.status == 422
+    assert request.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert response == {
         "message": "Token request failed",
         "errors": [
@@ -140,7 +141,7 @@ def test_mint_token_from_oidc_invalid_payload(body):
     req = Request()
     resp = views.mint_token_from_oidc(req)
 
-    assert req.response.status == 422
+    assert req.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp["message"] == "Token request failed"
     assert isinstance(resp["errors"], list)
     for err in resp["errors"]:
@@ -179,7 +180,7 @@ def test_mint_token_from_oidc_invalid_payload_malformed_jwt(body):
     req = Request()
     resp = views.mint_token_from_oidc(req)
 
-    assert req.response.status == 422
+    assert req.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp["message"] == "Token request failed"
     assert isinstance(resp["errors"], list)
     for err in resp["errors"]:
@@ -212,7 +213,7 @@ def test_mint_token_from_oidc_jwt_decode_leaky_exception(monkeypatch):
         pretend.call("jwt.decode raised generic error: oops")
     ]
 
-    assert req.response.status == 422
+    assert req.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp["message"] == "Token request failed"
     assert isinstance(resp["errors"], list)
     for err in resp["errors"]:
@@ -245,7 +246,7 @@ def test_mint_token_from_oidc_unknown_issuer(metrics):
     req = Request()
     resp = views.mint_token_from_oidc(req)
 
-    assert req.response.status == 422
+    assert req.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp["message"] == "Token request failed"
     assert isinstance(resp["errors"], list)
     for err in resp["errors"]:
@@ -329,7 +330,7 @@ def test_mint_token_from_trusted_publisher_verify_jwt_signature_fails():
     response = views.mint_token(
         oidc_service, DUMMY_GITHUB_OIDC_JWT, claims["iss"], request
     )
-    assert request.response.status == 422
+    assert request.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert response == {
         "message": "Token request failed",
         "errors": [
@@ -365,7 +366,7 @@ def test_mint_token_trusted_publisher_lookup_fails():
     response = views.mint_token(
         oidc_service, DUMMY_GITHUB_OIDC_JWT, claims["iss"], request
     )
-    assert request.response.status == 422
+    assert request.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert response == {
         "message": "Token request failed",
         "errors": [
@@ -409,7 +410,7 @@ def test_mint_token_duplicate_token():
     response = views.mint_token(
         oidc_service, DUMMY_GITHUB_OIDC_JWT, claims["iss"], request
     )
-    assert request.response.status == 422
+    assert request.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert response == {
         "message": "Token request failed",
         "errors": [
@@ -443,7 +444,7 @@ def test_mint_token_pending_publisher_project_already_exists(db_request):
     resp = views.mint_token(
         oidc_service, DUMMY_GITHUB_OIDC_JWT, claims["iss"], db_request
     )
-    assert db_request.response.status_code == 422
+    assert db_request.response.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp == {
         "message": "Token request failed",
         "errors": [
@@ -1106,6 +1107,140 @@ def test_should_send_environment_warning_email(
     assert should_send_environment_warning_email(publisher, claims) == should_send
 
 
+def test_burn_oidc_issued_token_invalid_payload(metrics):
+    request = pretend.stub(
+        body=json.dumps({"token": None}),
+        response=pretend.stub(status=None),
+        metrics=metrics,
+    )
+
+    response = views.burn_oidc_issued_token(request)
+
+    assert request.response.status == http.HTTPStatus.ACCEPTED
+    assert response == {"message": "Accepted", "errors": []}
+    assert request.metrics.increment.calls == [
+        pretend.call(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:failure", "failure_reason:invalid_payload"],
+        ),
+    ]
+
+
+def test_burn_oidc_issued_token_invalid_macaroon(metrics):
+    macaroon_service = pretend.stub(
+        find_from_raw=pretend.call_recorder(pretend.raiser(views.InvalidMacaroonError))
+    )
+
+    def find_service(iface, **kw):
+        return {
+            IMacaroonService: macaroon_service,
+        }[iface]
+
+    request = pretend.stub(
+        body=json.dumps({"token": "invalid-macaroon"}),
+        response=pretend.stub(status=None),
+        find_service=pretend.call_recorder(find_service),
+        metrics=metrics,
+    )
+
+    response = views.burn_oidc_issued_token(request)
+
+    assert request.response.status == http.HTTPStatus.ACCEPTED
+    assert response == {"message": "Accepted", "errors": []}
+    assert request.find_service.calls == [
+        pretend.call(IMacaroonService, context=None),
+    ]
+    assert macaroon_service.find_from_raw.calls == [pretend.call("invalid-macaroon")]
+    assert request.metrics.increment.calls == [
+        pretend.call(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:failure", "failure_reason:invalid_macaroon"],
+        ),
+    ]
+
+
+def test_burn_oidc_issued_token_user_macaroon(metrics, monkeypatch):
+    macaroon = pretend.stub(
+        id="fake-macaroon-id",
+        oidc_publisher=None,
+        user=pretend.stub(username="fakeuser"),
+    )
+    macaroon_service = pretend.stub(
+        find_from_raw=pretend.call_recorder(lambda token: macaroon),
+        delete_macaroon=pretend.call_recorder(lambda macaroon_id: None),
+    )
+    capture_message = pretend.call_recorder(lambda message: None)
+    monkeypatch.setattr(views.sentry_sdk, "capture_message", capture_message)
+
+    def find_service(iface, **kw):
+        return {
+            IMacaroonService: macaroon_service,
+        }[iface]
+
+    request = pretend.stub(
+        body=json.dumps({"token": "user-macaroon"}),
+        response=pretend.stub(status=None),
+        find_service=pretend.call_recorder(find_service),
+        metrics=metrics,
+    )
+
+    response = views.burn_oidc_issued_token(request)
+
+    assert request.response.status == http.HTTPStatus.ACCEPTED
+    assert response == {"message": "Accepted", "errors": []}
+    assert macaroon_service.find_from_raw.calls == [pretend.call("user-macaroon")]
+    assert macaroon_service.delete_macaroon.calls == []
+    assert capture_message.calls == [
+        pretend.call("Tried to burn an API token corresponding to a user: 'fakeuser'")
+    ]
+    assert request.metrics.increment.calls == [
+        pretend.call(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:failure", "failure_reason:not_oidc_publisher"],
+        ),
+    ]
+
+
+def test_burn_oidc_issued_token_success(metrics):
+    publisher = pretend.stub(publisher_name="GitHub")
+    macaroon = pretend.stub(
+        id="fake-macaroon-id",
+        oidc_publisher=publisher,
+    )
+    macaroon_service = pretend.stub(
+        find_from_raw=pretend.call_recorder(lambda token: macaroon),
+        delete_macaroon=pretend.call_recorder(lambda macaroon_id: None),
+    )
+
+    def find_service(iface, **kw):
+        return {
+            IMacaroonService: macaroon_service,
+        }[iface]
+
+    request = pretend.stub(
+        body=json.dumps({"token": "oidc-macaroon"}),
+        response=pretend.stub(status=None),
+        find_service=pretend.call_recorder(find_service),
+        metrics=metrics,
+    )
+
+    response = views.burn_oidc_issued_token(request)
+
+    assert request.response.status == http.HTTPStatus.ACCEPTED
+    assert response == {"message": "Accepted", "errors": []}
+    assert request.find_service.calls == [
+        pretend.call(IMacaroonService, context=None),
+    ]
+    assert macaroon_service.find_from_raw.calls == [pretend.call("oidc-macaroon")]
+    assert macaroon_service.delete_macaroon.calls == [pretend.call("fake-macaroon-id")]
+    assert request.metrics.increment.calls == [
+        pretend.call(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:success", "publisher_name:GitHub"],
+        ),
+    ]
+
+
 def test_mint_token_jti_stored_before_macaroon_creation(monkeypatch, db_request):
     """
     Verify that the JTI is atomically claimed before the macaroon is minted,
@@ -1216,5 +1351,5 @@ def test_mint_token_jti_stored_before_macaroon_creation(monkeypatch, db_request)
         "https://token.actions.githubusercontent.com",
         db_request,
     )
-    assert "422" in str(db_request.response.status)
+    assert str(http.HTTPStatus.UNPROCESSABLE_ENTITY) in str(db_request.response.status)
     assert response2["errors"][0]["code"] == "invalid-reuse-token"

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -1137,7 +1137,9 @@ def test_burn_oidc_issued_token_invalid_payload(metrics):
 
 def test_burn_oidc_issued_token_invalid_macaroon(metrics):
     macaroon_service = pretend.stub(
-        find_from_raw=pretend.call_recorder(pretend.raiser(views.InvalidMacaroonError))
+        verify_signature_only=pretend.call_recorder(
+            pretend.raiser(views.InvalidMacaroonError)
+        )
     )
 
     def find_service(iface, **kw):
@@ -1159,7 +1161,9 @@ def test_burn_oidc_issued_token_invalid_macaroon(metrics):
     assert request.find_service.calls == [
         pretend.call(IMacaroonService, context=None),
     ]
-    assert macaroon_service.find_from_raw.calls == [pretend.call("invalid-macaroon")]
+    assert macaroon_service.verify_signature_only.calls == [
+        pretend.call("invalid-macaroon")
+    ]
     assert request.metrics.increment.calls == [
         pretend.call(
             "warehouse.oidc.burn_oidc_issued_token",
@@ -1175,7 +1179,7 @@ def test_burn_oidc_issued_token_user_macaroon(metrics, monkeypatch):
         user=pretend.stub(username="fakeuser"),
     )
     macaroon_service = pretend.stub(
-        find_from_raw=pretend.call_recorder(lambda token: macaroon),
+        verify_signature_only=pretend.call_recorder(lambda token: macaroon),
         delete_macaroon=pretend.call_recorder(lambda macaroon_id: None),
     )
     capture_message = pretend.call_recorder(lambda message: None)
@@ -1197,7 +1201,9 @@ def test_burn_oidc_issued_token_user_macaroon(metrics, monkeypatch):
 
     assert request.response.status == http.HTTPStatus.ACCEPTED
     assert response == {"message": "Accepted", "errors": []}
-    assert macaroon_service.find_from_raw.calls == [pretend.call("user-macaroon")]
+    assert macaroon_service.verify_signature_only.calls == [
+        pretend.call("user-macaroon")
+    ]
     assert macaroon_service.delete_macaroon.calls == []
     assert capture_message.calls == [
         pretend.call("Tried to burn an API token corresponding to a user: 'fakeuser'")
@@ -1218,7 +1224,7 @@ def test_burn_oidc_issued_token_success(metrics):
         oidc_publisher=publisher,
     )
     macaroon_service = pretend.stub(
-        find_from_raw=pretend.call_recorder(lambda token: macaroon),
+        verify_signature_only=pretend.call_recorder(lambda token: macaroon),
         delete_macaroon=pretend.call_recorder(lambda macaroon_id: None),
     )
 
@@ -1241,7 +1247,9 @@ def test_burn_oidc_issued_token_success(metrics):
     assert request.find_service.calls == [
         pretend.call(IMacaroonService, context=None),
     ]
-    assert macaroon_service.find_from_raw.calls == [pretend.call("oidc-macaroon")]
+    assert macaroon_service.verify_signature_only.calls == [
+        pretend.call("oidc-macaroon")
+    ]
     assert macaroon_service.delete_macaroon.calls == [pretend.call("fake-macaroon-id")]
     assert request.metrics.increment.calls == [
         pretend.call(

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -2,6 +2,7 @@
 
 import http
 import json
+import uuid
 
 from datetime import datetime
 
@@ -1183,7 +1184,7 @@ def test_burn_oidc_issued_token_invalid_macaroon(metrics):
 
 def test_burn_oidc_issued_token_user_macaroon(metrics, monkeypatch):
     macaroon = pretend.stub(
-        id="fake-macaroon-id",
+        id=uuid.uuid4(),
         oidc_publisher=None,
         user=pretend.stub(username="fakeuser"),
     )
@@ -1228,8 +1229,9 @@ def test_burn_oidc_issued_token_user_macaroon(metrics, monkeypatch):
 def test_burn_oidc_issued_token_success(metrics):
     projects = [pretend.stub(record_event=pretend.call_recorder(lambda *a, **kw: None))]
     publisher = pretend.stub(publisher_name="GitHub", projects=projects)
+    macaroon_id = uuid.uuid4()
     macaroon = pretend.stub(
-        id="fake-macaroon-id",
+        id=macaroon_id,
         oidc_publisher=publisher,
     )
     macaroon_service = pretend.stub(
@@ -1259,7 +1261,7 @@ def test_burn_oidc_issued_token_success(metrics):
     assert macaroon_service.verify_signature_only.calls == [
         pretend.call("oidc-macaroon")
     ]
-    assert macaroon_service.delete_macaroon.calls == [pretend.call("fake-macaroon-id")]
+    assert macaroon_service.delete_macaroon.calls == [pretend.call(str(macaroon_id))]
     assert request.metrics.increment.calls == [
         pretend.call(
             "warehouse.oidc.burn_oidc_issued_token",

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -1116,9 +1116,18 @@ def test_should_send_environment_warning_email(
     assert should_send_environment_warning_email(publisher, claims) == should_send
 
 
-def test_burn_oidc_issued_token_invalid_payload(metrics):
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"token": None},
+        {"token": 123},
+        {"token": [123]},
+        {},
+    ],
+)
+def test_burn_oidc_issued_token_invalid_payload(metrics, payload):
     request = pretend.stub(
-        body=json.dumps({"token": None}),
+        body=json.dumps(payload),
         response=pretend.stub(status=None),
         metrics=metrics,
     )

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -1211,7 +1211,8 @@ def test_burn_oidc_issued_token_user_macaroon(metrics, monkeypatch):
 
 
 def test_burn_oidc_issued_token_success(metrics):
-    publisher = pretend.stub(publisher_name="GitHub")
+    projects = [pretend.stub(record_event=pretend.call_recorder(lambda *a, **kw: None))]
+    publisher = pretend.stub(publisher_name="GitHub", projects=projects)
     macaroon = pretend.stub(
         id="fake-macaroon-id",
         oidc_publisher=publisher,
@@ -1247,6 +1248,14 @@ def test_burn_oidc_issued_token_success(metrics):
             "warehouse.oidc.burn_oidc_issued_token",
             tags=["status:success", "publisher_name:GitHub"],
         ),
+    ]
+
+    assert macaroon.oidc_publisher.projects[0].record_event.calls == [
+        pretend.call(
+            tag=EventTag.Project.ShortLivedAPITokenRevoked,
+            request=request,
+            additional={},
+        )
     ]
 
 

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import http
 import json
 
 from datetime import datetime
@@ -96,7 +97,7 @@ def test_mint_token_from_oidc_not_enabled(token, service_name, request):
     )
 
     response = views.mint_token_from_oidc(request)
-    assert request.response.status == 422
+    assert request.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert response == {
         "message": "Token request failed",
         "errors": [
@@ -140,7 +141,7 @@ def test_mint_token_from_oidc_invalid_payload(body):
     req = Request()
     resp = views.mint_token_from_oidc(req)
 
-    assert req.response.status == 422
+    assert req.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp["message"] == "Token request failed"
     assert isinstance(resp["errors"], list)
     for err in resp["errors"]:
@@ -179,7 +180,7 @@ def test_mint_token_from_oidc_invalid_payload_malformed_jwt(body):
     req = Request()
     resp = views.mint_token_from_oidc(req)
 
-    assert req.response.status == 422
+    assert req.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp["message"] == "Token request failed"
     assert isinstance(resp["errors"], list)
     for err in resp["errors"]:
@@ -212,7 +213,7 @@ def test_mint_token_from_oidc_jwt_decode_leaky_exception(monkeypatch):
         pretend.call("jwt.decode raised generic error: oops")
     ]
 
-    assert req.response.status == 422
+    assert req.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp["message"] == "Token request failed"
     assert isinstance(resp["errors"], list)
     for err in resp["errors"]:
@@ -245,7 +246,7 @@ def test_mint_token_from_oidc_unknown_issuer(metrics):
     req = Request()
     resp = views.mint_token_from_oidc(req)
 
-    assert req.response.status == 422
+    assert req.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp["message"] == "Token request failed"
     assert isinstance(resp["errors"], list)
     for err in resp["errors"]:
@@ -329,7 +330,7 @@ def test_mint_token_from_trusted_publisher_verify_jwt_signature_fails():
     response = views.mint_token(
         oidc_service, DUMMY_GITHUB_OIDC_JWT, claims["iss"], request
     )
-    assert request.response.status == 422
+    assert request.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert response == {
         "message": "Token request failed",
         "errors": [
@@ -365,7 +366,7 @@ def test_mint_token_trusted_publisher_lookup_fails():
     response = views.mint_token(
         oidc_service, DUMMY_GITHUB_OIDC_JWT, claims["iss"], request
     )
-    assert request.response.status == 422
+    assert request.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert response == {
         "message": "Token request failed",
         "errors": [
@@ -409,7 +410,7 @@ def test_mint_token_duplicate_token():
     response = views.mint_token(
         oidc_service, DUMMY_GITHUB_OIDC_JWT, claims["iss"], request
     )
-    assert request.response.status == 422
+    assert request.response.status == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert response == {
         "message": "Token request failed",
         "errors": [
@@ -443,7 +444,7 @@ def test_mint_token_pending_publisher_project_already_exists(db_request):
     resp = views.mint_token(
         oidc_service, DUMMY_GITHUB_OIDC_JWT, claims["iss"], db_request
     )
-    assert db_request.response.status_code == 422
+    assert db_request.response.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp == {
         "message": "Token request failed",
         "errors": [
@@ -1115,6 +1116,140 @@ def test_should_send_environment_warning_email(
     assert should_send_environment_warning_email(publisher, claims) == should_send
 
 
+def test_burn_oidc_issued_token_invalid_payload(metrics):
+    request = pretend.stub(
+        body=json.dumps({"token": None}),
+        response=pretend.stub(status=None),
+        metrics=metrics,
+    )
+
+    response = views.burn_oidc_issued_token(request)
+
+    assert request.response.status == http.HTTPStatus.ACCEPTED
+    assert response == {"message": "Accepted", "errors": []}
+    assert request.metrics.increment.calls == [
+        pretend.call(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:failure", "failure_reason:invalid_payload"],
+        ),
+    ]
+
+
+def test_burn_oidc_issued_token_invalid_macaroon(metrics):
+    macaroon_service = pretend.stub(
+        find_from_raw=pretend.call_recorder(pretend.raiser(views.InvalidMacaroonError))
+    )
+
+    def find_service(iface, **kw):
+        return {
+            IMacaroonService: macaroon_service,
+        }[iface]
+
+    request = pretend.stub(
+        body=json.dumps({"token": "invalid-macaroon"}),
+        response=pretend.stub(status=None),
+        find_service=pretend.call_recorder(find_service),
+        metrics=metrics,
+    )
+
+    response = views.burn_oidc_issued_token(request)
+
+    assert request.response.status == http.HTTPStatus.ACCEPTED
+    assert response == {"message": "Accepted", "errors": []}
+    assert request.find_service.calls == [
+        pretend.call(IMacaroonService, context=None),
+    ]
+    assert macaroon_service.find_from_raw.calls == [pretend.call("invalid-macaroon")]
+    assert request.metrics.increment.calls == [
+        pretend.call(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:failure", "failure_reason:invalid_macaroon"],
+        ),
+    ]
+
+
+def test_burn_oidc_issued_token_user_macaroon(metrics, monkeypatch):
+    macaroon = pretend.stub(
+        id="fake-macaroon-id",
+        oidc_publisher=None,
+        user=pretend.stub(username="fakeuser"),
+    )
+    macaroon_service = pretend.stub(
+        find_from_raw=pretend.call_recorder(lambda token: macaroon),
+        delete_macaroon=pretend.call_recorder(lambda macaroon_id: None),
+    )
+    capture_message = pretend.call_recorder(lambda message: None)
+    monkeypatch.setattr(views.sentry_sdk, "capture_message", capture_message)
+
+    def find_service(iface, **kw):
+        return {
+            IMacaroonService: macaroon_service,
+        }[iface]
+
+    request = pretend.stub(
+        body=json.dumps({"token": "user-macaroon"}),
+        response=pretend.stub(status=None),
+        find_service=pretend.call_recorder(find_service),
+        metrics=metrics,
+    )
+
+    response = views.burn_oidc_issued_token(request)
+
+    assert request.response.status == http.HTTPStatus.ACCEPTED
+    assert response == {"message": "Accepted", "errors": []}
+    assert macaroon_service.find_from_raw.calls == [pretend.call("user-macaroon")]
+    assert macaroon_service.delete_macaroon.calls == []
+    assert capture_message.calls == [
+        pretend.call("Tried to burn an API token corresponding to a user: 'fakeuser'")
+    ]
+    assert request.metrics.increment.calls == [
+        pretend.call(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:failure", "failure_reason:not_oidc_publisher"],
+        ),
+    ]
+
+
+def test_burn_oidc_issued_token_success(metrics):
+    publisher = pretend.stub(publisher_name="GitHub")
+    macaroon = pretend.stub(
+        id="fake-macaroon-id",
+        oidc_publisher=publisher,
+    )
+    macaroon_service = pretend.stub(
+        find_from_raw=pretend.call_recorder(lambda token: macaroon),
+        delete_macaroon=pretend.call_recorder(lambda macaroon_id: None),
+    )
+
+    def find_service(iface, **kw):
+        return {
+            IMacaroonService: macaroon_service,
+        }[iface]
+
+    request = pretend.stub(
+        body=json.dumps({"token": "oidc-macaroon"}),
+        response=pretend.stub(status=None),
+        find_service=pretend.call_recorder(find_service),
+        metrics=metrics,
+    )
+
+    response = views.burn_oidc_issued_token(request)
+
+    assert request.response.status == http.HTTPStatus.ACCEPTED
+    assert response == {"message": "Accepted", "errors": []}
+    assert request.find_service.calls == [
+        pretend.call(IMacaroonService, context=None),
+    ]
+    assert macaroon_service.find_from_raw.calls == [pretend.call("oidc-macaroon")]
+    assert macaroon_service.delete_macaroon.calls == [pretend.call("fake-macaroon-id")]
+    assert request.metrics.increment.calls == [
+        pretend.call(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:success", "publisher_name:GitHub"],
+        ),
+    ]
+
+
 def test_mint_token_jti_stored_before_macaroon_creation(monkeypatch, db_request):
     """
     Verify that the JTI is atomically claimed before the macaroon is minted,
@@ -1225,5 +1360,5 @@ def test_mint_token_jti_stored_before_macaroon_creation(monkeypatch, db_request)
         "https://token.actions.githubusercontent.com",
         db_request,
     )
-    assert "422" in str(db_request.response.status)
+    assert str(http.HTTPStatus.UNPROCESSABLE_ENTITY) in str(db_request.response.status)
     assert response2["errors"][0]["code"] == "invalid-reuse-token"

--- a/warehouse/events/tags.py
+++ b/warehouse/events/tags.py
@@ -109,6 +109,7 @@ class EventTag:
 
         # Name = "source_type:subject_type:action"
         ShortLivedAPITokenAdded = "account:short_lived_api_token:added"
+        ShortLivedAPITokenRevoked = "project:short_lived_api_token:revoked"
         APITokenAdded = "project:api_token:added"
         APITokenRemoved = "project:api_token:removed"
         OIDCPublisherAdded = "project:oidc:publisher-added"

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2043,10 +2043,10 @@ msgstr ""
 #: warehouse/templates/accounts/register.html:67
 #: warehouse/templates/manage/account.html:149
 #: warehouse/templates/manage/account.html:635
-#: warehouse/templates/manage/project/history.html:284
-#: warehouse/templates/manage/project/history.html:295
-#: warehouse/templates/manage/project/history.html:306
-#: warehouse/templates/manage/project/history.html:317
+#: warehouse/templates/manage/project/history.html:286
+#: warehouse/templates/manage/project/history.html:297
+#: warehouse/templates/manage/project/history.html:308
+#: warehouse/templates/manage/project/history.html:319
 #: warehouse/templates/manage/unverified-account.html:119
 msgid "Name"
 msgstr ""
@@ -3904,7 +3904,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:713
 #: warehouse/templates/manage/account.html:732
-#: warehouse/templates/manage/project/history.html:247
+#: warehouse/templates/manage/project/history.html:249
 #: warehouse/templates/manage/unverified-account.html:349
 #: warehouse/templates/manage/unverified-account.html:368
 msgid "Reason:"
@@ -4112,15 +4112,15 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:858
 #: warehouse/templates/manage/account.html:880
-#: warehouse/templates/manage/project/history.html:238
-#: warehouse/templates/manage/project/history.html:245
+#: warehouse/templates/manage/project/history.html:240
+#: warehouse/templates/manage/project/history.html:247
 #: warehouse/templates/manage/unverified-account.html:468
 #: warehouse/templates/manage/unverified-account.html:490
 msgid "Token name:"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:873
-#: warehouse/templates/manage/project/history.html:240
+#: warehouse/templates/manage/project/history.html:242
 #: warehouse/templates/manage/unverified-account.html:483
 msgid "API token removed"
 msgstr ""
@@ -4216,7 +4216,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:950
 #: warehouse/templates/manage/organization/history.html:213
-#: warehouse/templates/manage/project/history.html:333
+#: warehouse/templates/manage/project/history.html:335
 #: warehouse/templates/manage/team/history.html:87
 #: warehouse/templates/manage/unverified-account.html:530
 msgid "Event"
@@ -4225,8 +4225,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:951
 #: warehouse/templates/manage/organization/history.html:214
 #: warehouse/templates/manage/organization/history.html:223
-#: warehouse/templates/manage/project/history.html:334
-#: warehouse/templates/manage/project/history.html:343
+#: warehouse/templates/manage/project/history.html:336
+#: warehouse/templates/manage/project/history.html:345
 #: warehouse/templates/manage/team/history.html:88
 #: warehouse/templates/manage/team/history.html:97
 #: warehouse/templates/manage/unverified-account.html:531
@@ -4253,7 +4253,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:967
 #: warehouse/templates/manage/organization/history.html:230
-#: warehouse/templates/manage/project/history.html:350
+#: warehouse/templates/manage/project/history.html:352
 #: warehouse/templates/manage/team/history.html:104
 #: warehouse/templates/manage/unverified-account.html:546
 msgid "Device Info"
@@ -4608,8 +4608,8 @@ msgstr ""
 #: warehouse/templates/manage/project/history.html:119
 #: warehouse/templates/manage/project/history.html:163
 #: warehouse/templates/manage/project/history.html:188
-#: warehouse/templates/manage/project/history.html:282
-#: warehouse/templates/manage/project/history.html:304
+#: warehouse/templates/manage/project/history.html:284
+#: warehouse/templates/manage/project/history.html:306
 #: warehouse/templates/manage/team/history.html:68
 msgid "Added by:"
 msgstr ""
@@ -6080,8 +6080,8 @@ msgid "Created by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:158
-#: warehouse/templates/manage/project/history.html:293
-#: warehouse/templates/manage/project/history.html:315
+#: warehouse/templates/manage/project/history.html:295
+#: warehouse/templates/manage/project/history.html:317
 #: warehouse/templates/manage/team/history.html:57
 msgid "Deleted by:"
 msgstr ""
@@ -6119,7 +6119,7 @@ msgid "Revoked by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:210
-#: warehouse/templates/manage/project/history.html:330
+#: warehouse/templates/manage/project/history.html:332
 #: warehouse/templates/manage/team/history.html:84
 #, python-format
 msgid "Security history for %(source_name)s"
@@ -6847,13 +6847,13 @@ msgid "Short-lived API token created"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:201
-#: warehouse/templates/manage/project/history.html:229
-#: warehouse/templates/manage/project/history.html:241
+#: warehouse/templates/manage/project/history.html:231
+#: warehouse/templates/manage/project/history.html:243
 msgid "Permissions: Can upload to this project"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:204
-#: warehouse/templates/manage/project/history.html:236
+#: warehouse/templates/manage/project/history.html:238
 msgid "Expiration:"
 msgstr ""
 
@@ -6870,76 +6870,80 @@ msgid "Creator"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:228
+msgid "Short-lived API token revoked"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:230
 msgid "API token created"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:232
-#: warehouse/templates/manage/project/history.html:243
+#: warehouse/templates/manage/project/history.html:234
+#: warehouse/templates/manage/project/history.html:245
 msgid "Controlled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:251
+#: warehouse/templates/manage/project/history.html:253
 msgid "Trusted publisher added"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:254
+#: warehouse/templates/manage/project/history.html:256
 msgid "Trusted publisher removed"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:258
+#: warehouse/templates/manage/project/history.html:260
 msgid "2FA requirement enabled"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:260
+#: warehouse/templates/manage/project/history.html:262
 msgid "Enabled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:263
+#: warehouse/templates/manage/project/history.html:265
 msgid "2FA requirement disabled"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:265
+#: warehouse/templates/manage/project/history.html:267
 msgid "Disabled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:269
+#: warehouse/templates/manage/project/history.html:271
 msgid "Project archived"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:271
+#: warehouse/templates/manage/project/history.html:273
 msgid "Archived by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:274
+#: warehouse/templates/manage/project/history.html:276
 msgid "Project unarchived"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:276
+#: warehouse/templates/manage/project/history.html:278
 msgid "Unarchived by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:280
-#: warehouse/templates/manage/project/history.html:302
+#: warehouse/templates/manage/project/history.html:282
+#: warehouse/templates/manage/project/history.html:304
 msgid "Project alternate repository added"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:285
-#: warehouse/templates/manage/project/history.html:296
-#: warehouse/templates/manage/project/history.html:307
-#: warehouse/templates/manage/project/history.html:318
+#: warehouse/templates/manage/project/history.html:287
+#: warehouse/templates/manage/project/history.html:298
+#: warehouse/templates/manage/project/history.html:309
+#: warehouse/templates/manage/project/history.html:320
 msgid "Url"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:291
-#: warehouse/templates/manage/project/history.html:313
+#: warehouse/templates/manage/project/history.html:293
+#: warehouse/templates/manage/project/history.html:315
 msgid "Project alternate repository deleted"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:335
+#: warehouse/templates/manage/project/history.html:337
 msgid "Additional info"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:347
+#: warehouse/templates/manage/project/history.html:349
 #: warehouse/templates/manage/team/history.html:101
 msgid "Location info"
 msgstr ""

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2052,10 +2052,10 @@ msgstr ""
 #: warehouse/templates/accounts/register.html:67
 #: warehouse/templates/manage/account.html:137
 #: warehouse/templates/manage/account.html:623
-#: warehouse/templates/manage/project/history.html:284
-#: warehouse/templates/manage/project/history.html:295
-#: warehouse/templates/manage/project/history.html:306
-#: warehouse/templates/manage/project/history.html:317
+#: warehouse/templates/manage/project/history.html:286
+#: warehouse/templates/manage/project/history.html:297
+#: warehouse/templates/manage/project/history.html:308
+#: warehouse/templates/manage/project/history.html:319
 #: warehouse/templates/manage/unverified-account.html:119
 msgid "Name"
 msgstr ""
@@ -4256,7 +4256,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:701
 #: warehouse/templates/manage/account.html:720
-#: warehouse/templates/manage/project/history.html:247
+#: warehouse/templates/manage/project/history.html:249
 #: warehouse/templates/manage/unverified-account.html:349
 #: warehouse/templates/manage/unverified-account.html:368
 msgid "Reason:"
@@ -4464,15 +4464,15 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:846
 #: warehouse/templates/manage/account.html:868
-#: warehouse/templates/manage/project/history.html:238
-#: warehouse/templates/manage/project/history.html:245
+#: warehouse/templates/manage/project/history.html:240
+#: warehouse/templates/manage/project/history.html:247
 #: warehouse/templates/manage/unverified-account.html:468
 #: warehouse/templates/manage/unverified-account.html:490
 msgid "Token name:"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:861
-#: warehouse/templates/manage/project/history.html:240
+#: warehouse/templates/manage/project/history.html:242
 #: warehouse/templates/manage/unverified-account.html:483
 msgid "API token removed"
 msgstr ""
@@ -4568,7 +4568,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:938
 #: warehouse/templates/manage/organization/history.html:213
-#: warehouse/templates/manage/project/history.html:333
+#: warehouse/templates/manage/project/history.html:335
 #: warehouse/templates/manage/team/history.html:87
 #: warehouse/templates/manage/unverified-account.html:530
 msgid "Event"
@@ -4577,8 +4577,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:939
 #: warehouse/templates/manage/organization/history.html:214
 #: warehouse/templates/manage/organization/history.html:223
-#: warehouse/templates/manage/project/history.html:334
-#: warehouse/templates/manage/project/history.html:343
+#: warehouse/templates/manage/project/history.html:336
+#: warehouse/templates/manage/project/history.html:345
 #: warehouse/templates/manage/team/history.html:88
 #: warehouse/templates/manage/team/history.html:97
 #: warehouse/templates/manage/unverified-account.html:531
@@ -4605,7 +4605,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:955
 #: warehouse/templates/manage/organization/history.html:230
-#: warehouse/templates/manage/project/history.html:350
+#: warehouse/templates/manage/project/history.html:352
 #: warehouse/templates/manage/team/history.html:104
 #: warehouse/templates/manage/unverified-account.html:546
 msgid "Device Info"
@@ -4960,8 +4960,8 @@ msgstr ""
 #: warehouse/templates/manage/project/history.html:119
 #: warehouse/templates/manage/project/history.html:163
 #: warehouse/templates/manage/project/history.html:188
-#: warehouse/templates/manage/project/history.html:282
-#: warehouse/templates/manage/project/history.html:304
+#: warehouse/templates/manage/project/history.html:284
+#: warehouse/templates/manage/project/history.html:306
 #: warehouse/templates/manage/team/history.html:68
 msgid "Added by:"
 msgstr ""
@@ -6417,8 +6417,8 @@ msgid "Created by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:158
-#: warehouse/templates/manage/project/history.html:293
-#: warehouse/templates/manage/project/history.html:315
+#: warehouse/templates/manage/project/history.html:295
+#: warehouse/templates/manage/project/history.html:317
 #: warehouse/templates/manage/team/history.html:57
 msgid "Deleted by:"
 msgstr ""
@@ -6456,7 +6456,7 @@ msgid "Revoked by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:210
-#: warehouse/templates/manage/project/history.html:330
+#: warehouse/templates/manage/project/history.html:332
 #: warehouse/templates/manage/team/history.html:84
 #, python-format
 msgid "Security history for %(source_name)s"
@@ -7184,13 +7184,13 @@ msgid "Short-lived API token created"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:201
-#: warehouse/templates/manage/project/history.html:229
-#: warehouse/templates/manage/project/history.html:241
+#: warehouse/templates/manage/project/history.html:231
+#: warehouse/templates/manage/project/history.html:243
 msgid "Permissions: Can upload to this project"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:204
-#: warehouse/templates/manage/project/history.html:236
+#: warehouse/templates/manage/project/history.html:238
 msgid "Expiration:"
 msgstr ""
 
@@ -7207,76 +7207,80 @@ msgid "Creator"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:228
+msgid "Short-lived API token revoked"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:230
 msgid "API token created"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:232
-#: warehouse/templates/manage/project/history.html:243
+#: warehouse/templates/manage/project/history.html:234
+#: warehouse/templates/manage/project/history.html:245
 msgid "Controlled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:251
+#: warehouse/templates/manage/project/history.html:253
 msgid "Trusted publisher added"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:254
+#: warehouse/templates/manage/project/history.html:256
 msgid "Trusted publisher removed"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:258
+#: warehouse/templates/manage/project/history.html:260
 msgid "2FA requirement enabled"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:260
+#: warehouse/templates/manage/project/history.html:262
 msgid "Enabled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:263
+#: warehouse/templates/manage/project/history.html:265
 msgid "2FA requirement disabled"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:265
+#: warehouse/templates/manage/project/history.html:267
 msgid "Disabled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:269
+#: warehouse/templates/manage/project/history.html:271
 msgid "Project archived"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:271
+#: warehouse/templates/manage/project/history.html:273
 msgid "Archived by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:274
+#: warehouse/templates/manage/project/history.html:276
 msgid "Project unarchived"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:276
+#: warehouse/templates/manage/project/history.html:278
 msgid "Unarchived by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:280
-#: warehouse/templates/manage/project/history.html:302
+#: warehouse/templates/manage/project/history.html:282
+#: warehouse/templates/manage/project/history.html:304
 msgid "Project alternate repository added"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:285
-#: warehouse/templates/manage/project/history.html:296
-#: warehouse/templates/manage/project/history.html:307
-#: warehouse/templates/manage/project/history.html:318
+#: warehouse/templates/manage/project/history.html:287
+#: warehouse/templates/manage/project/history.html:298
+#: warehouse/templates/manage/project/history.html:309
+#: warehouse/templates/manage/project/history.html:320
 msgid "Url"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:291
-#: warehouse/templates/manage/project/history.html:313
+#: warehouse/templates/manage/project/history.html:293
+#: warehouse/templates/manage/project/history.html:315
 msgid "Project alternate repository deleted"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:335
+#: warehouse/templates/manage/project/history.html:337
 msgid "Additional info"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:347
+#: warehouse/templates/manage/project/history.html:349
 #: warehouse/templates/manage/team/history.html:101
 msgid "Location info"
 msgstr ""

--- a/warehouse/macaroons/interfaces.py
+++ b/warehouse/macaroons/interfaces.py
@@ -30,6 +30,19 @@ class IMacaroonService(Interface):
         Raises InvalidMacaroonError if the macaroon is not valid.
         """
 
+    def verify_signature_only(raw_macaroon):
+        """
+        Returns a macaroon model from the DB if the given raw (serialized)
+        macaroon exists and has a valid signature.
+
+        **NOTE**: this API is not a substitute for `verify`; most
+        users should call `verify` to validate both the signature
+        *and* the macaroon's caveats relative to the request.
+
+        Raises InvalidMacaroonError if the macaroon has an invalid
+        signature.
+        """
+
     def create_macaroon(
         location,
         description,

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -55,6 +55,14 @@ def deserialize_raw_macaroon(raw_macaroon: str | None) -> pymacaroons.Macaroon:
         raise InvalidMacaroonError("malformed macaroon") from e
 
 
+def _decode_identifier(macaroon: pymacaroons.Macaroon) -> str:
+    """Return a macaroon's UTF-8 identifier or raise InvalidMacaroonError."""
+    try:
+        return macaroon.identifier.decode()
+    except UnicodeDecodeError as e:
+        raise InvalidMacaroonError("malformed macaroon identifier") from e
+
+
 def _record_attenuations(request: Request, extra: list[str] | None) -> None:
     """
     Record how a verified macaroon was attenuated, as `attenuated:<state>` on
@@ -126,12 +134,8 @@ class DatabaseMacaroonService:
         """
         try:
             m = deserialize_raw_macaroon(raw_macaroon)
+            identifier = _decode_identifier(m)
         except InvalidMacaroonError:
-            return None
-
-        try:
-            identifier = m.identifier.decode()
-        except UnicodeDecodeError:
             return None
 
         dm = self.find_macaroon(identifier)
@@ -151,13 +155,7 @@ class DatabaseMacaroonService:
         Returns a DB macaroon matching the input, or raises InvalidMacaroonError
         """
         m = deserialize_raw_macaroon(raw_macaroon)
-
-        try:
-            identifier = m.identifier.decode()
-        except UnicodeDecodeError:
-            raise InvalidMacaroonError("Macaroon not found")
-
-        dm = self.find_macaroon(identifier)
+        dm = self.find_macaroon(_decode_identifier(m))
 
         if not dm:
             raise InvalidMacaroonError("Macaroon not found")
@@ -171,7 +169,7 @@ class DatabaseMacaroonService:
         Raises InvalidMacaroonError if the macaroon is not valid.
         """
         m = deserialize_raw_macaroon(raw_macaroon)
-        dm = self.find_macaroon(m.identifier.decode())
+        dm = self.find_macaroon(_decode_identifier(m))
 
         if dm is None:
             raise InvalidMacaroonError("deleted or nonexistent macaroon")
@@ -264,7 +262,7 @@ class DatabaseMacaroonService:
         """
 
         m = deserialize_raw_macaroon(raw_macaroon)
-        dm = self.find_macaroon(m.identifier.decode())
+        dm = self.find_macaroon(_decode_identifier(m))
 
         if not dm:
             raise InvalidMacaroonError("Macaroon not found")

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -250,6 +250,38 @@ class DatabaseMacaroonService:
 
         raise InvalidMacaroonError(verified.msg)
 
+    def verify_signature_only(self, raw_macaroon: str) -> Macaroon:
+        """
+        Returns a macaroon model from the DB if the given raw (serialized)
+        macaroon exists and has a valid signature.
+
+        **NOTE**: this API is not a substitute for `verify`; most
+        users should call `verify` to validate both the signature
+        *and* the macaroon's caveats relative to the request.
+
+        Raises InvalidMacaroonError if the macaroon has an invalid
+        signature.
+        """
+
+        m = deserialize_raw_macaroon(raw_macaroon)
+        dm = self.find_macaroon(m.identifier.decode())
+
+        if not dm:
+            raise InvalidMacaroonError("Macaroon not found")
+
+        try:
+            verifier = pymacaroons.Verifier()
+            # Satisfy every caveat trivially, so that they get incorporated
+            # into the signature check.
+            verifier.satisfy_general(lambda _: True)
+            verifier.verify(m, dm.key)
+            return dm
+        except (
+            pymacaroons.exceptions.MacaroonInvalidSignatureException,
+            Exception,  # noqa: BLE001 https://github.com/ecordell/pymacaroons/issues/50
+        ):
+            raise InvalidMacaroonError("Invalid signature")
+
     def create_macaroon(
         self,
         location: str,

--- a/warehouse/oidc/__init__.py
+++ b/warehouse/oidc/__init__.py
@@ -76,6 +76,7 @@ def includeme(config: Configurator) -> None:
     # NOTE: This is a legacy route for the above. Pyramid requires route
     # names to be unique, so we can't deduplicate it.
     config.add_route("oidc.github.mint_token", "/_/oidc/github/mint-token", domain=auth)
+    config.add_route("oidc.burn_token", "/_/oidc/burn-token", domain=auth)
 
     # Compute OIDC metrics periodically
     config.add_periodic_task(crontab(minute=0, hour="*"), compute_oidc_metrics)

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -504,6 +504,13 @@ def burn_oidc_issued_token(request: Request):
         )
         return _accepted(request=request)
 
+    for project in macaroon.oidc_publisher.projects:
+        project.record_event(
+            tag=EventTag.Project.ShortLivedAPITokenRevoked,
+            request=request,
+            additional={},
+        )
+
     macaroon_service.delete_macaroon(macaroon.id)
     request.metrics.increment(
         "warehouse.oidc.burn_oidc_issued_token",

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import http
 import time
 
 from datetime import datetime
@@ -20,8 +21,9 @@ from warehouse.email import (
     send_pending_trusted_publisher_reified_email,
 )
 from warehouse.events.tags import EventTag
-from warehouse.macaroons import caveats
+from warehouse.macaroons import InvalidMacaroonError, caveats
 from warehouse.macaroons.interfaces import IMacaroonService
+from warehouse.macaroons.models import Macaroon
 from warehouse.macaroons.services import DatabaseMacaroonService
 from warehouse.metrics.interfaces import IMetricsService
 from warehouse.oidc.errors import InvalidPublisherError, ReusedTokenError
@@ -71,12 +73,18 @@ def _ratelimiters(request: Request) -> dict[str, IRateLimiter]:
 
 
 def _invalid(errors: list[Error], request: Request) -> JsonResponse:
-    request.response.status = 422
+    request.response.status = http.HTTPStatus.UNPROCESSABLE_ENTITY
 
     return {
         "message": "Token request failed",
         "errors": errors,
     }
+
+
+def _accepted(request: Request) -> JsonResponse:
+    request.response.status = http.HTTPStatus.ACCEPTED
+
+    return {"message": "Accepted", "errors": []}
 
 
 @view_config(
@@ -435,3 +443,74 @@ def should_send_environment_warning_email(
     claims_env = claims.get("environment")
 
     return publisher.environment == "" and claims_env is not None and claims_env != ""
+
+
+class BurnPayload(BaseModel):
+    token: StrictStr
+
+
+@view_config(
+    route_name="oidc.burn_token",
+    require_methods=["POST"],
+    renderer="json",
+    require_csrf=False,
+)
+def burn_oidc_issued_token(request: Request):
+    """
+    "Burns" (i.e. revokes) a PyPI token that was previously issued by
+    `mint_token_from_oidc`.
+
+    Downstream integrators can call this endpoint to expedite the invalidation of a
+    Trusted Publishing-issued token.
+
+    Unlike our other Trusted Publishing APIs, this API only ever returns an
+    HTTP Accepted (indicating receipt, but not communicating the outcome).
+    """
+
+    try:
+        payload = BurnPayload.model_validate_json(request.body)
+        unverified_macaroon = payload.token
+    except ValidationError:
+        request.metrics.increment(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:failure", "failure_reason:invalid_payload"],
+        )
+        return _accepted(request=request)
+
+    macaroon_service: DatabaseMacaroonService = request.find_service(
+        IMacaroonService, context=None
+    )
+
+    try:
+        macaroon: Macaroon = macaroon_service.find_from_raw(unverified_macaroon)
+    except InvalidMacaroonError:
+        request.metrics.increment(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:failure", "failure_reason:invalid_macaroon"],
+        )
+        return _accepted(request=request)
+
+    if macaroon.oidc_publisher is None:
+        # This macaroon was issued to a principal other than a Trusted Publisher,
+        # which means this endpoint can't burn it.
+        # NOTE: mypy can't see that `user` and `oidc_publisher` are disjoint.
+        username = macaroon.user.username  # type: ignore[union-attr]
+        sentry_sdk.capture_message(
+            f"Tried to burn an API token corresponding to a user: {username!r}"
+        )
+        request.metrics.increment(
+            "warehouse.oidc.burn_oidc_issued_token",
+            tags=["status:failure", "failure_reason:not_oidc_publisher"],
+        )
+        return _accepted(request=request)
+
+    macaroon_service.delete_macaroon(macaroon.id)
+    request.metrics.increment(
+        "warehouse.oidc.burn_oidc_issued_token",
+        tags=[
+            "status:success",
+            f"publisher_name:{macaroon.oidc_publisher.publisher_name}",
+        ],
+    )
+
+    return _accepted(request=request)

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -517,7 +517,7 @@ def burn_oidc_issued_token(request: Request):
             additional={},
         )
 
-    macaroon_service.delete_macaroon(macaroon.id)
+    macaroon_service.delete_macaroon(str(macaroon.id))
     request.metrics.increment(
         "warehouse.oidc.burn_oidc_issued_token",
         tags=[

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -482,7 +482,13 @@ def burn_oidc_issued_token(request: Request):
     )
 
     try:
-        macaroon: Macaroon = macaroon_service.find_from_raw(unverified_macaroon)
+        # NOTE: We intentionally don't use `macaroon_service.verify` here, since
+        # that would verify caveats, which don't matter (and don't adhere to the burn
+        # path). Instead, we check that the signature is valid (which stops someone
+        # from spoofing a macaroon if they know just the UUID) and we check that the
+        # macaroon corresponds to an OIDC publisher below (since we don't allow burning
+        # of macaroons from non-OIDC principals).
+        macaroon: Macaroon = macaroon_service.verify_signature_only(unverified_macaroon)
     except InvalidMacaroonError:
         request.metrics.increment(
             "warehouse.oidc.burn_oidc_issued_token",

--- a/warehouse/templates/manage/project/history.html
+++ b/warehouse/templates/manage/project/history.html
@@ -224,6 +224,8 @@
       <small>{% trans %}Workflow:{% endtrans %} {{ event.additional.workflow }}</small>
     {% endif %}
   </small>
+{% elif event.tag == EventTag.Project.ShortLivedAPITokenRevoked %}
+  <strong>{% trans %}Short-lived API token revoked{% endtrans %}</strong>
 {% elif event.tag == EventTag.Project.APITokenAdded %}
   <strong>{% trans %}API token created{% endtrans %}</strong>
   <small>{% trans %}Permissions: Can upload to this project{% endtrans %}</small>


### PR DESCRIPTION
This implements the (hopefully) uncontroversial part of #20125: we don't expose a general-purpose revocation API for now, just one that's specific to Trusted Publishing flows.

The basic idea: clients (like twine and uv) that implement Trusted Publishing can choose to explicitly "burn" their temporary token immediately after it's used. This adds a layer of protection atop TP tokens already being short-lived, since the publishing client can proactively invalidate them before they'd otherwise expire.

For prior art: crates.io's implementation of Trusted Publishing supports this, and their default integration (`rust-lang/crates-io-auth-action`) performs it by default as a post-hook when invoked:

https://github.com/rust-lang/crates-io-auth-action/blob/a1c979fa8eec9cf00f2c01904184fe133deb0ce9/src/post.ts#L29-L47

Signed-off-by: William Woodruff <william@yossarian.net>