### PR TITLE
test: avoid MX record lookups for bar.net

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -874,6 +874,7 @@ class TestRegistrationForm:
 
 
 class TestRequestPasswordResetForm:
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     @pytest.mark.parametrize(
         "form_input",
         [


### PR DESCRIPTION
Most tests are already skipping the email deliverability check, and this one kept working until recently when `bar.net` delisted thier MX records, causing the test to fail.