### PR TITLE
docs: add deprecation notice for License classifiers (PEP 639)

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -8197,6 +8197,20 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/pages/classifiers.html:17
+msgid "Notice:"
+msgstr ""
+
+#: warehouse/templates/pages/classifiers.html:17
+msgid ""
+"As of <a href=\"https://packaging.python.org/en/latest/specifications"
+"/license-expression/\" target=\"_blank\" rel=\"noopener\">PEP 639</a>, "
+"the use of <code>License</code> Trove classifiers is deprecated. Please "
+"use <a href=\"https://packaging.python.org/en/latest/specifications"
+"/license-expression/\" target=\"_blank\" rel=\"noopener\">license "
+"expressions</a> in <code>pyproject.toml</code> instead."
+msgstr ""
+
+#: warehouse/templates/pages/classifiers.html:20
 #, python-format
 msgid ""
 "Instructions for how to add Trove classifiers to a project can be found "
@@ -8207,14 +8221,14 @@ msgid ""
 "title=\"Python enhancement proposal\">PEP</abbr> 301</a>."
 msgstr ""
 
-#: warehouse/templates/pages/classifiers.html:29
+#: warehouse/templates/pages/classifiers.html:32
 msgid ""
 "To prevent a package from being uploaded to PyPI, use the special "
 "\"Private :: Do Not Upload\" classifier. PyPI will always reject packages"
 " with classifiers beginning with \"Private ::\"."
 msgstr ""
 
-#: warehouse/templates/pages/classifiers.html:31
+#: warehouse/templates/pages/classifiers.html:34
 msgid "List of classifiers"
 msgstr ""
 
@@ -10332,4 +10346,3 @@ msgid "There were no results for '%(filters)s' filter"
 msgid_plural "There were no results for '%(filters)s' filters"
 msgstr[0] ""
 msgstr[1] ""
-

--- a/warehouse/templates/pages/classifiers.html
+++ b/warehouse/templates/pages/classifiers.html
@@ -13,6 +13,9 @@
       <p>
         {% trans %}These standardized classifiers can then be used by community members to find projects based on their desired criteria.{% endtrans %}
       </p>
+      <div class="callout callout--warning" role="alert">
+        <p><strong>{% trans %}Notice:{% endtrans %}</strong> {% trans %}As of <a href="https://packaging.python.org/en/latest/specifications/license-expression/" target="_blank" rel="noopener">PEP 639</a>, the use of <code>License</code> Trove classifiers is deprecated. Please use <a href="https://packaging.python.org/en/latest/specifications/license-expression/" target="_blank" rel="noopener">license expressions</a> in <code>pyproject.toml</code> instead.{% endtrans %}</p>
+      </div>
       <p>
         {% trans ppug_href='https://packaging.python.org/guides/writing-pyproject-toml/#classifiers', pep301_href='https://peps.python.org/pep-0301/#distutils-trove-classification', title=gettext('External link') %}
         Instructions for how to add Trove classifiers to a project can be found on the <a href="{{ ppug_href }}"


### PR DESCRIPTION
Addresses #17868

## Summary

- add a warning callout to the classifiers page explaining that `License` Trove classifiers are deprecated by PEP 639
- direct publishers to SPDX license expressions in `pyproject.toml`
- update the translation template for the new notice

## Validation

- Babel parsed the translation catalog successfully (1,798 messages)
- all three Read the Docs checks pass
- branch rebuilt on the current `warehouse/main`; PR is mergeable

## Review follow-up

- uses `License` rather than `License ::`
- preserves the existing template indentation
- resolved both review threads