### PR TITLE
Add Deprecated status to Project and Release lifecycle backend

### DIFF
--- a/tests/unit/api/test_simple.py
+++ b/tests/unit/api/test_simple.py
@@ -512,6 +512,29 @@ class TestSimpleDetail:
         ("content_type", "renderer_override"),
         CONTENT_TYPE_PARAMS,
     )
+    def test_with_deprecated_project(self, db_request, content_type, renderer_override):
+        db_request.accept = content_type
+        project = ProjectFactory.create(lifecycle_status="deprecated")
+        _ = ReleaseFactory.create_batch(3, project=project)
+
+        context = {
+            "meta": {"_last-serial": 0, "api-version": API_VERSION},
+            "name": project.normalized_name,
+            "project-status": {"status": "deprecated"},
+            "files": [],
+            "versions": [],
+        }
+        context = _update_context(context, content_type, renderer_override)
+
+        assert simple.simple_detail(project, db_request) == context
+
+        if renderer_override is not None:
+            assert db_request.override_renderer == renderer_override
+
+    @pytest.mark.parametrize(
+        ("content_type", "renderer_override"),
+        CONTENT_TYPE_PARAMS,
+    )
     def test_with_quarantined_release_omitted(
         self, db_request, content_type, renderer_override
     ):

--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -20,12 +20,14 @@ from warehouse.utils.project import (
     clear_project_quarantine,
     clear_release_quarantine,
     confirm_project,
+    deprecate_project,
     destroy_docs,
     quarantine_project,
     quarantine_release,
     remove_documentation,
     remove_project,
     remove_release,
+    undeprecate_project,
 )
 
 from ...common.db.accounts import UserFactory
@@ -159,6 +161,78 @@ def test_clear_project_quarantine(db_request, flash, mocker):
         .first()
     )
     assert flash_spy.called == flash
+
+
+def test_deprecate_project(db_request, mocker):
+    user = UserFactory.create()
+    project = ProjectFactory.create(name="foo")
+    RoleFactory.create(user=user, project=project)
+
+    db_request.user = user
+    flash_spy = mocker.spy(db_request.session, "flash")
+
+    deprecate_project(project, db_request)
+
+    assert (
+        db_request.db.query(Project).filter(Project.name == project.name).count() == 1
+    )
+    assert (
+        db_request.db.query(Project)
+        .filter(Project.name == project.name)
+        .filter(Project.lifecycle_status == LifecycleStatus.Deprecated)
+        .first()
+    )
+    assert flash_spy.called
+
+
+def test_deprecate_project_already_archived(db_request, mocker):
+    user = UserFactory.create()
+    project = ProjectFactory.create(
+        name="foo", lifecycle_status=LifecycleStatus.ArchivedNoindex
+    )
+    RoleFactory.create(user=user, project=project)
+
+    db_request.user = user
+    flash_spy = mocker.spy(db_request.session, "flash")
+
+    deprecate_project(project, db_request)
+
+    assert project.lifecycle_status == LifecycleStatus.ArchivedNoindex
+    flash_spy.assert_called_once_with(
+        "Cannot deprecate project with status archived-noindex", queue="error"
+    )
+
+
+def test_undeprecate_project(db_request, mocker):
+    user = UserFactory.create()
+    project = ProjectFactory.create(
+        name="foo", lifecycle_status=LifecycleStatus.Deprecated
+    )
+    RoleFactory.create(user=user, project=project)
+
+    db_request.user = user
+    flash_spy = mocker.spy(db_request.session, "flash")
+
+    undeprecate_project(project, db_request)
+
+    assert project.lifecycle_status is None
+    assert flash_spy.called
+
+
+def test_undeprecate_project_not_deprecated(db_request, mocker):
+    user = UserFactory.create()
+    project = ProjectFactory.create(name="foo")
+    RoleFactory.create(user=user, project=project)
+
+    db_request.user = user
+    flash_spy = mocker.spy(db_request.session, "flash")
+
+    undeprecate_project(project, db_request)
+
+    assert project.lifecycle_status is None
+    flash_spy.assert_called_once_with(
+        "Can only undeprecate a deprecated project", queue="error"
+    )
 
 
 @pytest.mark.parametrize("flash", [True, False])

