### PR TITLE
fix: rate limit email changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,6 +248,7 @@ def pyramid_services(
     services.register_service(search_service, ISearchService)
     services.register_service(domain_status_service, IDomainStatusService)
     services.register_service(ratelimit_service, IRateLimiter, name="email.add")
+    services.register_service(ratelimit_service, IRateLimiter, name="email.change")
     services.register_service(ratelimit_service, IRateLimiter, name="email.verify")
     services.register_service(
         ratelimit_service, IRateLimiter, name="project.create.user"

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -111,6 +111,7 @@ def test_includeme(monkeypatch):
                 "warehouse.account.2fa_user_ratelimit_string": "5 per 5 minutes, 20 per hour, 50 per day",  # noqa: E501
                 "warehouse.account.2fa_ip_ratelimit_string": "10 per 5 minutes, 50 per hour",  # noqa: E501
                 "warehouse.account.email_add_ratelimit_string": "2 per day",
+                "warehouse.account.email_change_ratelimit_string": "5 per 5 minutes, 20 per hour",  # noqa: E501
                 "warehouse.account.verify_email_ratelimit_string": "3 per 6 hours",
                 "warehouse.account.password_reset_ratelimit_string": "5 per day",
                 "warehouse.account.accounts_search_ratelimit_string": "100 per hour",
@@ -171,6 +172,7 @@ def test_includeme(monkeypatch):
         pretend.call("5 per 5 minutes, 20 per hour, 50 per day", "2fa.user"),
         pretend.call("10 per 5 minutes, 50 per hour", "2fa.ip"),
         pretend.call("2 per day", "email.add"),
+        pretend.call("5 per 5 minutes, 20 per hour", "email.change"),
         pretend.call("5 per day", "password.reset"),
         pretend.call("3 per 6 hours", "email.verify"),
         pretend.call("100 per hour", "accounts.search"),
@@ -221,6 +223,7 @@ def test_includeme_with_gitlab_oauth():
                 "warehouse.account.2fa_user_ratelimit_string": "5 per 5 minutes, 20 per hour, 50 per day",  # noqa: E501
                 "warehouse.account.2fa_ip_ratelimit_string": "10 per 5 minutes, 50 per hour",  # noqa: E501
                 "warehouse.account.email_add_ratelimit_string": "2 per day",
+                "warehouse.account.email_change_ratelimit_string": "5 per 5 minutes, 20 per hour",  # noqa: E501
                 "warehouse.account.verify_email_ratelimit_string": "3 per 6 hours",
                 "warehouse.account.password_reset_ratelimit_string": "5 per day",
                 "warehouse.account.accounts_search_ratelimit_string": "100 per hour",

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -153,6 +153,8 @@ class TestManageUnverifiedAccount:
         user_service = pretend.stub(
             add_email=pretend.call_recorder(lambda *a, **kw: new_email),
         )
+        limiter = pretend.stub(test=lambda *a: True, hit=lambda *a: True)
+        limiters = {"email.change": limiter, "email.add": limiter}
         request = pretend.stub(
             POST={"change_unverified_primary_email": "correct@example.com"},
             user=user,
@@ -160,12 +162,9 @@ class TestManageUnverifiedAccount:
                 delete=pretend.call_recorder(lambda obj: None),
                 flush=lambda: None,
             ),
-            find_service=lambda svc, *a, **kw: {
-                IRateLimiter: pretend.stub(
-                    test=lambda *a: True,
-                    hit=lambda *a: None,
-                ),
-            }.get(svc, user_service),
+            find_service=lambda svc, *a, name=None, **kw: limiters.get(
+                name, user_service
+            ),
             session=pretend.stub(
                 flash=pretend.call_recorder(lambda *a, **kw: None),
             ),
@@ -207,6 +206,7 @@ class TestManageUnverifiedAccount:
         ]
 
     def test_change_unverified_primary_email_validation_fails(self, monkeypatch):
+        """A failed validation still spends the attempt budget."""
         user = pretend.stub(
             id=pretend.stub(),
             username="testuser",
@@ -217,12 +217,18 @@ class TestManageUnverifiedAccount:
             projects=[],
         )
         user_service = pretend.stub()
+        attempt_limiter = pretend.stub(hit=pretend.call_recorder(lambda *a: True))
+        add_limiter = pretend.stub(
+            test=lambda *a: True,
+            hit=pretend.call_recorder(lambda *a: True),
+        )
+        limiters = {"email.change": attempt_limiter, "email.add": add_limiter}
         request = pretend.stub(
             POST={"change_unverified_primary_email": "bad"},
             user=user,
-            find_service=lambda svc, *a, **kw: {
-                IRateLimiter: pretend.stub(test=lambda *a: True),
-            }.get(svc, user_service),
+            find_service=lambda svc, *a, name=None, **kw: limiters.get(
+                name, user_service
+            ),
             help_url=lambda *a, **kw: "/help",
             remote_addr="1.2.3.4",
         )
@@ -237,6 +243,48 @@ class TestManageUnverifiedAccount:
             "help_url": "/help",
             "change_unverified_primary_email_form": form_obj,
         }
