### PR TITLE
feat(packaging): detect files added late to a release

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -6801,9 +6801,7 @@ class TestFileUpload:
         )
 
         now = datetime.datetime.now()
-        then = now - datetime.timedelta(
-            seconds=legacy.MAXIMUM_AGE_FOR_NEW_UPLOADS_SECONDS + 1
-        )
+        then = now - legacy.MAXIMUM_AGE_FOR_NEW_UPLOADS - datetime.timedelta(seconds=1)
 
         user = UserFactory.create()
         EmailFactory.create(user=user)
@@ -6844,7 +6842,7 @@ class TestFileUpload:
         assert resp.status_code == 400
         assert (
             f"Uploading new files to releases older than "
-            f"{legacy.MAXIMUM_AGE_FOR_NEW_UPLOADS_DAYS} days is not allowed."
+            f"{legacy.MAXIMUM_AGE_FOR_NEW_UPLOADS.days} days is not allowed."
             in resp.status
         )
 
@@ -6856,9 +6854,7 @@ class TestFileUpload:
         # when used with --skip-existing on old releases.
 
         now = datetime.datetime.now()
-        then = now - datetime.timedelta(
-            seconds=legacy.MAXIMUM_AGE_FOR_NEW_UPLOADS_SECONDS + 1
-        )
+        then = now - legacy.MAXIMUM_AGE_FOR_NEW_UPLOADS - datetime.timedelta(seconds=1)
 
         user = UserFactory.create()
         pyramid_config.testing_securitypolicy(identity=user)

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -17,7 +17,13 @@ from warehouse.attestations.models import (
     PublisherSource,
 )
 from warehouse.authnz import Permissions
-from warehouse.constants import MAX_FILESIZE, MAX_PROJECT_SIZE, ONE_GIB, ONE_MIB
+from warehouse.constants import (
+    MAX_FILESIZE,
+    MAX_PROJECT_SIZE,
+    MAXIMUM_AGE_FOR_NEW_UPLOADS,
+    ONE_GIB,
+    ONE_MIB,
+)
 from warehouse.macaroons import caveats
 from warehouse.macaroons.models import Macaroon
 from warehouse.oidc.models import GitHubPublisher
@@ -54,6 +60,27 @@ from ...common.db.packaging import (
     RoleFactory as DBRoleFactory,
     RoleInvitationFactory as DBRoleInvitationFactory,
 )
+
+_RELEASED_AT = datetime.datetime(2024, 3, 1, 12, 0, 0)
+
+
+def _release_with_uploads(*delays):
+    """
+    A release published at `_RELEASED_AT`, with one file per delay after it.
+
+    `packagetype` is pinned because `FileFactory` picks one at random and only
+    one sdist is allowed per release, which would otherwise make a multi-file
+    release fail on some seeds and not others.
+    """
+    release = DBReleaseFactory.create(version="1.0", created=_RELEASED_AT)
+    for index, delay in enumerate(delays):
+        DBFileFactory.create(
+            release=release,
+            filename=f"{release.project.name}-1.0-{index}.whl",
+            packagetype="bdist_wheel",
+            upload_time=_RELEASED_AT + delay,
+        )
+    return release
 
 
 def _release_pair(days_apart=4):
@@ -1887,6 +1914,143 @@ class TestRelease:
 
         assert db_session.query(Description).filter_by(id=description_id).count() == 0
 
