### PR TITLE
test(admin): share the 2FA login helper across functional admin tests

### DIFF
--- a/tests/functional/admin/conftest.py
+++ b/tests/functional/admin/conftest.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+from http import HTTPStatus
+
+import pytest
+
+from tests.common.constants import REMOTE_ADDR
+from tests.common.db import Session
+from tests.common.db.accounts import UserFactory, UserUniqueLoginFactory
+from tests.common.db.ip_addresses import IpAddressFactory
+from warehouse.accounts.models import UniqueLoginStatus
+from warehouse.ip_addresses.models import IpAddress
+from warehouse.utils.otp import _get_totp
+
+
+@pytest.fixture
+def login_user(webtest):
+    """Log a 2FA-enabled user in, from an already-confirmed IP address."""
+
+    def _login(user):
+        # `ip_address` is unique and any request already served in this test
+        # will have inserted the row, since every request upserts it in
+        # warehouse.utils.wsgi._ip_address. Reuse it rather than collide.
+        ip_address = Session.query(IpAddress).filter_by(
+            ip_address=REMOTE_ADDR
+        ).one_or_none() or IpAddressFactory.create(ip_address=REMOTE_ADDR)
+        UserUniqueLoginFactory.create(
+            user=user,
+            ip_address=ip_address,
+            status=UniqueLoginStatus.CONFIRMED,
+        )
+
+        login_page = webtest.get("/account/login/", status=HTTPStatus.OK)
+        login_form = login_page.forms["login-form"]
+        login_form["username"] = user.username
+        login_form["password"] = "password"
+
+        two_factor_page = login_form.submit().follow(status=HTTPStatus.OK)
+        two_factor_form = two_factor_page.forms["totp-auth-form"]
+        two_factor_form["totp_value"] = (
+            _get_totp(user.totp_secret).generate(time.time()).decode()
+        )
+        two_factor_form.submit().follow(status=HTTPStatus.OK)
+        return user
+
+    return _login
+
+
+# Every flag that grants some admin role. Naming one picks the role outright,
+# so a test asserting that a moderator is turned away cannot accidentally get a
+# superuser as well and pass without exercising anything.
+_ADMIN_ROLES = frozenset(
+    {"is_superuser", "is_support", "is_moderator", "is_psf_staff", "is_observer"}
+)
+
+
+@pytest.fixture
+def login_admin(login_user):
+    """Create an admin user and log it in, returning the user.
+
+    Defaults to a superuser; naming any role flag replaces that default, e.g.
+    ``login_admin(is_moderator=True)`` logs in a moderator and nothing more.
+    """
+
+    def _login(**kwargs):
+        roles = {} if _ADMIN_ROLES & kwargs.keys() else {"is_superuser": True}
+        return login_user(
+            UserFactory.create(
+                **{
+                    **roles,
+                    "with_verified_primary_email": True,
+                    "clear_pwd": "password",
+                    **kwargs,
+                }
+            )
+        )
+
+    return _login

--- a/tests/functional/admin/test_malware_reports.py
+++ b/tests/functional/admin/test_malware_reports.py
@@ -1,59 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import time
-
 from http import HTTPStatus
 
 from webob.multidict import MultiDict
 
-from tests.common.constants import REMOTE_ADDR
-from tests.common.db.accounts import UserFactory, UserUniqueLoginFactory
-from tests.common.db.ip_addresses import IpAddressFactory
+from tests.common.db.accounts import UserFactory
 from tests.common.db.observations import ObserverFactory
 from tests.common.db.packaging import (
     ProjectFactory,
     ProjectObservationFactory,
     ReleaseFactory,
 )
-from warehouse.accounts.models import UniqueLoginStatus
-from warehouse.utils.otp import _get_totp
 
 
 class TestMalwareReportDetail:
