### PR TITLE
Orgs(promo): Add org landing page

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -65,6 +65,8 @@ METRICS_BACKEND=warehouse.metrics.DataDogMetrics host=notdatadog
 
 STATUSPAGE_URL=https://2p66nmmycsj3.statuspage.io
 
+ORGANIZATION_SERVICE_AGREEMENT_SURVEY_URL=https://www.surveymonkey.com/r/H53HHSS
+
 TOKEN_PASSWORD_SECRET="an insecure password reset secret key"
 TOKEN_EMAIL_SECRET="an insecure email verification secret key"
 TOKEN_TWO_FACTOR_SECRET="an insecure two-factor auth secret key"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -404,6 +404,9 @@ def get_app_config(database, nondefaults=None):
         "sessions.secret": "123456",
         "sessions.url": "redis://localhost:0/",
         "statuspage.url": "https://2p66nmmycsj3.statuspage.io",
+        "warehouse.organizations.service_agreement_survey_url": (
+            "https://example.com/service-agreement-survey"
+        ),
         "warehouse.xmlrpc.cache.url": "redis://localhost:0/",
         "terms.revision": "initial",
         "oidc.jwk_cache_url": "redis://localhost:0/",

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -77,10 +77,6 @@ def test_robots_txt(app_config, domain, indexable):
 
 
 def test_organizations_landing_page(webtest):
-    """
-    The Organizations landing page renders for anonymous users, including the
-    service agreement survey call to action.
-    """
     resp = webtest.get("/organizations/", status=HTTPStatus.OK)
     assert "https://www.surveymonkey.com/r/H53HHSS" in resp.text
     assert "/manage/organizations/" in resp.text

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -78,7 +78,7 @@ def test_robots_txt(app_config, domain, indexable):
 
 def test_organizations_landing_page(webtest):
     resp = webtest.get("/organizations/", status=HTTPStatus.OK)
-    assert "https://www.surveymonkey.com/r/H53HHSS" in resp.text
+    assert "https://example.com/service-agreement-survey" in resp.text
     assert "/manage/organizations/" in resp.text
 
 

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -76,6 +76,16 @@ def test_robots_txt(app_config, domain, indexable):
         )
 
 
+def test_organizations_landing_page(webtest):
+    """
+    The Organizations landing page renders for anonymous users, including the
+    service agreement survey call to action.
+    """
+    resp = webtest.get("/organizations/", status=HTTPStatus.OK)
+    assert "https://www.surveymonkey.com/r/H53HHSS" in resp.text
+    assert "/manage/organizations/" in resp.text
+
+
 def test_non_existent_route_404(webtest):
     resp = webtest.get("/asdadadasdasd/", status=HTTPStatus.NOT_FOUND)
     assert resp.status_code == HTTPStatus.NOT_FOUND

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -682,6 +682,13 @@ def test_routes(warehouse, mocker):
             view_kw={"has_translations": True},
         ),
         mocker.call(
+            "organizations",
+            "/organizations/",
+            "pages/organizations.html",
+            route_kw={"domain": warehouse},
+            view_kw={"has_translations": True},
+        ),
+        mocker.call(
             "sponsors",
             "/sponsors/",
             "pages/sponsors.html",

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -625,6 +625,11 @@ def configure(settings=None):
         coercer=int,
         default=3,
     )
+    maybe_set(
+        settings,
+        "warehouse.organizations.service_agreement_survey_url",
+        "ORGANIZATION_SERVICE_AGREEMENT_SURVEY_URL",
+    )
 
     # Add the settings we use when the environment is set to development.
     if settings["warehouse.env"] == Environment.development:

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1149,6 +1149,9 @@ msgstr ""
 #: warehouse/templates/pages/help.html:1493
 #: warehouse/templates/pages/help.html:1499
 #: warehouse/templates/pages/help.html:1506
+#: warehouse/templates/pages/organizations.html:24
+#: warehouse/templates/pages/organizations.html:83
+#: warehouse/templates/pages/organizations.html:88
 #: warehouse/templates/pages/sponsors.html:36
 #: warehouse/templates/pages/sponsors.html:47
 #: warehouse/templates/pages/sponsors.html:55