+        assert attempt_limiter.hit.calls == [pretend.call(user.id)]
+        # The strict per-IP budget is only spent on a successful change.
+        assert add_limiter.hit.calls == []
+
+    def test_change_unverified_primary_email_attempt_rate_limited(self):
+        """Exhausting the attempt budget blocks before the form is validated."""
+        user = pretend.stub(
+            id=pretend.stub(),
+            username="testuser",
+            has_primary_verified_email=False,
+            has_two_factor=False,
+            emails=[],
+            projects=[],
+        )
+        attempt_limiter = pretend.stub(hit=pretend.call_recorder(lambda *a: False))
+        limiters = {
+            "email.change": attempt_limiter,
+            "email.add": pretend.stub(test=lambda *a: True),
+        }
+        request = pretend.stub(
+            POST={"change_unverified_primary_email": "new@example.com"},
+            user=user,
+            find_service=lambda svc, *a, name=None, **kw: limiters.get(
+                name, pretend.stub()
+            ),
+            session=pretend.stub(
+                flash=pretend.call_recorder(lambda *a, **kw: None),
+            ),
+            remote_addr="1.2.3.4",
+            route_path=lambda *a, **kw: "/manage/unverified/",
+        )
+        view = views.ManageUnverifiedAccountViews(request)
+        result = view.change_unverified_primary_email()
+
+        assert isinstance(result, HTTPSeeOther)
+        assert request.session.flash.calls == [
+            pretend.call(
+                "Too many email change attempts. Try again later.",
+                queue="error",
+            )
+        ]
+        assert attempt_limiter.hit.calls == [pretend.call(user.id)]
 
     def test_change_unverified_primary_email_blocked_if_verified(self):
         request = pretend.stub(
@@ -297,7 +345,7 @@ class TestManageUnverifiedAccount:
             pretend.call(expected_message, queue="error")
         ]
 
-    def test_change_unverified_primary_email_rate_limited(self):
+    def test_change_unverified_primary_email_ip_rate_limited(self):
         user = pretend.stub(
             id=pretend.stub(),
             username="testuser",
@@ -306,12 +354,17 @@ class TestManageUnverifiedAccount:
             emails=[],
             projects=[],
         )
+        attempt_limiter = pretend.stub(hit=pretend.call_recorder(lambda *a: True))
+        limiters = {
+            "email.change": attempt_limiter,
+            "email.add": pretend.stub(test=lambda *a: False),
+        }
         request = pretend.stub(
             POST={"change_unverified_primary_email": "new@example.com"},
             user=user,
-            find_service=lambda svc, *a, **kw: {
-                IRateLimiter: pretend.stub(test=lambda *a: False),
-            }.get(svc, pretend.stub()),
+            find_service=lambda svc, *a, name=None, **kw: limiters.get(
+                name, pretend.stub()
+            ),
             session=pretend.stub(
                 flash=pretend.call_recorder(lambda *a, **kw: None),
             ),
@@ -328,6 +381,8 @@ class TestManageUnverifiedAccount:
                 queue="error",
             )
         ]
