### PR TITLE
feat(macaroons): measure caveat attenuation

### DIFF
--- a/tests/unit/macaroons/test_caveats.py
+++ b/tests/unit/macaroons/test_caveats.py
@@ -22,6 +22,7 @@ from warehouse.macaroons.caveats import (
     ProjectName,
     RequestUser,
     Success,
+    attenuations,
     deserialize,
     serialize,
     verify,
@@ -158,6 +159,42 @@ class TestDeserialization:
         pyramid_request.user = None
         with pytest.raises(CaveatError):
             deserialize(b'{"version": 1, "permissions": "user"}')
+
+    @pytest.mark.parametrize(
+        ("data", "expected"),
+        [
+            (b'{"exp": 50, "nbf": 10}', "caveat:Expiration"),
+            (
+                b'{"version": 1, "permissions": {"projects": ["foo"]}}',
+                "caveat:ProjectName",
+            ),
+            (b'{"project_ids": ["123uuid"]}', "caveat:ProjectID"),
+        ],
+    )
+    def test_legacy_caveats_are_counted(
+        self, pyramid_request, pyramid_config, data, expected
+    ):
+        """We count the old caveat format to know when its adapter can go."""
+        deserialize(data)
+
+        pyramid_request.metrics.increment.assert_called_once_with(
+            "warehouse.macaroon.caveat.legacy", tags=[expected]
+        )
+
+    def test_unadaptable_legacy_caveat_is_counted(
+        self, pyramid_request, pyramid_config
+    ):
+        with pytest.raises(CaveatError):
+            deserialize(b'{"nothing": "we can adapt"}')
+
+        pyramid_request.metrics.increment.assert_called_once_with(
+            "warehouse.macaroon.caveat.legacy", tags=["caveat:unknown"]
+        )
+
+    def test_current_caveats_are_not_counted(self, pyramid_request, pyramid_config):
+        deserialize(b"[0,50,10]")
+
+        pyramid_request.metrics.increment.assert_not_called()
 
     def test_deserialize_with_defaults(self):
         assert SampleCaveat.__deserialize__([1]) == SampleCaveat(
@@ -497,3 +534,59 @@ class TestVerification:
         )
         assert not status
         assert status.msg == "unknown error"
+
+
+_FOO = ProjectName(normalized_names=["foo"])
+_EXPIRES = Expiration(expires_at=10, not_before=0)
+
+
+@pytest.mark.parametrize(
+    ("issued", "embedded", "expected"),
+    [
+        pytest.param([_FOO], [], [], id="issued-but-not-embedded"),
+        pytest.param([_FOO], [serialize(_FOO)], [], id="issued-and-embedded"),
+        pytest.param(
+            [_FOO, _EXPIRES],
+            [serialize(_FOO), serialize(_EXPIRES)],
+            [],
+            id="every-issued-caveat-embedded",
+        ),
+        pytest.param(
+            [_FOO],
+            [serialize(_FOO), serialize(_EXPIRES)],
+            ["Expiration"],
+            id="user-added-a-caveat",
+        ),
+        pytest.param(
+            [ProjectName(normalized_names=["foo", "bar"])],
+            [serialize(_FOO)],
+            ["ProjectName"],
+            id="user-narrowed-an-issued-caveat",
+        ),
+        pytest.param(
+            [_FOO],
+            [serialize(_FOO), serialize(_FOO)],
+            ["ProjectName"],
+            id="user-duplicated-an-issued-caveat",
+        ),
+        pytest.param(
+            [],
+            [b'{"version":1,"permissions":{"projects":["foo"]}}'],
+            ["ProjectName"],
+            id="legacy-caveat-reported-as-its-modern-kind",
+        ),
+        pytest.param([], [b"[9999]"], ["unknown"], id="tag-we-do-not-know"),
+        pytest.param([], [b"[]"], ["unknown"], id="caveat-without-a-tag"),
+        pytest.param([], [b"[[1],2]"], ["unknown"], id="tag-we-cannot-look-up"),
+        pytest.param([], [b"not json at all"], ["unknown"], id="not-json"),
+        pytest.param(
+            [], [b'{"nothing": "we can adapt"}'], ["unknown"], id="unadaptable-mapping"
+        ),
+    ],
+)
+def test_attenuations(issued, embedded, expected):
+    m = Macaroon(location="somewhere", identifier="something", key=b"a secure key")
+    for predicate in embedded:
+        m.add_first_party_caveat(predicate)
+
+    assert attenuations(m, issued) == expected

--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -223,7 +223,9 @@ class TestDatabaseMacaroonService:
                 mocker.sentinel.permissions,
             )
 
