### PR TITLE
Add `Project.provenance_statuses`

### DIFF
--- a/tests/unit/attestations/test_models.py
+++ b/tests/unit/attestations/test_models.py
@@ -14,7 +14,6 @@ from warehouse.attestations.models import (
     PublisherSource,
     get_provenance_sources,
 )
-from warehouse.packaging.models import Release
 
 
 def test_provenance_as_model(db_request, integrity_service, dummy_attestation):
@@ -144,7 +143,7 @@ def _counts(**kwargs) -> ProvenanceCounts:
 
 def _comparison(**kwargs) -> ProvenanceComparison:
     """A comparison against a release the delta logic never has to read."""
-    return ProvenanceComparison(release=Release(), counts=_counts(**kwargs))
+    return ProvenanceComparison(version="0.9.0", counts=_counts(**kwargs))
 
 
 def _status(**kwargs) -> ProvenanceStatus:

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -11,7 +11,11 @@ import pytest
 from pyramid.authorization import Allow, Authenticated
 from pyramid.location import lineage
 
-from warehouse.attestations.models import ProvenanceState, PublisherSource
+from warehouse.attestations.models import (
+    ProvenanceCounts,
+    ProvenanceState,
+    PublisherSource,
+)
 from warehouse.authnz import Permissions
 from warehouse.constants import MAX_FILESIZE, MAX_PROJECT_SIZE, ONE_GIB, ONE_MIB
 from warehouse.macaroons import caveats
@@ -81,6 +85,28 @@ def _provenanced_file(release, publisher=None, **kwargs):
         publisher=publisher,
     )
     return file
+
+
+def _provenance_history(publisher=None):
+    """
+    A project whose three releases exercise every comparison branch.
+
+    The middle release carries no provenance, so the newest one has to reach
+    past it to find something to compare against, and the oldest has nothing
+    before it at all. Passing `publisher` publishes the newest release from
+    somewhere other than the factory default, which is what makes the newest
+    release's comparison report a change.
+    """
+    oldest, newest = _release_pair()
+    _provenanced_file(oldest, packagetype="sdist")
+    DBFileFactory.create(release=oldest, packagetype="bdist_wheel")
+    middle = DBReleaseFactory.create(
+        project=oldest.project,
+        created=oldest.created + datetime.timedelta(days=2),
+    )
+    DBFileFactory.create(release=middle, packagetype="bdist_wheel")
+    _provenanced_file(newest, publisher=publisher)
+    return oldest.project
 
 
 class TestRole:
@@ -617,6 +643,239 @@ class TestProject:
         )
 
         assert project.latest_version is None