+        # Turned away before validation, so it doesn't cost the user an attempt.
+        assert attempt_limiter.hit.calls == []
 
 
 class TestManageAccount:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -326,6 +326,7 @@ def test_configure(monkeypatch, mocker, settings, environment):
         "warehouse.account.2fa_user_ratelimit_string": "5 per 5 minutes, 20 per hour, 50 per day",  # noqa: E501
         "warehouse.account.2fa_ip_ratelimit_string": "10 per 5 minutes, 50 per hour",
         "warehouse.account.email_add_ratelimit_string": "2 per day",
+        "warehouse.account.email_change_ratelimit_string": "5 per 5 minutes, 20 per hour",  # noqa: E501
         "warehouse.account.verify_email_ratelimit_string": "3 per 6 hours",
         "warehouse.account.accounts_search_ratelimit_string": "100 per hour",
         "warehouse.account.password_reset_ratelimit_string": "5 per day",

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -196,6 +196,10 @@ def includeme(config):
         "warehouse.account.email_add_ratelimit_string"
     )
     config.register_rate_limiter(email_add_ratelimit_string, "email.add")
+    email_change_ratelimit_string = config.registry.settings.get(
+        "warehouse.account.email_change_ratelimit_string"
+    )
+    config.register_rate_limiter(email_change_ratelimit_string, "email.change")
     password_reset_ratelimit_string = config.registry.settings.get(
         "warehouse.account.password_reset_ratelimit_string"
     )

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -553,6 +553,12 @@ def configure(settings=None):
     )
     maybe_set(
         settings,
+        "warehouse.account.email_change_ratelimit_string",
+        "EMAIL_CHANGE_RATELIMIT_STRING",
+        default="5 per 5 minutes, 20 per hour",
+    )
+    maybe_set(
+        settings,
         "warehouse.account.accounts_search_ratelimit_string",
         "ACCOUNTS_SEARCH_RATELIMIT_STRING",
         default="100 per hour",

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -162,7 +162,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:623 warehouse/manage/views/__init__.py:953
+#: warehouse/accounts/views.py:623 warehouse/manage/views/__init__.py:957
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -525,117 +525,117 @@ msgstr ""
 msgid "This team name has already been used. Choose a different team name."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:407
+#: warehouse/manage/views/__init__.py:411
 msgid "Account details updated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:438
+#: warehouse/manage/views/__init__.py:442
 #, python-brace-format
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:900
+#: warehouse/manage/views/__init__.py:904
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:902
+#: warehouse/manage/views/__init__.py:906
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1010
+#: warehouse/manage/views/__init__.py:1014
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1112
+#: warehouse/manage/views/__init__.py:1116
 msgid "API Token does not exist."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1144
+#: warehouse/manage/views/__init__.py:1148
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1315
-#: warehouse/manage/views/__init__.py:1637
-#: warehouse/manage/views/__init__.py:1748
+#: warehouse/manage/views/__init__.py:1319
+#: warehouse/manage/views/__init__.py:1641
+#: warehouse/manage/views/__init__.py:1752
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1437
+#: warehouse/manage/views/__init__.py:1441
 msgid "This release is in quarantine and cannot be modified."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1461
-#: warehouse/manage/views/__init__.py:1549
-#: warehouse/manage/views/__init__.py:1653
-#: warehouse/manage/views/__init__.py:1756
+#: warehouse/manage/views/__init__.py:1465
+#: warehouse/manage/views/__init__.py:1553
+#: warehouse/manage/views/__init__.py:1657
+#: warehouse/manage/views/__init__.py:1760
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1474
+#: warehouse/manage/views/__init__.py:1478
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1562
+#: warehouse/manage/views/__init__.py:1566
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1666
+#: warehouse/manage/views/__init__.py:1670
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1768
+#: warehouse/manage/views/__init__.py:1772
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1773
+#: warehouse/manage/views/__init__.py:1777
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1921
+#: warehouse/manage/views/__init__.py:1925
 #, python-brace-format
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2028
+#: warehouse/manage/views/__init__.py:2032
 #, python-brace-format
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2095
+#: warehouse/manage/views/__init__.py:2099
 #, python-brace-format
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2126
+#: warehouse/manage/views/__init__.py:2130
 #, python-brace-format
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2139
+#: warehouse/manage/views/__init__.py:2143
 #: warehouse/manage/views/organizations.py:922
 #, python-brace-format
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2204
+#: warehouse/manage/views/__init__.py:2208
 #: warehouse/manage/views/organizations.py:997
 #, python-brace-format
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2236
+#: warehouse/manage/views/__init__.py:2240
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2247
+#: warehouse/manage/views/__init__.py:2251
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2280
+#: warehouse/manage/views/__init__.py:2284
 #: warehouse/manage/views/organizations.py:1197
 #, python-brace-format
 msgid "Invitation revoked from '${username}'."

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -254,37 +254,41 @@ class ManageUnverifiedAccountViews(ManageAccountMixin):
         request_param=ChangeUnverifiedPrimaryEmailForm.__params__,
     )
     def change_unverified_primary_email(self):