+    def test_late_file_status_is_none_without_files(self, db_session):
+        """A release whose files have all been removed has nothing to report."""
+        release = _release_with_uploads(datetime.timedelta(0))
+        for file in release.files:
+            db_session.delete(file)
+        db_session.flush()
+
+        assert release.late_file_status is None
+
+    def test_late_file_status_needs_a_session(self):
+        """
+        An unattached Release raises rather than reporting itself clean.
+
+        `files` is `lazy="dynamic"`, and reading it detached hands back an
+        empty collection, which would otherwise make a release with late files
+        indistinguishable from one without.
+        """
+        with pytest.raises(NoSessionError):
+            _ = Release().late_file_status
+
+    def test_late_file_status_is_cached(self, db_session, query_recorder):
+        """
+        Repeat reads cost one query between them.
+
+        `files` cannot be eagerly loaded, so every uncached read is its own
+        SELECT; a template reading several attributes off the status must not
+        pay for each one.
+        """
+        release = _release_with_uploads(
+            datetime.timedelta(0), datetime.timedelta(days=30)
+        )
+        db_session.flush()
+        assert release.created is not None  # load the release row before counting
+
+        query_recorder.clear()
+        with query_recorder:
+            statuses = [release.late_file_status for _ in range(3)]
+
+        assert len(statuses[0].late_files) == 1
+        assert all(repeat is statuses[0] for repeat in statuses)
+        assert len(query_recorder.queries) == 1, query_recorder.queries
+
+    def test_late_file_status_brackets_the_uploads(self, db_session):
+        """The first and last arrivals bracket the release's files."""
+        release = _release_with_uploads(
+            datetime.timedelta(hours=2),
+            datetime.timedelta(0),
+            datetime.timedelta(days=3),
+        )
+
+        status = release.late_file_status
+
+        assert status.total_files == 3
+        assert status.first_upload == _RELEASED_AT
+        assert status.last_upload == _RELEASED_AT + datetime.timedelta(days=3)
+
+    def test_late_file_status_ignores_punctual_files(self, db_session):
+        """Files arriving inside the window are not late."""
+        release = _release_with_uploads(
+            datetime.timedelta(0),
+            datetime.timedelta(days=1),
+            MAXIMUM_AGE_FOR_NEW_UPLOADS - datetime.timedelta(hours=1),
+        )
+
+        status = release.late_file_status
+
+        assert status.late_files == ()
+
+    def test_late_file_status_finds_a_late_file(self, db_session):
+        """A file past the window is reported, with how long it took to arrive."""
+        release = _release_with_uploads(
+            datetime.timedelta(0),
+            datetime.timedelta(days=30),
+        )
+
+        status = release.late_file_status
+
+        assert status.total_files == 2
+        (late,) = status.late_files
+        assert late.filename == f"{release.project.name}-1.0-1.whl"
+        assert late.upload_time == _RELEASED_AT + datetime.timedelta(days=30)
+        assert late.delay == datetime.timedelta(days=30)
+
+    def test_late_file_status_reports_every_late_file_oldest_first(self, db_session):
+        """Several late files are all reported, ordered by when they arrived."""
+        release = _release_with_uploads(
+            datetime.timedelta(days=90),
+            datetime.timedelta(0),
+            datetime.timedelta(days=20),
+        )
+
+        status = release.late_file_status
+
+        assert [late.delay for late in status.late_files] == [
+            datetime.timedelta(days=20),
+            datetime.timedelta(days=90),
+        ]
+
+    @pytest.mark.parametrize(
+        ("delay", "late"),
+        [
+            (MAXIMUM_AGE_FOR_NEW_UPLOADS, False),
+            (MAXIMUM_AGE_FOR_NEW_UPLOADS + datetime.timedelta(hours=23), True),
+        ],
+    )
+    def test_late_file_status_measures_the_window_to_the_second(
+        self, db_session, delay, late
+    ):
+        """
+        The window is measured to the second.
+
+        A file arriving on the window's last day plus twenty-three hours is
+        late; truncating the delta to whole days would let it pass.
+        """
+        release = _release_with_uploads(datetime.timedelta(0), delay)
+
+        assert bool(release.late_file_status.late_files) is late
+
+    def test_late_file_status_measures_from_the_release(self, db_session):
+        """
+        Deleting a release's original files must not clear the flag from the
+        one it was raised for.
+        """
+        release = _release_with_uploads(
+            datetime.timedelta(0),
+            datetime.timedelta(days=30),
+        )
+        first, _ = sorted(release.files, key=lambda file: file.upload_time)
+        db_session.delete(first)
+        db_session.flush()
+
+        status = release.late_file_status
+
+        assert status.total_files == 1
+        assert len(status.late_files) == 1
+        assert status.first_upload == _RELEASED_AT + datetime.timedelta(days=30)
+
 
 class TestFile:
     def test_requires_python(self, db_session):
@@ -2015,6 +2179,21 @@ class TestFile:
         )
 
         assert rfile.pretty_wheel_tags == ["Source"]
