### PR TITLE
Use the caveats stored in the db as additional caveats for Macaroon verification

### DIFF
--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -297,6 +297,10 @@ class TestDatabaseMacaroonService:
             user_id=user.id,
         )
 
+        dm = macaroon_service.find_from_raw(raw_macaroon)
+        # Add a database only caveat that has not been embedded into the macaroon
+        dm.caveats = [*dm.caveats, caveats.Expiration(expires_at=5, not_before=2)]
+
         verify = mocker.patch.object(
             caveats, "verify", autospec=True, return_value=True
         )
@@ -307,8 +311,29 @@ class TestDatabaseMacaroonService:
 
         assert macaroon_service.verify(raw_macaroon, request, context, permissions)
         verify.assert_called_once_with(
-            mocker.ANY, mocker.ANY, request, context, permissions
+            mocker.ANY, dm.key, request, context, permissions
         )
+
+        # Ensure that the macaroon that was verified is what was expected.
+        vm = verify.call_args.args[0]
+        assert vm.location == "fake location"
+        assert vm.identifier == str(dm.id).encode("utf8")
+        assert [c.to_dict() for c in vm.caveats] == [
+            # The embedded RequestUser caveat
+            {
+                "cid": f'[3,"{user.id!s}"]',
+                "cl": None,
+                "vid": None,
+            },
+            # The database stored RequestUser caveat
+            {
+                "cid": f'[3,"{user.id!s}"]',
+                "cl": None,
+                "vid": None,
+            },
+            # The database stored Expiration caveat
+            {"cid": "[0,5,2]", "cl": None, "vid": None},
+        ]
 
     def test_delete_macaroon(self, user_service, macaroon_service):
         user = UserFactory.create()

--- a/warehouse/macaroons/models.py
+++ b/warehouse/macaroons/models.py
@@ -71,13 +71,13 @@ class Macaroon(db.Model):
         JSONB,
         server_default=sql.text("'{}'"),
         comment=(
-            "The list of caveats that were attached to this Macaroon when we "
-            "generated it. Users can add additional caveats at any time without "
-            "communicating those additional caveats to us, which would not be "
-            "reflected in this data, and thus this field must only be used for "
-            "informational purposes and must not be used during the authorization "
-            "or authentication process. Older Macaroons may be missing caveats as "
-            "previously only the legacy permissions caveat were stored."
+            "The list of system generated caveats for this Macaroon. Users can add "
+            "additional caveats at any time without communicating those additional "
+            "caveats to us, which would not be reflected in this data, and thus this "
+            "if this field is used for authorization or authentication purposes, it "
+            "MUST be used as additional caveats along with whatever caveats are "
+            "attached to the Macaroon. Older Macaroons may be missing caveats as "
+            "previously only the legacy permissions caveats were stored."
         ),
     )
 

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -132,6 +132,43 @@ class DatabaseMacaroonService:
         if dm is None:
             raise InvalidMacaroonError("deleted or nonexistent macaroon")
 
+        # Macaroons traditionally have caveats embedded inside them which act to
+        # restrict the scope of what that macaroon is able to do. However, each caveat
+        # that is added has to be serialized into the Macaroon which makes them longer
+        # the more restricted they become.
+        #
+        # In the common case, end users often don't add their own caveats to the
+        # macaroons we give them, the only caveats that exist are the ones that were
+        # added by Warehouse when the macaroons was first created. This allows end users
+        # to introspect the macaroon without having to talk to PyPI, but means that they
+        # are already longer than is typical for an API token out of the gate.
+        #
+        # Relying strictly on the embedded caveats also makes it more difficult to
+        # evolve the use cases that the token system is able to handle over time when
+        # assumptions that used to be made can no longer be assumed (such as they're
+        # only used for uploads and then wanting to use them for other use cases).
+        #
+        # To solve this, what we do is we allow storing caveats in the database in
+        # addition to the embedded caveats, and when verifying the macaroon we append
+        # those caveats to the end of the macaroon.
+        #
+        # This means:
+        #  1. The system generated caveats do not need to be embedded, because they are
+        #     in the database and dynamically added at verify time.
+        #  2. We can add new caveats to any existing macaroon by adding the caveat to
+        #     the stored caveats in the database.
+        #  3. When the macaroon has the system generated caveats embedded, appending
+        #     them is harmless (other than a small cpu cost) because it's just verifying
+        #     the same restrictions twice.
+        #
+        # NOTE: We choose to mutate the macaroon that was given to us by appending the
+        #       stored caveats to the end of it. This is safe and means that the caveat
+        #       verification code doesn't have to do anything special for stored vs
+        #       embedded caveats. However, it does mean that the macaroon we actually
+        #       end up verifying is a "sub" macaroon of what the user provided us.
+        for caveat in dm.caveats:
+            m.add_first_party_caveat(caveats.serialize(caveat))
+
         verified = caveats.verify(m, dm.key, request, context, permission)
         if verified:
             # Update last_used without dirtying the ORM object. A dirty
@@ -209,6 +246,8 @@ class DatabaseMacaroonService:
             key=dm.key,
             version=pymacaroons.MACAROON_V2,
         )