-    def test_verify_invalid_macaroon(self, mocker, user_service, macaroon_service):
+    def test_verify_invalid_macaroon(
+        self, mocker, db_request, user_service, macaroon_service
+    ):
         user = UserFactory.create()
         raw_macaroon, _ = macaroon_service.create_macaroon(
             "fake location",
@@ -236,7 +238,7 @@ class TestDatabaseMacaroonService:
             caveats, "verify", autospec=True, return_value=WarehouseDenied("foo")
         )
 
-        request = mocker.sentinel.request
+        request = db_request
         context = mocker.sentinel.context
         permissions = mocker.sentinel.permissions
 
@@ -288,7 +290,7 @@ class TestDatabaseMacaroonService:
         with pytest.raises(services.InvalidMacaroonError):
             macaroon_service.verify("pypi-thiswillnotdeserialize", None, None, None)
 
-    def test_verify_valid_macaroon(self, mocker, macaroon_service):
+    def test_verify_valid_macaroon(self, mocker, db_request, macaroon_service):
         user = UserFactory.create()
         raw_macaroon, _ = macaroon_service.create_macaroon(
             "fake location",
@@ -305,7 +307,7 @@ class TestDatabaseMacaroonService:
             caveats, "verify", autospec=True, return_value=True
         )
 
-        request = mocker.sentinel.request
+        request = db_request
         context = mocker.sentinel.context
         permissions = mocker.sentinel.permissions
 
@@ -333,6 +335,101 @@ class TestDatabaseMacaroonService:
             },
             # The database stored Expiration caveat
             {"cid": "[0,5,2]", "cl": None, "vid": None},
+        ]
+
+    @pytest.fixture
+    def user_macaroon(self, macaroon_service):
+        """A user-scoped macaroon, as a (raw, database model) pair."""
+        user = UserFactory.create()
+        return macaroon_service.create_macaroon(
+            "fake location",
+            "fake description",
+            [caveats.RequestUser(user_id=str(user.id))],
+            user_id=user.id,
+        )
+
+    def test_verify_records_unattenuated_macaroon(
+        self, mocker, db_request, macaroon_service, user_macaroon
+    ):
+        raw_macaroon, _ = user_macaroon
+        mocker.patch.object(caveats, "verify", autospec=True, return_value=True)
+
+        macaroon_service.verify(
+            raw_macaroon,
+            db_request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
+        )
+
+        db_request.metrics.increment.assert_any_call(
+            "warehouse.macaroon.verify.attenuated", tags=["attenuated:false"]
+        )
+
+    def test_verify_records_attenuated_macaroon(
+        self, mocker, db_request, macaroon_service, user_macaroon
+    ):
+        raw_macaroon, _ = user_macaroon
+        # Attenuate the macaroon the way an end user would, without telling us.
+        m = services.deserialize_raw_macaroon(raw_macaroon)
+        m.add_first_party_caveat(
+            caveats.serialize(caveats.Expiration(expires_at=10, not_before=0))
+        )
+        mocker.patch.object(caveats, "verify", autospec=True, return_value=True)
+
+        macaroon_service.verify(
+            f"pypi-{m.serialize()}",
+            db_request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
+        )
+
+        db_request.metrics.increment.assert_any_call(
+            "warehouse.macaroon.verify.attenuated", tags=["attenuated:true"]
+        )
+        db_request.metrics.increment.assert_any_call(
+            "warehouse.macaroon.verify.attenuation_kind", tags=["caveat:Expiration"]
+        )
+
+    def test_verify_records_macaroon_without_stored_caveats(
+        self, mocker, db_request, macaroon_service, user_macaroon
+    ):
+        """Macaroons issued before we stored caveats have nothing to compare to."""
+        raw_macaroon, dm = user_macaroon
+        dm.caveats = []
+        mocker.patch.object(caveats, "verify", autospec=True, return_value=True)
+
+        macaroon_service.verify(
+            raw_macaroon,
+            db_request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
+        )
+
+        db_request.metrics.increment.assert_any_call(
+            "warehouse.macaroon.verify.attenuated", tags=["attenuated:unknown"]
+        )
+
+    def test_verify_records_nothing_for_invalid_macaroon(
+        self, mocker, db_request, macaroon_service, user_macaroon
+    ):
+        """Anyone can present a macaroon, so only verified ones are counted."""
+        raw_macaroon, _ = user_macaroon
+        mocker.patch.object(
+            caveats, "verify", autospec=True, return_value=WarehouseDenied("foo")
+        )
+
+        with pytest.raises(services.InvalidMacaroonError):
+            macaroon_service.verify(
+                raw_macaroon,
+                db_request,
+                mocker.sentinel.context,
+                mocker.sentinel.permission,
+            )
+
+        assert not [
+            call
+            for call in db_request.metrics.increment.call_args_list
+            if call.args[0].startswith("warehouse.macaroon.verify.attenuat")
         ]
 
     def test_delete_macaroon(self, user_service, macaroon_service):

