### PR TITLE
don't embed system generated caveats in macaroons

### DIFF
--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -154,7 +154,7 @@ class TestDatabaseMacaroonService:
     def test_find_userid_valid_macaroon_trailinglinebreak(self, macaroon_service):
         user = UserFactory.create()
         raw_macaroon, _ = macaroon_service.create_macaroon(
-            "fake location",
+            "a fake location",
             "fake description",
             [caveats.ProjectName(normalized_names=["foo"])],
             user_id=user.id,
@@ -319,12 +319,6 @@ class TestDatabaseMacaroonService:
         assert vm.location == "fake location"
         assert vm.identifier == str(dm.id).encode("utf8")
         assert [c.to_dict() for c in vm.caveats] == [
-            # The embedded RequestUser caveat
-            {
-                "cid": f'[3,"{user.id!s}"]',
-                "cl": None,
-                "vid": None,
-            },
             # The database stored RequestUser caveat
             {
                 "cid": f'[3,"{user.id!s}"]',

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -246,10 +246,6 @@ class DatabaseMacaroonService:
             key=dm.key,
             version=pymacaroons.MACAROON_V2,
         )
-        # TODO: Remove this to stop emitting embedded caveats, which are now
-        #       being stored in the database while still being verified.
-        for caveat in scopes:
-            m.add_first_party_caveat(caveats.serialize(caveat))
         serialized_macaroon = f"pypi-{m.serialize()}"
         return serialized_macaroon, dm
 


### PR DESCRIPTION
With https://github.com/pypi/warehouse/pull/20364 we no longer require that every caveat that we want to apply to a macaroon be embedded into the macaroon itself, as we include the caveats stored in the database as additional caveats that must also be respected.

Currently that is not really being used (other than by hypothetically allowing us to retroactively append additional caveats to all existing macaroons), but this PR changes it so that new macaroons no longer embed our "system generated" caveats into the macaroons themselves, and instead only emit them into the database (where they will get verified still due to https://github.com/pypi/warehouse/pull/20364).

Normally you would not want to risk emitting a macaroon with no caveats (e.g. what if a bad database migration removes all of the db stored caveats), but we do not make it possible to emit "god" macaroons that can do anything they want, every macaroon is scoped to either a user or an OIDC publisher and thus, at most, it's only possible for a macaroon's to impact a single user or OIDC publisher, so the risk is limited.

This PR is safe to revert even after it lands, as long as https://github.com/pypi/warehouse/pull/20364 remains, but once this PR lands we cannot revert https://github.com/pypi/warehouse/pull/20364 without invalidating any macaroons that have been generated without any embedded caveats.

With this change, our API tokens now look like this:

```
pypi-AgEJbG9jYWxob3N0AiQ1ZjFlYzFmZi00Y2E1LTQzMzktOTdkMC1kYWE5NTc0YTY4N2YAAAYg0Ak0ZqmFKl6WMCWSJ74Yyt0afq_jKavzNK1L0ffPyvI
```

This is regardless of how many system generated caveats have been added to the token (of course, end user added caveats will still increase the size of the API token).


**NOTE: I am keeping this PR a draft until https://github.com/pypi/warehouse/pull/20364 has time to bake in production and we make sure there are no surprise issues that crop up.**