+        # TODO: Remove this to stop emitting embedded caveats, which are now
+        #       being stored in the database while still being verified.
         for caveat in scopes:
             m.add_first_party_caveat(caveats.serialize(caveat))
         serialized_macaroon = f"pypi-{m.serialize()}"

--- a/warehouse/migrations/versions/964076d0c4ad_update_the_comment_on_the_caveats_column.py
+++ b/warehouse/migrations/versions/964076d0c4ad_update_the_comment_on_the_caveats_column.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Update the comment on the caveats column
+
+Revision ID: 964076d0c4ad
+Revises: 423ffda7411f
+Create Date: 2026-08-08 14:29:44.710940
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "964076d0c4ad"
+down_revision = "423ffda7411f"
+
+
+def upgrade():
+    op.alter_column(
+        "macaroons",
+        "caveats",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        comment=(
+            "The list of system generated caveats for this Macaroon. Users can add "
+            "additional caveats at any time without communicating those additional "
+            "caveats to us, which would not be reflected in this data, and thus this "
+            "if this field is used for authorization or authentication purposes, it "
+            "MUST be used as additional caveats along with whatever caveats are "
+            "attached to the Macaroon. Older Macaroons may be missing caveats as "
+            "previously only the legacy permissions caveats were stored."
+        ),
+        existing_comment=(
+            "The list of caveats that were attached to this Macaroon when we generated "
+            "it. Users can add additional caveats at any time without communicating "
+            "those additional caveats to us, which would not be reflected in this "
+            "data, and thus this field must only be used for informational purposes "
+            "and must not be used during the authorization or authentication process. "
+            "Older Macaroons may be missing caveats as previously only the legacy "
+            "permissions caveat were stored."
+        ),
+        existing_nullable=False,
+        existing_server_default=sa.text("'{}'::jsonb"),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "macaroons",
+        "caveats",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        comment=(
+            "The list of caveats that were attached to this Macaroon when we generated "
+            "it. Users can add additional caveats at any time without communicating "
+            "those additional caveats to us, which would not be reflected in this "
+            "data, and thus this field must only be used for informational purposes "
+            "and must not be used during the authorization or authentication process. "
+            "Older Macaroons may be missing caveats as previously only the legacy "
+            "permissions caveat were stored."
+        ),
+        existing_comment=(
+            "The list of system generated caveats for this Macaroon. Users can add "
+            "additional caveats at any time without communicating those additional "
+            "caveats to us, which would not be reflected in this data, and thus this "
+            "if this field is used for authorization or authentication purposes, it "
+            "MUST be used as additional caveats along with whatever caveats are "
+            "attached to the Macaroon. Older Macaroons may be missing caveats as "
+            "previously only the legacy permissions caveats were stored."
+        ),
+        existing_server_default=sa.text("'{}'::jsonb"),
+    )


### PR DESCRIPTION
Traditionally all caveats that exist for a Macaroon get embedded into the Macaroon, inflating the size and making it impossible for the system/us to further restrict the Macaroon once it's been created.

This isn't a required thing for Macaroons though, it's just a choice we made when implementing them, so this PR adjusts that choice so that instead of embedding the "system generated" caveats into the Macaroon that we give the user, we instead *only* store them in the database. When we go to verify the macaroon, we pull out any caveats that are stored in the database and dynamically append them to the Macaroon before we verify it.

This ends up meaning that the logical set of caveats changes from what is embedded in the Macaroon, to additionally include what is stored in the database.

The Macaroons stored in the database will exist in a few states:

1. Ones that predate the caveats column but whose caveats were able to be solely reflected by the legacy permissions caveat.
2. Ones that predate the caveats column but whose caveats were not able to be solely reflected by the legacy permissions caveat.
3. Ones that have been generated since the caveats column was introduced.
4. Ones that will have been generated after this change.

All of these cases will be correctly handled:

1. These macaroons should have had their system generated caveats synthesized from the legacy permissions caveat when the caveats column was added, so they will have the correct caveats stored in the caveats column, but it doesn't matter because the correct ones are embedded in the macaroon and the database caveats add to not replace the embedded caveats.
2. These macaroons do not have their system generated caveats correctly reflected in the caveats column, but it doesn't matter because the correct ones are embedded in the macaroon and the database caveats add to not replace the embedded caveats.
3. These macaroons will have their system generated caveats exist in both the database *and* embedded, so ultimately those caveats will exist twice when the macaroon is verified, but that is fine (although duplicative) because it's just asserting the same thing twice.
4. These macaroons will only have their system generated macaroons exist in the database, and the macaroon itself will not have any caveats included by the system (but they could have had ones added by the users).

In all cases, if the user has added any caveats to the macaroon, those will still be honored because the database caveats are added to whatever is embedded in the macaroon, so both "sources" of caveats are honored.

~~This PR still needs the tests updated, and we might want to still emit macaroons that have the caveats embedded to give the verification side of things some time to get run through its paces, because once we stop emitting the embedded caveats we can't revert this change or else those caveats won't be trusted.~~