--- a/warehouse/events/tags.py
+++ b/warehouse/events/tags.py
@@ -120,6 +120,8 @@ class EventTag:
         ProjectArchiveEnter = "project:archive:enter"
         ProjectArchiveExit = "project:archive:exit"
         ProjectCreate = "project:create"
+        ProjectDeprecateEnter = "project:deprecate:enter"
+        ProjectDeprecateExit = "project:deprecate:exit"
         ProjectQuarantineEnter = "project:quarantine:enter"
         ProjectQuarantineExit = "project:quarantine:exit"
         ProjectSetTotalSizeLimit = "admin:project:set_total_size_limit"

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1006,7 +1006,7 @@ msgid "Just now"
 msgstr ""
 
 #: warehouse/subscriptions/models.py:24
-#: warehouse/templates/manage/project/history.html:209
+#: warehouse/templates/manage/project/history.html:223
 msgid "Active"
 msgstr ""
 
@@ -2051,10 +2051,10 @@ msgstr ""
 #: warehouse/templates/accounts/register.html:67
 #: warehouse/templates/manage/account.html:137
 #: warehouse/templates/manage/account.html:623
-#: warehouse/templates/manage/project/history.html:284
-#: warehouse/templates/manage/project/history.html:295
-#: warehouse/templates/manage/project/history.html:306
-#: warehouse/templates/manage/project/history.html:317
+#: warehouse/templates/manage/project/history.html:363
+#: warehouse/templates/manage/project/history.html:374
+#: warehouse/templates/manage/project/history.html:385
+#: warehouse/templates/manage/project/history.html:396
 #: warehouse/templates/manage/unverified-account.html:119
 msgid "Name"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:701
 #: warehouse/templates/manage/account.html:720
-#: warehouse/templates/manage/project/history.html:247
+#: warehouse/templates/manage/project/history.html:261
 #: warehouse/templates/manage/unverified-account.html:349
 #: warehouse/templates/manage/unverified-account.html:368
 msgid "Reason:"
@@ -4425,15 +4425,15 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:846
 #: warehouse/templates/manage/account.html:868
-#: warehouse/templates/manage/project/history.html:238
-#: warehouse/templates/manage/project/history.html:245
+#: warehouse/templates/manage/project/history.html:252
+#: warehouse/templates/manage/project/history.html:259
 #: warehouse/templates/manage/unverified-account.html:468
 #: warehouse/templates/manage/unverified-account.html:490
 msgid "Token name:"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:861
-#: warehouse/templates/manage/project/history.html:240
+#: warehouse/templates/manage/project/history.html:254
 #: warehouse/templates/manage/unverified-account.html:483
 msgid "API token removed"
 msgstr ""
@@ -4529,7 +4529,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:938
 #: warehouse/templates/manage/organization/history.html:213
-#: warehouse/templates/manage/project/history.html:333
+#: warehouse/templates/manage/project/history.html:412
 #: warehouse/templates/manage/team/history.html:87
 #: warehouse/templates/manage/unverified-account.html:530
 msgid "Event"
@@ -4538,8 +4538,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:939
 #: warehouse/templates/manage/organization/history.html:214
 #: warehouse/templates/manage/organization/history.html:223
-#: warehouse/templates/manage/project/history.html:334
-#: warehouse/templates/manage/project/history.html:343
+#: warehouse/templates/manage/project/history.html:413
+#: warehouse/templates/manage/project/history.html:422
 #: warehouse/templates/manage/team/history.html:88
 #: warehouse/templates/manage/team/history.html:97
 #: warehouse/templates/manage/unverified-account.html:531
@@ -4566,7 +4566,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:955
 #: warehouse/templates/manage/organization/history.html:230
