### PR TITLE
refactor: route email blocklist writes through a helper

### DIFF
--- a/tests/unit/accounts/test_utils.py
+++ b/tests/unit/accounts/test_utils.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from warehouse.accounts.models import ProhibitedEmailDomain
+from warehouse.accounts.utils import prohibit_email_domain
+
+
+class TestProhibitEmailDomain:
+    def test_empty_domain_is_refused(self, db_request):
+        """
+        A domain='' row would match every address whose host has no
+        registrable domain, and the admin UI has no way to delete it, so
+        an empty domain is refused outright rather than inserted.
+        """
+        assert prohibit_email_domain(db_request.db, "") is False
+        assert db_request.db.query(ProhibitedEmailDomain).all() == []
+
+    def test_non_empty_domain_is_added(self, db_request):
+        assert prohibit_email_domain(db_request.db, "example.com") is True
+        prohibited = db_request.db.query(ProhibitedEmailDomain).one()
+        assert prohibited.domain == "example.com"

--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -8,6 +8,7 @@ import pretend
 import pytest
 
 from pyramid.httpexceptions import HTTPBadRequest, HTTPMovedPermanently, HTTPSeeOther
+from sqlalchemy import func, select
 from sqlalchemy.orm import joinedload
 from webob.multidict import MultiDict, NoVars
 
@@ -25,7 +26,12 @@ from warehouse.organizations.models import OrganizationRoleType
 from warehouse.packaging.models import JournalEntry, Project, ReleaseURL
 from warehouse.subscriptions.models import StripeSubscriptionStatus
 