+
+    def test_provenance_statuses_agree_with_each_release(self, db_session):
+        """
+        The batched statuses are the per-release ones, for every release.
+
+        Pinning them to each other is what lets the release history page read
+        the project-wide mapping while a release page reads its own status,
+        without the two drifting apart. The count is asserted first, so that
+        both sides returning nothing cannot satisfy the equality.
+        """
+        project = _provenance_history()
+
+        statuses = project.provenance_statuses
+
+        assert len(statuses) == 3
+        assert statuses == {
+            release.version: release.provenance_status
+            for release in project.releases
+            if release.provenance_status is not None
+        }
+
+    def test_provenance_statuses_costs_one_query_once(self, db_session, query_recorder):
+        """
+        Every release's status comes back in a single query, run only once.
+
+        This is the whole point of the property. The release history page
+        renders one card per release and reads several attributes off each
+        status, so neither the release count nor the number of reads may cost
+        another query.
+        """
+        project = _provenance_history()
+        db_session.flush()
+        assert project.id is not None  # load the project row before counting
+
+        query_recorder.clear()
+        with query_recorder:
+            statuses = [project.provenance_statuses for _ in range(3)]
+
+        assert len(statuses[0]) == 3
+        assert all(repeat is statuses[0] for repeat in statuses)
+        assert len(query_recorder.queries) == 1, query_recorder.queries
+
+    def test_provenance_statuses_omits_releases_without_files(self, db_session):
+        """A release with no files has no status, the same as on the release."""
+        project = DBProjectFactory.create()
+        empty = DBReleaseFactory.create(project=project, version="1.0")
+        populated = DBReleaseFactory.create(project=project, version="2.0")
+        _provenanced_file(populated)
+
+        assert empty.provenance_status is None
+        assert set(project.provenance_statuses) == {"2.0"}
+
+    def test_provenance_statuses_stop_at_the_comparison_window(self, db_session):
+        """A predecessor outside the window is not compared against."""
+        old, recent = _release_pair(
+            days_apart=PROVENANCE_COMPARISON_WINDOW_DAYS + 1,
+        )
+        _provenanced_file(old)
+        DBFileFactory.create(release=recent, packagetype="bdist_wheel")
+
+        status = old.project.provenance_statuses[recent.version]
+
+        assert status.comparison is None
+        assert status.states == {ProvenanceState.NO_PROVENANCE}
+
+    def test_provenance_statuses_report_a_publisher_change(self, db_session):
+        """
+        The batched path reports a change of publisher, not just coverage.
+
+        Every other test here publishes everything from the factory's default
+        publisher, so without this the mapping has never produced a state that
+        depends on reading publisher identity out of a payload.
+        """
+        project = _provenance_history(
+            publisher=pypi_attestations.GitHubPublisher(
+                repository="other/repo", workflow="publish.yml"
+            )
+        )
+        newest = max(project.releases, key=lambda release: release.created)
+
+        status = project.provenance_statuses[newest.version]
+
+        assert ProvenanceState.CHANGED_PROVENANCE in status.states
+        assert status.added_sources == {PublisherSource("GitHub", "other/repo")}
+        assert status.removed_sources == {
+            PublisherSource("GitHub", "example-org/example")
+        }
+        assert status.added_workflows == {"publish.yml"}
+        assert status.removed_workflows == {"release.yml"}
+
+    def test_provenance_statuses_suppress_a_change_against_unreadable(self, db_session):
+        """
+        An unreadable payload counts as unreadable and silences the delta.
+
+        The publishers of an unreadable file are unknown rather than absent,
+        so the batched path must not read their absence as a publisher change,
+        the same way the per-release path does not.
+        """
+        older, newer = _release_pair()
+        _provenanced_file(older)
+        file = DBFileFactory.create(release=newer, packagetype="bdist_wheel")
+        DBProvenanceFactory.create(file=file, provenance={"not": "a provenance object"})
+
+        status = older.project.provenance_statuses[newer.version]
+
+        assert status.counts.unreadable_files == 1
+        assert status.counts.files_with_provenance == 1
+        assert ProvenanceState.CHANGED_PROVENANCE not in status.states
+        assert status.removed_sources == set()
+
+    def test_provenance_statuses_break_created_ties(self, db_session):
+        """
+        Two releases sharing a `created` are compared against deterministically.
+
+        `Release.created` defaults to a transaction-scoped `now()`, so every
+        release of a batch insert ties on it. Both paths break the tie the same
+        way, and on the later version rather than on whichever row Postgres
+        happens to return first, so the release page and the release history
+        page name the same comparison.
+
+        Inserted oldest-version-first, so that physical row order and version
+        order disagree and only the tiebreak can produce the expected answer.
+        """
+        project = DBProjectFactory.create()
+        tied = datetime.datetime(2026, 7, 1, 12, 0, 0)
+        for version in ("1.0", "1.1"):
+            _provenanced_file(
+                DBReleaseFactory.create(project=project, version=version, created=tied)
+            )
+        newest = DBReleaseFactory.create(
+            project=project,
+            version="2.0",
+            created=tied + datetime.timedelta(days=1),
+        )
+        _provenanced_file(newest)
+
+        batched = project.provenance_statuses["2.0"].comparison
+
+        assert batched is not None
+        assert batched.version == "1.1"
+        assert newest.provenance_status.comparison.version == "1.1"
+
+    def test_provenance_statuses_compare_at_the_window_edge(self, db_session):
+        """
+        A predecessor exactly at the window edge is still compared against.
+
+        The window is spelled twice, as a SQL `>=` on the release page and as a
+        Python `<` cutoff here, so the inclusive boundary is the one place the
+        two can drift apart without either looking wrong on its own.
+        """
+        old, recent = _release_pair(days_apart=PROVENANCE_COMPARISON_WINDOW_DAYS)
+        _provenanced_file(old)
+        DBFileFactory.create(release=recent, packagetype="bdist_wheel")
+
+        status = old.project.provenance_statuses[recent.version]
+
+        assert status.comparison is not None
+        assert status.comparison.version == old.version
+        assert recent.provenance_status.comparison.version == old.version
+
+    def test_provenance_statuses_without_any_provenance(self, db_session):
+        """
+        A project that attests nothing reports no provenance and no comparison.
+
+        This is most projects, and the shape the comparison walk is skipped
+        for: with nothing to compare against, scanning for a predecessor can
+        only ever come back empty.
+        """
+        older, newer = _release_pair()
+        for release in (older, newer):
+            DBFileFactory.create(release=release, packagetype="bdist_wheel")
+
+        statuses = older.project.provenance_statuses
+
+        assert set(statuses) == {older.version, newer.version}
+        assert all(status.comparison is None for status in statuses.values())
+        assert statuses[newer.version].states == {ProvenanceState.NO_PROVENANCE}
+        assert statuses == {
+            release.version: release.provenance_status for release in (older, newer)
+        }
+
+    def test_provenance_statuses_drive_the_security_cascade(self, db_session):
+        """
+        Every state the release pages branch on is reachable from the mapping.
+
+        `project-security.html` and the metadata sidebar pick the most serious
+        of six states for one release; the release history page wants the same
+        verdict per release, from here. A mapping that could only report
+        coverage would show a release as fully attested while its own page
+        warned that its publisher had changed.
+        """
+        project = DBProjectFactory.create()
+        elsewhere = pypi_attestations.GitHubPublisher(
+            repository="other/repo", workflow="publish.yml"
+        )
+        day = datetime.datetime(2026, 7, 1, 12, 0, 0)
+
+        def _release(version, days):
+            return DBReleaseFactory.create(
+                project=project,
+                version=version,
+                created=day + datetime.timedelta(days=days),
+            )
+
+        no_prov = _release("1.0", 0)
+        DBFileFactory.create(release=no_prov, packagetype="bdist_wheel")
+        full = _release("2.0", 1)
+        _provenanced_file(full)
+        partial = _release("3.0", 2)
+        _provenanced_file(partial)
+        DBFileFactory.create(
+            release=partial, packagetype="sdist", python_version="source"
+        )
+        inconsistent = _release("4.0", 3)
+        _provenanced_file(inconsistent)
+        _provenanced_file(inconsistent, publisher=elsewhere)
+        changed = _release("5.0", 4)
+        _provenanced_file(changed, publisher=elsewhere)
+        lost = _release("6.0", 5)
+        DBFileFactory.create(release=lost, packagetype="bdist_wheel")
+
+        statuses = project.provenance_statuses
+
+        assert ProvenanceState.NO_PROVENANCE in statuses["1.0"].states
+        assert ProvenanceState.FULL_PROVENANCE in statuses["2.0"].states
+        assert ProvenanceState.PARTIAL_PROVENANCE in statuses["3.0"].states
+        assert ProvenanceState.INCONSISTENT_PROVENANCE in statuses["4.0"].states
+        assert ProvenanceState.CHANGED_PROVENANCE in statuses["5.0"].states
+        assert ProvenanceState.LOST_PROVENANCE in statuses["6.0"].states
+
+        # And each matches the verdict that release's own page would render.
+        for release in (no_prov, full, partial, inconsistent, changed, lost):
+            assert statuses[release.version].states == release.provenance_status.states
 
 
 class TestDependency:
