### PR TITLE
test: drop click's deprecated isolated_filesystem

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,10 +315,9 @@ def pyramid_user(pyramid_request):
 
 
 @pytest.fixture
-def cli():
-    runner = click.testing.CliRunner()
-    with runner.isolated_filesystem():
-        yield runner
+def cli(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return click.testing.CliRunner()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
click 8.5 deprecates CliRunner.isolated_filesystem in favor of a temp directory the caller manages. tmp_path plus monkeypatch.chdir does the same job and restores the working directory on teardown.

Refs: https://github.com/pallets/click/pull/3704