-    def _login_admin(self, webtest, user):
-        """Log in a superuser with 2FA and a pre-confirmed IP."""
-        ip_address = IpAddressFactory.create(ip_address=REMOTE_ADDR)
-        UserUniqueLoginFactory.create(
-            user=user,
-            ip_address=ip_address,
-            status=UniqueLoginStatus.CONFIRMED,
-        )
-
-        login_page = webtest.get("/account/login/", status=HTTPStatus.OK)
-        login_form = login_page.forms["login-form"]
-        login_form["username"] = user.username
-        login_form["password"] = "password"
-
-        two_factor_page = login_form.submit().follow(status=HTTPStatus.OK)
-        two_factor_form = two_factor_page.forms["totp-auth-form"]
-        two_factor_form["totp_value"] = (
-            _get_totp(user.totp_secret).generate(time.time()).decode()
-        )
-        two_factor_form.submit().follow(status=HTTPStatus.OK)
-
-    def test_remove_release_checks_only_reported_version(self, webtest):
+    def test_remove_release_checks_only_reported_version(self, webtest, login_admin):
         """
         The remove-release modal pre-checks the release named in the report's
         inspector_url. Only the exact version is checked — a shorter version that
         is a substring of the reported one (e.g. ``0.11.9`` inside ``0.11.97``)
         must not be checked.
         """
-        admin = UserFactory.create(
-            is_superuser=True,
-            with_verified_primary_email=True,
-            clear_pwd="password",
-        )
-        self._login_admin(webtest, admin)
+        login_admin()
 
         project = ProjectFactory.create()
         reported = ReleaseFactory.create(project=project, version="0.11.97")
@@ -84,19 +52,14 @@ class TestMalwareReportDetail:
         assert reported_box.has_attr("checked")
         assert not substring_box.has_attr("checked")
 
-    def test_remove_release_accepts_multiple_versions(self, webtest):
+    def test_remove_release_accepts_multiple_versions(self, webtest, login_admin):
         """
         Selecting more than one release submits the ``versions`` key once per
         checked box. The view reads them with ``request.POST.getall`` and so
         must permit duplicate POST keys, which the global deriver otherwise
         rejects with a 400.
         """
-        admin = UserFactory.create(
-            is_superuser=True,
-            with_verified_primary_email=True,
-            clear_pwd="password",
-        )
-        self._login_admin(webtest, admin)
+        login_admin()
 
         project = ProjectFactory.create()
         ReleaseFactory.create(project=project, version="0.0.3")

--- a/tests/functional/admin/test_prohibited_project_names.py
+++ b/tests/functional/admin/test_prohibited_project_names.py
@@ -1,54 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import time
-
 from http import HTTPStatus
 
-from tests.common.constants import REMOTE_ADDR
-from tests.common.db.accounts import UserFactory, UserUniqueLoginFactory
-from tests.common.db.ip_addresses import IpAddressFactory
 from tests.common.db.organizations import OrganizationFactory, OrganizationRoleFactory
 from tests.common.db.packaging import ProhibitedProjectFactory
-from warehouse.accounts.models import UniqueLoginStatus
 from warehouse.organizations.models import OrganizationProject
 from warehouse.packaging.models import Project
-from warehouse.utils.otp import _get_totp
 
 
 class TestReleaseProhibitedProjectName:
-    def _login_admin(self, webtest, user):
-        """Log in a superuser with 2FA and a pre-confirmed IP."""
-        ip_address = IpAddressFactory.create(ip_address=REMOTE_ADDR)
-        UserUniqueLoginFactory.create(
-            user=user,
-            ip_address=ip_address,
-            status=UniqueLoginStatus.CONFIRMED,
-        )
-
-        login_page = webtest.get("/account/login/", status=HTTPStatus.OK)
-        login_form = login_page.forms["login-form"]
-        login_form["username"] = user.username
-        login_form["password"] = "password"
-
-        two_factor_page = login_form.submit().follow(status=HTTPStatus.OK)
-        two_factor_form = two_factor_page.forms["totp-auth-form"]
-        two_factor_form["totp_value"] = (
-            _get_totp(user.totp_secret).generate(time.time()).decode()
-        )
-        two_factor_form.submit().follow(status=HTTPStatus.OK)
-
-    def test_release_to_organization_redirects_to_project_detail(self, webtest):
+    def test_release_to_organization_redirects_to_project_detail(
+        self, webtest, login_admin
+    ):
         """
         Releasing a prohibited name to an organization returns a 303 to the new
         project's admin detail page, and following that redirect resolves (the
         project is committed before the browser follows it, so it is not a 404).
         """
