### PR TITLE
docs: update ActiveState Trusted Publishing links

### DIFF
--- a/docs/user/trusted-publishers/adding-a-publisher.md
+++ b/docs/user/trusted-publishers/adding-a-publisher.md
@@ -99,7 +99,7 @@ each.
 
     For ActiveState, you must provide the name of the ActiveState project,
     the ActiveState organization that project belongs to, and the ActiveState user performing
-    the publish action. Learn more about getting set up on the ActiveState Platform [here](https://docs.activestate.com/platform/start/pypi/).
+    the publish action. Learn more about getting set up on the ActiveState Platform [here](https://docs.activestate.com/platform/open-source-collaboration/pypi/).
     ![Image showing adding a new ActiveState publisher](../assets/trusted-publishing/activestate/project-publishing-form.png)
     Once you click "Add", your publisher will be registered and will appear at the top of the page:
     ![Image showing a newly added ActiveState publisher](../assets/trusted-publishing/activestate/project-publisher-registered.png)

--- a/docs/user/trusted-publishers/creating-a-project-through-oidc.md
+++ b/docs/user/trusted-publishers/creating-a-project-through-oidc.md
@@ -74,7 +74,7 @@ provide the name of the PyPI project that will be created.
     Setting up ActiveState to create a PyPI project is the same as
     updating a project. You need to provide the name of the ActiveState project,
     the ActiveState organization that project belongs to, and the ActiveState user who will be performing
-    the publish action. Learn more about getting set up on the ActiveState Platform [here](https://docs.activestate.com/platform/start/pypi/).
+    the publish action. Learn more about getting set up on the ActiveState Platform [here](https://docs.activestate.com/platform/open-source-collaboration/pypi/).
 
     ![Image showing adding a new ActiveState publisher](../assets/trusted-publishing/activestate/pending-publisher-form-filled.png)
 

--- a/docs/user/trusted-publishers/security-model.md
+++ b/docs/user/trusted-publishers/security-model.md
@@ -197,7 +197,7 @@ own security model and considerations.
     * The ActiveState Platform project must be private.
 
     For more information about Trusted Publishing using the ActiveState Platform please
-    see the [PyPI configuration documentation](https://docs.activestate.com/platform/start/pypi/) and the [ActiveState Platform documentation](https://docs.activestate.com/platform).
+    see the [PyPI configuration documentation](https://docs.activestate.com/platform/open-source-collaboration/pypi/) and the [ActiveState Platform documentation](https://docs.activestate.com/platform).
 
 === "GitLab CI/CD"
 


### PR DESCRIPTION
Part of https://github.com/pypi/warehouse/issues/19759

Follow up to https://github.com/pypi/warehouse/pull/20381, updating all the other instances of the link too.