-#: warehouse/templates/manage/project/history.html:350
+#: warehouse/templates/manage/project/history.html:429
 #: warehouse/templates/manage/team/history.html:104
 #: warehouse/templates/manage/unverified-account.html:546
 msgid "Device Info"
@@ -4917,12 +4917,12 @@ msgstr ""
 #: warehouse/templates/manage/organization/history.html:113
 #: warehouse/templates/manage/organization/history.html:179
 #: warehouse/templates/manage/project/history.html:27
-#: warehouse/templates/manage/project/history.html:80
-#: warehouse/templates/manage/project/history.html:119
-#: warehouse/templates/manage/project/history.html:163
-#: warehouse/templates/manage/project/history.html:188
-#: warehouse/templates/manage/project/history.html:282
-#: warehouse/templates/manage/project/history.html:304
+#: warehouse/templates/manage/project/history.html:94
+#: warehouse/templates/manage/project/history.html:133
+#: warehouse/templates/manage/project/history.html:177
+#: warehouse/templates/manage/project/history.html:202
+#: warehouse/templates/manage/project/history.html:361
+#: warehouse/templates/manage/project/history.html:383
 #: warehouse/templates/manage/team/history.html:68
 msgid "Added by:"
 msgstr ""
@@ -4931,10 +4931,10 @@ msgstr ""
 #: warehouse/templates/manage/organization/history.html:121
 #: warehouse/templates/manage/organization/history.html:184
 #: warehouse/templates/manage/project/history.html:46
-#: warehouse/templates/manage/project/history.html:111
-#: warehouse/templates/manage/project/history.html:126
-#: warehouse/templates/manage/project/history.html:171
-#: warehouse/templates/manage/project/history.html:196
+#: warehouse/templates/manage/project/history.html:125
+#: warehouse/templates/manage/project/history.html:140
+#: warehouse/templates/manage/project/history.html:185
+#: warehouse/templates/manage/project/history.html:210
 #: warehouse/templates/manage/team/history.html:73
 msgid "Removed by:"
 msgstr ""
@@ -4944,7 +4944,7 @@ msgid "Submitted by:"
 msgstr ""
 
 #: warehouse/templates/manage/manage_base.html:638
-#: warehouse/templates/manage/project/history.html:224
+#: warehouse/templates/manage/project/history.html:238
 msgid "Workflow:"
 msgstr ""
 
@@ -4958,7 +4958,7 @@ msgstr ""
 
 #: warehouse/templates/manage/manage_base.html:644
 #: warehouse/templates/manage/project/history.html:36
-#: warehouse/templates/manage/project/history.html:89
+#: warehouse/templates/manage/project/history.html:103
 msgid "URL:"
 msgstr ""
 
@@ -6378,8 +6378,8 @@ msgid "Created by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:158
-#: warehouse/templates/manage/project/history.html:293
-#: warehouse/templates/manage/project/history.html:315
+#: warehouse/templates/manage/project/history.html:372
+#: warehouse/templates/manage/project/history.html:394
 #: warehouse/templates/manage/team/history.html:57
 msgid "Deleted by:"
 msgstr ""
@@ -6398,26 +6398,28 @@ msgid "Declined by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:189
-#: warehouse/templates/manage/project/history.html:133
-#: warehouse/templates/manage/project/history.html:179
+#: warehouse/templates/manage/project/history.html:147
+#: warehouse/templates/manage/project/history.html:193
+#: warehouse/templates/manage/project/history.html:334
+#: warehouse/templates/manage/project/history.html:355
 #: warehouse/templates/manage/team/history.html:78
 msgid "Changed by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:194
 #: warehouse/templates/manage/organization/history.html:199
-#: warehouse/templates/manage/project/history.html:140
-#: warehouse/templates/manage/project/history.html:147
+#: warehouse/templates/manage/project/history.html:154
+#: warehouse/templates/manage/project/history.html:161
 msgid "Invited by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:204
-#: warehouse/templates/manage/project/history.html:154
+#: warehouse/templates/manage/project/history.html:168
 msgid "Revoked by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:210