--- a/warehouse/macaroons/caveats/__init__.py
+++ b/warehouse/macaroons/caveats/__init__.py
@@ -2,6 +2,7 @@
 
 import time
 
+from collections.abc import Sequence
 from typing import Any
 
 from pydantic import StrictInt, StrictStr
@@ -28,7 +29,14 @@ from warehouse.macaroons.caveats._core import (
 from warehouse.oidc.interfaces import SignedClaims
 from warehouse.packaging.models import Project
 
-__all__ = ["deserialize", "deserialize_obj", "serialize", "serialize_obj", "verify"]
+__all__ = [
+    "attenuations",
+    "deserialize",
+    "deserialize_obj",
+    "serialize",
+    "serialize_obj",
+    "verify",
+]
 
 
 # NOTE: Under the covers, caveat serialization is done as an array
@@ -142,6 +150,46 @@ class OIDCPublisher(Caveat):
             )
 
         return Success()
+
+
+def attenuations(macaroon: Macaroon, issued: Sequence[Caveat]) -> list[str]:
+    """
+    Return the kinds of caveats embedded in `macaroon` that we did not issue.
+
+    Users can attenuate the macaroons we give them at any time without telling us,
+    so any embedded caveat that `issued` cannot account for was added by someone
+    else. Each element is the name of a known `Caveat` subclass, or "unknown" for
+    a caveat we cannot deserialize at all.
+
+    An empty result means every embedded caveat is one of ours, which covers both
+    of the shapes we hand out: today we embed the caveats we issue, and if we ever
+    stop, a macaroon carrying none at all is just as unattenuated.
+
+    `issued` accounts for one embedded copy of each of its caveats, so a second
+    copy of one we issued is an attenuation. Comparison is by deserialized value
+    rather than by bytes, which keeps a caveat class gaining a defaulted field
+    from reading as an attenuation on every macaroon issued before the change.
+    """
+    unmatched = list(issued)
+    extra = []
+
+    for embedded in macaroon.caveats:
+        try:
+            caveat = deserialize(embedded.caveat_id_bytes)
+        except Exception:  # noqa: BLE001
+            # Anything a user can put in a caveat reaches this, so we catch broadly:
+            # recording a metric must never be able to fail the request.
+            extra.append("unknown")
+            continue
+
+        # Each issued caveat only accounts for one embedded copy of itself, so a
+        # duplicate is an attenuation like any other unaccounted for caveat.
+        if caveat in unmatched:
+            unmatched.remove(caveat)
+        else:
+            extra.append(type(caveat).__name__)
+
+    return extra
 
 
 def verify(

--- a/warehouse/macaroons/caveats/_core.py
+++ b/warehouse/macaroons/caveats/_core.py
@@ -13,6 +13,7 @@ from typing import Any, ClassVar, TypeVar
 from pydantic import ValidationError
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pyramid.request import Request
+from pyramid.threadlocal import get_current_request
 
 from warehouse.macaroons.caveats import _legacy
 
@@ -121,12 +122,36 @@ def serialize(caveat: Caveat) -> bytes:
     ).encode("utf8")
 
 
+def _record_legacy_caveat(adapted: Sequence | None) -> None:
+    """
+    Count caveats that reached us in our original mapping format.
+
+    Only macaroons old enough to predate the current caveat format carry these, so
+    once `warehouse.macaroon.caveat.legacy` goes quiet, `_legacy` can be dropped.
+    The `caveat` tag is the modern caveat the mapping adapted to, or "unknown" for
+    a mapping we no longer know how to read, which tells us which of the legacy
+    shapes are still in use rather than only that some of them are.
+    """
+    request = get_current_request()
+    if request is None:
+        # Caveats are deserialized outside of a request as well, where there is no
+        # metrics service to reach for.
+        return
+
+    cls = _caveat_registry.lookup(adapted[0]) if adapted else None
+    request.metrics.increment(
+        "warehouse.macaroon.caveat.legacy",
+        tags=[f"caveat:{cls.__name__ if cls else 'unknown'}"],
+    )
+
+
 def deserialize_obj(obj: Any) -> Caveat:
     # Our original caveats were implemented as a mapping with arbitrary keys,
     # so if we've gotten one of our those, we'll attempt to adapt it to our
     # new format.
     if isinstance(obj, Mapping):
         obj = _legacy.adapt(obj)
+        _record_legacy_caveat(obj)
         if obj is None:
             raise CaveatDeserializationError("caveat must be an array")
 

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -182,7 +182,7 @@ class DatabaseMacaroonService:
         # own stored caveats below, which would make the two indistinguishable. We
         # don't record this until we know the macaroon verifies, so that anyone who
         # reads an identifier out of a token can't skew the numbers with forgeries.
-        attenuated = caveats.attenuations(m, issued) if issued else None
+        attenuations = caveats.attenuations(m, issued) if issued else None
 
         # Macaroons traditionally have caveats embedded inside them which act to
         # restrict the scope of what that macaroon is able to do. However, each caveat