-        admin = UserFactory.create(
-            is_superuser=True,
-            with_verified_primary_email=True,
-            clear_pwd="password",
-        )
-        self._login_admin(webtest, admin)
+        admin = login_admin()
 
         organization = OrganizationFactory.create(name="release-org")
         OrganizationRoleFactory.create(organization=organization, user=admin)
@@ -85,18 +54,13 @@ class TestReleaseProhibitedProjectName:
             == 1
         )
 
-    def test_release_error_redirects_to_list(self, webtest):
+    def test_release_error_redirects_to_list(self, webtest, login_admin):
         """
         An error path (here, an unknown organization) returns a 303 whose target
         is the list page, not the POST-only release route. Following it resolves
         (200) rather than 404, and the flashed error is shown.
         """
-        admin = UserFactory.create(
-            is_superuser=True,
-            with_verified_primary_email=True,
-            clear_pwd="password",
-        )
-        self._login_admin(webtest, admin)
+        login_admin()
 
         ProhibitedProjectFactory.create(name="releasable")
 

--- a/tests/functional/admin/test_users.py
+++ b/tests/functional/admin/test_users.py
@@ -1,42 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import time
-
 from http import HTTPStatus
 
-from tests.common.constants import REMOTE_ADDR
-from tests.common.db.accounts import UserFactory, UserUniqueLoginFactory
-from tests.common.db.ip_addresses import IpAddressFactory
-from warehouse.accounts.models import UniqueLoginStatus
-from warehouse.utils.otp import _get_totp
+from tests.common.db.accounts import UserFactory
 
 
 class TestUserExport:
-    def _login(self, webtest, user):
-        """Log in a 2FA-enabled user with a pre-confirmed IP."""
-        ip_address = IpAddressFactory.create(ip_address=REMOTE_ADDR)
-        UserUniqueLoginFactory.create(
-            user=user, ip_address=ip_address, status=UniqueLoginStatus.CONFIRMED
-        )
-        login_page = webtest.get("/account/login/", status=HTTPStatus.OK)
-        login_form = login_page.forms["login-form"]
-        login_form["username"] = user.username
-        login_form["password"] = "password"
-        two_factor_page = login_form.submit().follow(status=HTTPStatus.OK)
-        two_factor_form = two_factor_page.forms["totp-auth-form"]
-        two_factor_form["totp_value"] = (
-            _get_totp(user.totp_secret).generate(time.time()).decode()
-        )
-        two_factor_form.submit().follow(status=HTTPStatus.OK)
-
-    def test_admin_sees_button_and_downloads(self, webtest):
+    def test_admin_sees_button_and_downloads(self, webtest, login_admin):
         """An admin sees the export button and downloads the document."""
-        admin = UserFactory.create(
-            is_superuser=True,
-            with_verified_primary_email=True,
-            clear_pwd="password",
-        )
-        self._login(webtest, admin)
+        login_admin()
         target = UserFactory.create()
 
         detail = webtest.get(f"/admin/users/{target.username}/", status=HTTPStatus.OK)
@@ -48,14 +20,9 @@ class TestUserExport:
         assert export.content_type == "application/json"
         assert export.json["user"]["username"] == target.username
 
-    def test_moderator_sees_no_button_and_is_denied(self, webtest):
+    def test_moderator_sees_no_button_and_is_denied(self, webtest, login_admin):
         """A moderator neither sees the button nor can hit the route."""
-        moderator = UserFactory.create(
-            is_moderator=True,
-            with_verified_primary_email=True,
-            clear_pwd="password",
-        )
-        self._login(webtest, moderator)
+        login_admin(is_moderator=True)
         target = UserFactory.create()
 
         detail = webtest.get(f"/admin/users/{target.username}/", status=HTTPStatus.OK)


### PR DESCRIPTION
Each functional admin test carried a byte-identical copy of the superuser login: create the IP address, confirm it, submit the login form, then the TOTP form. They take a `login_admin` fixture that builds the user and logs it in, or `login_user` for a user the test made itself.

Naming any role flag replaces the superuser default outright, so `login_admin(is_moderator=True)` logs in a moderator and nothing more. Merged with the default instead, a test asserting that a moderator is turned away would get a superuser as well and pass without exercising anything.

`IpAddress.ip_address` is unique and any request already served in the test will have inserted the row, since every request upserts it, so the fixture reuses it rather than colliding.