### PR TITLE
refactor: replace XMLPRC JSON cache with stdlib

### DIFF
--- a/tests/unit/legacy/api/xmlrpc/test_cache.py
+++ b/tests/unit/legacy/api/xmlrpc/test_cache.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
+import json
 import types
 
 import celery
 import pytest
 import redis
 
+from packaging.utils import canonicalize_name
 from pyramid.exceptions import ConfigurationError
 
 import warehouse.legacy.api.xmlrpc.cache
@@ -199,6 +202,57 @@ class TestRedisLru:
             func_test, [0, 1], {"kwarg0": 2, "kwarg1": 3}, None, None, None
         )
 
+    def test_stores_compact_json(self, mockredis):
+        """Values land in Redis as compact JSON that ``json.loads`` can read back."""
+        redis_lru = RedisLru(mockredis)
+
+        expected = func_test(0, 1)
+
+        assert redis_lru.fetch(func_test, [0, 1], {}, "[0,1]", None, None) == expected
+
+        stored = mockredis.cache["lru:tag:func_test"]["[0,1]"]
+        assert stored == '[[0,1],{"kwarg0":0,"kwarg1":1}]'
+        assert json.loads(stored) == expected
+
+    def test_stores_non_ascii_escaped(self, mockredis):
+        """Non-ASCII is escaped, keeping serializer output encodable by redis-py.
+
+        `ensure_ascii` is deliberately left at its default: with it disabled, a lone
+        surrogate serializes fine and then fails in redis-py's encoder with a
+        `UnicodeEncodeError`, which `add` does not handle.
+        """
+
+        def unicode_func():
+            return {"name": "日本語"}
+
+        redis_lru = RedisLru(mockredis)
+
+        assert redis_lru.fetch(unicode_func, [], {}, "[]", None, None) == {
+            "name": "日本語"
+        }
+
+        stored = mockredis.cache["lru:tag:unicode_func"]["[]"]
+        assert stored == '{"name":"\\u65e5\\u672c\\u8a9e"}'
+        assert stored.isascii()
+        assert json.loads(stored) == {"name": "日本語"}
+
+    def test_unserializable_value_raises(self, mockredis):
+        """Types the stdlib encoder rejects raise instead of being cached.
+
+        Limitation 1 on `xmlrpc_cache_by_project`. This covers `RedisLru` only; the
+        deriver's own handling of the raise is not exercised here.
+        """
+
+        def datetime_func():
+            return {"submitted": datetime.datetime(2020, 1, 1)}
+
+        redis_lru = RedisLru(mockredis)
+
+        with pytest.raises(TypeError, match="not JSON serializable"):
+            redis_lru.fetch(datetime_func, [], {}, "[]", None, None)
+
+        assert mockredis.cache == {}
+
     def test_redis_custom_metrics(self, metrics, mockredis, mocker):
         redis_lru = RedisLru(mockredis, metric_reporter=metrics)
 
@@ -317,6 +371,53 @@ class TestDeriver:
         derived_view = cached_return_view(view, info)
 
         assert derived_view(mocker.sentinel.context, request) is response