@@ -9924,6 +9927,146 @@ msgid ""
 "title=\"%(title)s\" target=\"_blank\" rel=\"noopener\">#pypa on IRC "
 "(Libera)</a>, or <a href=\"%(discourse_href)s\" title=\"%(title)s\" "
 "target=\"_blank\" rel=\"noopener\">browse the online board</a>."
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:4
+msgid "Organizations"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:10
+msgid "PyPI Organizations"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:11
+msgid "Collaborate on your projects, as a team"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:14
+msgid ""
+"Organizations let users from a company or community project assemble into"
+" teams and collaborate on projects, under a single unique brand on PyPI."
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:17
+msgid ""
+"Group your projects under one organization, with a shared organization "
+"profile"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:18
+msgid ""
+"Create teams and manage who can publish, maintain, or view each project "
+"in one place"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:19
+msgid ""
+"Give new maintainers the right permissions without assigning individual "
+"project roles"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:20
+msgid "Set up trusted publishing for your organization's projects"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:21
+msgid "Review your organization's history to see who changed what, and when"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:24
+#, python-format
+msgid ""
+"The features are the same for every organization. For full details, see "
+"the <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
+"rel=\"noopener\">organization accounts documentation</a>."
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:32
+msgid "Community organization"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:35
+msgid "For community projects, maintained in the open by volunteers."
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:36
+msgid ""
+"Non-profits, NGOs, schools, and other non-commercial groups belong here "
+"too; you do not need to be an informal project to qualify."
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:38
+msgid "All organization features, at no cost"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:39
+msgid "No payment or billing information required"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:40
+#: warehouse/templates/pages/organizations.html:61
+msgid "Applications are reviewed by the PyPI team"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:42
+msgid "Free for qualifying community projects"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:46
+msgid "Create a community organization"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:54
+msgid "Company organization"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:57
+msgid "For companies and other private organizations."
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:59
+msgid "All current organization features, on a monthly subscription"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:60
+msgid "Billed monthly by card through Stripe"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:63
+msgid "$5 per member, per month"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:67
+msgid "Apply for a company organization"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:77
+msgid "Does your company need a PyPI service agreement?"
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:79
+msgid ""
+"Some companies need a formal agreement with PyPI covering support, "
+"availability, or compliance requirements. We are gathering interest to "
+"understand what companies need."
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:81
+msgid ""
+"Tell us about your requirements and we will be in touch as this work "
+"progresses."
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:83
+#, python-format
+msgid ""
+"For help with an existing organization, see <a href=\"%(href)s\" "
+"title=\"%(title)s\" target=\"_blank\" rel=\"noopener\">organization "
+"accounts support</a>."
+msgstr ""
+
+#: warehouse/templates/pages/organizations.html:90
+msgid "PyPI Service Agreement Interest"
 msgstr ""
 
 #: warehouse/templates/pages/security-key-giveaway.html:7

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -50,6 +50,13 @@ def includeme(config):
         route_kw={"domain": warehouse},
         view_kw={"has_translations": True},
     )
+    config.add_template_view(
+        "organizations",
+        "/organizations/",
+        "pages/organizations.html",
+        route_kw={"domain": warehouse},
+        view_kw={"has_translations": True},
+    )
     # Redirect the old "sponsor PyPI" page to the sponsors page
     config.add_redirect("/sponsor/", "/sponsors/", domain=warehouse)
     config.add_template_view(

--- a/warehouse/static/sass/blocks/_sponsor-packages.scss
+++ b/warehouse/static/sass/blocks/_sponsor-packages.scss
@@ -118,4 +118,9 @@
       margin-bottom: 15px;
     }
   }
+
+  &--equal-height {
+    height: calc(100% - #{grid.$spacing-unit});
+    margin-top: grid.$spacing-unit;
+  }
 }

--- a/warehouse/static/sass/blocks/_sponsor-packages.scss
+++ b/warehouse/static/sass/blocks/_sponsor-packages.scss
@@ -32,7 +32,7 @@
 .sponsor-packages {
   display: grid;
   grid-gap: grid.$spacing-unit;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   margin: (grid.$spacing-unit * 1.5) 0 (grid.$spacing-unit * 2);
 
   @media screen and (max-width: breakpoints.$mobile) {
@@ -117,10 +117,5 @@
       width: 100%;
       margin-bottom: 15px;
     }
-  }
-
-  &--equal-height {
-    height: calc(100% - #{grid.$spacing-unit});
-    margin-top: grid.$spacing-unit;
   }
 }

