### PR TITLE
Add snapshot tests for the HTML representation freeze

### DIFF
--- a/docs/dev/development/getting-started.md
+++ b/docs/dev/development/getting-started.md
@@ -293,7 +293,7 @@ The password for every account has been set to the string `password`.
 Using different accounts will allow you to see different parts of the site,
 and have slightly different experiences.
 
-Note that there are no Moderator accounts in the dev db. Any Superuser can 
+Note that there are no Moderator accounts in the dev db. Any Superuser can
 change a user to a moderator if needed.
 
 #### TOTP and Recovery Codes
@@ -303,7 +303,7 @@ To generate a TOTP token, run the following from your terminal:
 ```shell
 make totp
 ```
-Alternatively, you can scan the QR code below to add these accounts to 
+Alternatively, you can scan the QR code below to add these accounts to
 your authenticator app:
 
 ![TOTP QR Code](../assets/warehouse_admin_totp.png){ width="100" }
@@ -323,7 +323,7 @@ edc6ce3800c0fc94 -- burned
 
 #### Email Verification
 
-Auth verification emails are output to the console, or can be accessed 
+Auth verification emails are output to the console, or can be accessed
 from http://localhost:1080.
 
 See [Testing Emails](email.md#testing-e-mails) for more information.
@@ -763,6 +763,25 @@ formatting and linting. You can reformat with:
 
 ```shell
 make reformat
+```
+
+### Updating snapshots
+
+Some of Warehouse's tests make use of snapshots, specifically via the
+[inline_snapshot](https://15r10nk.github.io/inline-snapshot/) library.
+
+While running the tests in parallel, you may encounter a message like this:
+
+```
+INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but
+snapshot(x) will only return x and inline-snapshot will not be able to fix snapshots or generate reports.
+```
+
+If you need to update a specific snapshot, you can do so by selecting its module, which will
+disable test parallelism and enable the snapshot approval dialogue. For example:
+
+```shell
+T=tests/functional/api/test_simple.py make tests
 ```
 
 ## Building translations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ exclude_also = [
   "class \\w+\\(Interface\\):",
   "if (typing\\.)?TYPE_CHECKING:",
   "if __name__ == .__main__.:",
-  "pytest.fail\\(",  # Use for test branches that should never be reached.
+  "pytest.fail\\(",                # Use for test branches that should never be reached.
   # Remove once resolved: https://github.com/nedbat/coveragepy/issues/1563
   "case _:\\n\\s*pytest\\.fail\\(",
 ]
@@ -77,29 +77,29 @@ cache_dir = ".cache/mypy"
 [[tool.mypy.overrides]]
 # These modules do not yet have types available.
 module = [
-  "bpython.*",  # https://github.com/bpython/bpython/issues/892
-  "b2sdk.*",  # https://github.com/Backblaze/b2-sdk-python/issues/148
-  "celery.app.backends.*",  # https://github.com/celery/celery/issues/7394
-  "celery.backends.redis.*",  # https://github.com/celery/celery/issues/7394
-  "cgi.*",  # legacy stdlib module for webob, installed via `legacy_cgi` package
+  "bpython.*",               # https://github.com/bpython/bpython/issues/892
+  "b2sdk.*",                 # https://github.com/Backblaze/b2-sdk-python/issues/148
+  "celery.app.backends.*",   # https://github.com/celery/celery/issues/7394
+  "celery.backends.redis.*", # https://github.com/celery/celery/issues/7394
+  "cgi.*",                   # legacy stdlib module for webob, installed via `legacy_cgi` package
   "google.cloud.storage.*",  # https://github.com/googleapis/python-storage/issues/393
   "forcediphttpsadapter.*",
-  "IPython.*",  # has types, but only installed in dev
-  "packaging_legacy.*",  # https://github.com/di/packaging_legacy/pull/5
+  "IPython.*",               # has types, but only installed in dev
+  "packaging_legacy.*",      # https://github.com/di/packaging_legacy/pull/5
   "paginate.*",
   "paginate_sqlalchemy.*",
   "premailer.*",
-  "pymacaroons.*",  # https://github.com/ecordell/pymacaroons/issues/41
-  "pyramid.*",  # https://github.com/Pylons/pyramid/issues/2638
+  "pymacaroons.*",           # https://github.com/ecordell/pymacaroons/issues/41
+  "pyramid.*",               # https://github.com/Pylons/pyramid/issues/2638
   "pyramid_jinja2.*",
   "pyramid_mailer.*",
   "pyramid_retry.*",
   "pyramid_rpc.*",
   "pyqrcode.*",
-  "rfc3986.*",  # https://github.com/python-hyper/rfc3986/issues/122
+  "rfc3986.*",               # https://github.com/python-hyper/rfc3986/issues/122
   "transaction.*",
   "venusian.*",
-  "whitenoise.*",  # https://github.com/evansd/whitenoise/pull/410
+  "whitenoise.*",            # https://github.com/evansd/whitenoise/pull/410
   "zope.sqlalchemy.*",
 ]
 ignore_missing_imports = true
@@ -156,31 +156,31 @@ target-version = "py314"
 select = ["ALL"]
 ignore = [
   "RUF012",  # this lint triggers in cases where it's impossible for us to fix it
-  "TC",  # the circular imports in our db models breaks this
+  "TC",      # the circular imports in our db models breaks this
   "PIE807",  # turns `lambda: dict()` into just `dict`, which changes the signature
-  "FIX",  # we regularly leave TODO comments in the code, which this rejects
-  "TD",  # this wants TODO comments to have author and link, which we don't do
-  "ERA",  # this has a REALLY high false positive rate
-  "ANN",  # requires typing annotations, which has almost 15k errors for us
-  "S101",  # We use assert in the test suite, but more importantly for type narrowing
-  "FBT",  # rejects boolean params that change function behavior, requires api changes
-  "B019",  # we have some uses of this, we should probably fix them
-  "B904",  # rejects raise without from, requires manual review
-  "A",  # rejects shadowing builtins, which we do a bit and would need closer review
-  "SLF",  # rejects using _private items, would need careful review to add
-  "DTZ",  # prevents using naive datetimes, probably useful, but needs manual review
-  "TRY",  # would require reworking some of our exceptions to make this work
-  "EM",  # would require reworking some of our exceptions to make this work
-  "PLR0911",  # too many return statements; I'm suspect on the value of the "too many X" rules
-  "PLR0912",  # too many branches; I'm suspect on the value of the "too many X" rules
-  "PLR0913",  # too many arguments; I'm suspect on the value of the "too many X" rules
-  "PLR0915",  # too many statements; I'm suspect on the value of the "too many X" rules
-  "PLR2004",  # we use a lot of magic values, maybe we shouldn't but for now allow it
-  "PLW1641",  # we don't need every object to implement __hash__
-  "PTH",  # tries to enforce pathlib, but most of our paths are abstract urls/keys
-  "ARG",  # rejects unused arguments, but we have to have them in a lot of places
-  "C90",  # enforces mccabe complexity, adding would require refactoring
-  "D",  # requires doc strings, super high error rate for us and not much value
+  "FIX",     # we regularly leave TODO comments in the code, which this rejects
+  "TD",      # this wants TODO comments to have author and link, which we don't do
+  "ERA",     # this has a REALLY high false positive rate
+  "ANN",     # requires typing annotations, which has almost 15k errors for us
+  "S101",    # We use assert in the test suite, but more importantly for type narrowing
+  "FBT",     # rejects boolean params that change function behavior, requires api changes
+  "B019",    # we have some uses of this, we should probably fix them
+  "B904",    # rejects raise without from, requires manual review
+  "A",       # rejects shadowing builtins, which we do a bit and would need closer review
+  "SLF",     # rejects using _private items, would need careful review to add
+  "DTZ",     # prevents using naive datetimes, probably useful, but needs manual review
+  "TRY",     # would require reworking some of our exceptions to make this work
+  "EM",      # would require reworking some of our exceptions to make this work
+  "PLR0911", # too many return statements; I'm suspect on the value of the "too many X" rules
+  "PLR0912", # too many branches; I'm suspect on the value of the "too many X" rules
+  "PLR0913", # too many arguments; I'm suspect on the value of the "too many X" rules
+  "PLR0915", # too many statements; I'm suspect on the value of the "too many X" rules
+  "PLR2004", # we use a lot of magic values, maybe we shouldn't but for now allow it
+  "PLW1641", # we don't need every object to implement __hash__
+  "PTH",     # tries to enforce pathlib, but most of our paths are abstract urls/keys
+  "ARG",     # rejects unused arguments, but we have to have them in a lot of places
+  "C90",     # enforces mccabe complexity, adding would require refactoring
+  "D",       # requires doc strings, super high error rate for us and not much value
   "COM812",  # incompatible with the formatter, no idea why this even exists
   "COM819",  # redundant with the formatter, also no idea why this even exists
 ]
@@ -209,14 +209,14 @@ ignore = [
 "tests/unit/test_views.py" = ["PT009"]
 
 "tests/**/*.py" = [
-  "TID252",  # pretty much all of our tests use relative imports
-  "S104",  # tests use 0.0.0.0 as a sentinel value sometimes
-  "S105",  # tests aren't used in production and can use hardcoded pws for tests
-  "S106",  # tests aren't used in production and can use hardcoded pws for tests
-  "S108",  # tests use hardcoded tmp paths that get stubbed out
-  "S303",  # strength of the hash functions used in tests doesn't matter
-  "S311",  # tests don't need cryptographically strong randomness
-  "S324"  # strength of the hash functions used in tests doesn't matter
+  "TID252", # pretty much all of our tests use relative imports
+  "S104",   # tests use 0.0.0.0 as a sentinel value sometimes
+  "S105",   # tests aren't used in production and can use hardcoded pws for tests
+  "S106",   # tests aren't used in production and can use hardcoded pws for tests
+  "S108",   # tests use hardcoded tmp paths that get stubbed out
+  "S303",   # strength of the hash functions used in tests doesn't matter
+  "S311",   # tests don't need cryptographically strong randomness
+  "S324",   # strength of the hash functions used in tests doesn't matter
 ]
 
 [tool.ruff.lint.isort]
@@ -236,3 +236,6 @@ classmethod-decorators = [
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "urllib.parse.urlparse".msg = "Prefer `urllib3.util.parse_url` over `urllib.parse.urlparse`"
+
+[tool.inline-snapshot]
+format-command = "ruff format --stdin-filename {filename}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ exclude_also = [
   "class \\w+\\(Interface\\):",
   "if (typing\\.)?TYPE_CHECKING:",
   "if __name__ == .__main__.:",
-  "pytest.fail\\(",                # Use for test branches that should never be reached.
+  "pytest.fail\\(",  # Use for test branches that should never be reached.
   # Remove once resolved: https://github.com/nedbat/coveragepy/issues/1563
   "case _:\\n\\s*pytest\\.fail\\(",
 ]
@@ -65,6 +65,9 @@ extend_exclude = "warehouse/templates/api/simple/*"
 # T028: Handled by warehouse config. See: https://github.com/pypi/warehouse/pull/14709
 ignore = "H006,T002,T003,T028"
 
+[tool.inline-snapshot]
+format-command = "ruff format --stdin-filename {filename}"
+
 [tool.mypy]
 python_version = "3.14"
 warn_unreachable = true
@@ -77,29 +80,29 @@ cache_dir = ".cache/mypy"
 [[tool.mypy.overrides]]
 # These modules do not yet have types available.
 module = [
-  "bpython.*",               # https://github.com/bpython/bpython/issues/892
-  "b2sdk.*",                 # https://github.com/Backblaze/b2-sdk-python/issues/148
-  "celery.app.backends.*",   # https://github.com/celery/celery/issues/7394
-  "celery.backends.redis.*", # https://github.com/celery/celery/issues/7394
-  "cgi.*",                   # legacy stdlib module for webob, installed via `legacy_cgi` package
+  "bpython.*",  # https://github.com/bpython/bpython/issues/892
+  "b2sdk.*",  # https://github.com/Backblaze/b2-sdk-python/issues/148
+  "celery.app.backends.*",  # https://github.com/celery/celery/issues/7394
+  "celery.backends.redis.*",  # https://github.com/celery/celery/issues/7394
+  "cgi.*",  # legacy stdlib module for webob, installed via `legacy_cgi` package
   "google.cloud.storage.*",  # https://github.com/googleapis/python-storage/issues/393
   "forcediphttpsadapter.*",
-  "IPython.*",               # has types, but only installed in dev
-  "packaging_legacy.*",      # https://github.com/di/packaging_legacy/pull/5
+  "IPython.*",  # has types, but only installed in dev
+  "packaging_legacy.*",  # https://github.com/di/packaging_legacy/pull/5
   "paginate.*",
   "paginate_sqlalchemy.*",
   "premailer.*",
-  "pymacaroons.*",           # https://github.com/ecordell/pymacaroons/issues/41
-  "pyramid.*",               # https://github.com/Pylons/pyramid/issues/2638
+  "pymacaroons.*",  # https://github.com/ecordell/pymacaroons/issues/41
+  "pyramid.*",  # https://github.com/Pylons/pyramid/issues/2638
   "pyramid_jinja2.*",
   "pyramid_mailer.*",
   "pyramid_retry.*",
   "pyramid_rpc.*",
   "pyqrcode.*",
-  "rfc3986.*",               # https://github.com/python-hyper/rfc3986/issues/122
+  "rfc3986.*",  # https://github.com/python-hyper/rfc3986/issues/122
   "transaction.*",
   "venusian.*",
-  "whitenoise.*",            # https://github.com/evansd/whitenoise/pull/410
+  "whitenoise.*",  # https://github.com/evansd/whitenoise/pull/410
   "zope.sqlalchemy.*",
 ]
 ignore_missing_imports = true
@@ -156,31 +159,31 @@ target-version = "py314"
 select = ["ALL"]
 ignore = [
   "RUF012",  # this lint triggers in cases where it's impossible for us to fix it
-  "TC",      # the circular imports in our db models breaks this
+  "TC",  # the circular imports in our db models breaks this
   "PIE807",  # turns `lambda: dict()` into just `dict`, which changes the signature
-  "FIX",     # we regularly leave TODO comments in the code, which this rejects
-  "TD",      # this wants TODO comments to have author and link, which we don't do
-  "ERA",     # this has a REALLY high false positive rate
-  "ANN",     # requires typing annotations, which has almost 15k errors for us
-  "S101",    # We use assert in the test suite, but more importantly for type narrowing
-  "FBT",     # rejects boolean params that change function behavior, requires api changes
-  "B019",    # we have some uses of this, we should probably fix them
-  "B904",    # rejects raise without from, requires manual review
-  "A",       # rejects shadowing builtins, which we do a bit and would need closer review
-  "SLF",     # rejects using _private items, would need careful review to add
-  "DTZ",     # prevents using naive datetimes, probably useful, but needs manual review
-  "TRY",     # would require reworking some of our exceptions to make this work
-  "EM",      # would require reworking some of our exceptions to make this work
-  "PLR0911", # too many return statements; I'm suspect on the value of the "too many X" rules
-  "PLR0912", # too many branches; I'm suspect on the value of the "too many X" rules
-  "PLR0913", # too many arguments; I'm suspect on the value of the "too many X" rules
-  "PLR0915", # too many statements; I'm suspect on the value of the "too many X" rules
-  "PLR2004", # we use a lot of magic values, maybe we shouldn't but for now allow it
-  "PLW1641", # we don't need every object to implement __hash__
-  "PTH",     # tries to enforce pathlib, but most of our paths are abstract urls/keys
-  "ARG",     # rejects unused arguments, but we have to have them in a lot of places
-  "C90",     # enforces mccabe complexity, adding would require refactoring
-  "D",       # requires doc strings, super high error rate for us and not much value
+  "FIX",  # we regularly leave TODO comments in the code, which this rejects
+  "TD",  # this wants TODO comments to have author and link, which we don't do
+  "ERA",  # this has a REALLY high false positive rate
+  "ANN",  # requires typing annotations, which has almost 15k errors for us
+  "S101",  # We use assert in the test suite, but more importantly for type narrowing
+  "FBT",  # rejects boolean params that change function behavior, requires api changes
+  "B019",  # we have some uses of this, we should probably fix them
+  "B904",  # rejects raise without from, requires manual review
+  "A",  # rejects shadowing builtins, which we do a bit and would need closer review
+  "SLF",  # rejects using _private items, would need careful review to add
+  "DTZ",  # prevents using naive datetimes, probably useful, but needs manual review
+  "TRY",  # would require reworking some of our exceptions to make this work
+  "EM",  # would require reworking some of our exceptions to make this work
+  "PLR0911",  # too many return statements; I'm suspect on the value of the "too many X" rules
+  "PLR0912",  # too many branches; I'm suspect on the value of the "too many X" rules
+  "PLR0913",  # too many arguments; I'm suspect on the value of the "too many X" rules
+  "PLR0915",  # too many statements; I'm suspect on the value of the "too many X" rules
+  "PLR2004",  # we use a lot of magic values, maybe we shouldn't but for now allow it
+  "PLW1641",  # we don't need every object to implement __hash__
+  "PTH",  # tries to enforce pathlib, but most of our paths are abstract urls/keys
+  "ARG",  # rejects unused arguments, but we have to have them in a lot of places
+  "C90",  # enforces mccabe complexity, adding would require refactoring
+  "D",  # requires doc strings, super high error rate for us and not much value
   "COM812",  # incompatible with the formatter, no idea why this even exists
   "COM819",  # redundant with the formatter, also no idea why this even exists
 ]
@@ -209,14 +212,14 @@ ignore = [
 "tests/unit/test_views.py" = ["PT009"]
 
 "tests/**/*.py" = [
-  "TID252", # pretty much all of our tests use relative imports
-  "S104",   # tests use 0.0.0.0 as a sentinel value sometimes
-  "S105",   # tests aren't used in production and can use hardcoded pws for tests
-  "S106",   # tests aren't used in production and can use hardcoded pws for tests
-  "S108",   # tests use hardcoded tmp paths that get stubbed out
-  "S303",   # strength of the hash functions used in tests doesn't matter
-  "S311",   # tests don't need cryptographically strong randomness
-  "S324",   # strength of the hash functions used in tests doesn't matter
+  "TID252",  # pretty much all of our tests use relative imports
+  "S104",  # tests use 0.0.0.0 as a sentinel value sometimes
+  "S105",  # tests aren't used in production and can use hardcoded pws for tests
+  "S106",  # tests aren't used in production and can use hardcoded pws for tests
+  "S108",  # tests use hardcoded tmp paths that get stubbed out
+  "S303",  # strength of the hash functions used in tests doesn't matter
+  "S311",  # tests don't need cryptographically strong randomness
+  "S324",  # strength of the hash functions used in tests doesn't matter
 ]
 
 [tool.ruff.lint.isort]
@@ -236,6 +239,3 @@ classmethod-decorators = [
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "urllib.parse.urlparse".msg = "Prefer `urllib3.util.parse_url` over `urllib.parse.urlparse`"
-
-[tool.inline-snapshot]
-format-command = "ruff format --stdin-filename {filename}"

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,6 +1,7 @@
 coverage
 factory_boy
 freezegun
+inline-snapshot==0.35.3
 pretend
 pytest
 pytest-icdiff

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,7 +1,7 @@
 coverage
 factory_boy
 freezegun
-inline-snapshot==0.35.3
+inline-snapshot
 pretend
 pytest
 pytest-icdiff

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements/tests.txt requirements/tests.in
 #
+asttokens==3.0.2 \
+    --hash=sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2 \
+    --hash=sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933
+    # via inline-snapshot
 beautifulsoup4==4.15.0 \
     --hash=sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7 \
     --hash=sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9
@@ -255,6 +259,10 @@ execnet==2.1.2 \
     --hash=sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd \
     --hash=sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec
     # via pytest-xdist
+executing==2.2.1 \
+    --hash=sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4 \
+    --hash=sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017
+    # via inline-snapshot
 factory-boy==3.3.3 \
     --hash=sha256:1c39e3289f7e667c4285433f305f8d506efc2fe9c73aaea4151ebd5cdea394fc \
     --hash=sha256:866862d226128dfac7f2b4160287e899daf54f2612778327dd03d0e2cb1e3d03
@@ -279,10 +287,22 @@ iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
     --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
     # via pytest
+inline-snapshot==0.35.3 \
+    --hash=sha256:3decb255b15d6f5956fbc0648c56acf6ceeb9a331b26868e3bf16d2a393c2e31 \
+    --hash=sha256:5d76f3b4b134fb190b7883669eb496f5c3e7d1c9549bbd6d78b5b8ac17e553e3
+    # via -r requirements/tests.in
 legacy-cgi==2.6.4 \
     --hash=sha256:7e235ce58bf1e25d1fc9b2d299015e4e2cd37305eccafec1e6bac3fc04b878cd \
     --hash=sha256:abb9dfc7835772f7c9317977c63253fd22a7484b5c9bbcdca60a29dcce97c577
     # via webob
+markdown-it-py==4.2.0 \
+    --hash=sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49 \
+    --hash=sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
+    # via rich
+mdurl==0.1.2 \
+    --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
+    --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
+    # via markdown-it-py
 mirakuru==3.0.2 \
     --hash=sha256:10e5dac4a8f26872c63e9cdfdc01b775aaa2beb3ced98abc497279d2dc525b8f \
     --hash=sha256:21192186a8680ea7567ca68170261df3785768b12962dd19fe8cccab15ad3441
@@ -339,12 +359,15 @@ psycopg==3.3.4 \
 pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
-    # via pytest
+    # via
+    #   pytest
+    #   rich
 pytest==9.1.1 \
     --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
     --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
     # via
     #   -r requirements/tests.in
+    #   inline-snapshot
     #   pytest-icdiff
     #   pytest-mock
     #   pytest-postgresql
@@ -471,6 +494,10 @@ responses==0.26.1 \
     --hash=sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2 \
     --hash=sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345
     # via -r requirements/tests.in
+rich==15.0.0 \
+    --hash=sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb \
+    --hash=sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36
+    # via inline-snapshot
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
@@ -486,7 +513,9 @@ termcolor==3.3.0 \
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
-    # via beautifulsoup4
+    # via
+    #   beautifulsoup4
+    #   inline-snapshot
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897

--- a/tests/functional/api/test_simple.py
+++ b/tests/functional/api/test_simple.py
@@ -3,6 +3,7 @@
 from http import HTTPStatus
 
 from warehouse.api.simple import MIME_PYPI_SIMPLE_V1_JSON
+from inline_snapshot import snapshot
 
 from ...common.db.packaging import (
     FileFactory,
@@ -10,8 +11,6 @@ from ...common.db.packaging import (
     ProvenanceFactory,
     ReleaseFactory,
 )
-
-from inline_snapshot import snapshot
 
 
 def test_simple_api_html(webtest):

--- a/tests/functional/api/test_simple.py
+++ b/tests/functional/api/test_simple.py
@@ -2,9 +2,9 @@
 
 from http import HTTPStatus
 
-from warehouse.api.simple import MIME_PYPI_SIMPLE_V1_JSON
 from inline_snapshot import snapshot
 
+from warehouse.api.simple import MIME_PYPI_SIMPLE_V1_JSON
 from warehouse.packaging.models import LifecycleStatus
 
 from ...common.db.packaging import (

--- a/tests/functional/api/test_simple.py
+++ b/tests/functional/api/test_simple.py
@@ -11,6 +11,8 @@ from ...common.db.packaging import (
     ReleaseFactory,
 )
 
+from inline_snapshot import snapshot
+
 
 def test_simple_api_html(webtest):
     resp = webtest.get("/simple/", status=HTTPStatus.OK)
@@ -81,3 +83,62 @@ def test_simple_api_has_provenance(webtest):
             f"http://localhost/integrity/{file.release.project.normalized_name}/"
             f"{file.release.version}/{file.filename}/provenance"
         )
+
+
+def test_pep833_simple_api_base_html_frozen(webtest):
+    """
+    WARNING! PEP 833 freezes the HTML representation of the simple API;
+    this test backstops that freeze by ensuring that we don't accidentally
+    the HTML representation.
+
+    If you're *intentionally* changing the HTML representation, even
+    just the whitespace, make sure you have a good reason for doing do!
+    """
+
+    resp = webtest.get("/simple/", status=HTTPStatus.OK)
+
+    assert resp.text == snapshot("""\
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="pypi:repository-version" content="1.4">
+    <title>Simple index</title>
+  </head>
+  <body>
+</body>
+</html>\
+""")
+
+
+def test_pep833_simple_api_detail_html_frozen(webtest):
+    """
+    WARNING! PEP 833 freezes the HTML representation of the simple API;
+    this test backstops that freeze by ensuring that we don't accidentally
+    the HTML representation.
+
+    If you're *intentionally* changing the HTML representation, even
+    just the whitespace, make sure you have a good reason for doing do!
+    """
+
+    project = ProjectFactory.create(name="example")
+    release = ReleaseFactory.create(project=project, version="1.0.0")
+    FileFactory.create(
+        filename="example-1.0.0.tar.gz", release=release, packagetype="sdist"
+    )
+
+    resp = webtest.get(f"/simple/{project.normalized_name}/", status=HTTPStatus.OK)
+
+    assert resp.text == snapshot("""\
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="pypi:repository-version" content="1.4">
+<meta name="pypi:project-status" content="active">    <title>Links for example</title>
+  </head>
+  <body>
+    <h1>Links for example</h1>
+<a href="http://localhost:7000/#sha256=7e657eb56fc128fcfbbc8c6c613f4b67ae589e93871c96aeb502754bbf24987f" >example-1.0.0.tar.gz</a><br />
+</body>
+</html>
+<!--SERIAL 0-->\
+""")

--- a/tests/functional/api/test_simple.py
+++ b/tests/functional/api/test_simple.py
@@ -5,6 +5,8 @@ from http import HTTPStatus
 from warehouse.api.simple import MIME_PYPI_SIMPLE_V1_JSON
 from inline_snapshot import snapshot
 
+from warehouse.packaging.models import LifecycleStatus
+
 from ...common.db.packaging import (
     FileFactory,
     ProjectFactory,
@@ -119,6 +121,7 @@ def test_pep833_simple_api_detail_html_frozen(webtest):
     just the whitespace, make sure you have a good reason for doing do!
     """
 
+    # Basic example.
     project = ProjectFactory.create(name="example")
     release = ReleaseFactory.create(project=project, version="1.0.0")
     FileFactory.create(
@@ -137,6 +140,35 @@ def test_pep833_simple_api_detail_html_frozen(webtest):
   <body>
     <h1>Links for example</h1>
 <a href="http://localhost:7000/#sha256=7e657eb56fc128fcfbbc8c6c613f4b67ae589e93871c96aeb502754bbf24987f" >example-1.0.0.tar.gz</a><br />
+</body>
+</html>
+<!--SERIAL 0-->\
+""")  # noqa: E501
+
+    # A slightly less basic example, with a project status and requires-python marker.
+    project = ProjectFactory.create(
+        name="example2",
+        lifecycle_status=LifecycleStatus.Archived,
+    )
+    release = ReleaseFactory.create(
+        project=project, version="1.0.0", requires_python=">=3.14"
+    )
+    FileFactory.create(
+        filename="example2-1.0.0.tar.gz", release=release, packagetype="sdist"
+    )
+
+    resp = webtest.get(f"/simple/{project.normalized_name}/", status=HTTPStatus.OK)
+
+    assert resp.text == snapshot("""\
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="pypi:repository-version" content="1.4">
+<meta name="pypi:project-status" content="archived">    <title>Links for example2</title>
+  </head>
+  <body>
+    <h1>Links for example2</h1>
+<a href="http://localhost:7000/#sha256=a1dce4642866a610552fab0817cc7926f12d9ecc11f7016eb07bd5e721cee61e" data-requires-python="&gt;=3.14" >example2-1.0.0.tar.gz</a><br />
 </body>
 </html>
 <!--SERIAL 0-->\

--- a/tests/functional/api/test_simple.py
+++ b/tests/functional/api/test_simple.py
@@ -121,31 +121,6 @@ def test_pep833_simple_api_detail_html_frozen(webtest):
     just the whitespace, make sure you have a good reason for doing do!
     """
 
-    # Basic example.
-    project = ProjectFactory.create(name="example")
-    release = ReleaseFactory.create(project=project, version="1.0.0")
-    FileFactory.create(
-        filename="example-1.0.0.tar.gz", release=release, packagetype="sdist"
-    )
-
-    resp = webtest.get(f"/simple/{project.normalized_name}/", status=HTTPStatus.OK)
-
-    assert resp.text == snapshot("""\
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta name="pypi:repository-version" content="1.4">
-<meta name="pypi:project-status" content="active">    <title>Links for example</title>
-  </head>
-  <body>
-    <h1>Links for example</h1>
-<a href="http://localhost:7000/#sha256=7e657eb56fc128fcfbbc8c6c613f4b67ae589e93871c96aeb502754bbf24987f" >example-1.0.0.tar.gz</a><br />
-</body>
-</html>
-<!--SERIAL 0-->\
-""")  # noqa: E501
-
-    # A slightly less basic example, with a project status and requires-python marker.
     project = ProjectFactory.create(
         name="example2",
         lifecycle_status=LifecycleStatus.Archived,

--- a/tests/functional/api/test_simple.py
+++ b/tests/functional/api/test_simple.py
@@ -140,4 +140,4 @@ def test_pep833_simple_api_detail_html_frozen(webtest):
 </body>
 </html>
 <!--SERIAL 0-->\
-""")
+""")  # noqa: E501


### PR DESCRIPTION
Closes #20374.

I've used `inline-snapshot` for this, although if others don't think it's worthwhile as a new dep for just this case then it'd be trivial to drop and replace with a normal comparison.

Also noting: we already had some functional tests for the simple API, but I've intentionally written these as new tests to emphasize their singular role/apartness.