+        def _error(message):
+            self.request.session.flash(message, queue="error")
+            return HTTPSeeOther(self.request.route_path("manage.unverified-account"))
+
         # Guard: redirect if already verified
         if self.request.user.has_primary_verified_email:
             return HTTPSeeOther(self.request.route_path("manage.account"))
 
         # Guard: block if user has 2FA (higher-risk account, needs admin help)
         if self.request.user.has_two_factor:
-            self.request.session.flash(
+            return _error(
                 "Cannot change email address on accounts with two-factor "
-                "authentication enabled",
-                queue="error",
+                "authentication enabled"
             )
-            return HTTPSeeOther(self.request.route_path("manage.unverified-account"))
 
         # Guard: block if user owns any projects (not a fresh registration)
         if self.request.user.projects:
-            self.request.session.flash(
-                "Cannot change email address on accounts with projects",
-                queue="error",
-            )
-            return HTTPSeeOther(self.request.route_path("manage.unverified-account"))
+            return _error("Cannot change email address on accounts with projects")
 
-        # Rate limit email changes by IP
-        email_change_ratelimit = self.request.find_service(
-            IRateLimiter, name="email.add"
+        # Rate limit successful email changes by IP. Checked first so that a
+        # request turned away here doesn't also cost the user an attempt.
+        email_add_ratelimit = self.request.find_service(IRateLimiter, name="email.add")
+        if not email_add_ratelimit.test(self.request.remote_addr):
+            return _error("Too many email change attempts. Try again later.")
+
+        # Rate limit attempts by user, spent whether or not the change
+        # succeeds. Validating the address costs us DNS lookups and tells the
+        # caller whether it is already registered, so failures have to be
+        # bounded too. `hit` tests and spends atomically, consuming nothing
+        # when it denies.
+        email_attempt_ratelimit = self.request.find_service(
+            IRateLimiter, name="email.change"
         )
-        if not email_change_ratelimit.test(self.request.remote_addr):
-            self.request.session.flash(
-                "Too many email change attempts. Try again later.",
-                queue="error",
-            )
-            return HTTPSeeOther(self.request.route_path("manage.unverified-account"))
+        if not email_attempt_ratelimit.hit(self.request.user.id):
+            return _error("Too many email change attempts. Try again later.")
 
         # Map the POST param to the "email" field expected by NewEmailMixin
         form = ChangeUnverifiedPrimaryEmailForm(
@@ -314,7 +318,7 @@ class ManageUnverifiedAccountViews(ManageAccountMixin):
             old_primary.primary = False
             self.request.db.delete(old_primary)
 
-        email_change_ratelimit.hit(self.request.remote_addr)
+        email_add_ratelimit.hit(self.request.remote_addr)
 
         # Send verification email to the new address
         send_email_verification_email(self.request, (self.request.user, new_email))


### PR DESCRIPTION
In #19662 I added the ability to change an email post-username registration, but that doesn't have any rate limits on failed attempts, allowing a user to brute-force different providers until one works.

Adding a rate limiter to count attempts as well as successes, scoped to a **user account** means that they already have begun a registration process, and are now trying to verify an email address.