--- a/warehouse/templates/pages/organizations.html
+++ b/warehouse/templates/pages/organizations.html
@@ -1,0 +1,95 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+{% extends "base.html" %}
+{% block title %}
+  {% trans %}Organizations{% endtrans %}
+{% endblock %}
+{% block content %}
+  <div class="horizontal-section">
+    <div class="site-container">
+      <div class="heading-wsubtitle">
+        <h1 class="heading-wsubtitle__heading">{% trans %}PyPI Organizations{% endtrans %}</h1>
+        <p class="heading-wsubtitle__subtitle">{% trans %}Collaborate on your projects, as a team{% endtrans %}</p>
+      </div>
+      <p class="lede-paragraph">
+        {% trans %}Organizations let users from a company or community project assemble into teams and collaborate on projects, under a single unique brand on PyPI.{% endtrans %}
+      </p>
+      <ul class="hooray-list">
+        <li>{% trans %}Group your projects under one organization, with a shared organization profile{% endtrans %}</li>
+        <li>{% trans %}Create teams and manage who can publish, maintain, or view each project in one place{% endtrans %}</li>
+        <li>{% trans %}Give new maintainers the right permissions without handing out individual project roles{% endtrans %}</li>
+        <li>{% trans %}Set up trusted publishing for your organization's projects{% endtrans %}</li>
+        <li>{% trans %}Review your organization's history to see who changed what, and when{% endtrans %}</li>
+      </ul>
+      <p>
+        {% trans href='https://docs.pypi.org/organization-accounts/', title=gettext('External link') %}The features are the same for every organization. For full details, see the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">organization accounts documentation</a>.{% endtrans %}
+      </p>
+      <div class="col-grid">
+        <div class="col-half">
+          <div class="sponsor-package sponsor-package--equal-height">
+            <div class="sponsor-package__header">
+              <div class="sponsor-package__icon">
+                <i class="fas fa-users" aria-hidden="true"></i>
+              </div>
+              <h2>{% trans %}Community organization{% endtrans %}</h2>
+            </div>
+            <div class="sponsor-package__body">
+              <p>{% trans %}For community projects, maintained in the open by volunteers.{% endtrans %}</p>
+              <ul>
+                <li>{% trans %}All organization features, at no cost{% endtrans %}</li>
+                <li>{% trans %}No payment or billing information required{% endtrans %}</li>
+                <li>{% trans %}Applications are reviewed by the PyPI team{% endtrans %}</li>
+              </ul>
+              <p>{% trans %}Free for qualifying community projects{% endtrans %}</p>
+            </div>
+            <div class="sponsor-package__button">
+              <a class="button button--primary"
+                 href="{{ request.route_path('manage.organizations') }}">{% trans %}Create a community organization{% endtrans %}</a>
+            </div>
+          </div>
+        </div>
+        <div class="col-half">
+          <div class="sponsor-package sponsor-package--equal-height">
+            <div class="sponsor-package__header">
+              <div class="sponsor-package__icon">
+                <i class="fas fa-building" aria-hidden="true"></i>
+              </div>
+              <h2>{% trans %}Company organization{% endtrans %}</h2>
+            </div>
+            <div class="sponsor-package__body">
+              <p>{% trans %}For companies and other private organizations.{% endtrans %}</p>
+              <ul>
+                <li>{% trans %}All current organization features, on a monthly subscription{% endtrans %}</li>
+                <li>{% trans %}Billed monthly by card through Stripe{% endtrans %}</li>
+                <li>{% trans %}Applications are reviewed by the PyPI team{% endtrans %}</li>
+              </ul>
+              <p>{% trans %}$5 per member, per month{% endtrans %}</p>
+            </div>
+            <div class="sponsor-package__button">
+              <a class="button button--primary"
+                 href="{{ request.route_path('manage.organizations') }}">{% trans %}Apply for a company organization{% endtrans %}</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="horizontal-section horizontal-section--grey horizontal-section--medium">
+    <div class="narrow-container">
+      <h2>{% trans %}Does your company need a PyPI service agreement?{% endtrans %}</h2>
+      <p>
+        {% trans %}Some companies need a formal agreement with PyPI covering support, availability, or compliance requirements. We are gathering interest to understand what companies need.{% endtrans %}
+      </p>
+      <p>{% trans %}Tell us about your requirements and we will be in touch as this work progresses.{% endtrans %}</p>
+      <p>
+        {% trans href='https://docs.pypi.org/organization-accounts/support/', title=gettext('External link') %}For help with an existing organization, see <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">organization accounts support</a>.{% endtrans %}
+      </p>
+      <p>
+        <a class="button button--primary"
+           href="https://www.surveymonkey.com/r/H53HHSS"
+           title="{% trans %}External link{% endtrans %}"
+           target="_blank"
+           rel="noopener">{% trans %}PyPI Service Agreement Interest{% endtrans %}</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/warehouse/templates/pages/organizations.html
+++ b/warehouse/templates/pages/organizations.html
@@ -23,51 +23,47 @@
       <p>
         {% trans href='https://docs.pypi.org/organization-accounts/', title=gettext('External link') %}The features are the same for every organization. For full details, see the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">organization accounts documentation</a>.{% endtrans %}
       </p>