@@ -223,7 +223,7 @@ class DatabaseMacaroonService:
 
         verified = caveats.verify(m, dm.key, request, context, permission)
         if verified:
-            _record_attenuations(request, attenuated)
+            _record_attenuations(request, attenuations)
 
             # Update last_used without dirtying the ORM object. A dirty
             # macaroon causes autoflush during Project.__acl__() evaluation,

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import datetime
 import typing
 import uuid
@@ -15,6 +17,9 @@ from warehouse.macaroons import caveats
 from warehouse.macaroons.errors import InvalidMacaroonError
 from warehouse.macaroons.interfaces import IMacaroonService
 from warehouse.macaroons.models import Macaroon
+
+if typing.TYPE_CHECKING:
+    from pyramid.request import Request
 
 
 def _extract_raw_macaroon(prefixed_macaroon: str | None) -> str | None:
@@ -48,6 +53,45 @@ def deserialize_raw_macaroon(raw_macaroon: str | None) -> pymacaroons.Macaroon:
         Exception,  # https://github.com/ecordell/pymacaroons/issues/50
     ) as e:
         raise InvalidMacaroonError("malformed macaroon") from e
+
+
+def _record_attenuations(request: Request, extra: list[str] | None) -> None:
+    """
+    Record how a verified macaroon was attenuated, as `attenuated:<state>` on
+    `warehouse.macaroon.verify.attenuated`. `extra` is the result of
+    `caveats.attenuations()`, or None if there was nothing to compare against.
+
+    The states are:
+
+    * `unknown`: we have no stored caveats for this macaroon, so we cannot tell
+      which of its embedded caveats are ours. Only macaroons created before we
+      started storing our caveats in the database land here, so this bucket
+      should shrink over time as those tokens are replaced.
+    * `false`: every embedded caveat is one that we issued. This is what a token
+      we minted looks like when the user hasn't touched it.
+    * `true`: the macaroon carries caveats that we did not issue, so someone
+      restricted it further after we handed it over. Each kind is counted on
+      `warehouse.macaroon.verify.attenuation_kind`, where "unknown" means a
+      caveat we could not deserialize at all rather than a `Caveat` subclass.
+
+    Only macaroons that passed verification are recorded, so these counts
+    describe tokens in real use rather than anything an anonymous caller can
+    present.
+    """
+    if extra is None:
+        request.metrics.increment(
+            "warehouse.macaroon.verify.attenuated", tags=["attenuated:unknown"]
+        )
+        return
+
+    request.metrics.increment(
+        "warehouse.macaroon.verify.attenuated",
+        tags=[f"attenuated:{'true' if extra else 'false'}"],
+    )
+    for kind in sorted(set(extra)):
+        request.metrics.increment(
+            "warehouse.macaroon.verify.attenuation_kind", tags=[f"caveat:{kind}"]
+        )
 
 
 @implementer(IMacaroonService)
@@ -132,6 +176,14 @@ class DatabaseMacaroonService:
         if dm is None:
             raise InvalidMacaroonError("deleted or nonexistent macaroon")
 
+        issued = dm.caveats
+
+        # Work out which caveats the end user added themselves before we append our
+        # own stored caveats below, which would make the two indistinguishable. We
+        # don't record this until we know the macaroon verifies, so that anyone who
+        # reads an identifier out of a token can't skew the numbers with forgeries.
+        attenuated = caveats.attenuations(m, issued) if issued else None
+
         # Macaroons traditionally have caveats embedded inside them which act to
         # restrict the scope of what that macaroon is able to do. However, each caveat
         # that is added has to be serialized into the Macaroon which makes them longer
@@ -166,11 +218,13 @@ class DatabaseMacaroonService:
         #       verification code doesn't have to do anything special for stored vs
         #       embedded caveats. However, it does mean that the macaroon we actually
         #       end up verifying is a "sub" macaroon of what the user provided us.
-        for caveat in dm.caveats:
+        for caveat in issued:
             m.add_first_party_caveat(caveats.serialize(caveat))
 
         verified = caveats.verify(m, dm.key, request, context, permission)
         if verified:
+            _record_attenuations(request, attenuated)
+
             # Update last_used without dirtying the ORM object. A dirty
             # macaroon causes autoflush during Project.__acl__() evaluation,
             # which can deadlock with the journal advisory lock under


### PR DESCRIPTION
Users can add caveats to the macaroons we issue whenever they like. We have no idea how often that happens, and we'd want to know before deciding on whether to continue to use this capability.

Once a macaroon verifies, diff its embedded caveats against the ones we stored when we issued it and count verified left over caveats.

Also counts caveats that still show up in the old mapping format, which is how we'll know when the legacy adapter can go.