+
+    @pytest.mark.parametrize(
+        ("delay", "expected"),
+        [
+            (datetime.timedelta(0), False),
+            (MAXIMUM_AGE_FOR_NEW_UPLOADS, False),
+            (MAXIMUM_AGE_FOR_NEW_UPLOADS + datetime.timedelta(seconds=1), True),
+        ],
+    )
+    def test_added_late(self, db_session, delay, expected):
+        """A file knows on its own whether it arrived late."""
+        release = _release_with_uploads(delay)
+        (file,) = release.files
+
+        assert file.added_late is expected
 
 
 class TestProjectLimitProperties:

--- a/warehouse/cli/db/seed.py
+++ b/warehouse/cli/db/seed.py
@@ -13,7 +13,8 @@ def seed(config):  # pragma: no cover # dev-only tool
 
     Creates a standard set of projects whose releases exhibit each of the
     provenance states surfaced in the UI (full/partial/inconsistent/lost/
-    changed provenance), owned by the `seed-user` account.
+    changed provenance) and each of the "file added late" cases, owned by the
+    `seed-user` account.
 
     Attestation material is fabricated; nothing seeded here will pass cryptographic
     verification.
@@ -26,6 +27,7 @@ def seed(config):  # pragma: no cover # dev-only tool
     from sqlalchemy import delete, select
 
     from warehouse.config import Environment
+    from warehouse.constants import MAXIMUM_AGE_FOR_NEW_UPLOADS
 
     # bail early if not in development
     if not config.registry.settings.get("warehouse.env") == Environment.development:
@@ -60,49 +62,108 @@ def seed(config):  # pragma: no cover # dev-only tool
     repo_a = ("seed-org/alpha", "release.yml")
     repo_b = ("seed-org/beta", "publish.yml")
 
-    # Each release is (version, days_ago, file_specs); each file spec is
-    # (predicate_types, (repository, workflow)) or None for no provenance.
+    # A file spec is (predicate_types, (repository, workflow), days_after_release),
+    # with `predicate_types` None for a file carrying no provenance. The named
+    # specs below all arrive with their release; `after()` moves one later.
+    pypi_a = ([pypi], repo_a, 0)
+    slsa_a = ([slsa], repo_a, 0)
+    both_a = ([pypi, slsa], repo_a, 0)
+    pypi_b = ([pypi], repo_b, 0)
+    unattested = (None, None, 0)
+
+    def after(spec, days):
+        """The same file, arriving `days` days after its release."""
+        predicate_types, repo, _ = spec
+        return (predicate_types, repo, days)
+
+    # Each release is (version, days_ago, file_specs). A release's `days_ago`
+    # has to exceed its longest delay, or its files would arrive in the future.
     scenarios = [
         {
             "name": "seed-provenance-full-pypi",
             "summary": "Dev seed: all files have PyPI publish attestations",
-            "releases": [("1.0.0", 1, [([pypi], repo_a)] * 3)],
+            "releases": [("1.0.0", 1, [pypi_a] * 3)],
         },
         {
             "name": "seed-provenance-full-slsa",
             "summary": "Dev seed: all files have SLSA provenance attestations",
-            "releases": [("1.0.0", 1, [([slsa], repo_a)] * 3)],
+            "releases": [("1.0.0", 1, [slsa_a] * 3)],
         },
         {
             "name": "seed-provenance-both",
             "summary": "Dev seed: all files have PyPI and SLSA attestations",
-            "releases": [("1.0.0", 1, [([pypi, slsa], repo_a)] * 3)],
+            "releases": [("1.0.0", 1, [both_a] * 3)],
         },
         {
             "name": "seed-provenance-partial",
             "summary": "Dev seed: 3 of 5 files have attestations",
-            "releases": [("1.0.0", 1, [([pypi], repo_a)] * 3 + [None] * 2)],
+            "releases": [("1.0.0", 1, [pypi_a] * 3 + [unattested] * 2)],
         },
         {
             "name": "seed-provenance-inconsistent",
             "summary": "Dev seed: files attested from two different repos",
-            "releases": [("1.0.0", 1, [([pypi], repo_a)] * 2 + [([pypi], repo_b)] * 2)],
+            "releases": [("1.0.0", 1, [pypi_a] * 2 + [pypi_b] * 2)],
         },
         {
             "name": "seed-provenance-lost",
             "summary": "Dev seed: previous release attested, this one is not",
             "releases": [
-                ("1.0.0", 7, [([pypi], repo_a)] * 2),
-                ("2.0.0", 1, [None] * 2),
+                ("1.0.0", 7, [pypi_a] * 2),
+                ("2.0.0", 1, [unattested] * 2),
             ],
         },
         {
             "name": "seed-provenance-changed",
             "summary": "Dev seed: repo/workflow changed since previous release",
             "releases": [
-                ("1.0.0", 7, [([pypi], repo_a)] * 2),
-                ("2.0.0", 1, [([pypi], repo_b)] * 2),
+                ("1.0.0", 7, [pypi_a] * 2),
+                ("2.0.0", 1, [pypi_b] * 2),
             ],
+        },
+        {
+            "name": "seed-late-file-single",
+            "summary": "Dev seed: one file added late, one just inside the window",
+            # The middle file is the control: the window is compared
+            # strictly, so its own final day is still punctual.
+            "releases": [
+                (
+                    "1.0.0",
+                    60,
+                    [
+                        pypi_a,
+                        after(pypi_a, MAXIMUM_AGE_FOR_NEW_UPLOADS.days),
+                        after(pypi_a, 45),
+                    ],
+                )
+            ],
+        },
+        {
+            "name": "seed-late-file-multiple",
+            "summary": "Dev seed: three files added late, at increasing delays",
+            "releases": [
+                (
+                    "1.0.0",
+                    100,
+                    [
+                        pypi_a,
+                        after(pypi_a, 20),
+                        after(pypi_a, 40),
+                        after(pypi_a, 80),
+                    ],
+                )
+            ],
+        },
+        {
+            "name": "seed-late-file-unattested",
+            "summary": "Dev seed: an unattested file added late to an attested release",
+            "releases": [("1.0.0", 60, [pypi_a] * 2 + [after(unattested, 45)])],
+        },
+        {
+            "name": "seed-late-file-changed-publisher",
+            "summary": "Dev seed: a file added late from a different repository",
+            # Two warnings at once: the release reads as inconsistent, and the
+            # file that made it so is the late one.
+            "releases": [("1.0.0", 60, [pypi_a] * 2 + [after(pypi_b, 45)])],
         },
     ]
 
