### PR TITLE
Add npm dependency cooldown

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
Adds an npm cooldown, matching the Dependabot one. The idea is to guard against local updates as well, if/when those happen during dev flows.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>