### PR TITLE
Show the PSF sponsor tier from level_name instead of activity text

### DIFF
--- a/warehouse/static/sass/blocks/_sponsor-grid.scss
+++ b/warehouse/static/sass/blocks/_sponsor-grid.scss
@@ -15,6 +15,7 @@
         <img alt="logo">
       </div>
       <h2>Heading Here</h2>
+      <span class="badge badge--light sponsor-grid__sponsor-level">Visionary sponsor</span>
       <div class="sponsor-grid__sponsor-activity">
         <p>Information about what the sponsor gives us</p>
       </div>
@@ -55,6 +56,12 @@
     font-size: 1.15rem;
     max-width: 700px;
     margin: 0 auto;
+  }
+
+  &__sponsor-level {
+    display: inline-block;
+    margin-top: 5px;
+    margin-left: 0;
   }
 
   &__sponsor-link {

--- a/warehouse/templates/pages/sponsors.html
+++ b/warehouse/templates/pages/sponsors.html
@@ -1,11 +1,15 @@
 {# SPDX-License-Identifier: Apache-2.0 -#}
 {% extends "base.html" %}
-{% macro sponsor_card(sponsor, name_class="") %}
+{% macro sponsor_card(sponsor, name_class="", show_level=False) %}
   <div class="sponsor-grid__sponsor">
     <div class="sponsor-grid__sponsor-img">{{ sponsor.color_logo_img|camoify|safe }}</div>
     <div class="sponsor-grid__sponsor-description">
       <h2 {% if name_class %}class="{{ name_class }}"{% endif %}>{{ sponsor.name }}</h2>
-      <div class="sponsor-grid__sponsor-activity">{{ sponsor.activity|safe }}</div>
+      {% if show_level and sponsor.level_name %}
+        <span class="badge badge--light sponsor-grid__sponsor-level">{{ sponsor.level_name }} sponsor</span>
+      {% else %}
+        <div class="sponsor-grid__sponsor-activity">{{ sponsor.activity|safe }}</div>
+      {% endif %}
     </div>
     <a href="{{ sponsor.link_url }}"
        target="_blank"
@@ -153,7 +157,9 @@
              rel="noopener"
              class="sponsor-grid__sponsor-link button button--primary">See sponsorship packages</a>
         </div>
-        {% for sponsor in request.sponsors["psf"] %}{{ sponsor_card(sponsor, "sponsor-grid__sponsor-name") }}{% endfor %}
+        {% for sponsor in request.sponsors["psf"] %}
+          {{ sponsor_card(sponsor, "sponsor-grid__sponsor-name", show_level=True) }}
+        {% endfor %}
       </div>
       <div class="centered-heading">
         <h2 class="centered-heading__title">Infrastructure sponsors</h2>


### PR DESCRIPTION
Rebased and cut down substantially — #19803 landed yesterday and already does the sorting half of this, so that part is gone. What is left is one template change and its style.

The PSF sponsor grid describes a sponsor's tier using the hand-entered `activity` markdown. It is only set on some sponsors, and because it is entered by hand it drifts: pypi.org currently calls Netflix a *partner* sponsor and Microsoft a *visionary* sponsor, while python.org has them at *supporting* and *sustainability* today.

`level_name` comes from the pythondotorg logo-placement API and is refreshed hourly, so it does not drift. #19803 already uses it in the footer, which now renders `{{ group.tier }} sponsor` — so the same page currently describes tiers two different ways, and the grid is the one using the stale source. This makes the grid agree with the footer.

`sponsor_card` takes a `show_level` flag rather than changing behaviour for every caller. The infrastructure and one-time sections are untouched and keep their `activity` text, which describes what those sponsors actually donate rather than restating a tier.

`djlint --profile jinja --check` is clean and the stylesheet compiles. Note the branch was rebased onto current `main`, so this is a force-push over the previous version.

On #20434 — the sorting it asked for shipped with #19803, so it can probably be closed independently of this. I have dropped the `Closes` line accordingly.

Happy to drop the badge for plain text, or to use a different modifier than `badge--light`, if you had something else in mind.