-#: warehouse/templates/manage/project/history.html:330
+#: warehouse/templates/manage/project/history.html:409
 #: warehouse/templates/manage/team/history.html:84
 #, python-format
 msgid "Security history for %(source_name)s"
@@ -7063,181 +7065,250 @@ msgstr ""
 msgid "<a href=\"%(href)s\">Version %(version)s</a> unyanked"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:65
+#: warehouse/templates/manage/project/history.html:64
+#, python-format
+msgid "<a href=\"%(href)s\">Version %(version)s</a> quarantined"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:67
+#: warehouse/templates/manage/project/history.html:307
+msgid "Quarantined by:"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:71
+#, python-format
+msgid "<a href=\"%(href)s\">Version %(version)s</a> quarantine cleared"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:74
+#: warehouse/templates/manage/project/history.html:312
+msgid "Cleared by:"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:79
 #, python-format
 msgid "File added to <a href=\"%(href)s\">version %(version)s</a>"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:77
-#: warehouse/templates/manage/project/history.html:108
+#: warehouse/templates/manage/project/history.html:91
+#: warehouse/templates/manage/project/history.html:122
 #: warehouse/templates/manage/project/release.html:122
 msgid "Filename:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:96
+#: warehouse/templates/manage/project/history.html:110
 #, python-format
 msgid "File removed from <a href=\"%(href)s\">version %(version)s</a>"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:116
+#: warehouse/templates/manage/project/history.html:130
 #, python-format
 msgid "<a href=\"%(href)s\">%(username)s</a> added as project %(role_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:123
+#: warehouse/templates/manage/project/history.html:137
 #, python-format
 msgid "<a href=\"%(href)s\">%(username)s</a> removed as project %(role_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:130
+#: warehouse/templates/manage/project/history.html:144
 #, python-format
 msgid "<a href=\"%(href)s\">%(username)s</a> changed to project %(role_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:137
+#: warehouse/templates/manage/project/history.html:151
 #, python-format
 msgid ""
 "<a href=\"%(href)s\">%(username)s</a> invited to join as project "
 "%(role_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:144
+#: warehouse/templates/manage/project/history.html:158
 #, python-format
 msgid ""
 "<a href=\"%(href)s\">%(username)s</a> declined invitation to join as "
 "project %(role_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:151
+#: warehouse/templates/manage/project/history.html:165
 #, python-format
 msgid ""
 "Revoked invitation for <a href=\"%(href)s\">%(username)s</a> to join as "
 "project %(role_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:160
+#: warehouse/templates/manage/project/history.html:174
 #, python-format
 msgid "%(team_name)s team added as project %(role_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:168
+#: warehouse/templates/manage/project/history.html:182
 #, python-format
 msgid "%(team_name)s team changed to project %(role_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:176
+#: warehouse/templates/manage/project/history.html:190
 #, python-format
 msgid "%(team_name)s team removed as project %(role_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:185
+#: warehouse/templates/manage/project/history.html:199
 #, python-format
 msgid "Project added to %(organization_name)s organization"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:193
+#: warehouse/templates/manage/project/history.html:207
 #, python-format
 msgid "Project removed from %(organization_name)s organization"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:200
+#: warehouse/templates/manage/project/history.html:214
 msgid "Short-lived API token created"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:201
-#: warehouse/templates/manage/project/history.html:229
-#: warehouse/templates/manage/project/history.html:241
+#: warehouse/templates/manage/project/history.html:215
+#: warehouse/templates/manage/project/history.html:243
+#: warehouse/templates/manage/project/history.html:255
 msgid "Permissions: Can upload to this project"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:204
-#: warehouse/templates/manage/project/history.html:236
+#: warehouse/templates/manage/project/history.html:218
+#: warehouse/templates/manage/project/history.html:250
 msgid "Expiration:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:207
+#: warehouse/templates/manage/project/history.html:221
 msgid "Expiration status:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:211
+#: warehouse/templates/manage/project/history.html:225
 msgid "Expired"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:216
