### PR TITLE
docs: update ActiveState links for OIDC

### DIFF
--- a/warehouse/templates/manage/account/publishing.html
+++ b/warehouse/templates/manage/account/publishing.html
@@ -282,7 +282,7 @@
 {% endmacro %}
 {% macro activestate_form(request, pending_activestate_pubisher_form) %}
   <p>
-    {% trans href="https://docs.activestate.com/platform/user/oidc/" %}
+    {% trans href="https://docs.activestate.com/platform/organizations/user-management/#multi-factor-authentication-for-organizations" %}
     Read more about ActiveState's OpenID Connect support <a href="{{ href }}">here</a>.
   {% endtrans %}
 </p>

--- a/warehouse/templates/manage/organization/publishing.html
+++ b/warehouse/templates/manage/organization/publishing.html
@@ -295,7 +295,7 @@
 {% endmacro %}
 {% macro activestate_form(request, pending_activestate_publisher_form, organization) %}
   <p>
-    {% trans href="https://docs.activestate.com/platform/user/oidc/" %}
+    {% trans href="https://docs.activestate.com/platform/organizations/user-management/#multi-factor-authentication-for-organizations" %}
     Read more about ActiveState's OpenID Connect support <a href="{{ href }}">here</a>.
   {% endtrans %}
 </p>

--- a/warehouse/templates/manage/project/publishing.html
+++ b/warehouse/templates/manage/project/publishing.html
@@ -269,7 +269,7 @@
 {% macro activestate_form(request, activestate_pubisher_form) %}
   {{ prefilled_warning() if prefilled_provider == "activestate" }}
   <p>
-    {% trans href="https://docs.activestate.com/platform/user/oidc/" %}
+    {% trans href="https://docs.activestate.com/platform/organizations/user-management/#multi-factor-authentication-for-organizations" %}
     Read more about ActiveState's OpenID Connect support <a href="{{ href }}">here</a>.
   {% endtrans %}
 </p>


### PR DESCRIPTION
Part of https://github.com/pypi/warehouse/issues/19759

Note: Yes, I know I'm changing URLs from "OIDC" to "MFA", but the page still has "OIDC" on it, and I emailed their support and they confirmed that this is the link to use.