@@ -149,7 +210,9 @@ def seed(config):  # pragma: no cover # dev-only tool
             # add_filename_to_registry); clear leftover reservations so
             # re-seeding after deleting the seed projects still works.
             session.execute(delete(Filename).where(Filename.filename.in_(filenames)))
-            for filename, spec in zip(filenames, file_specs, strict=True):
+            for filename, (predicate_types, repo, days_after) in zip(
+                filenames, file_specs, strict=True
+            ):
                 file = FileFactory.create(
                     release=release,
                     filename=filename,
@@ -161,10 +224,10 @@ def seed(config):  # pragma: no cover # dev-only tool
                         if filename.endswith(".tar.gz")
                         else filename.split("-")[-3]
                     ),
-                    upload_time=created,
+                    upload_time=created + datetime.timedelta(days=days_after),
                 )
-                if spec is not None:
-                    predicate_types, (repository, workflow) = spec
+                if predicate_types is not None:
+                    repository, workflow = repo
                     ProvenanceFactory.create(
                         file=file,
                         predicate_types=predicate_types,

--- a/warehouse/constants.py
+++ b/warehouse/constants.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
+
 ONE_MIB = 1 * 1024 * 1024
 ONE_GIB = 1 * 1024 * 1024 * 1024
 MAX_FILESIZE = 100 * ONE_MIB
@@ -7,3 +9,6 @@ MAX_PROJECT_SIZE = 10 * ONE_GIB
 UPLOAD_LIMIT_CAP = ONE_GIB
 # Taken from passlib
 MAX_PASSWORD_SIZE = 4096
+
+# After a release has been published for this long, reject new uploaded files.
+MAXIMUM_AGE_FOR_NEW_UPLOADS = datetime.timedelta(days=14)

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -40,7 +40,7 @@ from warehouse.attestations.errors import AttestationUploadError
 from warehouse.attestations.interfaces import IIntegrityService
 from warehouse.authnz import Permissions
 from warehouse.classifiers.models import Classifier
-from warehouse.constants import ONE_GIB, ONE_MIB
+from warehouse.constants import MAXIMUM_AGE_FOR_NEW_UPLOADS, ONE_GIB, ONE_MIB
 from warehouse.email import (
     send_api_token_used_in_trusted_publisher_project_email,
     send_wheel_record_mismatch_email,
@@ -77,13 +77,6 @@ from warehouse.utils.wheel import (
 )
 
 PATH_HASHER = "blake2_256"
-
-# After a release has been published for this
-# number of days reject new uploaded files.
-MAXIMUM_AGE_FOR_NEW_UPLOADS_DAYS = 14
-MAXIMUM_AGE_FOR_NEW_UPLOADS_SECONDS = datetime.timedelta(
-    days=MAXIMUM_AGE_FOR_NEW_UPLOADS_DAYS
-).total_seconds()
 
 COMPRESSION_RATIO_MIN_SIZE = 64 * ONE_MIB
 
@@ -1244,8 +1237,8 @@ def file_upload(request):
         # Note that this feature explicitly doesn't protect against
         # users deleting and recreating releases in the UI, only
         # against uploads through compromised API tokens or workflows.
-        oldest_release_age_allowed = datetime.datetime.now() - datetime.timedelta(
-            seconds=MAXIMUM_AGE_FOR_NEW_UPLOADS_SECONDS
+        oldest_release_age_allowed = (
+            datetime.datetime.now() - MAXIMUM_AGE_FOR_NEW_UPLOADS
         )
         if release.created < oldest_release_age_allowed:
             request.metrics.increment(
@@ -1254,7 +1247,7 @@ def file_upload(request):
             raise _exc_with_message(
                 HTTPBadRequest,
                 f"Uploading new files to releases older than "
-                f"{MAXIMUM_AGE_FOR_NEW_UPLOADS_DAYS} days is not allowed.",
+                f"{MAXIMUM_AGE_FOR_NEW_UPLOADS.days} days is not allowed.",
             )
 
         # Check to see if uploading this file would create a duplicate sdist

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -63,6 +63,7 @@ from warehouse.packaging.models import (
     Project,
     ProjectMacaroonWarningAssociation,
     Release,
+    added_late,
 )
 from warehouse.packaging.tasks import sync_file_to_cache, update_bigquery_release_files
 from warehouse.rate_limiting.interfaces import RateLimiterException
@@ -1237,10 +1238,7 @@ def file_upload(request):
         # Note that this feature explicitly doesn't protect against
         # users deleting and recreating releases in the UI, only
         # against uploads through compromised API tokens or workflows.
-        oldest_release_age_allowed = (
-            datetime.datetime.now() - MAXIMUM_AGE_FOR_NEW_UPLOADS
-        )
-        if release.created < oldest_release_age_allowed:
+        if added_late(datetime.datetime.now(), release.created):
             request.metrics.increment(
                 "warehouse.upload.failed", tags=["reason:closed-release"]
             )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -7,6 +7,7 @@ import enum
 import typing
 
 from collections import OrderedDict
+from dataclasses import dataclass
 from functools import cached_property
 from uuid import UUID
 
@@ -40,6 +41,7 @@ from sqlalchemy.dialects.postgresql import (
     ENUM,
     REGCLASS,
 )
+from sqlalchemy.engine import Row
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -65,7 +67,11 @@ from warehouse.attestations.models import (
 )
 from warehouse.authnz import Permissions
 from warehouse.classifiers.models import Classifier
-from warehouse.constants import MAX_FILESIZE, MAX_PROJECT_SIZE
+from warehouse.constants import (
+    MAX_FILESIZE,
+    MAX_PROJECT_SIZE,
+    MAXIMUM_AGE_FOR_NEW_UPLOADS,
+)
 from warehouse.events.models import HasEvents
 from warehouse.forklift import metadata
 from warehouse.integrations.vulnerabilities.models import VulnerabilityRecord
@@ -170,6 +176,82 @@ def _provenance_comparison(
         if other_created < created and counts.files_with_provenance:
             return ProvenanceComparison(version=version, counts=counts)
     return None
+
+
+@dataclass(frozen=True)
+class LateFile:
+    """
+    A file that arrived past the window its release accepts new files in.
+
+    Carries the filename instead of the `File`, so the surrounding status can
+    be built from rows a caller has already loaded.
+    """
+
+    filename: str
+    upload_time: datetime.datetime
+    # How long after the release was published the file arrived.
+    delay: datetime.timedelta
+
+
+@dataclass(frozen=True)
+class LateFileStatus:
+    """
+    When a release's files arrived, and which of them arrived late.
+
+    `first_upload` and `last_upload` bracket the files still present, so
+    neither is the release date: `first_upload` moves when the earliest file
+    is deleted, while `delay` stays anchored to `Release.created`.
+    """
+
+    total_files: int
+    first_upload: datetime.datetime
+    last_upload: datetime.datetime
+    late_files: tuple[LateFile, ...] = ()
+
+
+def added_late(upload_time: datetime.datetime, created: datetime.datetime) -> bool:
+    """
+    Whether a file arrived past the window its release accepts new files in.
+
+    Compared as timedeltas rather than whole days: `.days` truncates, and would
+    let a file arriving on the window's last day plus twenty-three hours pass
+    as punctual.
+    """
+    return upload_time - created > MAXIMUM_AGE_FOR_NEW_UPLOADS
+
+
+def late_file_status_from_files(
+    created: datetime.datetime, files: typing.Iterable[File | Row]
+) -> LateFileStatus | None:
+    """
+    Fold a release's files into the record of when they arrived.
+
+    Measured from `created` rather than the earliest surviving file: deleting
+    a release's original files would drag a first-file anchor forward and
+    clear the flag from the file it was raised for.
+
+    Returns `None` for a release with no files, the way `provenance_status`
+    does. Takes the files as an argument so a view already holding them need
+    not load them again; anything with `filename` and `upload_time` will do.
+    """
+    by_upload_time = sorted(files, key=lambda file: file.upload_time)
+    if not by_upload_time:
+        return None
+
+    return LateFileStatus(
+        total_files=len(by_upload_time),
+        first_upload=by_upload_time[0].upload_time,
+        last_upload=by_upload_time[-1].upload_time,
+        late_files=tuple(
+            LateFile(
+                filename=file.filename,
+                upload_time=file.upload_time,
+                delay=file.upload_time - created,
+            )
+            for file in by_upload_time
+            if added_late(file.upload_time, created)
+        ),
+    )
 
 
 class Role(db.Model):
@@ -1154,6 +1236,30 @@ class Release(HasObservations, db.Model):
             ),
         )
 
+    @cached_property
+    def late_file_status(self) -> LateFileStatus | None:
+        """
+        When this Release's files arrived, and which of them arrived late.
+
+        Reads two columns rather than iterating `files`, which is
+        `lazy="dynamic"` and eager-loads each file's provenance on the way
+        past. A caller already holding the files should use
+        `late_file_status_from_files`.
+
+        Cached like `provenance_status`, so a `Release` held across a commit
+        or a new upload keeps the answer it first gave; `File.added_late` is
+        not cached and can then disagree.
+        """
+        session = orm_session_from_obj(self)
+        return late_file_status_from_files(
+            self.created,
+            session.execute(
+                select(File.filename, File.upload_time).where(
+                    File.release_id == self.id
+                )
+            ).all(),
+        )
+
 
 class PackageType(enum.StrEnum):
     bdist_dmg = "bdist_dmg"
@@ -1234,6 +1340,17 @@ class File(HasEvents, db.Model):
         lazy="joined",
         passive_deletes=True,
     )
+
+    @property
+    def added_late(self) -> bool:
+        """
+        Whether this file arrived past the window its release accepts files in.
+
+        Reads `self.release`, so a caller listing files off a `File` query
+        should use the module-level `added_late` against a release it holds
+        rather than pay a SELECT per release.
+        """
+        return added_late(self.upload_time, self.release.created)
 
     @property
     def uploaded_via_trusted_publisher(self) -> bool:


### PR DESCRIPTION
Release.late_file_status reports when a release's files arrived and which
arrived late; File.added_late answers the same for one file. Both measure
from Release.created, so a late file is one the upload path would refuse
today, and deleting a release's original files cannot clear the flag from
the file it was raised for.

Refs: #20185

Easier to review commit-by commit