+#: warehouse/templates/manage/project/history.html:230
 msgid "Creator"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:228
+#: warehouse/templates/manage/project/history.html:242
 msgid "API token created"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:232
-#: warehouse/templates/manage/project/history.html:243
+#: warehouse/templates/manage/project/history.html:246
+#: warehouse/templates/manage/project/history.html:257
 msgid "Controlled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:251
+#: warehouse/templates/manage/project/history.html:265
 msgid "Trusted publisher added"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:254
+#: warehouse/templates/manage/project/history.html:268
 msgid "Trusted publisher removed"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:258
+#: warehouse/templates/manage/project/history.html:272
 msgid "2FA requirement enabled"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:260
+#: warehouse/templates/manage/project/history.html:274
 msgid "Enabled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:263
+#: warehouse/templates/manage/project/history.html:277
 msgid "2FA requirement disabled"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:265
+#: warehouse/templates/manage/project/history.html:279
 msgid "Disabled by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:269
+#: warehouse/templates/manage/project/history.html:283
 msgid "Project archived"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:271
+#: warehouse/templates/manage/project/history.html:285
 msgid "Archived by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:274
+#: warehouse/templates/manage/project/history.html:288
 msgid "Project unarchived"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:276
+#: warehouse/templates/manage/project/history.html:290
 msgid "Unarchived by:"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:280
-#: warehouse/templates/manage/project/history.html:302
+#: warehouse/templates/manage/project/history.html:294
+msgid "Project deprecated"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:296
+msgid "Deprecated by:"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:299
+msgid "Project undeprecated"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:301
+msgid "Undeprecated by:"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:305
+msgid "Project quarantined"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:310
+msgid "Project quarantine cleared"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:316
+msgid "Upload limit changed"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:318
+#: warehouse/templates/manage/project/history.html:339
+msgid "Previous limit:"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:322
+#: warehouse/templates/manage/project/history.html:330
+#: warehouse/templates/manage/project/history.html:343
+#: warehouse/templates/manage/project/history.html:351
+msgid "Default"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:326
+#: warehouse/templates/manage/project/history.html:347
+msgid "New limit:"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:337
+msgid "Total size limit changed"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:359
+#: warehouse/templates/manage/project/history.html:381
 msgid "Project alternate repository added"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:285
-#: warehouse/templates/manage/project/history.html:296
-#: warehouse/templates/manage/project/history.html:307
-#: warehouse/templates/manage/project/history.html:318
+#: warehouse/templates/manage/project/history.html:364
+#: warehouse/templates/manage/project/history.html:375
+#: warehouse/templates/manage/project/history.html:386
+#: warehouse/templates/manage/project/history.html:397
 msgid "Url"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:291
-#: warehouse/templates/manage/project/history.html:313
+#: warehouse/templates/manage/project/history.html:370
+#: warehouse/templates/manage/project/history.html:392
 msgid "Project alternate repository deleted"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:335
+#: warehouse/templates/manage/project/history.html:414
 msgid "Additional info"
 msgstr ""
 
-#: warehouse/templates/manage/project/history.html:347
+#: warehouse/templates/manage/project/history.html:426
 #: warehouse/templates/manage/team/history.html:101
 msgid "Location info"
 msgstr ""

