### PR TITLE
Pin "one-shot" tools

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-# https://github.com/woodruffw/zizmor
+# https://github.com/zizmorcore/zizmor-action
 name: GitHub Actions Security Analysis with Zizmor
 
 on:
@@ -23,15 +23,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       - name: Run zizmor
-        run: pipx run zizmor --format sarif . > results.sarif
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
-          # Path to SARIF file relative to the root of the repository
-          sarif_file: results.sarif
-          # Optional category for the results
-          # Used to differentiate multiple results for one commit
-          category: zizmor
+          online-audits: true

--- a/docs/dev/development/frontend.md
+++ b/docs/dev/development/frontend.md
@@ -122,7 +122,7 @@ Nimbus Sans, Liberation Sans, or Arimo.
 We aim to support all major browsers. We also support one-back,
 and follow the `defaults` recommendation from `browserslist`.
 
-You can see the full list of supported browsers by running `npx browserslist`
+You can see the full list of supported browsers by running `npx browserslist@4.28.1`
 in the root of the project.
 
 ## HTML Code Style


### PR DESCRIPTION
Invocations like `npx` and `pipx` should always install a specific version to prevent the latest version from being implicitly resolve. This addresses the only two instances of that I could find 🙂 

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>