-      <div class="col-grid">
-        <div class="col-half">
-          <div class="sponsor-package sponsor-package--equal-height">
-            <div class="sponsor-package__header">
-              <div class="sponsor-package__icon">
-                <i class="fas fa-users" aria-hidden="true"></i>
-              </div>
-              <h2>{% trans %}Community organization{% endtrans %}</h2>
+      <div class="sponsor-packages">
+        <div class="sponsor-package">
+          <div class="sponsor-package__header">
+            <div class="sponsor-package__icon">
+              <i class="fas fa-users" aria-hidden="true"></i>
             </div>
-            <div class="sponsor-package__body">
-              <p>{% trans %}For community projects, maintained in the open by volunteers.{% endtrans %}</p>
-              <ul>
-                <li>{% trans %}All organization features, at no cost{% endtrans %}</li>
-                <li>{% trans %}No payment or billing information required{% endtrans %}</li>
-                <li>{% trans %}Applications are reviewed by the PyPI team{% endtrans %}</li>
-              </ul>
-              <p>{% trans %}Free for qualifying community projects{% endtrans %}</p>
-            </div>
-            <div class="sponsor-package__button">
-              <a class="button button--primary"
-                 href="{{ request.route_path('manage.organizations') }}">{% trans %}Create a community organization{% endtrans %}</a>
-            </div>
+            <h2>{% trans %}Community organization{% endtrans %}</h2>
+          </div>
+          <div class="sponsor-package__body">
+            <p>{% trans %}For community projects, maintained in the open by volunteers.{% endtrans %}</p>
+            <ul>
+              <li>{% trans %}All organization features, at no cost{% endtrans %}</li>
+              <li>{% trans %}No payment or billing information required{% endtrans %}</li>
+              <li>{% trans %}Applications are reviewed by the PyPI team{% endtrans %}</li>
+            </ul>
+            <p>{% trans %}Free for qualifying community projects{% endtrans %}</p>
+          </div>
+          <div class="sponsor-package__button">
+            <a class="button button--primary"
+               href="{{ request.route_path('manage.organizations') }}">{% trans %}Create a community organization{% endtrans %}</a>
           </div>
         </div>
-        <div class="col-half">
-          <div class="sponsor-package sponsor-package--equal-height">
-            <div class="sponsor-package__header">
-              <div class="sponsor-package__icon">
-                <i class="fas fa-building" aria-hidden="true"></i>
-              </div>
-              <h2>{% trans %}Company organization{% endtrans %}</h2>
+        <div class="sponsor-package">
+          <div class="sponsor-package__header">
+            <div class="sponsor-package__icon">
+              <i class="fas fa-building" aria-hidden="true"></i>
             </div>
-            <div class="sponsor-package__body">
-              <p>{% trans %}For companies and other private organizations.{% endtrans %}</p>
-              <ul>
-                <li>{% trans %}All current organization features, on a monthly subscription{% endtrans %}</li>
-                <li>{% trans %}Billed monthly by card through Stripe{% endtrans %}</li>
-                <li>{% trans %}Applications are reviewed by the PyPI team{% endtrans %}</li>
-              </ul>
-              <p>{% trans %}$5 per member, per month{% endtrans %}</p>
-            </div>
-            <div class="sponsor-package__button">
-              <a class="button button--primary"
-                 href="{{ request.route_path('manage.organizations') }}">{% trans %}Apply for a company organization{% endtrans %}</a>
-            </div>
+            <h2>{% trans %}Company organization{% endtrans %}</h2>
+          </div>
+          <div class="sponsor-package__body">
+            <p>{% trans %}For companies and other private organizations.{% endtrans %}</p>
+            <ul>
+              <li>{% trans %}All current organization features, on a monthly subscription{% endtrans %}</li>
+              <li>{% trans %}Billed monthly by card through Stripe{% endtrans %}</li>
+              <li>{% trans %}Applications are reviewed by the PyPI team{% endtrans %}</li>
+            </ul>
+            <p>{% trans %}$5 per member, per month{% endtrans %}</p>
+          </div>
+          <div class="sponsor-package__button">
+            <a class="button button--primary"
+               href="{{ request.route_path('manage.organizations') }}">{% trans %}Apply for a company organization{% endtrans %}</a>
           </div>
         </div>
       </div>

