### PR TITLE
Makefile: add helpful `*-serve` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,11 +102,20 @@ lint: .state/docker-build-base .state/docker-build-static
 dev-docs: .state/docker-build-docs
 	docker compose run --rm dev-docs bin/dev-docs
 
+dev-docs-serve: .state/docker-build-docs
+	docker compose up dev-docs
+
 user-docs: .state/docker-build-docs
 	docker compose run --rm user-docs bin/user-docs
 
+user-docs-serve: .state/docker-build-docs
+	docker compose up user-docs
+
 blog: .state/docker-build-docs
 	docker compose run --rm blog mkdocs build -f docs/mkdocs-blog.yml
+
+blog-serve: .state/docker-build-docs
+	docker compose up blog
 
 licenses: .state/docker-build-base
 	docker compose run --rm base bin/licenses


### PR DESCRIPTION
Adds convenience targets for each of our MkDocs dev servers so I (or anyone else) don't need to find them in `docker-compose.yml` and run them manually.

See #20392 for context.