### PR TITLE
docs: Update docs for updated "good first issue" label

### DIFF
--- a/docs/dev/development/getting-started.md
+++ b/docs/dev/development/getting-started.md
@@ -6,7 +6,7 @@ We're pleased that you are interested in working on Warehouse.
 
 After you set up your development environment and ensure you can run
 the tests and build the documentation (using the instructions in this
-document), take a look at [our guide to the Warehouse codebase](../application.md). Then, look at our [open issues that are labelled "good first issue"](https://github.com/pypi/warehouse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), find one you want to work on, comment on it to say you're working on
+document), take a look at [our guide to the Warehouse codebase](../application.md). Then, look at our [open issues that are labelled "good first issue for humans"](https://github.com/pypi/warehouse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue+for+humans%22), find one you want to work on, comment on it to say you're working on
 it, then submit a pull request. Use our [submitting patches](submitting-patches.md) documentation
 to help.
 


### PR DESCRIPTION
The label name was changed to "good first issue for humans"

---

Coming from https://warehouse.pypa.io/development/getting-started/, one of the very first links 

> Then, look at our [open issues that are labelled "good first issue"](https://github.com/pypi/warehouse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)

goes to a filtered GitHub Issues page that fails with

<img width="1338" height="504" alt="Screenshot 2026-08-07 at 03 23 12 UTC@2x" src="https://github.com/user-attachments/assets/7257992e-08fb-4773-a478-11c190225443" />

It seems the label name was changed at some point in the past.