-from ....common.db.accounts import EmailFactory, User, UserFactory
+from ....common.db.accounts import (
+    EmailFactory,
+    ProhibitedEmailDomainFactory,
+    User,
+    UserFactory,
+)
 from ....common.db.organizations import (
     OrganizationFactory,
     OrganizationRoleFactory,
@@ -692,6 +698,80 @@ class TestUserFreeze:
         assert db_request.route_path.calls == [pretend.call("admin.user.list")]
         assert result.status_code == 303
         assert result.location == "/foobar"
+
+    def test_freeze_blocklists_own_registrable_domain(self, db_request):
+        """
+        An email whose domain IS its own registrable domain gets that
+        domain blocklisted -- the form that validate_email's database
+        check matches.
+        """
+        user = UserFactory.create()
+        EmailFactory.create(
+            user=user, verified=True, primary=True, email="x@evil-corp.com"
+        )
+
+        db_request.matchdict["username"] = str(user.username)
+        db_request.params = {"username": user.username}
+        db_request.route_path = lambda a: "/foobar"
+        db_request.user = UserFactory.create()
+
+        views.user_freeze(user, db_request)
+
+        db_request.db.flush()
+
+        prohibition = db_request.db.scalars(select(ProhibitedEmailDomain)).one()
+        assert prohibition.domain == "evil-corp.com"
+
+    def test_freeze_does_not_blocklist_subdomain_parent(self, db_request):
+        """
+        A subdomain-hosted address (grad.mit.edu, team.github.io) may live
+        under a shared parent apex that other accounts legitimately use, so
+        freezing this account must not blocklist the parent.
+        """
+        user = UserFactory.create()
+        EmailFactory.create(
+            user=user, verified=True, primary=True, email="x@mail.evil-corp.com"
+        )
+
+        db_request.matchdict["username"] = str(user.username)
+        db_request.params = {"username": user.username}
+        db_request.route_path = lambda a: "/foobar"
+        db_request.user = UserFactory.create()
+
+        views.user_freeze(user, db_request)
+
+        db_request.db.flush()
+
+        assert (
+            db_request.db.scalars(select(ProhibitedEmailDomain)).one_or_none() is None
+        )
+
+    def test_freezes_user_with_already_prohibited_domain(self, db_request):
+        """
+        Freezing a user whose email domain is already prohibited must not
+        insert a duplicate row into the unique domain column.
+        """
+        user = UserFactory.create()
+        verified_email = EmailFactory.create(user=user, verified=True, primary=True)
+        ProhibitedEmailDomainFactory.create(domain=verified_email.domain)
+
+        db_request.matchdict["username"] = str(user.username)
+        db_request.params = {"username": user.username}
+        db_request.route_path = lambda a: "/foobar"
+        db_request.user = UserFactory.create()
+
+        result = views.user_freeze(user, db_request)
+
+        db_request.db.flush()
+
+        assert db_request.db.get(User, user.id).is_frozen
+        assert (
+            db_request.db.scalar(
+                select(func.count()).select_from(ProhibitedEmailDomain)
+            )
+            == 1
+        )
+        assert result.status_code == 303
 
     def test_freezes_user_bad_confirm(self, db_request, monkeypatch):
         user = UserFactory.create(is_frozen=False)

--- a/warehouse/accounts/utils.py
+++ b/warehouse/accounts/utils.py
@@ -6,14 +6,20 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-from warehouse.accounts.models import Email
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from tldextract import TLDExtract
+
+from warehouse.accounts.models import Email, ProhibitedEmailDomain
 from warehouse.accounts.services import IDomainStatusService
 
 if TYPE_CHECKING:
     from pyramid.request import Request
+    from sqlalchemy.orm import Session
 
     from warehouse.accounts.models import User
     from warehouse.macaroons.models import Macaroon
+
+tld_extractor = TLDExtract(suffix_list_urls=())  # Updated during image build
 
 
 @dataclass
@@ -40,6 +46,44 @@ class UserContext:
 
     def __principals__(self) -> list[str]:
         return self.user.__principals__()
+
+
+def prohibit_email_domain(
+    db: Session,
+    domain: str,
+    *,
+    comment: str = "",
+    prohibited_by: User | None = None,
+    is_mx_record: bool = False,
+) -> bool:
+    """
+    Add a domain to the prohibited email domains blocklist.
+
+    Refuses an empty domain: a domain='' row would match every address
+    whose host has no registrable domain, and the admin UI has no way to
+    delete it.
+
+    Returns False without changing anything when an entry for the domain
+    already exists, whatever its is_mx_record flag: the domain column is
+    unique. ON CONFLICT closes the race between concurrent first uses of
+    the same domain, which a check-then-insert would lose (cf. the same
+    idiom in warehouse/utils/wsgi.py).
+    """
+    if not domain:
+        return False
+
+    inserted_id = db.execute(
+        pg_insert(ProhibitedEmailDomain)
+        .values(
+            domain=domain,
+            comment=comment,
+            _prohibited_by=prohibited_by.id if prohibited_by else None,
+            is_mx_record=is_mx_record,
+        )
+        .on_conflict_do_nothing(index_elements=["domain"])
+        .returning(ProhibitedEmailDomain.id)
+    ).scalar_one_or_none()
+    return inserted_id is not None
 
 
 def update_email_domain_status(email: Email, request: Request) -> None:

--- a/warehouse/admin/views/prohibited_email_domains.py
+++ b/warehouse/admin/views/prohibited_email_domains.py
@@ -3,10 +3,9 @@
 from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
 from pyramid.httpexceptions import HTTPBadRequest, HTTPSeeOther
 from pyramid.view import view_config
-from sqlalchemy import exists, select
-from tldextract import TLDExtract
 
 from warehouse.accounts.models import ProhibitedEmailDomain
+from warehouse.accounts.utils import prohibit_email_domain, tld_extractor
 from warehouse.authnz import Permissions
 from warehouse.utils.paginate import paginate_url_factory
 
@@ -58,32 +57,23 @@ def add_prohibited_email_domain(request):
         request.session.flash("Email domain is required.", queue="error")
         raise HTTPSeeOther(request.route_path("admin.prohibited_email_domains.list"))
     # validate that the domain is valid
-    extractor = TLDExtract(suffix_list_urls=())  # Updated during image build
-    registered_domain = extractor(email_domain).top_domain_under_public_suffix
+    registered_domain = tld_extractor(email_domain).top_domain_under_public_suffix
     if not registered_domain:
         request.session.flash(f"Invalid domain name '{email_domain}'", queue="error")
         raise HTTPSeeOther(request.route_path("admin.prohibited_email_domains.list"))
-    # make sure we don't have a duplicate entry
-    if request.db.scalar(
-        select(exists().where(ProhibitedEmailDomain.domain == registered_domain))
+    # Add the domain to the database, unless it's already prohibited
+    if not prohibit_email_domain(
+        request.db,
+        registered_domain,
+        comment=request.POST.get("comment") or "",
+        prohibited_by=request.user,
+        is_mx_record=bool(request.POST.get("is_mx_record")),
     ):
         request.session.flash(
             f"Email domain '{registered_domain}' already exists.", queue="error"
         )
         raise HTTPSeeOther(request.route_path("admin.prohibited_email_domains.list"))
 
-    # Add the domain to the database
-    is_mx_record = bool(request.POST.get("is_mx_record"))
-    comment = request.POST.get("comment")
-
-    prohibited_email_domain = ProhibitedEmailDomain(
-        domain=registered_domain,
-        is_mx_record=is_mx_record,
-        prohibited_by=request.user,
-        comment=comment,
-    )
-
-    request.db.add(prohibited_email_domain)
     request.session.flash("Prohibited email domain added.", queue="success")
 
     return HTTPSeeOther(request.route_path("admin.prohibited_email_domains.list"))

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -27,11 +27,14 @@ from warehouse.accounts.interfaces import (
 from warehouse.accounts.models import (
     DisableReason,
     Email,
-    ProhibitedEmailDomain,
     ProhibitedUserName,
     User,
 )
-from warehouse.accounts.utils import update_email_domain_status
+from warehouse.accounts.utils import (
+    prohibit_email_domain,
+    tld_extractor,
+    update_email_domain_status,
+)
 from warehouse.admin.user_export import export_user
 from warehouse.authnz import Permissions
 from warehouse.email import (
@@ -508,14 +511,21 @@ def user_freeze(user, request):
 
     user.is_frozen = True
 
+    # Blocklist only an email whose domain IS its own registrable: a
+    # subdomain-hosted address (grad.mit.edu, team.github.io) may live under
+    # a shared parent apex that other accounts legitimately use, so freezing
+    # one account must not blocklist the parent. Those are left for a
+    # deliberate admin decision.
     for email in user.emails:
-        if email.verified:
-            request.db.add(
-                ProhibitedEmailDomain(
-                    domain=email.domain,
-                    comment="frozen",
-                    prohibited_by=request.user,
-                )
+        if not email.verified:
+            continue
+        registrable = tld_extractor(email.domain).top_domain_under_public_suffix
+        if registrable and registrable == email.domain:
+            prohibit_email_domain(
+                request.db,
+                registrable,
+                comment="frozen",
+                prohibited_by=request.user,
             )
 
     request.session.flash(f"Froze user {user.username!r}", queue="success")


### PR DESCRIPTION
The admin add view and user_freeze each wrote to the blocklist with their own duplicate handling. Both now go through
prohibit_email_domain(), which does an atomic
INSERT .. ON CONFLICT DO NOTHING and returns whether a row was added. That closes the race between concurrent first writes of the same domain, and stops user_freeze crashing on a domain someone had already prohibited.

user_freeze now stores the registrable domain, which is the form the email validator's database check compares against. It used to store the raw host part, so a row written for a subdomain-hosted address never blocked anyone.