@@ -1364,7 +1623,7 @@ class TestRelease:
             ProvenanceState.NO_PROVENANCE,
             ProvenanceState.LOST_PROVENANCE,
         }
-        assert status.comparison.release == rel1
+        assert status.comparison.version == rel1.version
         assert status.comparison.counts.files_with_provenance == 1
         assert status.comparison.counts.total_files == 1
 
@@ -1490,7 +1749,7 @@ class TestRelease:
         status = rel2_same.provenance_status
         assert status is not None
         assert status.states == {ProvenanceState.FULL_PROVENANCE}
-        assert status.comparison.release == rel0
+        assert status.comparison.version == rel0.version
         assert status.comparison.counts.files_with_provenance == 1
         assert status.comparison.counts.total_files == 2
 
@@ -1587,6 +1846,27 @@ class TestRelease:
         assert first_access_queries > 0
         assert query_recorder.queries == []
         assert all(status is first_status for status in repeat_statuses)
+
+    def test_provenance_counts_when_the_release_row_is_gone(self, db_session):
+        """
+        A release deleted underneath a live object counts as empty, not raises.
+
+        A maintainer deleting a release, or a quarantine purge, can remove the
+        row while a request still holding the `Release` is rendering. Counting
+        it as having no files leaves `provenance_status` returning `None`, so
+        the page renders without the card rather than erroring.
+        """
+        release = DBReleaseFactory.create()
+        _provenanced_file(release)
+        db_session.flush()
+        db_session.query(Release).filter(Release.id == release.id).delete(
+            synchronize_session=False
+        )
+
+        assert release.provenance_counts == ProvenanceCounts(
+            total_files=0, files_with_provenance=0
+        )
+        assert release.provenance_status is None
 
     def test_description_relationship(self, db_session):
         """

--- a/warehouse/attestations/models.py
+++ b/warehouse/attestations/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import enum
 import typing
 
+from collections import Counter
 from dataclasses import dataclass, field
 from functools import cached_property
 from uuid import UUID
@@ -264,3 +265,35 @@ def get_provenance_sources(
         if workflow := publisher_workflow(bundle.publisher):
             workflows.add(workflow)
     return sources, workflows
+
+
+def counts_from_provenance(
+    total_files: int, provenance_objects: list[Provenance]
+) -> ProvenanceCounts:
+    """
+    Fold one release's provenance objects into its counts.
+
+    Kept beside the counts it builds rather than on the `Release`, so that a
+    caller counting many releases at once folds each of them the same way a
+    single release does.
+    """
+    source_counter: Counter[PublisherSource] = Counter()
+    workflow_counter: Counter[str] = Counter()
+    unreadable_files = 0
+
+    for provenance_object in provenance_objects:
+        extracted = get_provenance_sources(provenance_object)
+        if extracted is None:
+            unreadable_files += 1
+            continue
+        sources, workflows = extracted
+        source_counter.update(sources)
+        workflow_counter.update(workflows)
+
+    return ProvenanceCounts(
+        total_files=total_files,
+        files_with_provenance=len(provenance_objects),
+        unreadable_files=unreadable_files,
+        source_counts=dict(source_counter),
+        workflow_counts=dict(workflow_counter),
+    )

--- a/warehouse/attestations/models.py
+++ b/warehouse/attestations/models.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from warehouse import db
 
 if typing.TYPE_CHECKING:
-    from warehouse.packaging.models import File, Release
+    from warehouse.packaging.models import File
 
 logger = structlog.get_logger(__name__)
 
@@ -101,9 +101,15 @@ class ProvenanceCounts:
 
 @dataclass(frozen=True)
 class ProvenanceComparison:
-    """The release a status is measured against, and what it attested to."""
+    """
+    The release a status is measured against, and what it attested to.
 
