### PR TITLE
Orgs(promo): Link organizations from the homepage banner

### DIFF
--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -82,6 +82,12 @@ def test_organizations_landing_page(webtest):
     assert "/manage/organizations/" in resp.text
 
 
+def test_homepage_links_to_organizations(webtest):
+    resp = webtest.get("/", status=HTTPStatus.OK)
+    banner = resp.html.find("div", {"class": "homepage-banner"})
+    assert banner.find("a", href="/organizations/") is not None
+
+
 def test_non_existent_route_404(webtest):
     resp = webtest.get("/asdadadasdasd/", status=HTTPStatus.NOT_FOUND)
     assert resp.status_code == HTTPStatus.NOT_FOUND

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1074,7 +1074,7 @@ msgstr ""
 #: warehouse/templates/includes/packaging/project-files.html:48
 #: warehouse/templates/includes/packaging/project-files.html:66
 #: warehouse/templates/includes/packaging/project-files.html:82
-#: warehouse/templates/index.html:99 warehouse/templates/index.html:106
+#: warehouse/templates/index.html:102 warehouse/templates/index.html:109
 #: warehouse/templates/manage/account.html:241
 #: warehouse/templates/manage/account.html:248
 #: warehouse/templates/manage/account/totp-provision.html:17
@@ -1284,7 +1284,7 @@ msgstr ""
 msgid "PyPI, the Python Package Index"
 msgstr ""
 
-#: warehouse/templates/base.html:131 warehouse/templates/index.html:94
+#: warehouse/templates/base.html:131 warehouse/templates/index.html:97
 msgid ""
 "The Python Package Index (PyPI) is a repository of software for the "
 "Python programming language."
@@ -1551,49 +1551,54 @@ msgstr ""
 msgid "Or <a href=\"%(href)s\">browse projects</a>"
 msgstr ""
 
-#: warehouse/templates/index.html:56
+#: warehouse/templates/index.html:52
+#, python-format
+msgid "Publishing as a team? Use an <a href=\"%(href)s\">organization account</a>"
+msgstr ""
+
+#: warehouse/templates/index.html:59
 #, python-format
 msgid "%(num_projects_formatted)s project"
 msgid_plural "%(num_projects_formatted)s projects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/index.html:63
+#: warehouse/templates/index.html:66
 #, python-format
 msgid "%(num_releases_formatted)s release"
 msgid_plural "%(num_releases_formatted)s releases"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/index.html:70
+#: warehouse/templates/index.html:73
 #, python-format
 msgid "%(num_files_formatted)s file"
 msgid_plural "%(num_files_formatted)s files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/index.html:77
+#: warehouse/templates/index.html:80
 #, python-format
 msgid "%(num_users_formatted)s user"
 msgid_plural "%(num_users_formatted)s users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/index.html:97
+#: warehouse/templates/index.html:100
 msgid ""
 "PyPI helps you find and install software developed and shared by the "
 "Python community."
 msgstr ""
 
-#: warehouse/templates/index.html:101
+#: warehouse/templates/index.html:104
 msgid "Learn about installing packages"
 msgstr ""
 
-#: warehouse/templates/index.html:104
+#: warehouse/templates/index.html:107
 msgid "Package authors use PyPI to distribute their software."
 msgstr ""
 
-#: warehouse/templates/index.html:108
+#: warehouse/templates/index.html:111
 msgid "Learn how to package your Python code for PyPI"
 msgstr ""
 

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -48,6 +48,9 @@
       <p class="homepage-banner__browse">
         {% trans href=request.route_path('search') %}Or <a href="{{ href }}">browse projects</a>{% endtrans %}
       </p>
+      <p class="homepage-banner__browse">
+        {% trans href=request.route_path('organizations') %}Publishing as a team? Use an <a href="{{ href }}">organization account</a>{% endtrans %}
+      </p>
     </div>
   </div>
   <div class="horizontal-section horizontal-section--grey horizontal-section--thin horizontal-section--statistics">


### PR DESCRIPTION
Add callout on home page for orgs

<img width="859" height="389" alt="image" src="https://github.com/user-attachments/assets/f59b8431-702f-4bfe-85ca-66f776d209e6" />

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>