### PR TITLE
fix: only malware reports corroborate a quarantine

### DIFF
--- a/tests/unit/observations/test_tasks.py
+++ b/tests/unit/observations/test_tasks.py
@@ -143,6 +143,38 @@ class TestAutoQuarantineProject:
             pretend.call("Project has fewer than 2 observers. Not quarantining.")
         ]
 
+    def test_non_malware_observations_do_not_corroborate(self, db_request):
+        """Only malware reports count toward the corroboration threshold."""
+        dummy_task = pretend.stub(name="dummy_task")
+        observer_user = UserFactory.create(is_observer=True)
+        another_user = UserFactory.create()
+        db_request.user = observer_user
+        # An older project, so the trusted-observer fast-track doesn't apply
+        project = ProjectFactory.create(created=datetime.now(UTC) - timedelta(days=30))
+
+        observation = project.record_observation(
+            request=db_request,
+            kind=ObservationKind.IsMalware,
+            summary="Project Observation",
+            payload={},
+            actor=observer_user,
+        )
+        project.record_observation(
+            request=db_request,
+            kind=ObservationKind.IsSpam,
+            summary="Project Observation",
+            payload={},
+            actor=another_user,
+        )
+        db_request.db.flush()
+
+        evaluate_project_for_quarantine(dummy_task, db_request, observation.id)
+
+        assert project.lifecycle_status != LifecycleStatus.QuarantineEnter
+        assert db_request.log.info.calls == [
+            pretend.call("Project has fewer than 2 observers. Not quarantining.")
+        ]
+
     def test_no_observer_observers_does_not_quarantine(self, db_request):
         dummy_task = pretend.stub(name="dummy_task")
         user = UserFactory.create()

--- a/warehouse/observations/tasks.py
+++ b/warehouse/observations/tasks.py
@@ -166,7 +166,8 @@ def evaluate_project_for_quarantine(
     - Observed Project is not already quarantined
     - EITHER:
       - Trusted observer (`User.is_observer`) reports a young project (<24h old)
-      - OR: Project has at least 2 Observations, at least 1 by `User.is_observer`
+      - OR: Project has at least 2 malware Observations, at least 1 by
+        `User.is_observer`
     """
     # Fetch the Observation from the database, load the related Project
     observation = request.db.get(Observation, observation_id)
@@ -201,8 +202,14 @@ def evaluate_project_for_quarantine(
             "Auto-quarantining young project (<24h) reported by trusted observer."
         )
     else:
-        # Corroboration required: 2+ observers, at least 1 trusted
-        observer_users = {obs.observer.parent for obs in project.observations}
+        # Corroboration required: 2+ observers, at least 1 trusted.
+        # Only malware reports corroborate a malware report - observations of
+        # other kinds, including system-generated ones, must not tip the count.
+        observer_users = {
+            obs.observer.parent
+            for obs in project.observations
+            if OBSERVATION_KIND_MAP[obs.kind] == ObservationKind.IsMalware
+        }
         if len(observer_users) < 2:
             logger.info("Project has fewer than 2 observers. Not quarantining.")
             return


### PR DESCRIPTION
The auto-quarantine corroboration branch counted distinct observers across every observation on a project, whatever the kind. A single malware report plus an unrelated spam report from someone else was enough to trip the two-observer threshold.

Count only `IsMalware` observations, matching what the docstring describes.