### PR TITLE
Move project link icon selection to a template filter

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -121,6 +121,35 @@ def test_urlparse():
 
 
 @pytest.mark.parametrize(
+    ("name", "url", "expected"),
+    [
+        ("Download", "https://example.com", "fas fa-cloud-download-alt"),
+        ("Home", "https://example.com", "fas fa-home"),
+        ("Documentation", "https://example.com", "fas fa-book"),
+        ("Bug Tracker", "https://example.com", "fas fa-bug"),
+        ("Funding", "https://example.com", "fas fa-donate"),
+        ("Project", "https://github.com/example/project", "fab fa-github"),
+        ("Project", "https://gitlab.com/example/project", "fab fa-gitlab"),
+        ("Project", "https://codeberg.org/example/project", "fab fa-codeberg"),
+        ("Project", "https://discord.gg/example", "fab fa-discord"),
+        ("Project", "https://google.com/example", "fab fa-google"),
+        ("Project", "https://bitbucket.org/example/project", "fab fa-bitbucket"),
+        ("Project", "https://reddit.com/r/example", "fab fa-reddit-alien"),
+        ("Slack", "https://example.com", "fab fa-slack"),
+        ("Project", "https://x.com/example", "fab fa-twitter"),
+        ("Bluesky", "https://example.com", "fab fa-bluesky"),
+        ("Project", "https://circleci.com/example", "fas fa-tasks"),
+        ("Project", "https://pypi.org/project/example", "fas fa-cube"),
+        ("Project", "https://python.org", "fab fa-python"),
+        ("Project", "https://youtube.com/watch?v=example", "fab fa-youtube"),
+        ("Mastodon", "https://example.com", "fab fa-mastodon"),
+        ("Something else", "https://example.com", "fas fa-external-link-square-alt"),
+    ],
+)
+def test_url_icon(name, url, expected):
+    assert filters.url_icon(url, name) == expected
+
+@pytest.mark.parametrize(
     ("inp", "expected"),
     [
         (

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -710,6 +710,7 @@ def configure(settings=None):
     filters.setdefault("camoify", "warehouse.filters:camoify")
     filters.setdefault("shorten_number", "warehouse.filters:shorten_number")
     filters.setdefault("urlparse", "warehouse.filters:urlparse")
+    filters.setdefault("url_icon", "warehouse.filters:url_icon")
     filters.setdefault("contains_valid_uris", "warehouse.filters:contains_valid_uris")
     filters.setdefault("format_package_type", "warehouse.filters:format_package_type")
     filters.setdefault("parse_version", "warehouse.filters:parse_version")

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -98,6 +98,134 @@ def urlparse(value):
     return parse_url(value)
 
 
+def url_icon(url, name):
+    parsed = parse_url(url)
+    name = name.lower()
+    hostname = parsed.hostname or ""
+
+    match name, hostname:
+        case "download", _:
+            return "fas fa-cloud-download-alt"
+        case "home" | "homepage" | "home page", _:
+            return "fas fa-home"
+        case (
+            "changelog"
+            | "change log"
+            | "changes"
+            | "release notes"
+            | "news"
+            | "what's new"
+            | "history",
+            _,
+        ):
+            return "fas fa-scroll"
+        case name, hostname if (
+            name.startswith(("docs", "documentation"))
+            or hostname in {
+                "readthedocs.io",
+                "readthedocs.org",
+                "rtfd.io",
+                "rtfd.org",
+            }
+            or hostname.endswith(
+                (
+                    ".readthedocs.io",
+                    ".readthedocs.org",
+                    ".rtfd.io",
+                    ".rtfd.org",
+                )
+            )
+            or hostname.startswith(("docs.", "documentation."))
+        ):
+            return "fas fa-book"
+        case name, _ if name.startswith(("bug", "issue", "tracker", "report")):
+            return "fas fa-bug"
+        case name, _ if name.startswith(
+            ("funding", "donate", "donation", "sponsor")
+        ):
+            return "fas fa-donate"
+        case _, hostname if (
+            hostname in {"github.com", "github.io"}
+            or hostname.endswith((".github.com", ".github.io"))
+        ):
+            return "fab fa-github"
+        case _, hostname if (
+            hostname == "gitlab.com" or hostname.endswith(".gitlab.com")
+        ):
+            return "fab fa-gitlab"
+        case _, hostname if (
+            hostname in {"codeberg.org", "codeberg.page"}
+            or hostname.endswith((".codeberg.org", ".codeberg.page"))
+        ):
+            return "fab fa-codeberg"
+        case _, hostname if hostname == "gitter.im" or hostname.endswith(".gitter.im"):
+            return "fab fa-gitter"
+        case _, hostname if hostname in {"discord.com", "discordapp.com", "discord.gg"}:
+            return "fab fa-discord"
+        case _, hostname if hostname == "google.com" or hostname.endswith(".google.com"):
+            return "fab fa-google"
+
+        case _, hostname if (
+            hostname == "bitbucket.org" or hostname.endswith(".bitbucket.org")
+        ):
+            return "fab fa-bitbucket"
+        case _, hostname if hostname == "reddit.com" or hostname.endswith(".reddit.com"):
+            return "fab fa-reddit-alien"
+        case name, hostname if (
+            name.startswith("slack")
+            or hostname == "slack.com"
+            or hostname.endswith(".slack.com")
+        ):
+            return "fab fa-slack"
+        case _, hostname if (
+            hostname in {"twitter.com", "x.com"}
+            or hostname.endswith((".twitter.com", ".x.com"))
+        ):
+            return "fab fa-twitter"
+        case name, hostname if name == "bluesky" or hostname == "bsky.app":
+            return "fab fa-bluesky"
+
+        case _, hostname if (
+            hostname in {
+                "ci.appveyor.com",
+                "circleci.com",
+                "codecov.io",
+                "coveralls.io",
+                "travis-ci.com",
+                "travis-ci.org",
+            }
+            or hostname.endswith(
+                (
+                    ".appveyor.com",
+                    ".circleci.com",
+                    ".codecov.io",
+                    ".coveralls.io",
+                    ".travis-ci.org",
+                    ".travis-ci.com",
+                )
+            )
+        ):
+            return "fas fa-tasks"
+        case _, hostname if hostname in {
+            "cheeseshop.python.org",
+            "pypi.io",
+            "pypi.org",
+            "pypi.python.org",
+        }:
+            return "fas fa-cube"
+        case _, hostname if hostname == "python.org" or hostname.endswith(".python.org"):
+            return "fab fa-python"
+        case _, hostname if (
+            hostname in {"youtube.com", "youtu.be"}
+            or hostname.endswith((".youtube.com", ".youtu.be"))
+        ):
+            return "fab fa-youtube"
+        case "mastodon", _:
+            return "fab fa-mastodon"
+        case _:
+            return "fas fa-external-link-square-alt"
+
+
 def format_tags(tags):
     # split tags
     if re.search(r",", tags):

--- a/warehouse/templates/includes/packaging/metadata/project-links.html
+++ b/warehouse/templates/includes/packaging/metadata/project-links.html
@@ -1,55 +1,5 @@
 {# SPDX-License-Identifier: Apache-2.0 -#}
-{% macro url_icon(name, url) -%}
-  {% set parsed = url|urlparse %}
-  {% if name|lower == "download" %}
-    {% set icon = "fas fa-cloud-download-alt" %}
-  {% elif name|lower in ["home", "homepage", "home page"] %}
-    {% set icon = "fas fa-home" %}
-  {% elif name|lower in ["changelog", "change log", "changes", "release notes", "news", "what's new", "history"] %}
-    {% set icon = "fas fa-scroll" %}
-  {% elif name.lower().startswith(("docs", "documentation")) or parsed.netloc in ["readthedocs.io", "readthedocs.org", "rtfd.io", "rtfd.org"] or parsed.netloc.endswith((".readthedocs.io", ".readthedocs.org", ".rtfd.io", ".rtfd.org")) or parsed.netloc.startswith(("docs.", "documentation.")) %}
-    {% set icon = "fas fa-book" %}
-  {% elif name.lower().startswith(("bug", "issue", "tracker", "report")) %}
-    {% set icon = "fas fa-bug" %}
-  {% elif name.lower().startswith(("funding", "donate", "donation", "sponsor")) %}
-    {% set icon = "fas fa-donate" %}
-  {% elif parsed.netloc in ["github.com", "github.io"] or parsed.netloc.endswith((".github.com", ".github.io")) %}
-    {% set icon = "fab fa-github" %}
-  {% elif parsed.netloc == "gitlab.com" or parsed.netloc.endswith(".gitlab.com") %}
-    {% set icon = "fab fa-gitlab" %}
-  {% elif parsed.netloc in ["codeberg.org", "codeberg.page"] or parsed.netloc.endswith((".codeberg.org", ".codeberg.page")) %}
-    {% set icon = "fab fa-codeberg" %}
-  {% elif parsed.netloc == "gitter.im" or parsed.netloc.endswith(".gitter.im") %}
-    {% set icon = "fab fa-gitter" %}
-  {% elif parsed.netloc in ["discord.com", "discordapp.com", "discord.gg"] %}
-    {% set icon = "fab fa-discord" %}
-  {% elif parsed.netloc == "google.com" or parsed.netloc.endswith(".google.com") %}
-    {% set icon = "fab fa-google" %}
-  {% elif parsed.netloc == "bitbucket.org" or parsed.netloc.endswith(".bitbucket.org") %}
-    {% set icon = "fab fa-bitbucket" %}
-  {% elif parsed.netloc == "reddit.com" or parsed.netloc.endswith(".reddit.com") %}
-    {% set icon = "fab fa-reddit-alien" %}
-  {% elif name.lower().startswith("slack") or parsed.netloc == "slack.com" or parsed.netloc.endswith(".slack.com") %}
-    {% set icon = "fab fa-slack" %}
-  {% elif parsed.netloc in ["twitter.com", "x.com"] or parsed.netloc.endswith((".twitter.com", ".x.com")) %}
-    {% set icon = "fab fa-twitter" %}
-  {% elif name|lower == "bluesky" or parsed.netloc == "bsky.app" %}
-    {% set icon = "fab fa-bluesky" %}
-  {% elif parsed.netloc in ["ci.appveyor.com", "circleci.com", "codecov.io", "coveralls.io", "travis-ci.com", "travis-ci.org"] or parsed.netloc.endswith((".appveyor.com", ".circleci.com", ".codecov.io", ".coveralls.io", ".travis-ci.org", ".travis-ci.com")) %}
-    {% set icon = "fas fa-tasks" %}
-  {% elif parsed.netloc in ["cheeseshop.python.org", "pypi.io", "pypi.org", "pypi.python.org"] %}
-    {% set icon = "fas fa-cube" %}
-  {% elif parsed.netloc == "python.org" or parsed.netloc.endswith(".python.org") %}
-    {% set icon = "fab fa-python" %}
-  {% elif parsed.netloc in ["youtube.com", "youtu.be"] or parsed.netloc.endswith((".youtube.com", ".youtu.be")) %}
-    {% set icon = "fab fa-youtube" %}
-  {% elif name|lower == "mastodon" %}
-    {% set icon = "fab fa-mastodon" %}
-  {% else %}
-    {% set icon = "fas fa-external-link-square-alt" %}
-  {% endif %}
-  <i class="{{ icon }}" aria-hidden="true"></i>
-{%- endmacro %}
+
 <div class="sidebar-section">
   <h2 class="sidebar-section__title">{% trans %}Project links{% endtrans %}</h2>
   {% if release.urls_by_verify_status(verified=True).values() | contains_valid_uris %}
@@ -68,7 +18,7 @@
           {% for name, url in release.urls_by_verify_status(verified=True).items() %}
             {% if is_valid_uri(url) %}
               <li>
-                <a class="sidebar-links__link" href="{{ url }}" rel="nofollow">{{ url_icon(name, url) }}{{ name }}</a>
+                <a class="sidebar-links__link" href="{{ url }}" rel="nofollow"><i class="{{ url|url_icon(name) }}" aria-hidden="true"></i>{{ name }}</a>
               </li>
             {% endif %}
           {% endfor %}
@@ -82,7 +32,7 @@
         {% for name, url in release.urls_by_verify_status(verified=False).items() %}
           {% if is_valid_uri(url) %}
             <li>
-              <a class="sidebar-links__link" href="{{ url }}" rel="nofollow">{{ url_icon(name, url) }}{{ name }}</a>
+              <a class="sidebar-links__link" href="{{ url }}" rel="nofollow"><i class="{{ url|url_icon(name) }}" aria-hidden="true"></i>{{ name }}</a>
             </li>
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
Fixes  #20354 
## Summary

Move project link icon selection from the template into a reusable `url_icon` template filter, making the logic easier to test and maintain.

## Changes

* Added a `url_icon` filter to `warehouse.filters` containing the project link icon selection logic previously implemented in the Jinja template.
* Registered the new filter in `warehouse.config`.
* Updated `project-links.html` to use the `url_icon` filter instead of the inline Jinja macro.
* Added unit tests covering the supported link types and the fallback icon.

## Testing

Ran `docker compose run --rm tests pytest tests/unit/test_filters.py -k url_icon` — all 21 tests pass.

Ran `docker compose run --rm tests pytest tests/functional/test_templates.py -k render_templates` — all 191 tests pass.

Ran `git diff --check` — no issues.
