### PR TITLE
Rework Org app UI

### DIFF
--- a/tests/unit/admin/views/test_organization_applications.py
+++ b/tests/unit/admin/views/test_organization_applications.py
@@ -13,6 +13,7 @@ from tests.common.db.organizations import (
 )
 from warehouse.admin.views import organizations as views
 from warehouse.organizations import services
+from warehouse.organizations.checks import Verdict
 from warehouse.organizations.models import (
     OrganizationApplicationStatus,
     OrganizationType,
@@ -241,6 +242,12 @@ class TestOrganizationApplicationDetail:
         assert result["form"].name.data == organization_application.name
         assert result["conflicting_applications"] == []
         assert result["organization_application"] == organization_application
+        assert {check.key for check in result["checks"]} >= {
+            "domain_match",
+            "email_verified",
+            "has_projects",
+        }
+        assert result["verdict"] in set(Verdict)
 
     def test_detail_edit(self, db_request):
         organization_application = OrganizationApplicationFactory.create()
@@ -449,6 +456,28 @@ class TestOrganizationApplicationActions:
             result.location
             == f"/admin/organization_applications/{organization_application.id}/"
         )
+
+    def test_defer_with_note(self, db_request):
+        admin = UserFactory.create()
+        user = UserFactory.create()
+        organization_application = OrganizationApplicationFactory.create(
+            name="example", submitted_by=user
+        )
+
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
+        )
+        db_request.user = admin
+        db_request.route_path = _organization_application_routes
+        db_request.params["message"] = "Jurisdiction review pending."
+
+        result = views.organization_application_defer(db_request)
+
+        assert organization_application.status == OrganizationApplicationStatus.Deferred
+        assert [note.payload["message"] for note in organization_application.notes] == [
+            "Jurisdiction review pending."
+        ]
+        assert result.status_code == 303
 
     def test_defer_turbo_mode(self, db_request):
         admin = UserFactory.create()