--- a/warehouse/migrations/versions/d3dac0f3bb25_add_new_lifecyclestatus_for_deprecated.py
+++ b/warehouse/migrations/versions/d3dac0f3bb25_add_new_lifecyclestatus_for_deprecated.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Add new LifecycleStatus for Deprecated
+
+Revision ID: d3dac0f3bb25
+Revises: 423ffda7411f
+Create Date: 2026-07-22 00:00:00.000000
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "d3dac0f3bb25"
+down_revision = "423ffda7411f"
+
+
+def upgrade():
+    op.execute("ALTER TYPE public.lifecyclestatus ADD VALUE IF NOT EXISTS 'deprecated'")
+
+
+def downgrade():
+    op.sync_enum_values(
+        enum_schema="public",
+        enum_name="lifecyclestatus",
+        new_values=[
+            "quarantine-enter",
+            "quarantine-exit",
+            "archived",
+            "archived-noindex",
+        ],
+        affected_columns=[
+            TableReference(
+                table_schema="public",
+                table_name="projects",
+                column_name="lifecycle_status",
+            ),
+            TableReference(
+                table_schema="public",
+                table_name="releases",
+                column_name="lifecycle_status",
+            ),
+        ],
+        enum_values_to_rename=[],
+    )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -175,6 +175,7 @@ class LifecycleStatus(enum.StrEnum):
     QuarantineExit = "quarantine-exit"
     Archived = "archived"
     ArchivedNoindex = "archived-noindex"
+    Deprecated = "deprecated"
 
 
 class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
@@ -526,9 +527,10 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
             LifecycleStatus.ArchivedNoindex,
         ):
             return ProjectStatusMarker.Archived
+        if self.lifecycle_status == LifecycleStatus.Deprecated:
+            return ProjectStatusMarker.Deprecated
 
-        # PyPI doesn't yet have a deprecated lifecycle status
-        # and "quarantine-exit" means a return to active.
+        # "quarantine-exit" means a return to active.
         return ProjectStatusMarker.Active
 
     @property

--- a/warehouse/templates/manage/project/history.html
+++ b/warehouse/templates/manage/project/history.html
@@ -59,6 +59,20 @@
       <small>
         {% trans %}Yanked by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.submitted_by) }}">{{ event.additional.submitted_by }}</a>
       </small>
+    {% elif event.tag == EventTag.Project.ReleaseQuarantineEnter %}
+      <strong>
+        {% trans href=request.route_path('manage.project.release', project_name=project.name, version=event.additional.canonical_version), version=event.additional.canonical_version %}<a href="{{ href }}">Version {{ version }}</a> quarantined{% endtrans %}
+      </strong>
+      <small>
+        {% trans %}Quarantined by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.submitted_by) }}">{{ event.additional.submitted_by }}</a>
+      </small>
+    {% elif event.tag == EventTag.Project.ReleaseQuarantineExit %}
+      <strong>
+        {% trans href=request.route_path('manage.project.release', project_name=project.name, version=event.additional.canonical_version), version=event.additional.canonical_version %}<a href="{{ href }}">Version {{ version }}</a> quarantine cleared{% endtrans %}
+      </strong>
+      <small>
+        {% trans %}Cleared by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.submitted_by) }}">{{ event.additional.submitted_by }}</a>
+      </small>
       {# Display file events #}
     {% elif event.tag == EventTag.File.FileAdd %}
       <strong>
@@ -274,6 +288,71 @@
   <strong>{% trans %}Project unarchived{% endtrans %}</strong>
   <small>
     {% trans %}Unarchived by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.submitted_by) }}">{{ event.additional.submitted_by }}</a>
