### PR TITLE
feat(admin): show frozen status in IP address unique logins

### DIFF
--- a/warehouse/admin/templates/admin/ip_addresses/detail.html
+++ b/warehouse/admin/templates/admin/ip_addresses/detail.html
@@ -71,6 +71,7 @@
           <tr>
             <th scope="col">Created</th>
             <th scope="col">User</th>
+            <th scope="col">Frozen</th>
             <th scope="col">Status</th>
             <th scope="col">Device Information</th>
           </tr>
@@ -80,6 +81,7 @@
           <tr>
             <td>{{ login.created }}</td>
             <td><a href="{{ request.route_path('admin.user.detail', username=login.user.username ) }}">{{ login.user.username }}</a></td>
+            <td>{% if login.user.is_frozen %}<i class="fa fa-check text-red"></i>{% endif %}</td>
             <td>{{ login.status.value }}</td>
             <td>{{ login.device_information }}</td>
           </tr>

--- a/warehouse/admin/views/ip_addresses.py
+++ b/warehouse/admin/views/ip_addresses.py
@@ -10,6 +10,7 @@ from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
 from pyramid.httpexceptions import HTTPBadRequest, HTTPSeeOther
 from pyramid.view import view_config
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import joinedload
 
 from warehouse.accounts.models import UserUniqueLogin
 from warehouse.authnz import Permissions
@@ -62,6 +63,7 @@ def ip_address_detail(request: Request) -> dict[str, IpAddress]:
 
     unique_logins = (
         request.db.query(UserUniqueLogin)
+        .options(joinedload(UserUniqueLogin.user))
         .filter(UserUniqueLogin.ip_address == ip_address)
         .order_by(UserUniqueLogin.created.desc())
         .all()


### PR DESCRIPTION
Aid with administrative review of account-to-IP relationships.

Also cheapens the page load by removing an N+1 that previously existed for `user.username` loading, but at small user-to-IP volumes, this wasn't felt. At larger ones (such as proxies or VPN exits) the page loads are heavier than they need to be.