--- a/warehouse/templates/pages/organizations.html
+++ b/warehouse/templates/pages/organizations.html
@@ -70,23 +70,26 @@
       </div>
     </div>
   </div>
-  <div class="horizontal-section horizontal-section--grey horizontal-section--medium">
-    <div class="narrow-container">
-      <h2>{% trans %}Does your company need a PyPI service agreement?{% endtrans %}</h2>
-      <p>
-        {% trans %}Some companies need a formal agreement with PyPI covering support, availability, or compliance requirements. We are gathering interest to understand what companies need.{% endtrans %}
-      </p>
-      <p>{% trans %}Tell us about your requirements and we will be in touch as this work progresses.{% endtrans %}</p>
-      <p>
-        {% trans href='https://docs.pypi.org/organization-accounts/support/', title=gettext('External link') %}For help with an existing organization, see <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">organization accounts support</a>.{% endtrans %}
-      </p>
-      <p>
-        <a class="button button--primary"
-           href="https://www.surveymonkey.com/r/H53HHSS"
-           title="{% trans %}External link{% endtrans %}"
-           target="_blank"
-           rel="noopener">{% trans %}PyPI Service Agreement Interest{% endtrans %}</a>
-      </p>
+  {% set survey_url = request.registry.settings.get("warehouse.organizations.service_agreement_survey_url") %}
+  {% if survey_url %}
+    <div class="horizontal-section horizontal-section--grey horizontal-section--medium">
+      <div class="narrow-container">
+        <h2>{% trans %}Does your company need a PyPI service agreement?{% endtrans %}</h2>
+        <p>
+          {% trans %}Some companies need a formal agreement with PyPI covering support, availability, or compliance requirements. We are gathering interest to understand what companies need.{% endtrans %}
+        </p>
+        <p>{% trans %}Tell us about your requirements and we will be in touch as this work progresses.{% endtrans %}</p>
+        <p>
+          {% trans href='https://docs.pypi.org/organization-accounts/support/', title=gettext('External link') %}For help with an existing organization, see <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">organization accounts support</a>.{% endtrans %}
+        </p>
+        <p>
+          <a class="button button--primary"
+             href="{{ survey_url }}"
+             title="{% trans %}External link{% endtrans %}"
+             target="_blank"
+             rel="noopener">{% trans %}PyPI Service Agreement Interest{% endtrans %}</a>
+        </p>
+      </div>
     </div>
-  </div>
+  {% endif %}
 {% endblock %}

--- a/warehouse/templates/pages/organizations.html
+++ b/warehouse/templates/pages/organizations.html
@@ -16,7 +16,7 @@
       <ul class="hooray-list">
         <li>{% trans %}Group your projects under one organization, with a shared organization profile{% endtrans %}</li>
         <li>{% trans %}Create teams and manage who can publish, maintain, or view each project in one place{% endtrans %}</li>
-        <li>{% trans %}Give new maintainers the right permissions without handing out individual project roles{% endtrans %}</li>
+        <li>{% trans %}Give new maintainers the right permissions without assigning individual project roles{% endtrans %}</li>
         <li>{% trans %}Set up trusted publishing for your organization's projects{% endtrans %}</li>
         <li>{% trans %}Review your organization's history to see who changed what, and when{% endtrans %}</li>
       </ul>

--- a/warehouse/templates/pages/organizations.html
+++ b/warehouse/templates/pages/organizations.html
@@ -33,6 +33,7 @@
           </div>
           <div class="sponsor-package__body">
             <p>{% trans %}For community projects, maintained in the open by volunteers.{% endtrans %}</p>
+            <p>{% trans %}Non-profits, NGOs, schools, and other non-commercial groups belong here too; you do not need to be an informal project to qualify.{% endtrans %}</p>
             <ul>
               <li>{% trans %}All organization features, at no cost{% endtrans %}</li>
               <li>{% trans %}No payment or billing information required{% endtrans %}</li>


### PR DESCRIPTION
Add landing pages for orgs

<img width="1726" height="993" alt="image" src="https://github.com/user-attachments/assets/76fde366-939e-4948-8d1b-0b9b57c6c3fe" />

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>