-    release: Release
+    A version rather than a `Release`: it is all a template can render or
+    route to, and carrying the ORM object would force a caller building
+    statuses in bulk to load every release row to fill it.
+    """
+
+    version: str
     counts: ProvenanceCounts
 
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -6,7 +6,7 @@ import datetime
 import enum
 import typing
 
-from collections import Counter, OrderedDict
+from collections import OrderedDict
 from functools import cached_property
 from uuid import UUID
 
@@ -60,8 +60,7 @@ from warehouse.attestations.models import (
     ProvenanceComparison,
     ProvenanceCounts,
     ProvenanceStatus,
-    PublisherSource,
-    get_provenance_sources,
+    counts_from_provenance,
 )
 from warehouse.authnz import Permissions
 from warehouse.classifiers.models import Classifier
@@ -1003,25 +1002,7 @@ class Release(HasObservations, db.Model):
             .options(orm.undefer(Provenance.provenance))
             .all()
         )
-        source_counter: Counter[PublisherSource] = Counter()
-        workflow_counter: Counter[str] = Counter()
-        unreadable_files = 0
-        for provenance_object in provenance_objects:
-            extracted = get_provenance_sources(provenance_object)
-            if extracted is None:
-                unreadable_files += 1
-                continue
-            sources, workflows = extracted
-            source_counter.update(sources)
-            workflow_counter.update(workflows)
-
-        return ProvenanceCounts(
-            total_files=total_files,
-            files_with_provenance=len(provenance_objects),
-            unreadable_files=unreadable_files,
-            source_counts=dict(source_counter),
-            workflow_counts=dict(workflow_counter),
-        )
+        return counts_from_provenance(total_files, provenance_objects)
 
     @cached_property
     def provenance_status(self) -> ProvenanceStatus | None:

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -50,6 +50,7 @@ from sqlalchemy.orm import (
     mapped_column,
     validates,
 )
+from sqlalchemy.sql import Select
 from urllib3.exceptions import LocationParseError
 from urllib3.util import parse_url
 
@@ -91,6 +92,84 @@ PROJECT_NAME_PATTERN = "^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$"
 
 # How far back to look for a release to compare provenance against.
 PROVENANCE_COMPARISON_WINDOW_DAYS = 14
+
+
+def _provenance_query() -> Select:
+    """
+    One row per release file, carrying the provenance that file has.
+
+    Outer-joined throughout, so a release with no files still yields a row and
+    a caller can tell a release it has counted from one it has not seen.
+
+    Ordered newest first. `created` defaults to a transaction-scoped `now()`,
+    so every release of a batch insert ties on it and date alone would leave
+    the comparison a release is measured against following physical row order.
+    `_pypi_ordering` breaks those ties the way the rest of this class already
+    orders releases, and `id` breaks the remainder, since `_pypi_ordering` is
+    nullable and cannot be relied on for a total order by itself.
+    """
+    return (
+        select(Release.version, Release.created, File.id, Provenance)
+        .select_from(Release)
+        .outerjoin(File, File.release_id == Release.id)
+        .outerjoin(Provenance, Provenance.file_id == File.id)
+        .options(orm.undefer(Provenance.provenance))
+        .order_by(
+            Release.created.desc(),
+            Release._pypi_ordering.desc(),
+            Release.id.desc(),
+        )
+    )
+
+
+def _counted_releases(rows) -> list[tuple[str, datetime.datetime, ProvenanceCounts]]:
+    """
+    Fold `_provenance_query` rows into one entry per release, newest first.
+
+    The joins fan out, so files are collected into a set rather than counted
+    row by row.
+    """
+    grouped: dict[str, tuple[datetime.datetime, set[UUID], list[Provenance]]] = {}
+    for version, created, file_id, provenance in rows:
+        if version not in grouped:  # not setdefault: it would build a bucket per row
+            grouped[version] = (created, set(), [])
+        _, file_ids, provenances = grouped[version]
+        if file_id is not None:
+            file_ids.add(file_id)
+        if provenance is not None:
+            provenances.append(provenance)
+
+    return [
+        (version, created, counts_from_provenance(len(file_ids), provenances))
+        for version, (created, file_ids, provenances) in grouped.items()
+    ]
+
+
+def _provenance_comparison(
+    counted: list[tuple[str, datetime.datetime, ProvenanceCounts]],
+    start: int,
+    created: datetime.datetime,
+    cutoff: datetime.datetime,
+) -> ProvenanceComparison | None:
+    """
+    The release a status is measured against, from the releases before it.
+
+    `counted` is ordered newest first, so the entries from `start` on are the
+    preceding releases. Indexed rather than sliced: the loop almost always
+    stops on its first or second entry, and both slicing and `islice` would
+    walk or copy the whole tail first, making the caller quadratic for no gain.
+
+    Walks past a nearer release carrying no provenance the same way
+    `Release.comparison_provenance_release` reaches past it by inner-joining,
+    and stops at `cutoff` rather than filtering on it.
+    """
+    for index in range(start, len(counted)):
+        version, other_created, counts = counted[index]
+        if other_created < cutoff:
+            return None
+        if other_created < created and counts.files_with_provenance:
+            return ProvenanceComparison(version=version, counts=counts)
+    return None
 
 
 class Role(db.Model):
@@ -483,6 +562,51 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
             .order_by(Release._pypi_ordering.desc())
             .all()
         )
+
+    @cached_property
+    def provenance_statuses(self) -> dict[str, ProvenanceStatus]:
+        """
+        Every release's provenance status, keyed by version.
+
+        The release history page needs a status per release. Reading
+        `Release.provenance_status` in a loop costs three queries for each one;
+        this takes one, and resolves each release's comparison against the
+        counts it is already holding.
+
+        A release with no files is absent from the mapping, matching
+        `Release.provenance_status` returning `None`. Read it with `.get()`:
+        a project can hold a release whose files have all been removed.
+
+        Cached for the life of the `Project`, so a caller holding one across a
+        commit sees the statuses as they were when it first asked. That suits
+        a request, which reads them once and renders; a long-lived task
+        wanting fresh counts should ask a `Release` instead.
+        """
+        counted = _counted_releases(
+            orm_session_from_obj(self)
+            .execute(_provenance_query().where(Release.project_id == self.id))
+            .all()
+        )
+        window = datetime.timedelta(days=PROVENANCE_COMPARISON_WINDOW_DAYS)
+        # Most projects attest nothing, and there the comparison walk can only
+        # ever come back empty. Checking once beats letting every release scan
+        # its whole window to find that out, which for releases sharing a
+        # `created` is the entire project.
+        attested = any(counts.files_with_provenance for _, _, counts in counted)
+        return {
+            version: ProvenanceStatus(
+                counts=counts,
+                comparison=(
+                    _provenance_comparison(
+                        counted, index + 1, created, created - window
+                    )
+                    if attested
+                    else None
+                ),
+            )
+            for index, (version, created, counts) in enumerate(counted)
+            if counts.total_files
+        }
 
     @property
     def latest_version(self):
@@ -967,6 +1091,12 @@ class Release(HasObservations, db.Model):
         This inner-joins provenance, so it reaches past a nearer preceding
         release that has none. Any release it returns therefore has at least
         one file with provenance.
+
+        Releases are ordered by id as well as date, because `created` defaults
+        to a transaction-scoped `now()` and so ties across every release of a
+        batch insert. Without the tiebreak this picks arbitrarily among them,
+        and can disagree with `Project.provenance_statuses` about which
+        release a status is measured against.
         """
         session = orm_session_from_obj(self)
         window = datetime.timedelta(days=PROVENANCE_COMPARISON_WINDOW_DAYS)
