### PR TITLE
docs: update link to ActiveState's Trusted Publishing docs

### DIFF
--- a/docs/user/trusted-publishers/using-a-publisher.md
+++ b/docs/user/trusted-publishers/using-a-publisher.md
@@ -271,7 +271,7 @@ below describe the setup process for each supported Trusted Publisher.
     dependencies to automatically build cross-platform wheels of your PyPI
     projects. Once you're set up on the Platform and have linked your PyPI project,
     you're ready to publish. For more information on getting started with
-    ActiveState, go [here](https://docs.activestate.com/platform/start/pypi/). To
+    ActiveState, go [here](https://docs.activestate.com/platform/open-source-collaboration/pypi/). To
     begin:
 
     Publish your package to ActiveState's catalog. This will allow


### PR DESCRIPTION
The old link is 404ing, not sure when this was changed.