--- a/tests/unit/organizations/test_checks.py
+++ b/tests/unit/organizations/test_checks.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from warehouse.organizations.checks import (
+    Check,
+    CheckStatus,
+    Verdict,
+    _email_domain,
+    _Link,
+    review_checks,
+    verdict,
+)
+from warehouse.organizations.models import OrganizationApplicationStatus
+
+from ...common.db.accounts import (
+    EmailFactory,
+    OAuthAccountAssociationFactory,
+    UserFactory,
+)
+from ...common.db.organizations import OrganizationApplicationFactory
+from ...common.db.packaging import RoleFactory
+
+
+def find(checks, key):
+    return next((check for check in checks if check.key == key), None)
+
+
+class TestLink:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("https://acme.com/about", "acme.com"),
+            ("https://dept.acme.com", "acme.com"),
+            ("https://acme.co.uk", "acme.co.uk"),
+            ("https://localhost", None),
+        ],
+    )
+    def test_registered_domain(self, value, expected):
+        assert _Link(value).registered_domain == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("https://acme.com", "com"),
+            ("https://acme.co.ir", "ir"),
+            ("https://acme.ir", "ir"),
+            ("https://localhost", ""),
+        ],
+    )
+    def test_terminal_tld(self, value, expected):
+        assert _Link(value).terminal_tld == expected
+
+    @pytest.mark.parametrize(
+        ("value", "unverifiable", "github"),
+        [
+            ("https://acme.com", False, False),
+            ("https://github.com/acme", True, True),
+            ("https://acme.github.io", True, True),
+            ("https://gitlab.com/acme", True, False),
+        ],
+    )
+    def test_host_classification(self, value, unverifiable, github):
+        link = _Link(value)
+        assert (link.unverifiable, link.github) == (unverifiable, github)
+
+    def test_host_falls_back_to_raw(self):
+        assert _Link("not a url").host == "not a url"
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("jdoe@acme.com", "acme.com"),
+            ("jdoe@mail.acme.com", "acme.com"),
+            ("jdoe@localhost", None),
+            ("", None),
+        ],
+    )
+    def test_email_domain(self, value, expected):
+        assert _email_domain(value) == expected
+
+
+class TestDomainMatch:
+    def test_unreadable_url_is_unknown(self, db_request):
+        # `link_url` is constrained to ^https?:// at the database level, but a bare
+        # host still has no registrable domain to match an email against.
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://localhost", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "domain_match")
+        assert check.status == CheckStatus.Unknown
+        assert "No domain could be read" in check.detail
+
+    def test_shared_host_is_unknown(self, db_request):
+        user = UserFactory.create()
+        EmailFactory.create(user=user, email="jdoe@acme.com", verified=True)
+        application = OrganizationApplicationFactory.create(
+            link_url="https://github.com/acme", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "domain_match")
+        assert check.status == CheckStatus.Unknown
+        assert "hosts many unrelated organizations" in check.detail
+
+    def test_verified_match_passes(self, db_request):
+        user = UserFactory.create()
+        EmailFactory.create(user=user, email="jdoe@acme.com", verified=True)
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "domain_match")
+        assert check.status == CheckStatus.Ok
+
+    def test_no_verified_email_is_unknown(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "domain_match")
+        assert check.status == CheckStatus.Unknown
+        assert "No verified address" in check.detail
+
+    def test_matching_but_unverified_fails(self, db_request):
+        user = UserFactory.create()
+        EmailFactory.create(user=user, email="jdoe@gmail.com", verified=True)
+        EmailFactory.create(
+            user=user, email="jdoe@acme.com", verified=False, primary=False
+        )
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "domain_match")
+        assert check.status == CheckStatus.Fail
+        assert "not verified" in check.detail
+
+    def test_mismatch_fails(self, db_request):
+        user = UserFactory.create()
+        EmailFactory.create(user=user, email="jdoe@gmail.com", verified=True)
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "domain_match")
+        assert check.status == CheckStatus.Fail
+        assert "jdoe@gmail.com" in check.detail
+
+
+class TestURLShape:
+    def test_own_domain_omits_check(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        checks = review_checks(application, user)
+        assert find(checks, "url_shape_github") is None
+        assert find(checks, "url_shape_codehost") is None
+
+    def test_github_url(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://github.com/acme", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "url_shape_github")
+        assert check.status == CheckStatus.Warn
+        assert "github.com" in check.detail
+
+    def test_other_code_host(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://gitlab.com/acme", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "url_shape_codehost")
+        assert check.status == CheckStatus.Warn
+        assert "gitlab.com" in check.detail
+
+
+class TestNameDomainMatch:
+    def test_omitted_for_shared_hosts(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            name="acme", link_url="https://github.com/acme", submitted_by=user
+        )
+
+        assert find(review_checks(application, user), "name_domain_match") is None
+
+    def test_omitted_without_a_domain_label(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            name="acme", link_url="https://localhost", submitted_by=user
+        )
+
+        assert find(review_checks(application, user), "name_domain_match") is None
+
+    @pytest.mark.parametrize(
+        ("name", "link_url"),
+        [
+            ("acme", "https://acme.com"),
+            ("acme", "https://acme-corp.com"),
+            ("acme-corp", "https://acme.com"),
+            ("Acme", "https://ACME.com"),
+            ("acmee", "https://acme.com"),
+        ],
+    )
+    def test_related_names_pass(self, db_request, name, link_url):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            name=name, display_name=name, link_url=link_url, submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "name_domain_match")
+        assert check.status == CheckStatus.Ok
+
+    @pytest.mark.parametrize(
+        ("name", "link_url"),
+        [
+            ("acme", "https://globex.com"),
+            ("initech", "https://umbrella.org"),
+        ],
+    )
+    def test_unrelated_names_warn(self, db_request, name, link_url):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            name=name, display_name=name, link_url=link_url, submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "name_domain_match")
+        assert check.status == CheckStatus.Warn
+        assert "looks unrelated" in check.detail
+
+    def test_display_name_can_carry_the_match(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            name="ac-2026",
+            display_name="Acme Corporation",
+            link_url="https://acme.com",
+            submitted_by=user,
+        )
+
+        check = find(review_checks(application, user), "name_domain_match")
+        assert check.status == CheckStatus.Ok
+
+    def test_short_names_do_not_match_on_containment(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            name="ab",
+            display_name="ab",
+            link_url="https://cabbage.com",
+            submitted_by=user,
+        )
+
+        check = find(review_checks(application, user), "name_domain_match")
+        assert check.status == CheckStatus.Warn
+
+
+class TestEmailVerified:
+    def test_passes_with_verified_email(self, db_request):
+        user = UserFactory.create()
+        EmailFactory.create(user=user, email="jdoe@acme.com", verified=True)
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        assert (
+            find(review_checks(application, user), "email_verified").status
+            == CheckStatus.Ok
+        )
+
+    def test_fails_without_any_verified_email(self, db_request):
+        user = UserFactory.create()
+        EmailFactory.create(
+            user=user, email="jdoe@acme.com", verified=False, primary=False
+        )
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        assert (
+            find(review_checks(application, user), "email_verified").status
+            == CheckStatus.Fail
+        )
+
+
+class TestGitHubAssociation:
+    def test_omitted_for_non_github_urls_when_unlinked(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        assert find(review_checks(application, user), "github_association") is None
+
+    def test_reported_for_non_github_urls_when_linked(self, db_request):
+        # A linked account corroborates identity whatever the application URL is.
+        user = UserFactory.create()
+        OAuthAccountAssociationFactory.create(
+            user=user, service="github", external_username="jdoe"
+        )
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "github_association")
+        assert check.status == CheckStatus.Ok
+        assert "jdoe" in check.detail
+
+    def test_warns_when_unlinked(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://github.com/acme", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "github_association")
+        assert check.status == CheckStatus.Warn
+
+    def test_passes_when_linked(self, db_request):
+        user = UserFactory.create()
+        OAuthAccountAssociationFactory.create(
+            user=user, service="github", external_username="jdoe"
+        )
+        application = OrganizationApplicationFactory.create(
+            link_url="https://github.com/acme", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "github_association")
+        assert check.status == CheckStatus.Ok
+        assert "jdoe" in check.detail
+
+
+class TestProjects:
+    def test_warns_with_no_projects(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        assert (
+            find(review_checks(application, user), "has_projects").status
+            == CheckStatus.Warn
+        )
+
+    def test_singular_project(self, db_request):
+        user = UserFactory.create()
+        RoleFactory.create(user=user)
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "has_projects")
+        assert check.status == CheckStatus.Ok
+        assert check.detail == "1 project on PyPI."
+
+    def test_plural_projects(self, db_request):
+        user = UserFactory.create()
+        RoleFactory.create(user=user)
+        RoleFactory.create(user=user)
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "has_projects")
+        assert check.detail == "2 projects on PyPI."
+
+
+class TestRestrictedTLD:
+    def test_omitted_for_ordinary_tld(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        assert find(review_checks(application, user), "restricted_tld") is None
+
+    @pytest.mark.parametrize("tld", ["cu", "ir", "kp", "sy"])
+    def test_warns_for_embargoed_tld(self, db_request, tld):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url=f"https://acme.{tld}", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "restricted_tld")
+        assert check.status == CheckStatus.Warn
+        assert f".{tld}" in check.detail
+        assert "comprehensively embargoed" in check.detail
+
+    @pytest.mark.parametrize("tld", ["by", "ru"])
+    def test_warns_for_sectoral_tld(self, db_request, tld):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url=f"https://acme.{tld}", submitted_by=user
+        )
+
+        check = find(review_checks(application, user), "restricted_tld")
+        assert check.status == CheckStatus.Warn
+        assert "targeted sectoral sanctions" in check.detail
+
+
+class TestNameConflict:
+    def test_omitted_without_conflicts(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        assert find(review_checks(application, user, []), "name_conflict") is None
+
+    def test_declined_conflicts_are_ignored(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            name="acme", link_url="https://acme.com", submitted_by=user
+        )
+        other = OrganizationApplicationFactory.create(
+            name="acme", status=OrganizationApplicationStatus.Declined
+        )
+
+        assert find(review_checks(application, user, [other]), "name_conflict") is None
+
+    def test_warns_on_open_conflict(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            name="acme", link_url="https://acme.com", submitted_by=user
+        )
+        other = OrganizationApplicationFactory.create(name="acme")
+
+        check = find(review_checks(application, user, [other]), "name_conflict")
+        assert check.status == CheckStatus.Warn
+        assert "1 other open application" in check.detail
+
+    def test_pluralizes_multiple_conflicts(self, db_request):
+        user = UserFactory.create()
+        application = OrganizationApplicationFactory.create(
+            name="acme", link_url="https://acme.com", submitted_by=user
+        )
+        others = [
+            OrganizationApplicationFactory.create(name="acme"),
+            OrganizationApplicationFactory.create(name="acme"),
+        ]
+
+        check = find(review_checks(application, user, others), "name_conflict")
+        assert "2 other open applications" in check.detail
+
+
+class TestReviewChecks:
+    def test_orders_failures_before_passes(self, db_request):
+        user = UserFactory.create()
+        EmailFactory.create(user=user, email="jdoe@gmail.com", verified=True)
+        application = OrganizationApplicationFactory.create(
+            link_url="https://acme.com", submitted_by=user
+        )
+
+        order = [
+            CheckStatus.Fail,
+            CheckStatus.Warn,
+            CheckStatus.Unknown,
+            CheckStatus.Ok,
+        ]
+        ranks = [
+            order.index(check.status) for check in review_checks(application, user)
+        ]
+        assert ranks == sorted(ranks)
+
+
+class TestVerdict:
+    @pytest.mark.parametrize(
+        ("statuses", "expected"),
+        [
+            ([CheckStatus.Ok], Verdict.Ready),
+            ([CheckStatus.Ok, CheckStatus.Warn], Verdict.Review),
+            ([CheckStatus.Ok, CheckStatus.Unknown], Verdict.Review),
+            ([CheckStatus.Warn, CheckStatus.Fail], Verdict.NeedsInfo),
+            ([], Verdict.Ready),
+        ],
+    )
+    def test_precedence(self, statuses, expected):
+        checks = [
+            Check(f"k{i}", "label", status, "detail")
+            for i, status in enumerate(statuses)
+        ]
+        assert verdict(checks) == expected

--- a/warehouse/admin/static/css/admin.css
+++ b/warehouse/admin/static/css/admin.css
@@ -104,3 +104,220 @@ table.dataTable {
 .preserve-whitespace {
   white-space: pre-wrap;
 }
+
+/* Organization application review */
+.org-review-rail {
+  position: sticky;
+  top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+
+  /* Bootstrap 4's lg breakpoint. */
+  @media (width <= 991.98px) {
+    position: static;
+    max-height: none;
+    overflow-y: visible;
+  }
+}
+
+/* Per-cell ring, so dividers survive wrapping and a short last row paints nothing. */
+.org-review-checks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  margin: 0;
+  padding: 1px 0 0;
+  list-style: none;
+}
+
+.org-review-check {
+  display: flex;
+  flex: 1 1 19rem;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 8%);
+}
+
+.org-review-check-icon {
+  flex: 0 0 auto;
+  margin-top: 0.2rem;
+}
+
+.org-review-check-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.org-review-check-label {
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.org-review-check-detail {
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.org-review-check-ask {
+  align-self: flex-start;
+  margin-top: auto;
+}
+
+.org-review-key {
+  float: right;
+  padding: 0 0.3rem;
+  border: 1px solid currentcolor;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  opacity: 0.65;
+}
+
+.org-review-dl {
+  margin: 0;
+
+  & > div {
+    display: flex;
+    gap: 1.5rem;
+    padding: 0.5rem 0;
+
+    & + div {
+      border-top: 1px solid rgb(0 0 0 / 6%);
+    }
+  }
+
+  & dt {
+    flex: 0 0 11rem;
+    font-weight: 500;
+    color: #6c757d; /* Bootstrap $gray-600 */
+  }
+
+  & dd {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
+  @media (width <= 575.98px) {
+    & > div {
+      flex-direction: column;
+      gap: 0.15rem;
+    }
+  }
+}
+
+/* Rail chips float to a full-width button's far edge; modal buttons have none. */
+.org-review-key-inline {
+  float: none;
+  display: inline-block;
+  margin-left: 0.5rem;
+  vertical-align: baseline;
+}
+
+.org-review-identity {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem 1rem;
+  padding-bottom: 0.75rem;
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid rgb(0 0 0 / 8%);
+}
+
+.org-review-identity-name {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.org-review-email {
+  font-size: 0.875rem;
+  overflow-wrap: anywhere;
+
+  & .badge {
+    margin-left: 0.25rem;
+  }
+}
+
+.org-review-facets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.org-review-facet-empty,
+.org-review-facet > summary {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6c757d;
+}
+
+.org-review-facet > summary {
+  cursor: pointer;
+
+  &:hover {
+    color: #495057;
+  }
+}
+
+.org-review-count {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+}
+
+.org-review-facet-body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  max-height: 12rem;
+  overflow-y: auto;
+  padding: 0.45rem 0 0.15rem 1.1rem;
+}
+
+.org-review-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  max-width: 100%;
+  padding: 0.1rem 0.45rem;
+  border: 1px solid rgb(0 0 0 / 10%);
+  border-radius: 3px;
+  background-color: #f8f9fa;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+
+  & > a {
+    overflow-wrap: anywhere;
+  }
+}
+
+.org-review-chip-meta {
+  font-size: 0.6875rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.org-review-entry {
+  padding: 0.75rem 1rem 0;
+  border: 1px solid rgb(0 0 0 / 8%);
+  border-radius: 0.25rem;
+
+  & + & {
+    margin-top: 0.75rem;
+  }
+}
+
+.org-review-entry-open {
+  background-color: #fffaf0;
+}
+
+.org-review-entry-note {
+  background-color: #f6f6f7;
+}

--- a/warehouse/admin/static/css/admin.css
+++ b/warehouse/admin/static/css/admin.css
@@ -105,6 +105,20 @@ table.dataTable {
   white-space: pre-wrap;
 }
 
+/* AdminLTE renders sidebar labels inline, so a long one wraps beneath the icon and
+   escapes the highlight. Keep each label on the icon's row and truncate instead. */
+.nav-sidebar .nav-link {
+  display: flex;
+  align-items: center;
+}
+
+.nav-sidebar .nav-link > p {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Organization application review */
 .org-review-rail {
   position: sticky;

--- a/warehouse/admin/static/js/warehouse.js
+++ b/warehouse/admin/static/js/warehouse.js
@@ -302,32 +302,32 @@ if (organizationApplicationTurboModeSwitch !== null) {
   }
 }
 
+// `data-field` names the textarea to fill, defaulting to the request-more-info modal.
 const savedReplyButtons = document.querySelectorAll(".saved-reply-button");
 
-if (savedReplyButtons.length > 0) {
-  const requestMoreInfoModalMessage = document.getElementById("requestMoreInfoModalMessage");
+savedReplyButtons.forEach(button => {
+  button.addEventListener("click", () => {
+    const templateElement = document.getElementById(button.dataset.template);
+    const field = document.getElementById(button.dataset.field || "requestMoreInfoModalMessage");
 
-  if (requestMoreInfoModalMessage) {
-    savedReplyButtons.forEach(button => {
-      button.addEventListener("click", () => {
-        const templateId = button.dataset.template;
+    if (templateElement && field) {
+      field.value = templateElement.innerHTML
+        .trim()
+        .replace(/\n/g, " ")
+        .replace(/\s{2,}/g, " ");
+    }
+  });
+});
 
-        if (templateId) {
-          const templateElement = document.getElementById(templateId);
-
-          if (templateElement) {
-            const templateContent = templateElement.innerHTML;
-            const cleanedContent = templateContent
-              .trim()
-              .replace(/\n/g, " ")
-              .replace(/\s{2,}/g, " ");
-            requestMoreInfoModalMessage.value = cleanedContent;
-          }
-        }
-      });
-    });
-  }
-}
+// `requestSubmit` over `submit` so required fields still validate.
+document.querySelectorAll(".modal form").forEach(function(modalForm) {
+  modalForm.addEventListener("keydown", function(event) {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault();
+      modalForm.requestSubmit();
+    }
+  });
+});
 
 let editModalForm = document.getElementById("editModalForm");
 if (editModalForm !== null) {

--- a/warehouse/admin/templates/admin/base.html
+++ b/warehouse/admin/templates/admin/base.html
@@ -107,15 +107,27 @@
         <ul class="nav nav-pills nav-sidebar nav-child-indent flex-column" data-widget="treeview" role="menu" data-accordion="false">
           {# TODO: Is there a cleaner way to show/hide the allowed sections? #}
           {% if request.has_permission(Permissions.AdminDashboardSidebarRead) %}
-          <li class="nav-item">
-            <a href="{{ request.route_path('admin.organization_application.list') }}?q=is%3Asubmitted" class="nav-link">
-              <i class="fa fa-sitemap nav-icon"></i> <p>Organization Applications</p>
+          {% set in_organizations = request.matched_route and request.matched_route.name.startswith('admin.organization') %}
+          <li class="nav-item {{ 'menu-open' if in_organizations else 'menu-closed' }}">
+            <a href="#" class="nav-link">
+              <i class="fa fa-sitemap nav-icon"></i>
+              <p>
+                Organizations
+                <i class="right fas fa-angle-left"></i>
+              </p>
             </a>
-          </li>
-          <li class="nav-item">
-            <a href="{{ request.route_path('admin.organization.list') }}" class="nav-link">
-              <i class="fa fa-sitemap nav-icon"></i> <p>Organizations</p>
-            </a>
+            <ul class="nav nav-treeview">
+              <li class="nav-item">
+                <a href="{{ request.route_path('admin.organization_application.list') }}?q=is%3Asubmitted" class="nav-link">
+                  <i class="fa fa-inbox nav-icon"></i> <p>Applications</p>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="{{ request.route_path('admin.organization.list') }}" class="nav-link">
+                  <i class="fa fa-building nav-icon"></i> <p>All organizations</p>
+                </a>
+              </li>
+            </ul>
           </li>
           <li class="nav-item">
             <a href="{{ request.route_path('admin.user.list') }}" class="nav-link">

--- a/warehouse/admin/templates/admin/organization_applications/detail.html
+++ b/warehouse/admin/templates/admin/organization_applications/detail.html
@@ -37,561 +37,643 @@
 </div>
 {% endmacro %}
 
-{% block content %}
-  <div class="row">
-    <div class="col-md-3">
-      <div class="card card-primary">
-        <div class="card-body card-widget widget-user-1">
-          <div class="widget-user-header">
-            <h3 class="widget-user-username text-center">{{ organization_application.name }}</h3>
-            <h6 class="widget-user-username text-center">{{ organization_application.display_name }}</h6>
-          </div>
-        </div>
-        <div class="card-body">
-          <p class="text-muted text-center">
-            Submitted on {{ organization_application.submitted|format_date() }}
-          </p>
-        </div>
+{% macro correspondence_card(application, has_requests, outstanding, can_write, is_decided) %}
+<div class="card">
+  <div class="card-header with-border">
+    <h3 class="card-title">
+      Correspondence
+      {% if has_requests %}{% if outstanding %}<i class="fa-solid fa-envelope text-info" title="Awaiting a response"></i>{% else %}<i class="fa-solid fa-envelope-open text-green"></i><i class="fa-solid fa-reply text-green" title="Applicant responded"></i>{% endif %}{% endif %}
+    </h3>
+  </div>
+  <div class="card-body">
+  {% for entry in application.conversation %}
+    {% if entry.kind == "admin_note" %}
+    <div class="direct-chat direct-chat-primary org-review-entry org-review-entry-note">
+      <div class="direct-chat-messages unset-height">
+        {{ chat_message(entry.observer.parent.username ~ " (Internal Note)", entry.created|format_datetime, entry.observer.parent.email, entry.payload.message) }}
       </div>
+    </div>
+    {% else %}
+    <div class="direct-chat direct-chat-primary org-review-entry {{ 'org-review-entry-open' if not entry.additional.response }}">
+      <div class="direct-chat-messages unset-height">
+        {{ chat_message(entry.observer.parent.username ~ " (PyPI)", entry.created|format_datetime, entry.observer.parent.email, entry.payload.message) }}
+        {% if entry.additional.response %}
+        {{ chat_message(application.submitted_by.username, entry.additional.response_time|parse_isoformat|format_datetime, application.submitted_by.email, entry.additional.response, right=True) }}
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+  {% else %}
+  <p class="text-muted mb-0">No information requests or internal notes yet.</p>
+  {% endfor %}
+  </div>
+  {% if can_write and not is_decided %}
+  <div class="card-footer text-right">
+    <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle="modal" data-target="#addNoteModal">
+      <i class="fa fa-note-sticky"></i> Add Note
+    </button>
+    <button type="button" class="btn btn-info btn-sm" data-toggle="modal" data-target="#requestMoreInfoModal">
+      <i class="fa fa-question"></i> Request Info
+    </button>
+  </div>
+  {% endif %}
+</div>
+{% endmacro %}
 
-      <div class="card">
-        <div class="card-header with-border">
-          <h2 class="card-title">Actions</h2>
-        </div>
-        <div class="card-body">
-          <div class="form-group">
+{% macro field_row(label, value, extra_class=None) %}
+<div>
+  <dt>{{ label }}</dt>
+  <dd class="{{ extra_class }}">{{ value if value else "—" }}</dd>
+</div>
+{% endmacro %}
+
+{% block content %}
+  {#- Maps each check key to the saved reply that resolves it. Defaults target the
+      request-more-info modal; restricted_tld routes to defer instead. -#}
+  {% set reply_actions = {
+    "domain_match": {"template": "AddOrgEmailTemplate"},
+    "email_verified": {"template": "AddOrgEmailTemplate"},
+    "url_shape_github": {"template": "GitHubAssociationTemplate"},
+    "url_shape_codehost": {"template": "UnverifiableURLTemplate"},
+    "has_projects": {"template": "ReasonForApplicationTemplate"},
+    "restricted_tld": {
+      "template": "JurisdictionNoteTemplate",
+      "target": "#deferModal",
+      "field": "deferModalMessage",
+      "icon": "fa-stopwatch",
+      "label": "Note & defer",
+      "done_if": "deferred",
+      "done_label": "Deferred",
+    },
+  } %}
+  {% set check_icons = {
+    "ok": "fa-circle-check text-success",
+    "fail": "fa-circle-xmark text-danger",
+    "warn": "fa-triangle-exclamation text-warning",
+    "unknown": "fa-circle-question text-muted",
+  } %}
+  {% set verdict_display = {
+    "ready": ("card-success", "fa-circle-check", "Ready to approve"),
+    "review": ("card-warning", "fa-triangle-exclamation", "Needs a look"),
+    "needsinfo": ("card-danger", "fa-circle-xmark", "Information needed"),
+  } %}
+  {% set verdict_class, verdict_icon, verdict_title = verdict_display[verdict.value] %}
+  {% set status = organization_application.status %}
+  {% set is_decided = status.value in ['approved', 'declined'] %}
+  {% set can_write = request.has_permission(Permissions.AdminOrganizationsWrite) %}
+
+  {# ---------- Verdict ---------- #}
+  <div class="card {{ verdict_class }} card-outline">
+    <div class="card-header with-border">
+      <h3 class="card-title">
+        <i class="fa-solid {{ verdict_icon }}"></i> {{ verdict_title }}
+      </h3>
+    </div>
+    <div class="card-body p-0">
+      <ul class="org-review-checks">
+        {% for check in checks %}
+        <li class="org-review-check">
+          <i class="fa-solid {{ check_icons[check.status.value] }} org-review-check-icon"></i>
+          <div class="org-review-check-body">
+            <span class="org-review-check-label">{{ check.label }}</span>
+            <span class="org-review-check-detail text-muted">{{ check.detail }}</span>
+            {% set action = reply_actions.get(check.key) %}
+            {% if action and can_write and not is_decided and (check.status.value in ['fail', 'warn'] or action.done_if) %}
+            {% set done = action.done_if == status.value %}
             <button
               type="button"
-              class="btn btn-warning btn-block"
+              class="btn btn-xs btn-outline-{{ 'secondary' if action.target else 'info' }} saved-reply-button org-review-check-ask"
               data-toggle="modal"
-              data-hotkey-binding=78
-              data-target="#addNoteModal" {{ 'disabled' if not request.has_permission(Permissions.AdminOrganizationsWrite) }}
-              title="Add an internal note to this organization request"
+              data-target="{{ action.get('target', '#requestMoreInfoModal') }}"
+              data-template="{{ action.template }}"
+              data-field="{{ action.get('field', 'requestMoreInfoModalMessage') }}"
+              {{ 'disabled' if done }}
             >
-              <i class="icon fa fa-note-sticky text-white"></i> Add Note
+              <i class="fa-solid {{ 'fa-check' if done else action.get('icon', 'fa-reply') }}"></i>
+              {{ action.done_label if done else action.get('label', 'Ask about this') }}
             </button>
-
-            <button
-              type="button"
-              class="btn btn-primary btn-block"
-              data-toggle="modal"
-              data-hotkey-binding=65
-              data-target="#approveModal" {{ 'disabled' if not request.has_permission(Permissions.AdminOrganizationsWrite) or organization_application.status.value in ['approved', 'declined'] }}
-              title="Approve organization request"
-            >
-              <i class="icon fa fa-check"></i> Approve
-            </button>
-
-            <button
-              type="button"
-              class="btn btn-info btn-block"
-              data-toggle="modal"
-              data-hotkey-binding=82
-              data-target="#requestMoreInfoModal" {{ 'disabled' if not request.has_permission(Permissions.AdminOrganizationsWrite) or organization_application.status.value in ['approved', 'declined'] }}
-              title="Request more information on this organization request"
-            >
-              <i class="icon fa fa-question"></i> Request Info
-            </button>
-
-            <button
-              type="button"
-              class="btn btn-danger btn-block"
-              data-toggle="modal"
-              data-hotkey-binding=49
-              data-target="#declineModal" {{ 'disabled' if not request.has_permission(Permissions.AdminOrganizationsWrite) or organization_application.status.value in ['approved', 'declined'] }}
-              title="Decline organization request"
-            >
-              <i class="icon fa fa-times"></i> Decline
-            </button>
-
-            <button
-              type="button"
-              class="btn btn-secondary btn-block"
-              data-toggle="modal"
-              data-hotkey-binding=68
-              data-target="#deferModal" {{ 'disabled' if not request.has_permission(Permissions.AdminOrganizationsWrite) or organization_application.status in ['deferred', 'approved', 'declined'] }}
-              title="Defer organization request"
-            >
-              <i class="icon fa fa-stopwatch"></i> Defer
-            </button>
-
-            {% if user %}
-            <div class="modal fade" id="editModal" tabindex="-1" role="dialog">
-              <form method="POST" action="{{ request.current_route_path() }}" id="editModalForm" class="{% if form.errors %}edit-form-errors{% endif %}">
-                <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h4 class="modal-title" id="editModalLabel">
-                        Edit {{ organization_application.name }}?
-                      </h4>
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                      </button>
-                    </div>
-                    <div class="modal-body">
-                      {{ render_field("Organization Display Name", form.display_name, "organization-display-name", class="form-control") }}
-                      {{ render_field("Organization Name", form.name, "organization-name", class="form-control") }}
-                      {{ render_field("Organization URL", form.link_url, "organization-link-url", class="form-control") }}
-                      {{ render_field("Organization Description", form.description, "organization-description", class="form-control") }}
-                      {{ render_field("Organization Type", form.orgtype, "organization-type", class="form-control") }}
-                    </div>
-                    <div class="modal-footer justify-content-between">
-                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                      <button type="submit" class="btn btn-warning">
-                        <i class="icon fa fa-edit"></i> Update Application
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-
-            <div class="modal fade" id="approveModal" tabindex="-1" role="dialog">
-              <form method="POST" action="{{ request.route_path('admin.organization_application.approve', organization_application_id=organization_application.id) }}">
-                <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-                <input name="organization_applications_turbo_mode" type="hidden" value=0>
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h4 class="modal-title" id="approveModalLabel">
-                        Approve {{ organization_application.name }}?
-                      </h4>
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                      </button>
-                    </div>
-                    <div class="modal-body">
-                      <p>
-                        This will approve <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a>'s request for a new organization named <strong>{{ organization_application.name }}</strong>
-                      </p>
-                      <div class="form-group">
-                        <label for="approveModalMessage">
-                          Message
-                        </label>
-                        <textarea id="approveModalMessage" class="form-control" name="message" placeholder="Optional explanatory message"></textarea>
-                        <span id="approveModalMessageHelpBlock">
-                          This message will be included in the notification email.
-                        </span>
-                      </div>
-                    </div>
-                    <div class="modal-footer justify-content-between">
-                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                      <button type="submit" class="btn btn-primary">
-                        <i class="icon fa fa-check"></i> Approve organization request
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-
-            <div class="modal fade" id="deferModal" tabindex="-1" role="dialog">
-              <form method="POST" action="{{ request.route_path('admin.organization_application.defer', organization_application_id=organization_application.id) }}">
-                <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-                <input name="organization_applications_turbo_mode" type="hidden" value=0>
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h4 class="modal-title" id="deferModalLabel">
-                        Defer {{ organization_application.name }}?
-                      </h4>
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                      </button>
-                    </div>
-                    <div class="modal-body">
-                      <p>
-                        This will defer <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a>'s request for a new organization named <strong>{{ organization_application.name }}</strong>.
-                      </p>
-                    </div>
-                    <div class="modal-footer justify-content-between">
-                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                      <button type="submit" class="btn btn-secondary">
-                        <i class="icon fa fa-stopwatch"></i> Defer organization request
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-
-            <div class="modal fade" id="requestMoreInfoModal" tabindex="-1" role="dialog">
-              <form method="POST" action="{{ request.route_path('admin.organization_application.requestmoreinfo', organization_application_id=organization_application.id) }}">
-                <div class="hidden" id="AddOrgEmailTemplate">
-                    Hello {{ organization_application.submitted_by.username }}!
-                    We'd be happy to approve this organization request,
-                    but ask that you first add an @{% with parsed = organization_application.link_url|urlparse %}{% if parsed.host %}{{ parsed.host[4:] if parsed.host.startswith('www.') else parsed.host }}{% else %}NONE{% endif %}{% endwith %}
-                    email address to your PyPI account,
-                    complete the verification,
-                    and respond using the linked form.
-                </div>
-                <div class="hidden" id="BadURLTemplate">
-                    Hello {{ organization_application.submitted_by.username }}!
-                    Upon reviewing this organization application request, we were unable to find a related organization at the provided URL ({{ organization_application.link_url  }}).
-                    Please let us know if there is an updated URL we should use instead, otherwise we will decline this request.
-                </div>
-                <div class="hidden" id="UnverifiableURLTemplate">
-                    Hello {{ organization_application.submitted_by.username }}!
-                    Upon reviewing this organization application request, we were unable to determine your affiliation with the provided URL ({{ organization_application.link_url  }}).
-                    Please let us know if there is some other way for us to verify this, otherwise we will decline this request.
-                </div>
-                <div class="hidden" id="ShouldBeCompanyTemplate">
-                    Hello {{ organization_application.submitted_by.username }}!
-                    We’re reviewing your organization request and noticed that you might be a better fit for a Company organization.
-                    We can proceed with this request, but would need to change the name to suit, "{{ organization_application.name }}-community" or "{{ organization_application.name }}-opensource".
-                    Let us know if you’d like to do that, or switch this to a Company Organization request.
-                </div>
-                <div class="hidden" id="ReasonForApplicationTemplate">
-                    Hello {{ organization_application.submitted_by.username }}!
-                    We'd be happy to approve this organization request, but we need some more information first.
-                    We noticed that you don't have an existing project on PyPI yet.
-                    Since you don't have a project already, we need to know what your reason for applying for a PyPI Org account is and how having a PyPI Org account might help you.
-                    Let us know and we will go from there, thanks!
-                </div>
-                <div class="hidden" id="GitHubAssociationTemplate">
-                    Please ensure that your membership to the GitHub organization you've linked is public,
-                    and complete an Account Association to link your PyPI and GitHub accounts at
-                    https://pypi.org/manage/account/#account-associations
-
-                    Let us know when that is complete and we can proceed with your request.
-                </div>
-                <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-                <input name="organization_applications_turbo_mode" type="hidden" value=0>
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h4 class="modal-title" id="requestMoreInfoModalLabel">
-                        Request More Info for {{ organization_application.name }}?
-                      </h4>
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                      </button>
-                    </div>
-                    <div class="modal-body">
-                      <p>
-                        This will request more information for <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a>'s request for a new organization named <strong>{{ organization_application.name }}</strong>.
-                      </p>
-                      <div class="form-group">
-                        <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="AddOrgEmailTemplate">Add Org Email</button>
-                        <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="BadURLTemplate">Bad URL</button>
-                        <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="UnverifiableURLTemplate">Unverifiable URL</button>
-                        <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="ShouldBeCompanyTemplate">Should Be Company</button>
-                        <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="ReasonForApplicationTemplate">Reason For Application</button>
-                        <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="GitHubAssociationTemplate">GitHub Organization and Association</button>
-                      </div>
-                      <div class="form-group">
-                        <label for="requestMoreInfoModalMessage">
-                          Message
-                        </label>
-                        <textarea id="requestMoreInfoModalMessage" class="form-control" name="message" placeholder="Information you are requesting" rows=8></textarea>
-                        <span id="requestMoreInfoModalMessageHelpBlock">
-                          This message will be included in the notification email.
-                        </span>
-                      </div>
-                    </div>
-                    <div class="modal-footer justify-content-between">
-                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                      <button type="submit" class="btn btn-info">
-                        <i class="icon fa fa-question"></i> Request More Info
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-
-            <div class="modal fade" id="declineModal" tabindex="-1" role="dialog">
-              <form method="POST" action="{{ request.route_path('admin.organization_application.decline', organization_application_id=organization_application.id) }}">
-                <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-                <input name="organization_applications_turbo_mode" type="hidden" value=0>
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h4 class="modal-title" id="declineModalLabel">
-                        Decline {{ organization_application.name }}?
-                      </h4>
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                      </button>
-                    </div>
-                    <div class="modal-body">
-                      <p>
-                        This will decline <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a>'s request for a new organization named <strong>{{ organization_application.name }}</strong>.
-                      </p>
-                      <div class="form-group">
-                        <label for="declineModalMessage">
-                          Message
-                        </label>
-                        <textarea id="declineModalMessage" class="form-control" name="message" placeholder="Optional explanatory message"></textarea>
-                        <span id="declineModalMessageHelpBlock">
-                          This message will be included in the notification email.
-                        </span>
-                      </div>
-                    </div>
-                    <div class="modal-footer justify-content-between">
-                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                      <button type="submit" class="btn btn-danger">
-                        <i class="icon fa fa-times"></i> Decline organization request
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-
-            <div class="modal fade" id="addNoteModal" tabindex="-1" role="dialog">
-              <form method="POST" action="{{ request.route_path('admin.organization_application.addnote', organization_application_id=organization_application.id) }}">
-                <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h4 class="modal-title" id="addNoteModalLabel">
-                        Add Internal Note to {{ organization_application.name }}?
-                      </h4>
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                      </button>
-                    </div>
-                    <div class="modal-body">
-                      <p>
-                        This note is for internal admin reference only. It will not be emailed to the applicant.
-                      </p>
-                      <div class="form-group">
-                        <label for="addNoteModalMessage">
-                          Note
-                        </label>
-                        <textarea id="addNoteModalMessage" class="form-control" name="message" placeholder="Internal note" rows=6 required></textarea>
-                      </div>
-                    </div>
-                    <div class="modal-footer justify-content-between">
-                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                      <button type="submit" class="btn btn-warning">
-                        <i class="icon fa fa-note-sticky text-white"></i> Add Note
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-
             {% endif %}
           </div>
-          <div class="form-group">
-            <div class="custom-control custom-switch">
-              <input type="checkbox" class="custom-control-input" id="organizationApplicationTurboMode">
-              <label class="custom-control-label" for="organizationApplicationTurboMode">Turbo Mode</label>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+
+  <div class="row">
+    {# ---------- Action rail ---------- #}
+    <div class="col-lg-3 col-md-4">
+      <div class="org-review-rail">
+        <div class="card">
+          <div class="card-header with-border">
+            <h2 class="card-title">Actions</h2>
+          </div>
+          <div class="card-body">
+            <div class="form-group">
+              <button
+                type="button"
+                class="btn btn-primary btn-block"
+                data-toggle="modal"
+                data-hotkey-binding=65
+                data-target="#approveModal" {{ 'disabled' if not can_write or is_decided }}
+                title="Approve organization request"
+              >
+                <i class="icon fa fa-check"></i> Approve <span class="org-review-key">a</span>
+              </button>
+
+              <button
+                type="button"
+                class="btn btn-info btn-block"
+                data-toggle="modal"
+                data-hotkey-binding=82
+                data-target="#requestMoreInfoModal" {{ 'disabled' if not can_write or is_decided }}
+                title="Request more information on this organization request"
+              >
+                <i class="icon fa fa-question"></i> Request Info <span class="org-review-key">r</span>
+              </button>
+
+              <button
+                type="button"
+                class="btn btn-danger btn-block"
+                data-toggle="modal"
+                data-hotkey-binding=49
+                data-target="#declineModal" {{ 'disabled' if not can_write or is_decided }}
+                title="Decline organization request"
+              >
+                <i class="icon fa fa-times"></i> Decline <span class="org-review-key">1</span>
+              </button>
+
+              <button
+                type="button"
+                class="btn btn-secondary btn-block"
+                data-toggle="modal"
+                data-hotkey-binding=68
+                data-target="#deferModal" {{ 'disabled' if not can_write or organization_application.status in ['deferred', 'approved', 'declined'] }}
+                title="Defer organization request"
+              >
+                <i class="icon fa fa-stopwatch"></i> Defer <span class="org-review-key">d</span>
+              </button>
+
+              <button
+                type="button"
+                class="btn btn-outline-secondary btn-block"
+                data-toggle="modal"
+                data-hotkey-binding=78
+                data-target="#addNoteModal" {{ 'disabled' if not can_write }}
+                title="Add an internal note to this organization request"
+              >
+                <i class="icon fa fa-note-sticky"></i> Add Note <span class="org-review-key">n</span>
+              </button>
             </div>
+
+            <div class="form-group mb-0">
+              <div class="custom-control custom-switch">
+                <input type="checkbox" class="custom-control-input" id="organizationApplicationTurboMode">
+                <label class="custom-control-label" for="organizationApplicationTurboMode">Turbo Mode</label>
+              </div>
+              <small class="text-muted">Jump straight to the next submitted application after acting.</small>
+            </div>
+
+            {% if can_write %}
+            <div class="form-group mt-3 mb-0">
+              <button
+                type="button"
+                class="btn btn-warning btn-sm btn-block"
+                id="editModalButton"
+                data-toggle="modal"
+                data-target="#editModal" {{ 'disabled' if is_decided }}
+                title="Edit organization request"
+              >
+                <i class="fa-solid fa-pen-to-square"></i> Edit application
+              </button>
+            </div>
+            {% endif %}
           </div>
-          {% if request.has_permission(Permissions.AdminOrganizationsWrite) %}
-          <div class="form-group">
-            <button
-              type="button"
-              class="btn btn-warning btn-block"
-              id="editModalButton"
-              data-toggle="modal"
-              data-target="#editModal" {{ 'disabled' if organization_application.status.value in ['approved', 'declined'] }}
-              title="Edit organization request"
-            >
-              <i class="fa-solid fa-pen-to-square"></i> Edit
-            </button>
-          </div>
-          {% endif %}
         </div>
       </div>
     </div>
 
+    {# ---------- Evidence ---------- #}
     {% set information_requests = organization_application.information_requests %}
     {% set outstanding_information_requests = organization_application.information_requests|selectattr("additional", "defined")|map(attribute="additional")|selectattr("response", "undefined")|list %}
-    <div class="col-md-7 col-lg-6">
+    <div class="col-lg-9 col-md-8">
       <div class="card">
         <div class="card-header with-border">
-          <h3 class="card-title">Organization Request{% if information_requests %}{% if outstanding_information_requests %}  <i class="fa-solid fa-envelope text-info"></i>{% else %}  <i class="fa-solid fa-envelope-open text-green"></i><i class="fa-solid fa-reply text-green"></i>{% endif %}{% endif %}
-                - {{ organization_application.status.name }}
+          <h3 class="card-title">
+            {{ organization_application.name }}
+            <small class="text-muted">{{ organization_application.display_name }}</small>
+          </h3>
+          <div class="card-tools">
+            <span class="badge badge-{{ status.badge_style }}">{{ status.label }}</span>
+          </div>
+        </div>
+        <div class="card-body">
+          <dl class="org-review-dl">
+            <div>
+              <dt>Organization URL</dt>
+              <dd>
+              {#- warehouse.js reads element.firstChild here; keep the <i> first. -#}
+                <a href="{{ organization_application.link_url }}"
+                   rel="nofollow noopener noreferrer"
+                   target="_blank"
+                   data-check-link-url="{{ request.camo_url(organization_application.link_url) }}"><i class="fa fa-question"></i> {{ organization_application.link_url }} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
+              </dd>
+            </div>
+            {{ field_row("Type", organization_application.orgtype.value) }}
+            {{ field_row("Membership size", organization_application.membership_size.value) }}
+            {{ field_row("Submitted", organization_application.submitted|format_date()) }}
+            {{ field_row("Description", organization_application.description, extra_class="preserve-whitespace") }}
+            {{ field_row("Anticipated usage", organization_application.usage, extra_class="preserve-whitespace") }}
+          </dl>
+        </div>
+      </div>
+
+      {% if outstanding_information_requests %}
+      {{ correspondence_card(organization_application, information_requests, outstanding_information_requests, can_write, is_decided) }}
+      {% endif %}
+
+      <div class="card">
+        <div class="card-header with-border">
+          <h3 class="card-title">Applicant</h3>
+        </div>
+        <div class="card-body">
+          {% if user %}
+          {% set other_applications = user.organization_applications|sort(attribute='status', reverse=True)|rejectattr('status', 'equalto', 'approved')|list %}
+          <div class="org-review-identity">
+            <a class="org-review-identity-name" href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a>
+            {% for association in user.account_associations %}
+              {% if association.service == 'github' %}
+              <a href="https://github.com/{{ association.external_username }}" target="_blank" rel="noopener">
+                <i class="fa-brands fa-github"></i> {{ association.external_username }}
+              </a>
+              {% endif %}
+            {% endfor %}
+            {% for email in user.emails|sort(attribute='primary', reverse=True) %}
+            <span class="org-review-email" title="{{ 'Verified' if email.verified else 'Not verified' }}">
+              {% if email.verified %}<i class="fa fa-circle-check text-success"></i>{% else %}<i class="fa fa-circle-xmark text-danger"></i>{% endif %}
+              <a href="mailto:{{ email.email }}">{{ email.email }}</a>{% if email.primary %}<span class="badge badge-light">primary</span>{% endif %}
+            </span>
+            {% else %}
+            <span class="text-muted">No email addresses on file.</span>
+            {% endfor %}
+          </div>
+
+          <div class="org-review-facets">
+            {% set organization_roles = user.organization_roles|sort(attribute='role_name.value', reverse=True)|list %}
+            {% if organization_roles %}
+            <details class="org-review-facet" {{ 'open' if organization_roles|length <= 12 }}>
+              <summary>Organizations <span class="badge badge-pill badge-light org-review-count">{{ organization_roles|length }}</span></summary>
+              <div class="org-review-facet-body">
+                {% for organization_role in organization_roles %}
+                <span class="org-review-chip"><a href="{{ request.route_path('admin.organization.detail', organization_id=organization_role.organization.id) }}">{{ organization_role.organization.name }}</a><span class="org-review-chip-meta text-muted">{{ organization_role.role_name.value }}</span></span>
+                {% endfor %}
+              </div>
+            </details>
+            {% else %}
+            <p class="org-review-facet-empty">Organizations <span class="badge badge-pill badge-light org-review-count">0</span></p>
+            {% endif %}
+
+            {% if other_applications %}
+            <details class="org-review-facet" {{ 'open' if other_applications|length <= 12 }}>
+              <summary>Other applications <span class="badge badge-pill badge-light org-review-count">{{ other_applications|length }}</span></summary>
+              <div class="org-review-facet-body">
+                {% for org_app in other_applications %}
+                <span class="org-review-chip"><a href="{{ request.route_path('admin.organization_application.detail', organization_application_id=org_app.id) }}">{{ org_app.name }}</a><span class="org-review-chip-meta text-muted">{{ org_app.status.label }}</span></span>
+                {% endfor %}
+              </div>
+            </details>
+            {% else %}
+            <p class="org-review-facet-empty">Other applications <span class="badge badge-pill badge-light org-review-count">0</span></p>
+            {% endif %}
+
+            {% set projects = user.projects|sort(attribute='name')|list %}
+            {% if projects %}
+            <details class="org-review-facet" {{ 'open' if projects|length <= 12 }}>
+              <summary>Projects <span class="badge badge-pill badge-light org-review-count">{{ projects|length }}</span></summary>
+              <div class="org-review-facet-body">
+                {% for project in projects %}
+                <span class="org-review-chip"><a href="{{ request.route_path('admin.project.detail', project_name=project.normalized_name) }}">{{ project.name }}</a></span>
+                {% endfor %}
+              </div>
+            </details>
+            {% else %}
+            <p class="org-review-facet-empty">Projects <span class="badge badge-pill badge-light org-review-count">0</span></p>
+            {% endif %}
+          </div>
+          {% else %}
+          <p class="text-muted mb-0">The applicant account is no longer available.</p>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if conflicting_applications %}
+      <div class="card">
+        <div class="card-header with-border">
+          <h3 class="card-title">
+            <i class="fa fa-clipboard-question text-orange"></i> Conflicting applications
           </h3>
         </div>
-        <div class="card-body">
-          <div class="form-horizontal">
-            <div class="form-group">
-              <label class="col-12 control-label">
-                Applicant
-              </label>
-              <div class="col-12">
-                {% if user %}
-                <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a><br>
-                {% for email in user.emails %}
-                <i class="fa-solid fa-envelope"></i> <a href="mailto:{{ email.email }}">{{ email.email }}</a> {% if email.primary %}(primary){% endif %} {% if email.verified %}<i class="fa fa-check text-green"></i>{% else %}<i class="fa fa-times text-red"></i>{% endif %}<br>
-                {% endfor %}
+        <div class="card-body table-responsive p-0">
+          <table class="table">
+            <thead><tr><th>Application</th><th>Status</th><th>Submitted</th><th>Requester</th></tr></thead>
+            <tbody>
+            {% for application in conflicting_applications %}
+              <tr>
+                <td>
+                  {% if application.normalized_name == organization_application.normalized_name %}<i class="fa fa-equals text-red" title="Exact name match"></i>{% endif %}
+                  <a target="_blank" href="{{ request.route_url('admin.organization_application.detail', organization_application_id=application.id) }}">{{ application.name }}</a>
+                </td>
+                <td>{{ application.status.label }}</td>
+                <td>{{ application.submitted|format_date() }}</td>
+                <td><a target="_blank" href="{{ request.route_url('admin.user.detail', username=application.submitted_by.username) }}">{{ application.submitted_by.username }}</a></td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {% endif %}
 
-                {% if user.account_associations %}
-                  {% for association in user.account_associations %}
-                    {% if association.service == 'github' %}
-                      <i class="fa-brands fa-github"></i>
-                      <a href="https://github.com/{{ association.external_username }}" target="_blank" rel="noopener">
-                        {{ association.external_username }}
-                      </a>
-                    {% endif %}
-                  {% endfor %}
-                {% endif %}
-                {% else %}
-                <i>n/a</i>
-                {% endif %}
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="col-12 control-label">
-                Organization Account Name
-              </label>
-              <div class="col-12">
-                <input class="form-control" value="{{ organization_application.name }}" readonly>
-              </div>
-            </div>
-            {% if conflicting_applications %}
-            <div class="form-group">
-              <label class="col-12 control-label">
-                Conflicting Applications <i class="fa fa-clipboard-question text-orange"></i>
-              </label>
-              <div class="col-12">
-                <table class="table">
-                  <tr><th>Application</th><th>Status</th><th>Submitted</th><th>Requester</th></tr>
-                  {% for application in conflicting_applications %}
-                    <tr>
-                      <td>
-                        {% if application.normalized_name == organization_application.normalized_name %}<i class="fa fa-equals text-red"></i>{% endif %}
-                        <a target="_blank" href="{{ request.route_url('admin.organization_application.detail', organization_application_id=application.id) }}">{{ application.name }}</a>
-                      </td>
-                      <td>{{ application.status }}</td>
-                      <td>{{ application.submitted|format_date() }}</td>
-                      <td><a target="_blank" href="{{ request.route_url('admin.user.detail', username=application.submitted_by.username) }}">{{ application.submitted_by.username }}</a></td>
-                    </tr>
-                  {% endfor %}
-                </table>
-              </div>
-            </div>
-            {% endif %}
-            <div class="form-group">
-              <label class="col-12 control-label">
-                Organization Name
-              </label>
-              <div class="col-12">
-                <input class="form-control" value="{{ organization_application.display_name }}" readonly>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="col-12 control-label">
-                Organization URL <i class="fa-solid fa-arrow-up-right-from-square"></i>
-              </label>
-              <div class="col-12">
-                <a href="{{ organization_application.link_url }}" rel="nofollow noopener noreferrer" target="_blank" data-check-link-url="{{ request.camo_url(organization_application.link_url) }}"><input class="form-control" value="{{ organization_application.link_url }}" readonly></a>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="col-12 control-label">
-                Organization Type
-              </label>
-              <div class="col-12">
-                <input class="form-control" value="{{ organization_application.orgtype.value }}" readonly>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="col-12 control-label">
-                Organization Description
-              </label>
-              <div class="col-12">
-                <textarea class="form-control" rows="4" readonly>{{ organization_application.description }}</textarea>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="col-12 control-label">
-                Organization Membership Size
-              </label>
-              <div class="col-12">
-                <input class="form-control" value="{{ organization_application.membership_size.value }}" readonly>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="col-12 control-label">
-                Anticipated Usage
-              </label>
-              <div class="col-12">
-                <input class="form-control" value="{{ organization_application.usage }}" readonly>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      {% if not outstanding_information_requests %}
+      {{ correspondence_card(organization_application, information_requests, outstanding_information_requests, can_write, is_decided) }}
+      {% endif %}
     </div>
-    <div class="col-md-2 col-lg-3">
-      <div class="card">
-        <div class="card-header with-border">
-          <h4 class="card-title">User Organizations</h4>
-        </div>
-        <div class="card-body">
-          {% for organization_role in user.organization_roles|sort(attribute='role_name.value', reverse=True) %}
-          <div><a href="{{ request.route_path('admin.organization.detail', organization_id=organization_role.organization.id) }}">{{ organization_role.organization.name }}</a> - {{ organization_role.role_name.value }}</div>
-          {% else %}
-          <i>none!</i>
-          {% endfor %}
-        </div>
-      </div>
-      <div class="card">
-        <div class="card-header with-border">
-          <h4 class="card-title">User Organization Applications</h4>
-        </div>
-        <div class="card-body">
-          {% for org_app in user.organization_applications|sort(attribute='status', reverse=True)|rejectattr('status', 'equalto', 'approved') %}
-          <div><a href="{{ request.route_path('admin.organization_application.detail', organization_application_id=org_app.id) }}">{{ org_app.name }}</a> - {{ org_app.status }}</div>
-          {% else %}
-          <i>none!</i>
-          {% endfor %}
-        </div>
-      </div>
-      <div class="card">
-        <div class="card-header with-border">
-          <h4 class="card-title">User Projects</h4>
-        </div>
-        <div class="card-body">
-          {% for project in user.projects|sort(attribute='name') %}
-          <div><a href="{{ request.route_path('admin.project.detail', project_name=project.normalized_name) }}">{{ project.name }}</a></div>
-          {% else %}
-          <i>none!</i>
-          {% endfor %}
-        </div>
-      </div>
-    </div>
-    <div class="col-md-9 col-lg-6 offset-md-3">
-      <div class="card">
-        <div class="card-header with-border">
-          <h3 class="card-title">Information Requests</h3>
-        </div>
-        <div class="card-body">
-        {% for entry in organization_application.conversation %}
-          {% if entry.kind == "admin_note" %}
-          <div class="card card-warning card-outline direct-chat direct-chat-primary">
-            <div class="card-body">
-              <div class="direct-chat-messages unset-height">
-                {{ chat_message(entry.observer.parent.username ~ " (Internal Note)", entry.created|format_datetime, entry.observer.parent.email, entry.payload.message) }}
-              </div>
-            </div>
-          </div>
-          {% else %}
-          <div class="card {% if entry.additional.response %}card-neutral{% else %}card-warning{% endif %} direct-chat direct-chat-primary">
-            <div class="card-body">
-              <div class="direct-chat-messages unset-height">
-                {{ chat_message(entry.observer.parent.username ~ " (PyPI)", entry.created|format_datetime, entry.observer.parent.email, entry.payload.message) }}
-                {% if entry.additional.response %}
-                {{ chat_message(organization_application.submitted_by.username, entry.additional.response_time|parse_isoformat|format_datetime, organization_application.submitted_by.email, entry.additional.response, right=True) }}
-                {% endif %}
-              </div>
-            </div>
-          </div>
-          {% endif %}
-        {% else %}
-        <i>No information requests or internal notes yet.</i>
-        {% endfor %}
-        </div>
-      </div>
-    </div>
-
   </div>
+
+  {# ---------- Modals ----------
+     Deliberately outside the sticky rail: `position: sticky` creates a stacking context,
+     which would render these behind Bootstrap's body-level backdrop. -#}
+  {% if user %}
+  <div class="modal fade" id="editModal" tabindex="-1" role="dialog">
+    <form method="POST" action="{{ request.current_route_path() }}" id="editModalForm" class="{% if form.errors %}edit-form-errors{% endif %}">
+      <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" id="editModalLabel">
+              Edit {{ organization_application.name }}?
+            </h4>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            {{ render_field("Organization Display Name", form.display_name, "organization-display-name", class="form-control") }}
+            {{ render_field("Organization Name", form.name, "organization-name", class="form-control") }}
+            {{ render_field("Organization URL", form.link_url, "organization-link-url", class="form-control") }}
+            {{ render_field("Organization Description", form.description, "organization-description", class="form-control") }}
+            {{ render_field("Organization Type", form.orgtype, "organization-type", class="form-control") }}
+          </div>
+          <div class="modal-footer justify-content-between">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close <span class="org-review-key org-review-key-inline">esc</span></button>
+            <button type="submit" class="btn btn-warning">
+              <i class="icon fa fa-edit"></i> Update Application <span class="org-review-key org-review-key-inline" title="Ctrl/&#8984; + Enter">&#8984;&#9166;</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div class="modal fade" id="approveModal" tabindex="-1" role="dialog">
+    <form method="POST" action="{{ request.route_path('admin.organization_application.approve', organization_application_id=organization_application.id) }}">
+      <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+      <input name="organization_applications_turbo_mode" type="hidden" value=0>
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" id="approveModalLabel">
+              Approve {{ organization_application.name }}?
+            </h4>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>
+              This will approve <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a>'s request for a new organization named <strong>{{ organization_application.name }}</strong>
+            </p>
+            <div class="form-group">
+              <label for="approveModalMessage">
+                Message
+              </label>
+              <textarea id="approveModalMessage" class="form-control" name="message" placeholder="Optional explanatory message"></textarea>
+              <span id="approveModalMessageHelpBlock">
+                This message will be included in the notification email.
+              </span>
+            </div>
+          </div>
+          <div class="modal-footer justify-content-between">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close <span class="org-review-key org-review-key-inline">esc</span></button>
+            <button type="submit" class="btn btn-primary">
+              <i class="icon fa fa-check"></i> Approve organization request <span class="org-review-key org-review-key-inline" title="Ctrl/&#8984; + Enter">&#8984;&#9166;</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div class="modal fade" id="deferModal" tabindex="-1" role="dialog">
+    <form method="POST" action="{{ request.route_path('admin.organization_application.defer', organization_application_id=organization_application.id) }}">
+      <div class="hidden" id="JurisdictionNoteTemplate">
+          Deferred for jurisdiction review: the application URL ({{ organization_application.link_url }})
+          uses a restricted-jurisdiction TLD. Confirming sanctions status before proceeding.
+      </div>
+      <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+      <input name="organization_applications_turbo_mode" type="hidden" value=0>
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" id="deferModalLabel">
+              Defer {{ organization_application.name }}?
+            </h4>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>
+              This will defer <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a>'s request for a new organization named <strong>{{ organization_application.name }}</strong>.
+            </p>
+            <div class="form-group">
+              <label for="deferModalMessage">
+                Internal note
+              </label>
+              <textarea id="deferModalMessage" class="form-control" name="message" placeholder="Optional — why this is being set aside" rows=4></textarea>
+              <span id="deferModalMessageHelpBlock">
+                Recorded on the application for admins only. It is not emailed to the applicant.
+              </span>
+            </div>
+          </div>
+          <div class="modal-footer justify-content-between">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close <span class="org-review-key org-review-key-inline">esc</span></button>
+            <button type="submit" class="btn btn-secondary">
+              <i class="icon fa fa-stopwatch"></i> Defer organization request <span class="org-review-key org-review-key-inline" title="Ctrl/&#8984; + Enter">&#8984;&#9166;</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div class="modal fade" id="requestMoreInfoModal" tabindex="-1" role="dialog">
+    <form method="POST" action="{{ request.route_path('admin.organization_application.requestmoreinfo', organization_application_id=organization_application.id) }}">
+      <div class="hidden" id="AddOrgEmailTemplate">
+          Hello {{ organization_application.submitted_by.username }}!
+          We'd be happy to approve this organization request,
+          but ask that you first add an @{% with parsed = organization_application.link_url|urlparse %}{% if parsed.host %}{{ parsed.host[4:] if parsed.host.startswith('www.') else parsed.host }}{% else %}NONE{% endif %}{% endwith %}
+          email address to your PyPI account,
+          complete the verification,
+          and respond using the linked form.
+      </div>
+      <div class="hidden" id="BadURLTemplate">
+          Hello {{ organization_application.submitted_by.username }}!
+          Upon reviewing this organization application request, we were unable to find a related organization at the provided URL ({{ organization_application.link_url  }}).
+          Please let us know if there is an updated URL we should use instead, otherwise we will decline this request.
+      </div>
+      <div class="hidden" id="UnverifiableURLTemplate">
+          Hello {{ organization_application.submitted_by.username }}!
+          Upon reviewing this organization application request, we were unable to determine your affiliation with the provided URL ({{ organization_application.link_url  }}).
+          Please let us know if there is some other way for us to verify this, otherwise we will decline this request.
+      </div>
+      <div class="hidden" id="ShouldBeCompanyTemplate">
+          Hello {{ organization_application.submitted_by.username }}!
+          We’re reviewing your organization request and noticed that you might be a better fit for a Company organization.
+          We can proceed with this request, but would need to change the name to suit, "{{ organization_application.name }}-community" or "{{ organization_application.name }}-opensource".
+          Let us know if you’d like to do that, or switch this to a Company Organization request.
+      </div>
+      <div class="hidden" id="ReasonForApplicationTemplate">
+          Hello {{ organization_application.submitted_by.username }}!
+          We'd be happy to approve this organization request, but we need some more information first.
+          We noticed that you don't have an existing project on PyPI yet.
+          Since you don't have a project already, we need to know what your reason for applying for a PyPI Org account is and how having a PyPI Org account might help you.
+          Let us know and we will go from there, thanks!
+      </div>
+      <div class="hidden" id="GitHubAssociationTemplate">
+          Please ensure that your membership to the GitHub organization you've linked is public,
+          and complete an Account Association to link your PyPI and GitHub accounts at
+          https://pypi.org/manage/account/#account-associations
+
+          Let us know when that is complete and we can proceed with your request.
+      </div>
+      <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+      <input name="organization_applications_turbo_mode" type="hidden" value=0>
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" id="requestMoreInfoModalLabel">
+              Request More Info for {{ organization_application.name }}?
+            </h4>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>
+              This will request more information for <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a>'s request for a new organization named <strong>{{ organization_application.name }}</strong>.
+            </p>
+            <div class="form-group">
+              <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="AddOrgEmailTemplate">Add Org Email</button>
+              <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="BadURLTemplate">Bad URL</button>
+              <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="UnverifiableURLTemplate">Unverifiable URL</button>
+              <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="ShouldBeCompanyTemplate">Should Be Company</button>
+              <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="ReasonForApplicationTemplate">Reason For Application</button>
+              <button type="button" class="btn btn-outline-primary saved-reply-button" data-template="GitHubAssociationTemplate">GitHub Organization and Association</button>
+            </div>
+            <div class="form-group">
+              <label for="requestMoreInfoModalMessage">
+                Message
+              </label>
+              <textarea id="requestMoreInfoModalMessage" class="form-control" name="message" placeholder="Information you are requesting" rows=8></textarea>
+              <span id="requestMoreInfoModalMessageHelpBlock">
+                This message will be included in the notification email.
+              </span>
+            </div>
+          </div>
+          <div class="modal-footer justify-content-between">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close <span class="org-review-key org-review-key-inline">esc</span></button>
+            <button type="submit" class="btn btn-info">
+              <i class="icon fa fa-question"></i> Request More Info <span class="org-review-key org-review-key-inline" title="Ctrl/&#8984; + Enter">&#8984;&#9166;</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div class="modal fade" id="declineModal" tabindex="-1" role="dialog">
+    <form method="POST" action="{{ request.route_path('admin.organization_application.decline', organization_application_id=organization_application.id) }}">
+      <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+      <input name="organization_applications_turbo_mode" type="hidden" value=0>
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" id="declineModalLabel">
+              Decline {{ organization_application.name }}?
+            </h4>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>
+              This will decline <a href="{{ request.route_url('admin.user.detail', username=user.username) }}" title="{{ user.username }}">{{ user.username }}</a>'s request for a new organization named <strong>{{ organization_application.name }}</strong>.
+            </p>
+            <div class="form-group">
+              <label for="declineModalMessage">
+                Message
+              </label>
+              <textarea id="declineModalMessage" class="form-control" name="message" placeholder="Optional explanatory message"></textarea>
+              <span id="declineModalMessageHelpBlock">
+                This message will be included in the notification email.
+              </span>
+            </div>
+          </div>
+          <div class="modal-footer justify-content-between">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close <span class="org-review-key org-review-key-inline">esc</span></button>
+            <button type="submit" class="btn btn-danger">
+              <i class="icon fa fa-times"></i> Decline organization request <span class="org-review-key org-review-key-inline" title="Ctrl/&#8984; + Enter">&#8984;&#9166;</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div class="modal fade" id="addNoteModal" tabindex="-1" role="dialog">
+    <form method="POST" action="{{ request.route_path('admin.organization_application.addnote', organization_application_id=organization_application.id) }}">
+      <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" id="addNoteModalLabel">
+              Add Internal Note to {{ organization_application.name }}?
+            </h4>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>
+              This note is for internal admin reference only. It will not be emailed to the applicant.
+            </p>
+            <div class="form-group">
+              <label for="addNoteModalMessage">
+                Note
+              </label>
+              <textarea id="addNoteModalMessage" class="form-control" name="message" placeholder="Internal note" rows=6 required></textarea>
+            </div>
+          </div>
+          <div class="modal-footer justify-content-between">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close <span class="org-review-key org-review-key-inline">esc</span></button>
+            <button type="submit" class="btn btn-outline-secondary">
+              <i class="icon fa fa-note-sticky"></i> Add Note <span class="org-review-key org-review-key-inline" title="Ctrl/&#8984; + Enter">&#8984;&#9166;</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+  {% endif %}
 {% endblock %}

--- a/warehouse/admin/views/organizations.py
+++ b/warehouse/admin/views/organizations.py
@@ -25,6 +25,7 @@ from warehouse.constants import (
 )
 from warehouse.events.tags import EventTag
 from warehouse.manage.forms import OrganizationNameMixin, SaveOrganizationForm
+from warehouse.organizations.checks import review_checks, verdict
 from warehouse.organizations.interfaces import IOrganizationService
 from warehouse.organizations.models import (
     OIDCIssuerType,
@@ -671,11 +672,15 @@ def organization_application_detail(request):
 
     user = user_service.get_user(organization_application.submitted_by_id)
 
+    checks = review_checks(organization_application, user, conflicting_applications)
+
     return {
         "organization_application": organization_application,
         "form": form,
         "conflicting_applications": conflicting_applications,
         "user": user,
+        "checks": checks,
+        "verdict": verdict(checks),
     }
 
 

--- a/warehouse/organizations/checks.py
+++ b/warehouse/organizations/checks.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Automated review checks for organization applications.
+
+Every check is advisory: nothing here approves or declines an application. A check
+returns None when it does not apply, and CheckStatus.Unknown when it applies but
+cannot reach an answer.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import functools
+import re
+
+from collections.abc import Sequence
+from difflib import SequenceMatcher
+from typing import TYPE_CHECKING
+
+from tldextract import TLDExtract
+from urllib3.util import parse_url
+
+from warehouse.accounts.models import OAuthAccountAssociation
+from warehouse.organizations.models import OrganizationApplicationStatus
+
+if TYPE_CHECKING:
+    from warehouse.accounts.models import User
+    from warehouse.organizations.models import OrganizationApplication
+
+_extractor = TLDExtract(suffix_list_urls=())
+
+# Hosts that are public suffixes so domain matching cant be used to affiliate
+# to an org.
+UNVERIFIABLE_URL_HOSTS = {
+    "bitbucket.org",
+    "codeberg.org",
+    "gitee.com",
+    "github.com",
+    "github.io",
+    "gitlab.com",
+    "gitlab.io",
+    "pypi.org",
+    "readthedocs.io",
+    "readthedocs.org",
+    "sourceforge.net",
+}
+
+GITHUB_HOSTS = {"github.com", "github.io"}
+
+EMBARGOED_TLDS = {"cu", "ir", "kp", "sy"}
+SECTORAL_TLDS = {"by", "ru"}
+
+# Only reached for names the substring test misses, i.e. edits in the middle of a word.
+# A single dropped or transposed letter scores 0.75+, while unrelated names score under
+# 0.5 (`acme` against `globex` is 0.20), so any value in that gap behaves the same.
+NAME_SIMILARITY_THRESHOLD = 0.6
+
+_MIN_SUBSTRING_LENGTH = 3
+
+
+class CheckStatus(enum.StrEnum):
+    Ok = "ok"
+    Fail = "fail"
+    Warn = "warn"
+    Unknown = "unknown"
+
+
+class Verdict(enum.StrEnum):
+    Ready = "ready"
+    Review = "review"
+    NeedsInfo = "needsinfo"
+
+
+@dataclasses.dataclass(frozen=True)
+class Check:
+    key: str
+    label: str
+    status: CheckStatus
+    detail: str
+
+
+_STATUS_ORDER = {
+    CheckStatus.Fail: 0,
+    CheckStatus.Warn: 1,
+    CheckStatus.Unknown: 2,
+    CheckStatus.Ok: 3,
+}
+
+
+class _Link:
+    """Every view of an application's URL the checks need, parsed once."""
+
+    def __init__(self, raw: str) -> None:
+        extracted = _extractor(raw)
+        self.host = parse_url(raw).host or raw
+        self.registered_domain = extracted.top_domain_under_public_suffix or None
+        self.domain_label = extracted.domain
+        # The country-code label of a suffix, so `co.ir` reads as `ir`.
+        self.terminal_tld = extracted.suffix.rpartition(".")[2]
+        # `github.io` and `readthedocs.io` are themselves public suffixes, so a match
+        # can land on either component depending on the host.
+        parts = {extracted.top_domain_under_public_suffix, extracted.suffix}
+        self.unverifiable = bool(parts & UNVERIFIABLE_URL_HOSTS)
+        self.github = bool(parts & GITHUB_HOSTS)
+
+
+def _email_domain(email: str) -> str | None:
+    _, _, domain = email.rpartition("@")
+    return _extractor(domain).top_domain_under_public_suffix or None if domain else None
+
+
+def _comparable(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def _resembles(candidate: str, target: str) -> bool:
+    if min(len(candidate), len(target)) >= _MIN_SUBSTRING_LENGTH and (
+        candidate in target or target in candidate
+    ):
+        return True
+    return SequenceMatcher(None, candidate, target).ratio() >= NAME_SIMILARITY_THRESHOLD
+
+
+def _domain_match_check(link: _Link, user: User) -> Check:
+    check = functools.partial(
+        Check, "domain_match", "Verified email matches organization domain"
+    )
+
+    if link.registered_domain is None:
+        return check(
+            CheckStatus.Unknown, "No domain could be read from the application URL."
+        )
+
+    if link.unverifiable:
+        return check(
+            CheckStatus.Unknown,
+            f"{link.registered_domain} hosts many unrelated organizations, so an "
+            "address there would identify nobody. Establish affiliation another way.",
+        )
+
+    verified = [email.email for email in user.emails if email.verified]
+    if any(_email_domain(email) == link.registered_domain for email in verified):
+        return check(
+            CheckStatus.Ok, f"Verified @{link.registered_domain} address on file."
+        )
+
+    if not verified:
+        return check(
+            CheckStatus.Unknown,
+            f"No verified address to compare against {link.registered_domain}.",
+        )
+
+    if any(
+        _email_domain(email.email) == link.registered_domain
+        for email in user.emails
+        if not email.verified
+    ):
+        return check(
+            CheckStatus.Fail,
+            f"Has an @{link.registered_domain} address, but it is not verified.",
+        )
+
+    return check(
+        CheckStatus.Fail,
+        f"No verified @{link.registered_domain} address — "
+        f"holds {', '.join(sorted(verified))}.",
+    )
+
+
+def _url_shape_check(link: _Link) -> Check | None:
+    # Two keys: the template routes each to a different saved reply.
+    if not link.unverifiable:
+        return None
+
+    label = "Application URL is an organization homepage"
+    if link.github:  # TODO: may want to also check for other code forgers
+        return Check(
+            "url_shape_github",
+            label,
+            CheckStatus.Warn,
+            f"Points at {link.host} rather than the organization's own site. Ask for "
+            "public GitHub membership and an account association.",
+        )
+    return Check(
+        "url_shape_codehost",
+        label,
+        CheckStatus.Warn,
+        f"Points at {link.host}, a code or package host, rather than the "
+        "organization's own site.",
+    )
+
+
+def _name_domain_check(
+    application: OrganizationApplication, link: _Link
+) -> Check | None:
+    """Catch the `acme` application pointing at `globex.com`."""
+    check = functools.partial(
+        Check, "name_domain_match", "Organization name matches the domain"
+    )
+
+    if link.unverifiable or link.registered_domain is None:
+        return None
+
+    target = _comparable(link.domain_label)
+    candidates = {
+        _comparable(application.name),
+        _comparable(application.display_name or ""),
+    } - {""}
+    if not target or not candidates:
+        return None
+
+    if any(_resembles(candidate, target) for candidate in candidates):
+        return check(
+            CheckStatus.Ok, f"“{application.name}” lines up with {link.domain_label}."
+        )
+    return check(
+        CheckStatus.Warn,
+        f"“{application.name}” looks unrelated to {link.domain_label} — "
+        "confirm they are the same organization.",
+    )
+
+
+def _email_verified_check(user: User) -> Check:
+    check = functools.partial(Check, "email_verified", "Applicant has a verified email")
+
+    if any(email.verified for email in user.emails):
+        return check(CheckStatus.Ok, "Verified address on file.")
+    return check(CheckStatus.Fail, "No verified email address on this account.")
+
+
+def _github_association_check(link: _Link, user: User) -> Check | None:
+    """A link corroborates identity anywhere; absence only matters on GitHub URLs."""
+    check = functools.partial(Check, "github_association", "GitHub account association")
+
+    association = next(
+        (
+            a
+            for a in user.account_associations
+            if isinstance(a, OAuthAccountAssociation) and a.service == "github"
+        ),
+        None,
+    )
+    if association is not None:
+        return check(CheckStatus.Ok, f"Linked to {association.external_username}.")
+
+    if not link.github:
+        return None
+    return check(
+        CheckStatus.Warn, "No GitHub account linked, so membership cannot be verified."
+    )
+
+
+def _projects_check(user: User) -> Check:
+    check = functools.partial(Check, "has_projects", "Applicant has published projects")
+
+    count = len(user.projects)
+    if count:
+        return check(
+            CheckStatus.Ok, f"{count} project{'' if count == 1 else 's'} on PyPI."
+        )
+    return check(
+        CheckStatus.Warn, "No projects on PyPI — ask why an organization is needed."
+    )
+
+
+def _restricted_tld_check(link: _Link) -> Check | None:
+    if link.terminal_tld in EMBARGOED_TLDS:
+        reason = "a comprehensively embargoed jurisdiction"
+    elif link.terminal_tld in SECTORAL_TLDS:
+        reason = "a jurisdiction under targeted sectoral sanctions"
+    else:
+        return None
+
+    return Check(
+        "restricted_tld",
+        "Jurisdiction review",
+        CheckStatus.Warn,
+        f".{link.terminal_tld} maps to {reason} — confirm before approving.",
+    )
+
+
+def _name_conflict_check(
+    application: OrganizationApplication,
+    related_applications: Sequence[OrganizationApplication],
+) -> Check | None:
+    count = sum(
+        1
+        for other in related_applications
+        if other.normalized_name == application.normalized_name
+        and other.status != OrganizationApplicationStatus.Declined
+    )
+    if not count:
+        return None
+
+    return Check(
+        "name_conflict",
+        "Organization name is unclaimed",
+        CheckStatus.Warn,
+        f"{count} other open application{'' if count == 1 else 's'} "
+        f"for “{application.normalized_name}”.",
+    )
+
+
+def review_checks(
+    application: OrganizationApplication,
+    user: User,
+    related_applications: Sequence[OrganizationApplication] = (),
+) -> list[Check]:
+    """
+    Build the reviewer-facing checks, most actionable first.
+    """
+    link = _Link(application.link_url)
+    candidates = [
+        _domain_match_check(link, user),
+        _url_shape_check(link),
+        _name_domain_check(application, link),
+        _email_verified_check(user),
+        _github_association_check(link, user),
+        _projects_check(user),
+        _restricted_tld_check(link),
+        _name_conflict_check(application, related_applications),
+    ]
+    return sorted(
+        (check for check in candidates if check is not None),
+        key=lambda check: _STATUS_ORDER[check.status],
+    )
+
+
+def verdict(checks: list[Check]) -> Verdict:
+    statuses = {check.status for check in checks}
+    if CheckStatus.Fail in statuses:
+        return Verdict.NeedsInfo
+    if CheckStatus.Warn in statuses or CheckStatus.Unknown in statuses:
+        return Verdict.Review
+    return Verdict.Ready

--- a/warehouse/organizations/checks.py
+++ b/warehouse/organizations/checks.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 _extractor = TLDExtract(suffix_list_urls=())
 
-# Hosts that are public suffixes so domain matching cant be used to affiliate
+# Hosts that are public suffixes, so domain matching can't be used to affiliate
 # to an org.
 UNVERIFIABLE_URL_HOSTS = {
     "bitbucket.org",

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -679,6 +679,31 @@ class OrganizationApplicationStatus(enum.StrEnum):
     MoreInformationNeeded = "moreinformationneeded"
     Approved = "approved"
 
+    @property
+    def label(self) -> str:
+        return _ORGANIZATION_APPLICATION_STATUS_LABELS[self]
+
+    @property
+    def badge_style(self) -> str:
+        return _ORGANIZATION_APPLICATION_STATUS_STYLES[self]
+
+
+_ORGANIZATION_APPLICATION_STATUS_LABELS = {
+    OrganizationApplicationStatus.Submitted: "Submitted",
+    OrganizationApplicationStatus.Declined: "Declined",
+    OrganizationApplicationStatus.Deferred: "Deferred",
+    OrganizationApplicationStatus.MoreInformationNeeded: "Info Needed",
+    OrganizationApplicationStatus.Approved: "Approved",
+}
+
+_ORGANIZATION_APPLICATION_STATUS_STYLES = {
+    OrganizationApplicationStatus.Submitted: "info",
+    OrganizationApplicationStatus.Declined: "danger",
+    OrganizationApplicationStatus.Deferred: "secondary",
+    OrganizationApplicationStatus.MoreInformationNeeded: "warning",
+    OrganizationApplicationStatus.Approved: "success",
+}
+
 
 class OrganizationMembershipSize(enum.StrEnum):
     none = ""

--- a/warehouse/organizations/services.py
+++ b/warehouse/organizations/services.py
@@ -246,6 +246,16 @@ class DatabaseOrganizationService:
         )
         organization_application.status = OrganizationApplicationStatus.Deferred
 
+        # reason for deferring is optional
+        if message := request.params.get("message", ""):
+            organization_application.record_observation(
+                request=request,
+                actor=request.user,
+                summary="Admin note added",
+                kind=ObservationKind.AdminNote,
+                payload={"message": message},
+            )
+
         return organization_application
 
     def request_more_information(self, organization_application_id, request):


### PR DESCRIPTION
- Add header banner to show overall state
- Add hotkeys for quick buttons
- Add quick reply buttons on the new header banner to quickly open modal -> fill in correct reply
- Add domain checks for various things like public sites such as code forges
- ~~Add domain checks for OFAC compliance~~
- ~~Add quick reply for OFAC non-compliant orgs to add admin note & defer~~
- Nest Orgs under a tree: Orgs/{Orgs, Applications} to help with sizing issue but also to section it off nicer

<img width="1498" height="168" alt="image" src="https://github.com/user-attachments/assets/cc0c8057-f63b-4b98-8e33-f0cee6dcc05d" />
<img width="1478" height="993" alt="image" src="https://github.com/user-attachments/assets/ef82e737-e7b5-416e-bb20-7d41237394d7" />
<img width="352" height="301" alt="image" src="https://github.com/user-attachments/assets/fb48087e-e7b4-45eb-8646-52a500e80529" />