@@ -979,30 +1109,26 @@ class Release(HasObservations, db.Model):
                 Release.created < self.created,
                 Release.created >= self.created - window,
             )
-            .order_by(Release.created.desc())
+            .order_by(
+                Release.created.desc(),
+                Release._pypi_ordering.desc(),
+                Release.id.desc(),
+            )
         )
         return query.first()
 
     @cached_property
     def provenance_counts(self) -> ProvenanceCounts:
         """Count the files, sources and workflows this Release attests to."""
-        session = orm_session_from_obj(self)
-        total_files = (
-            session.query(func.count(File.id))
-            .filter(File.release_id == self.id)
-            .scalar()
-        )
-        if not total_files:
-            return ProvenanceCounts(total_files=0, files_with_provenance=0)
-
-        provenance_objects = (
-            session.query(Provenance)
-            .join(Provenance.file)
-            .filter(File.release_id == self.id)
-            .options(orm.undefer(Provenance.provenance))
+        counted = _counted_releases(
+            orm_session_from_obj(self)
+            .execute(_provenance_query().where(Release.id == self.id))
             .all()
         )
-        return counts_from_provenance(total_files, provenance_objects)
+        if not counted:  # the release row is gone from under a live object
+            return ProvenanceCounts(total_files=0, files_with_provenance=0)
+        _, _, counts = counted[0]
+        return counts
 
     @cached_property
     def provenance_status(self) -> ProvenanceStatus | None:
@@ -1018,7 +1144,7 @@ class Release(HasObservations, db.Model):
             counts=counts,
             comparison=(
                 ProvenanceComparison(
-                    release=comparison_release,
+                    version=comparison_release.version,
                     counts=comparison_release.provenance_counts,
                 )
                 if comparison_release


### PR DESCRIPTION
Adds `Project.provenance_statuses`, a project-wide mapping of version to
`ProvenanceStatus`, so a page showing one line per release can get every
release's provenance verdict in a single query.

Refs #20329
Closes #20410

## Why

Reading `Release.provenance_status` in a loop costs three queries per release.
[This review comment on #20329](https://github.com/pypi/warehouse/pull/20329/changes#r3778988535)
flagged it on the release history page, which currently assembles the mapping
in the template:

```jinja
{% set provenance_statuses = {} %}
{% for r in project.releases %}
  {% set _ = provenance_statuses.update({r.version: r.provenance_status}) %}
{% endfor %}
```

Jinja scopes `{% set %}` to the loop body, so accumulating across iterations
means mutating an object made outside it. That `{% set _ = %}` idiom appears
once elsewhere in our templates, and never to build a lookup table. The N+1 is
a symptom of assembling data in template-land, where the only way to express
"a status per release" is a loop over full ORM objects.

## What it does

`_provenance_query` fetches a release's files and their provenance together.
`_counted_releases` folds the rows. Because the result already holds every
release's date and coverage, each comparison is a walk over that list instead
of two more queries. `Release.provenance_counts` reuses the same query and
drops from two queries to one.

Both paths now break `created` ties on `_pypi_ordering` and `id`.
`Release.created` defaults to a transaction-scoped `now()`, so a batch insert
leaves every release of it sharing one, and without a tiebreak the batched and
per-release paths could name different comparison releases for the same
release and render contradictory verdicts.

## Measured

250 releases x 4 attested files, one dataset, best of 3:

| approach | queries | wall | states |
|---|---|---|---|
| `Release.provenance_status` in a loop (#20329 today) | 501 | 330 ms | all six |
| `Project.provenance_counts` (#20410) | 1 | 42 ms | four of six |
| `Project.provenance_statuses` (this PR) | 1 | 47 ms | all six |

#20410 solves the same N+1 and reads the same payloads, but has no comparison
between releases, so it cannot produce `lost-provenance` or
`changed-provenance` — two of the three warning states the cascade in #20408
puts at the top. It also names the property `Project.provenance_counts`, beside
`Release.provenance_counts`, which returns a different type.

## Against the security tab

#20408 renders one template per `ProvenanceState` through a priority cascade:

```
lost > changed > inconsistent > partial > full > no
```

`test_provenance_statuses_drive_the_security_cascade` builds one release per
state and asserts each is reachable from the mapping, then asserts every entry
equals what that release's own page renders. The release history list and the
detail page cannot disagree.

## Known cost, and the follow-up

This reads every provenance payload in the project on an uncached render,
because `inconsistent-provenance` is derived from each release's own publisher
set. Restricting the read to the comparison window would leave that state
silently absent outside it, and a jsonpath projection cannot distinguish "all
the publishers" from "the publishers I could see" — both were tried and
rejected on correctness.

The fix that removes the cost without losing states is storing publisher kind,
identity and workflow alongside the provenance row at upload. Then every state
is a cheap aggregate and this property, the security tab and the metadata
sidebar all get faster. Worth doing separately.

Coverage-only alternatives are cheaper still (one query, ~3 ms, no payload)
but reach only four of the six states, so the history badge would show a green
check on a release its own page warns about.

Pull Request description 🤖 Generated with [Claude Code](https://claude.com/claude-code)