+  </small>
+  {# Display project deprecation enter/exit events #}
+{% elif event.tag == EventTag.Project.ProjectDeprecateEnter %}
+  <strong>{% trans %}Project deprecated{% endtrans %}</strong>
+  <small>
+    {% trans %}Deprecated by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.submitted_by) }}">{{ event.additional.submitted_by }}</a>
+  </small>
+{% elif event.tag == EventTag.Project.ProjectDeprecateExit %}
+  <strong>{% trans %}Project undeprecated{% endtrans %}</strong>
+  <small>
+    {% trans %}Undeprecated by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.submitted_by) }}">{{ event.additional.submitted_by }}</a>
+  </small>
+  {# Display project quarantine enter/exit events #}
+{% elif event.tag == EventTag.Project.ProjectQuarantineEnter %}
+  <strong>{% trans %}Project quarantined{% endtrans %}</strong>
+  <small>
+    {% trans %}Quarantined by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.submitted_by) }}">{{ event.additional.submitted_by }}</a>
+  </small>
+{% elif event.tag == EventTag.Project.ProjectQuarantineExit %}
+  <strong>{% trans %}Project quarantine cleared{% endtrans %}</strong>
+  <small>
+    {% trans %}Cleared by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.submitted_by) }}">{{ event.additional.submitted_by }}</a>
+  </small>
+  {# Display admin-set limit events #}
+{% elif event.tag == EventTag.Project.ProjectSetUploadLimit %}
+  <strong>{% trans %}Upload limit changed{% endtrans %}</strong>
+  <small>
+    {% trans %}Previous limit:{% endtrans %}
+    {% if event.additional.old_upload_limit %}
+      {{ event.additional.old_upload_limit|filesizeformat(binary=True) }}
+    {% else %}
+      {% trans %}Default{% endtrans %}
+    {% endif %}
+  </small>
+  <small>
+    {% trans %}New limit:{% endtrans %}
+    {% if event.additional.new_upload_limit %}
+      {{ event.additional.new_upload_limit|filesizeformat(binary=True) }}
+    {% else %}
+      {% trans %}Default{% endtrans %}
+    {% endif %}
+  </small>
+  <small>
+    {% trans %}Changed by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.actor) }}">{{ event.additional.actor }}</a>
+  </small>
+{% elif event.tag == EventTag.Project.ProjectSetTotalSizeLimit %}
+  <strong>{% trans %}Total size limit changed{% endtrans %}</strong>
+  <small>
+    {% trans %}Previous limit:{% endtrans %}
+    {% if event.additional.old_total_size_limit %}
+      {{ event.additional.old_total_size_limit|filesizeformat(binary=True) }}
+    {% else %}
+      {% trans %}Default{% endtrans %}
+    {% endif %}
+  </small>
+  <small>
+    {% trans %}New limit:{% endtrans %}
+    {% if event.additional.new_total_size_limit %}
+      {{ event.additional.new_total_size_limit|filesizeformat(binary=True) }}
+    {% else %}
+      {% trans %}Default{% endtrans %}
+    {% endif %}
+  </small>
+  <small>
+    {% trans %}Changed by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.actor) }}">{{ event.additional.actor }}</a>
   </small>
   {# Display Project Alternate Repository events  #}
 {% elif event.tag == EventTag.Account.AlternateRepositoryAdd %}

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -348,3 +348,44 @@ def unarchive_project(project: Project, request) -> None:
         },
     )
     request.session.flash("Project unarchived", queue="success")
+
+
+def deprecate_project(project: Project, request) -> None:
+    if (
+        project.lifecycle_status is not None
+        and project.lifecycle_status != LifecycleStatus.QuarantineExit
+    ):
+        request.session.flash(
+            f"Cannot deprecate project with status {project.lifecycle_status}",
+            queue="error",
+        )
+        return
+
+    project.lifecycle_status = LifecycleStatus.Deprecated
+    project.record_event(
+        tag=EventTag.Project.ProjectDeprecateEnter,
+        request=request,
+        additional={
+            "submitted_by": request.user.username,
+        },
+    )
+    request.session.flash("Project deprecated", queue="success")
+
+
+def undeprecate_project(project: Project, request) -> None:
+    if project.lifecycle_status != LifecycleStatus.Deprecated:
+        request.session.flash(
+            "Can only undeprecate a deprecated project",
+            queue="error",
+        )
+        return
+
+    project.lifecycle_status = None
+    project.record_event(
+        tag=EventTag.Project.ProjectDeprecateExit,
+        request=request,
+        additional={
+            "submitted_by": request.user.username,
+        },
+    )
+    request.session.flash("Project undeprecated", queue="success")


### PR DESCRIPTION
This PR extends the Project/Release lifecycle state machine to add support for the `"deprecated"` status, closely following the implementation of the `archived` status, which has similar (but not equal) semantics, according to PEP 792, described in #18546

I'd figured the backend changes could be added first, laying the groundwork of adding the possibility of a new status, and then add the "frontend" portion to the warehouse frontend / index / documentation enabling project maintainers to use this status.