+        view.assert_called_once_with(mocker.sentinel.context, request)
+
+    def test_cache_key_is_a_json_string(self, mockredis, mocker):
+        """The derived cache key is a plain JSON string, used as-is for the hash field.
+
+        Pinned because the key format is part of the on-disk cache layout: changing
+        it orphans every existing entry. Mirrors what `xmlrpc_cache_by_project` and
+        `RedisXMLRPCCache.create_service` pass in production, so the asserted hash
+        name and field are the ones production would write.
+
+        The second call covers the read half of `RedisLru.fetch`, and shows the
+        tuple-to-list divergence documented as limitation 2: a miss returns the
+        view's tuples, a hit returns lists.
+        """
+        service = RedisXMLRPCCache(
+            "redis://127.0.0.2:6379/0", mocker.stub(name="purger"), name="xmlrpc"
+        )
+        service.redis_lru.conn = mockredis
+        fetch = mocker.spy(service, "fetch")
+        request = types.SimpleNamespace(
+            find_service=mocker.Mock(return_value=service),
+            rpc_method="package_roles",
+            rpc_args=("Django",),
+        )
+        view = mocker.Mock(
+            return_value=[("Owner", "someone")], __name__="package_roles"
+        )
+        info = types.SimpleNamespace(
+            options={
+                "xmlrpc_cache": True,
+                "xmlrpc_cache_tag": "project/%s",
+                "xmlrpc_cache_arg_index": 0,
+                "xmlrpc_cache_tag_processor": canonicalize_name,
+            },
+            exception_only=False,
+        )
+        derived_view = cached_return_view(view, info)
+
+        miss = derived_view(mocker.sentinel.context, request)
+        hit = derived_view(mocker.sentinel.context, request)
+
+        assert fetch.call_args.args[3] == '["Django"]'
+        assert mockredis.cache["xmlrpc:project/django:package_roles"] == {
+            '["Django"]': '[["Owner","someone"]]'
+        }
+        assert miss == [("Owner", "someone")]
+        assert hit == [["Owner", "someone"]]
         view.assert_called_once_with(mocker.sentinel.context, request)
 
     @pytest.mark.parametrize(

--- a/warehouse/legacy/api/xmlrpc/cache/derivers.py
+++ b/warehouse/legacy/api/xmlrpc/cache/derivers.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import orjson
+import json
 
 from warehouse.legacy.api.xmlrpc.cache import interfaces
 
@@ -21,7 +21,7 @@ def cached_return_view(view, info):
             except LookupError:
                 return view(context, request)
             try:
-                key = orjson.dumps(request.rpc_args[slice_obj])
+                key = json.dumps(request.rpc_args[slice_obj], separators=(",", ":"))
                 _tag = tag
                 if arg_index is not None:
                     _tag = tag % (tag_processor(str(request.rpc_args[arg_index])))

--- a/warehouse/legacy/api/xmlrpc/cache/fncache.py
+++ b/warehouse/legacy/api/xmlrpc/cache/fncache.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import orjson
+import json
+
 import redis
 
 from warehouse.legacy.api.xmlrpc.cache.interfaces import CacheError
@@ -16,7 +17,13 @@ class StubMetricReporter:
 class RedisLru:
     """
     Redis backed LRU cache for functions which return an object which
-    can survive orjson.dumps() and orjson.loads() intact
+    can survive json.dumps() and json.loads() intact.
+
+    Note the "intact" constraint is narrower than it looks: tuples come back as
+    lists, scalar dict keys are coerced to strings without complaint, and
+    anything the stdlib encoder cannot handle (datetime, date, time, UUID,
+    Decimal) raises TypeError on write. See the caveats documented on
+    `xmlrpc_cache_by_project` in warehouse/legacy/api/xmlrpc/views.py.
     """
 
     def __init__(self, conn, name="lru", expires=None, metric_reporter=None):
@@ -47,7 +54,7 @@ class RedisLru:
             return None
         if value:
             self.metric_reporter.increment(f"warehouse.{self.name}.cache.hit")
-            value = orjson.loads(value)
+            value = json.loads(value)
         return value
 
     def add(self, func_name, key, value, tag, expires):
@@ -55,7 +62,12 @@ class RedisLru:
             self.metric_reporter.increment(f"warehouse.{self.name}.cache.miss")
             pipeline = self.conn.pipeline()
             pipeline.hset(
-                self.format_key(func_name, tag), str(key), orjson.dumps(value)
+                self.format_key(func_name, tag),
+                str(key),
+                # `ensure_ascii` is left at its default so the serializer output is
+                # always encodable: redis-py raises UnicodeEncodeError on lone
+                # surrogates, which is not a RedisError and escapes the handler below.
+                json.dumps(value, separators=(",", ":")),
             )
             ttl = expires or self.expires
             pipeline.expire(self.format_key(func_name, tag), ttl)

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -157,6 +157,45 @@ def xmlrpc_method(**kwargs):
     return decorator
 
 
+# Caching wrappers for XML-RPC methods. Both store the view's return value in
+# Redis as JSON (see `warehouse.legacy.api.xmlrpc.cache`), so a view is only safe
+# to wrap if its return value survives a `json.dumps()`/`json.loads()` round
+# trip. Known limitations, roughly in order of how likely they are to bite:
+#
+# 1. Types the stdlib encoder rejects raise `TypeError` from inside the view
+#    deriver, and nothing catches it: the RPC call fails outright instead of
+#    degrading to an uncached response, after the view has already done its
+#    work. `datetime`, `date`, `time`, `UUID` and `Decimal` are all in this
+#    bucket, so convert them before wrapping a view -- see the POSIX-integer
+#    conversion in `changelog_since_serial`.
+#
+# 2. Tuples come back as lists. `xmlrpc.client` marshals both to `<array>`, so
+#    the wire format is unchanged, but a hit and a miss hand different Python
+#    types to any in-process caller.
+#
+# 3. Non-str dict keys are coerced silently, so `{1: "a"}` caches as
+#    `{"1": "a"}` and a hit no longer matches a miss. `float("nan")` and
+#    `float("inf")` serialize to the non-standard `NaN`/`Infinity` literals,
+#    which round-trip through our own cache but are not valid JSON.
+#
+# 4. Falsy results are never hits. `RedisLru.fetch` is `get(...) or add(...)`,
+#    so a view returning `[]`, `{}`, `0` or `None` re-runs its query on every
+#    request and rewrites the same entry each time.
+#
+# 5. The cache key is the JSON-encoded arguments verbatim while the purge tag is
+#    canonicalized, so `package_roles("Django")` and `package_roles("django")`
+#    occupy separate entries holding identical data. Both are purged together.
+#
+# 6. Invalidation is only as good as the `purge_keys` registered for the models
+#    a view reads (see `warehouse.packaging.includeme`). Wrapping a view whose
+#    result depends on a model with no matching purge key leaves it stale for up
+#    to `xmlrpc_cache_expires`.
+#
+# 7. Changing the serializer or the key format invalidates everything, and the
+#    orphans are not self-cleaning: `add` re-`expire`s the whole hash on every
+#    write, and Redis EXPIRE replaces the existing TTL, so a field written in the
+#    old format survives as long as any field in that hash keeps being written.
+#    `RedisLru` has no `hdel`, so only a `purge_tag` or Redis eviction clears it.
 xmlrpc_cache_by_project = functools.partial(
     xmlrpc_method,
     xmlrpc_cache=True,


### PR DESCRIPTION
Replace the usage of `orjson` for standard library's `json` to avoid deeply-nested XML artifacts from overflowing during cache deserialization operations.