### PR TITLE
Fix relative release dates for locales with a single plural form

### DIFF
--- a/tests/frontend/timeago_test.js
+++ b/tests/frontend/timeago_test.js
@@ -20,7 +20,7 @@ describe("time ago util", () => {
     await delay(25);
 
     const element = document.getElementById("element");
-    expect(element.innerText).toEqual("Just now");
+    expect(element.textContent).toEqual("Just now");
 
   });
 
@@ -37,7 +37,7 @@ describe("time ago util", () => {
     await delay(25);
 
     const element = document.getElementById("element");
-    expect(element.innerText).toEqual("About 5 hours ago");
+    expect(element.textContent).toEqual("About 5 hours ago");
   });
 
   it("shows 'About 36 minutes ago' for such a time'", async () => {
@@ -53,7 +53,7 @@ describe("time ago util", () => {
     await delay(25);
 
     const element = document.getElementById("element");
-    expect(element.innerText).toEqual("About 36 minutes ago");
+    expect(element.textContent).toEqual("About 36 minutes ago");
   });
 
   it("shows provided text for Yesterday'", async () => {
@@ -69,7 +69,7 @@ describe("time ago util", () => {
     await delay(25);
 
     const element = document.getElementById("element");
-    expect(element.innerText).toEqual("Yesterday");
+    expect(element.textContent).toEqual("Yesterday");
   });
 
   it("makes no call when not isBeforeCutoff", async () => {

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -983,37 +983,37 @@ msgstr ""
 msgid "Password is strong"
 msgstr ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:22
+#: warehouse/static/js/warehouse/utils/timeago.js:24
 msgid "Yesterday"
 msgstr ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:24
+#: warehouse/static/js/warehouse/utils/timeago.js:28
 msgid "About %1 day ago"
 msgid_plural "About %1 days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:28
+#: warehouse/static/js/warehouse/utils/timeago.js:34
 msgid "About an hour ago"
 msgstr ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:30
+#: warehouse/static/js/warehouse/utils/timeago.js:38
 msgid "About %1 hour ago"
 msgid_plural "About %1 hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:34
+#: warehouse/static/js/warehouse/utils/timeago.js:44
 msgid "About a minute ago"
 msgstr ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:36
+#: warehouse/static/js/warehouse/utils/timeago.js:48
 msgid "About %1 minute ago"
 msgid_plural "About %1 minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:39
+#: warehouse/static/js/warehouse/utils/timeago.js:53
 msgid "Just now"
 msgstr ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -985,23 +985,35 @@ msgstr ""
 
 #: warehouse/static/js/warehouse/utils/timeago.js:22
 msgid "Yesterday"
+msgstr ""
+
+#: warehouse/static/js/warehouse/utils/timeago.js:24
+msgid "About %1 day ago"
 msgid_plural "About %1 days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:26
+#: warehouse/static/js/warehouse/utils/timeago.js:28
 msgid "About an hour ago"
+msgstr ""
+
+#: warehouse/static/js/warehouse/utils/timeago.js:30
+msgid "About %1 hour ago"
 msgid_plural "About %1 hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:28
+#: warehouse/static/js/warehouse/utils/timeago.js:34
 msgid "About a minute ago"
+msgstr ""
+
+#: warehouse/static/js/warehouse/utils/timeago.js:36
+msgid "About %1 minute ago"
 msgid_plural "About %1 minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/static/js/warehouse/utils/timeago.js:30
+#: warehouse/static/js/warehouse/utils/timeago.js:39
 msgid "Just now"
 msgstr ""
 

--- a/warehouse/static/js/warehouse/utils/messages-access.js
+++ b/warehouse/static/js/warehouse/utils/messages-access.js
@@ -76,11 +76,10 @@ export function gettext(singular, ...extras) {
 export function ngettextCustom(singular, plural, num, extras, data, pluralForms) {
   // This function allows for testing and
   // allows ngettext and gettext to have the signatures required by pybabel.
-  const pluralFormsData = pluralForms(num);
   let value = getTranslationData(data, singular);
   if (Array.isArray(value)) {
-    value = value[pluralFormsData.index];
-  } else if (pluralFormsData.index > 0) {
+    value = value[pluralForms(num).index];
+  } else if (plural !== null && !Object.hasOwn(data, singular) && num !== 1) {
     value = plural;
   }
   return insertPlaceholderValues(value, extras);

--- a/warehouse/static/js/warehouse/utils/messages-access.js
+++ b/warehouse/static/js/warehouse/utils/messages-access.js
@@ -64,6 +64,42 @@ export function gettext(singular, ...extras) {
 }
 
 /**
+ * Check whether the current locale has a translation for a string.
+ * @param singular {string} The default string for the singular translation, used as the key.
+ * @returns {boolean}
+ */
+export function hasTranslation(singular) {
+  return hasTranslationCustom(singular, messagesAccessLocaleData);
+}
+
+/**
+ * Check whether the locale data has a translation for a string.
+ * @param singular {string} The default string for the singular translation, used as the key.
+ * @param data {{}} The locale data used for translation.
+ * @returns {boolean}
+ */
+export function hasTranslationCustom(singular, data) {
+  if (!singular) {
+    return false;
+  }
+  const language = data?.[""]?.["language"];
+  if (!language) {
+    return false;
+  }
+  if (language === "en") {
+    return true;
+  }
+  if (!Object.hasOwn(data, singular)) {
+    return false;
+  }
+  let value = data[singular];
+  if (!Array.isArray(value)) {
+    value = [value];
+  }
+  return value.length > 0 && value.every((str) => str !== "");
+}
+
+/**
  * Get the translation.
  * @param singular {string} The default string for the singular translation.
  * @param plural {string|null} The default string for the plural translation.

--- a/warehouse/static/js/warehouse/utils/timeago.js
+++ b/warehouse/static/js/warehouse/utils/timeago.js
@@ -18,17 +18,25 @@ const enumerateTime = (timestampString) => {
 const convertToReadableText = (time) => {
   let { numDays, numMinutes, numHours } = time;
 
-  if (numDays >= 1) {
-    return ngettext("Yesterday", "About %1 days ago", numDays, numDays);
+  if (numDays === 1) {
+    return gettext("Yesterday");
+  } else if (numDays > 1) {
+    return ngettext("About %1 day ago", "About %1 days ago", numDays, numDays);
   }
 
-  if (numHours > 0) {
-    return ngettext("About an hour ago", "About %1 hours ago", numHours, numHours);
-  } else if (numMinutes > 0) {
-    return ngettext("About a minute ago", "About %1 minutes ago", numMinutes, numMinutes);
-  } else {
-    return gettext("Just now", "another");
+  if (numHours === 1) {
+    return gettext("About an hour ago");
+  } else if (numHours > 1) {
+    return ngettext("About %1 hour ago", "About %1 hours ago", numHours, numHours);
   }
+
+  if (numMinutes === 1) {
+    return gettext("About a minute ago");
+  } else if (numMinutes > 1) {
+    return ngettext("About %1 minute ago", "About %1 minutes ago", numMinutes, numMinutes);
+  }
+
+  return gettext("Just now");
 };
 
 export default () => {
@@ -37,7 +45,7 @@ export default () => {
     const datetime = timeElement.getAttribute("datetime");
     const time = enumerateTime(datetime);
     if (time.isBeforeCutoff) {
-      timeElement.innerText = convertToReadableText(time);
+      timeElement.textContent = convertToReadableText(time);
     }
   }
 };

--- a/warehouse/static/js/warehouse/utils/timeago.js
+++ b/warehouse/static/js/warehouse/utils/timeago.js
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-import { gettext, ngettext } from "../utils/messages-access";
+import { gettext, ngettext, hasTranslation } from "../utils/messages-access";
 
 const enumerateTime = (timestampString) => {
   const now = new Date(),
@@ -15,28 +15,43 @@ const enumerateTime = (timestampString) => {
   return time;
 };
 
+// pybabel only extracts string literals, so the message ids are repeated.
 const convertToReadableText = (time) => {
-  let { numDays, numMinutes, numHours } = time;
+  const { numDays, numMinutes, numHours } = time;
 
   if (numDays === 1) {
-    return gettext("Yesterday");
+    return hasTranslation("Yesterday")
+      ? gettext("Yesterday")
+      : null;
   } else if (numDays > 1) {
-    return ngettext("About %1 day ago", "About %1 days ago", numDays, numDays);
+    return hasTranslation("About %1 day ago")
+      ? ngettext("About %1 day ago", "About %1 days ago", numDays, numDays)
+      : null;
   }
 
   if (numHours === 1) {
-    return gettext("About an hour ago");
+    return hasTranslation("About an hour ago")
+      ? gettext("About an hour ago")
+      : null;
   } else if (numHours > 1) {
-    return ngettext("About %1 hour ago", "About %1 hours ago", numHours, numHours);
+    return hasTranslation("About %1 hour ago")
+      ? ngettext("About %1 hour ago", "About %1 hours ago", numHours, numHours)
+      : null;
   }
 
   if (numMinutes === 1) {
-    return gettext("About a minute ago");
+    return hasTranslation("About a minute ago")
+      ? gettext("About a minute ago")
+      : null;
   } else if (numMinutes > 1) {
-    return ngettext("About %1 minute ago", "About %1 minutes ago", numMinutes, numMinutes);
+    return hasTranslation("About %1 minute ago")
+      ? ngettext("About %1 minute ago", "About %1 minutes ago", numMinutes, numMinutes)
+      : null;
   }
 
-  return gettext("Just now");
+  return hasTranslation("Just now")
+    ? gettext("Just now")
+    : null;
 };
 
 export default () => {
@@ -45,7 +60,10 @@ export default () => {
     const datetime = timeElement.getAttribute("datetime");
     const time = enumerateTime(datetime);
     if (time.isBeforeCutoff) {
-      timeElement.textContent = convertToReadableText(time);
+      const text = convertToReadableText(time);
+      if (text !== null) {
+        timeElement.textContent = text;
+      }
     }
   }
 };


### PR DESCRIPTION
On https://pypi.org/project/paimon/#history in a Chinese browser, 0.2.4 showed as released about an hour ago when it was about 20 hours old, and 0.2.3 and 0.2.2 showed as yesterday when they were several days old. The RSS feed had the right times, so the problem is in the front end.

<img width="857" height="773" alt="{EFA4F63B-3BAB-4A8A-99C4-99A66F5E53F3}" src="https://github.com/user-attachments/assets/4fafa2b1-502d-4c4e-b748-ba24069083d6" />


`timeago.js` uses "Yesterday" and "About %1 days ago" as the singular and plural of one message, and does the same for hours and minutes. For locales with `nplurals=1` (zh, ja, ko, vi and others) `ngettext` always picks index 0, so anything under 7 days shows as "Yesterday" or "About an hour ago". English is not affected.

This splits the one unit sentences into their own `gettext` calls and gives the plural pairs a `%1` placeholder in both forms. It also stops falling back to English when the locale has no translation for the relative time. A wrong relative time reads as "this package was just changed", and my first reaction was to check for a supply chain attack. When the translation is missing, the element is now left alone and the absolute date stays visible.
