### PR TITLE
fix(admin): make the declarative Tabulator layer apply its attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,23 @@
     "lint:fix": "eslint 'warehouse/static/js/warehouse/**' 'warehouse/admin/static/js/**' 'tests/frontend/**' 'webpack.*.js' --fix",
     "stylelint": "stylelint '**/*.scss' --cache --cache-location .cache/stylelint",
     "stylelint:fix": "stylelint '**/*.scss' --cache --cache-location .cache/stylelint --fix",
-    "test": "NODE_OPTIONS='$NODE_OPTIONS --experimental-vm-modules' jest --coverage"
+    "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --coverage"
   },
   "jest": {
     "setupFilesAfterEnv": [
       "./tests/frontend/setup.js"
     ],
     "testEnvironment": "jsdom",
-    "testRegex": ".*_test.js"
+    "testRegex": ".*_test.js",
+    "moduleNameMapper": {
+      "^tabulator-tables$": "<rootDir>/node_modules/tabulator-tables/dist/js/tabulator_esm.js"
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!tabulator-tables/)"
+    ],
+    "transform": {
+      "\\.m?[jt]sx?$": "babel-jest"
+    }
   },
   "dependencies": {
     "@fontsource/ewert": "^5.2.8",

--- a/tests/frontend/admin_tabulator_test.js
+++ b/tests/frontend/admin_tabulator_test.js
@@ -1,0 +1,249 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* global expect, describe, it, beforeEach, jest */
+
+/**
+ * Tests for the declarative admin tables, asserting on runtime behavior rather
+ * than on the markup that configures it.
+ *
+ * A `tabulator-*` attribute can be spelled correctly and still have no effect:
+ * Tabulator parses those inside HtmlTableImport, which initializes after the
+ * core modules and after GroupRows has decided whether to subscribe, so any
+ * table option consulted during a module's `initialize()` never sees one.
+ * Asserting that an attribute is present therefore proves nothing about
+ * whether the table does what it says.
+ */
+
+async function render(html) {
+  document.body.innerHTML = html;
+  let table;
+  await jest.isolateModulesAsync(async () => {
+    const { TabulatorFull } = await import("tabulator-tables");
+    await import("../../warehouse/admin/static/js/tabulator");
+    const mounted = document.querySelector(".tabulator") || document.querySelector("table");
+    table = TabulatorFull.findTable(mounted)[0];
+  });
+  await new Promise((resolve) => {
+    table.on("tableBuilt", resolve);
+    if (table.initialized) {
+      resolve();
+    }
+  });
+  return table;
+}
+
+const GROUPED = `
+  <table data-tabulator
+         tabulator-layout="fitDataFill"
+         tabulator-groupBy="project_name"
+         tabulator-pagination="true"
+         tabulator-paginationSize="25"
+         tabulator-paginationSizeSelector="25,50,100">
+    <thead><tr>
+      <th tabulator-visible="false">Project Name</th><th>Summary</th>
+    </tr></thead>
+    <tbody>
+      <tr><td><a href="/admin/projects/evil-pkg/">evil-pkg</a></td><td>one</td></tr>
+      <tr><td><a href="/admin/projects/evil-pkg/">evil-pkg</a></td><td>two</td></tr>
+      <tr><td><a href="/admin/projects/gone-pkg/">gone-pkg</a></td><td>three</td></tr>
+    </tbody>
+  </table>`;
+
+describe("declarative admin tables", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("groups rows by a hidden column", async () => {
+    const table = await render(GROUPED);
+    // Grouping is the only thing rendering the project name on the malware
+    // reports page, since its column is hidden.
+    expect(table.getGroups()).toHaveLength(2);
+    expect(table.getColumns()[0].isVisible()).toBe(false);
+  });
+
+  it("applies the layout mode named in the attribute", async () => {
+    const table = await render(GROUPED);
+    expect(table.modules.layout.mode).toBe("fitDataFill");
+  });
+
+  it("gives list and number options their real types", async () => {
+    const table = await render(GROUPED);
+    expect(table.options.paginationSize).toBe(25);
+    expect(table.options.paginationSizeSelector).toEqual([25, 50, 100]);
+  });
+
+  it("sorts on the text of a cell rather than its markup", async () => {
+    // Cell values are markup, so a naive sort compares hrefs.
+    const table = await render(`
+      <table data-tabulator><thead><tr><th>Name</th></tr></thead>
+        <tbody>
+          <tr><td><a href="/admin/sponsors/ffffffff/">Aardvark</a></td></tr>
+          <tr><td><a href="/admin/sponsors/00000000/">Zebra</a></td></tr>
+        </tbody></table>`);
+    table.setSort("name", "asc");
+    const names = table
+      .getData("active")
+      .map((row) => row.name.replace(/<[^>]*>/g, "").trim());
+    // Sorting the markup would lead with Zebra, whose href sorts first.
+    expect(names).toEqual(["Aardvark", "Zebra"]);
+  });
+
+  it.each([
+    ["asc", ["Gold", "Silver"]],
+    ["desc", ["Silver", "Gold"]],
+  ])("sorts blanks last going %s", async (dir, filled) => {
+    // A column of optional values keeps its filled-in rows together.
+    const table = await render(`
+      <table data-tabulator><thead><tr><th>Level</th></tr></thead>
+        <tbody>
+          <tr><td>Gold</td></tr><tr><td></td></tr><tr><td>Silver</td></tr>
+        </tbody></table>`);
+    table.setSort("level", dir);
+    expect(table.getData("active").map((row) => row.level)).toEqual([...filled, ""]);
+  });
+
+  it("filters a column on its text, and skips columns opted out", async () => {
+    const table = await render(`
+      <table data-tabulator>
+        <thead><tr>
+          <th>Name</th><th tabulator-headerFilter="false">Active?</th>
+        </tr></thead>
+        <tbody>
+          <tr><td><a href="/admin/sponsors/beeeee/">Aardvark</a></td>
+              <td><i class="fa fa-check"></i></td></tr>
+          <tr><td><a href="/admin/sponsors/aaaaaa/">Zebra</a></td>
+              <td><i class="fa fa-times"></i></td></tr>
+        </tbody></table>`);
+
+    const [name, active] = table.getColumns();
+    expect(name.getDefinition().headerFilter).toBe("input");
+    // An icon column has no text to match, so a filter box there could only
+    // ever empty the table.
+    expect(active.getDefinition().headerFilter).toBe(false);
+
+    // "beeeee" appears only inside the href, so a filter reading the markup
+    // would answer with Aardvark for a string nobody can see on the page.
+    table.setHeaderFilterValue("name", "beeeee");
+    expect(table.getData("active")).toEqual([]);
+
+    table.setHeaderFilterValue("name", "aardvark");
+    const shown = table
+      .getData("active")
+      .map((row) => row.name.replace(/<[^>]*>/g, "").trim());
+    expect(shown).toEqual(["Aardvark"]);
+  });
+
+  it("toggles a column once per click of its menu entry", async () => {
+    const table = await render(`
+      <table data-tabulator data-tabulator-column-menu>
+        <thead><tr><th tabulator-visible="false">IP address</th><th>Event</th></tr></thead>
+        <tbody><tr><td>127.0.0.1</td><td>login</td></tr></tbody></table>`);
+    const column = table.getColumns()[0];
+    const [entry] = table.options.columnDefaults.headerMenu.call(table);
+
+    // Tabulator listens on the menu item, so a <label> here would forward a
+    // second click to its own checkbox and toggle the column straight back.
+    const item = document.createElement("div");
+    item.appendChild(entry.label);
+    document.body.appendChild(item);
+    item.addEventListener("click", (event) => entry.action(event, column));
+    entry.label.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(column.isVisible()).toBe(true);
+  });
+  it("shows a column the responsive layout folded as still wanted", async () => {
+    const table = await render(`
+      <table data-tabulator data-tabulator-column-menu
+             tabulator-responsiveLayout="collapse">
+        <thead><tr><th>Event</th><th tabulator-responsive="2">User-Agent</th></tr></thead>
+        <tbody><tr><td>login</td><td>curl/8.0</td></tr></tbody></table>`);
+    const agent = table
+      .getColumns()
+      .find((column) => column.getDefinition().title === "User-Agent");
+
+    // What a narrow window does: fold the column into the collapsed block.
+    table.modules.responsiveLayout.hideColumn(agent);
+    expect(agent.isVisible()).toBe(false);
+
+    const entry = table.options.columnDefaults.headerMenu
+      .call(table)
+      .find((item) => item.label.textContent.trim() === "User-Agent");
+    // Reading `isVisible()` here would report a folded column as one the
+    // admin had hidden, and clicking it would then show it rather than hide.
+    expect(entry.label.querySelector("input").checked).toBe(true);
+  });
+
+  it("gives a collapsing table a handle to close the block with", async () => {
+    const table = await render(`
+      <table data-tabulator tabulator-responsiveLayout="collapse">
+        <thead><tr><th>Event</th></tr></thead>
+        <tbody><tr><td>login</td></tr></tbody></table>`);
+
+    // ResponsiveLayout wires up a toggle only when it finds this formatter,
+    // and no attribute can ask for it, so without one the collapsed block
+    // renders permanently open with nothing to close it.
+    const [handle] = table.getColumns();
+    expect(handle.getDefinition().formatter).toBe("responsiveCollapse");
+    expect(table.modules.responsiveLayout.collapseHandleColumn).toBeTruthy();
+    // No title, so it stays out of the column visibility menu.
+    expect(handle.getDefinition().title).toBeUndefined();
+  });
+
+  it("ignores an attribute naming only an Object prototype member", async () => {
+    // HTML lowercases attribute names, so `constructor` and `__proto__` reach
+    // the prototype chain of the option table and answer with something that
+    // is not an option at all.
+    document.body.innerHTML = `
+      <table id="first" data-tabulator tabulator-constructor="boom">
+        <thead><tr><th>Name</th></tr></thead>
+        <tbody><tr><td>a</td></tr></tbody></table>
+      <table id="second" data-tabulator>
+        <thead><tr><th>Name</th></tr></thead>
+        <tbody><tr><td>b</td></tr></tbody></table>`;
+    await jest.isolateModulesAsync(async () => {
+      await import("../../warehouse/admin/static/js/tabulator");
+    });
+    await new Promise((resolve) => setTimeout(resolve));
+
+    // Both tables built: a throw while reading the first one's attributes
+    // would have left the second as a plain <table>.
+    expect(document.querySelectorAll("div.tabulator")).toHaveLength(2);
+  });
+
+  it("exports what a cell shows rather than the markup showing it", async () => {
+    const table = await render(`
+      <table id="sponsors" data-tabulator data-tabulator-download>
+        <thead><tr><th>Name</th></tr></thead>
+        <tbody><tr><td><a href="/admin/sponsors/00000000/">Aardvark</a></td></tr>
+        </tbody></table>`);
+
+    const { accessorDownload, accessorClipboard } = table.options.columnDefaults;
+    const cell = "<a href=\"/admin/sponsors/00000000/\">Aardvark</a>";
+    expect(accessorDownload(cell)).toBe("Aardvark");
+    expect(accessorClipboard(cell)).toBe("Aardvark");
+
+    const download = jest.spyOn(table, "download").mockImplementation(() => {});
+    const copy = jest.spyOn(table, "copyToClipboard").mockImplementation(() => {});
+    const [copyButton, csvButton] = document.querySelectorAll(
+      "div.btn-group > button",
+    );
+    copyButton.click();
+    csvButton.click();
+
+    // Filtered and sorted as they stand, across every page, which is what the
+    // DataTables toolbar these replace exported.
+    expect(copy).toHaveBeenCalledWith("active");
+    // Without this the Clipboard module never binds the listener that
+    // `copyToClipboard` fires against, and the button does nothing at all.
+    expect(table.options.clipboard).toBe("copy");
+    expect(download).toHaveBeenCalledWith("csv", "sponsors.csv", {}, "active");
+  });
+
+  it("leaves the export buttons off a table that did not ask for them", async () => {
+    await render(`
+      <table data-tabulator><thead><tr><th>Name</th></tr></thead>
+        <tbody><tr><td>a</td></tr></tbody></table>`);
+    expect(document.querySelector("div.btn-group")).toBeNull();
+  });
+});

--- a/tests/unit/admin/test_tabulator_templates.py
+++ b/tests/unit/admin/test_tabulator_templates.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""The escaping rule the declarative admin tables rest on.
+
+Tabulator reads a server-rendered cell as innerHTML and, with the `html`
+formatter these tables default to, writes it back the same way. The group
+headings and the responsive-collapse block do that whatever the formatter is,
+so every cell of a `data-tabulator` table has to be Jinja-autoescaped output.
+
+Nothing in the rendering path can tell the difference, so the rule is checked
+here: the first `|safe` added to one of these tables would be script execution
+in an authenticated admin session.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+import warehouse.admin
+
+_TEMPLATES = pathlib.Path(warehouse.admin.__file__).parent / "templates" / "admin"
+
+# A <table data-tabulator ...> and everything up to its </table>.
+_TABLE = re.compile(
+    r"<table[^>]*\bdata-tabulator\b.*?</table>", re.DOTALL | re.IGNORECASE
+)
+
+# Anything that hands Jinja markup it will not escape.
+_UNESCAPED = re.compile(r"\|\s*safe\b|\bMarkup\(|{%\s*autoescape\s+false")
+
+
+def _tables():
+    for path in sorted(_TEMPLATES.rglob("*.html")):
+        source = path.read_text()
+        for match in _TABLE.finditer(source):
+            yield pytest.param(
+                match.group(0),
+                id=f"{path.parent.name}/{path.name}:"
+                f"{source.count(chr(10), 0, match.start()) + 1}",
+            )
+
+
+@pytest.mark.parametrize("table", list(_tables()))
+def test_declarative_table_cells_stay_escaped(table):
+    assert not _UNESCAPED.search(table)

--- a/warehouse/admin/static/css/admin.css
+++ b/warehouse/admin/static/css/admin.css
@@ -24,6 +24,17 @@ table.dataTable {
   max-width: 30em;
 }
 
+/* Tabulator replaces the <table> with divs, so the rule above cannot reach its
+   cells, and its own stylesheet clips each one to a single line. Wrap instead:
+   the columns capped at `maxInitialWidth` are the payload and caveat blobs
+   admins are on the page to read. `anywhere` breaks an unspaced token — a
+   base64 caveat, a long URL — rather than letting it set the column width. */
+.tabulator-cell {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+}
+
 .preserve-line-breaks {
   white-space: pre-line;
 }

--- a/warehouse/admin/static/js/tabulator.js
+++ b/warehouse/admin/static/js/tabulator.js
@@ -10,20 +10,335 @@ Tabulator.extendModule("format", "formatters", {
   filesize: (cell) => filesize(cell.getValue()),
 });
 
+// A cell's value is the markup the template rendered into it, so anything
+// comparing values — sorting, filtering — has to read the text out first,
+// or it compares `href`s and CSS class names instead of what is on screen.
+//
+// Sorting asks for the same handful of values O(n log n) times, and parsing
+// HTML is far and away the expensive part, so results are memoized. The cache
+// is keyed by the markup itself and shared by every table on the page, so it
+// is capped rather than left to grow: rows come and go as an admin filters or
+// pages, and nothing would ever drop the entries they leave behind. Refilling
+// it costs one parse per cell on screen, so it is emptied wholesale.
+const CELL_TEXT_CACHE_LIMIT = 4096;
+const cellTextCache = new Map();
+
+function cellText(value) {
+  if (typeof value !== "string") {
+    return value == null ? "" : String(value);
+  }
+  if (!value.includes("<") && !value.includes("&")) {
+    return value.trim();
+  }
+  let text = cellTextCache.get(value);
+  if (text === undefined) {
+    const holder = document.createElement("div");
+    holder.innerHTML = value;
+    text = holder.textContent.trim();
+    if (cellTextCache.size >= CELL_TEXT_CACHE_LIMIT) {
+      cellTextCache.clear();
+    }
+    cellTextCache.set(value, text);
+  }
+  return text;
+}
+
+Tabulator.extendModule("sort", "sorters", {
+  // Numbers embedded in text sort as numbers, so "10" follows "9".
+  //
+  // Blanks sort to the bottom in either direction, so a column of optional
+  // values keeps the filled-in rows together. The sort module swaps its
+  // operands for a descending sort rather than negating the result, so
+  // holding blanks down means answering relative to `dir`.
+  text: (a, b, aRow, bRow, column, dir) => {
+    const left = cellText(a);
+    const right = cellText(b);
+    if (!left || !right) {
+      if (left === right) {
+        return 0;
+      }
+      const blankLast = dir === "asc" ? 1 : -1;
+      return left ? -blankLast : blankLast;
+    }
+    return left.localeCompare(right, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    });
+  },
+});
+
 // Opt a server-rendered table in with `data-tabulator`. Everything else comes
 // from `tabulator-*` attributes on the <table> and its <th> elements, so
 // adding a table needs no JavaScript of its own. Tabulator takes column
 // titles from the header text and derives each field from it ("Total Size"
 // becomes `total_size`), and takes cell values from the cell's innerHTML.
-// Columns carrying links or badges need `tabulator-formatter="html"` to render
-// as markup rather than as escaped text; only reach for it where the cell holds
-// template-rendered markup, since the value is re-injected as innerHTML.
 //
-// `tabulator-responsiveLayout="collapse"` folds columns that do not fit into a
-// labelled block under each row, ordered by per-column `tabulator-responsive`
-// priorities (higher numbers fold first). It has no effect under
-// `tabulator-layout="fitColumns"`, which shrinks columns instead of ever
-// overflowing — pair it with `fitDataFill`.
-document.querySelectorAll("table[data-tabulator]").forEach(function (table) {
-  new Tabulator(table);
+// Tabulator can read `tabulator-*` attributes itself, but only from inside
+// the HtmlTableImport module, which initializes after the core modules and
+// after GroupRows has already decided whether to subscribe to anything. Any
+// option consulted during a module's `initialize()` — `layout`, `groupBy` —
+// is therefore read before the attribute is parsed, and silently keeps its
+// default. Table options are parsed here instead and handed to the
+// constructor, which is also where they get the right type: attributes are
+// strings, and Tabulator only ever coerces "true" and "false".
+//
+// Column options stay with Tabulator, since those are consumed later, when
+// the columns are built. They are still strings, so `tabulator-responsive`
+// priorities compare numerically but cannot be a real `0`, the one value
+// that would exclude a column from responsive folding altogether.
+//
+// Unmarked columns default to 1, and columns sharing a priority fold
+// rightmost first, so number every column that should fold before them with
+// a 2 or higher. Marking one `1` says nothing and leaves it to fold by
+// position.
+const TABLE_OPTIONS = {
+  layout: ["layout", String],
+  height: ["height", String],
+  responsivelayout: ["responsiveLayout", String],
+  placeholder: ["placeholder", String],
+  groupby: ["groupBy", String],
+  pagination: ["pagination", (v) => v !== "false"],
+  paginationsize: ["paginationSize", Number],
+  paginationsizeselector: [
+    "paginationSizeSelector",
+    (v) => v.split(",").map(Number),
+  ],
+};
+
+function tableOptions(table) {
+  const options = {};
+  const consumed = [];
+
+  for (const attribute of Array.from(table.attributes)) {
+    if (!attribute.name.startsWith("tabulator-")) {
+      continue;
+    }
+    // `hasOwn`, since HTML lowercases attribute names and a plain lookup on an
+    // object literal answers for `constructor` and `__proto__` too.
+    const name = attribute.name.slice("tabulator-".length);
+    if (Object.hasOwn(TABLE_OPTIONS, name)) {
+      const [option, parse] = TABLE_OPTIONS[name];
+      options[option] = parse(attribute.value);
+      consumed.push(attribute.name);
+    }
+  }
+
+  // HtmlTableImport parses these attributes too, late and as strings, and
+  // would put `paginationSize: "25"` back over the number parsed here.
+  // Removing them once read leaves this the only reader.
+  consumed.forEach((name) => table.removeAttribute(name));
+  return options;
+}
+
+// Whether an admin has asked to see a column, seeded from the markup.
+//
+// Deliberately not `column.isVisible()`: ResponsiveLayout hides a column it
+// folds into the collapsed block, so on a narrow window that answers false for
+// columns the admin never touched. The menu would then report a folded column
+// as one they had hidden, and clicking it would show it rather than hide it.
+const columnWanted = new WeakMap();
+
+function isColumnWanted(column) {
+  if (!columnWanted.has(column)) {
+    columnWanted.set(column, column.getDefinition().visible !== false);
+  }
+  return columnWanted.get(column);
+}
+
+// Put ResponsiveLayout's fold cursor back in step with its column list.
+//
+// Showing or hiding a column rebuilds that list and the record of which
+// columns are folded, but leaves `index` — the position it folds from — where
+// it was, so the next resize folds or unfolds whichever column now sits at the
+// stale index. Everything ahead of the cursor is folded, which is exactly what
+// the rebuilt list of folded columns counts.
+function resyncResponsiveFold(table) {
+  const responsive = table.modules.responsiveLayout;
+  if (responsive) {
+    responsive.index = responsive.hiddenColumns.length;
+  }
+}
+
+// Build the column list for a header menu, checked to match what the admin
+// asked for. Tabulator calls this with the table as `this` each time a menu
+// opens, so the checkboxes always reflect the columns as they stand.
+function columnVisibilityMenu() {
+  const table = this;
+
+  return table
+    .getColumns()
+    .filter((column) => column.getDefinition().title)
+    .map((column) => {
+      // Deliberately not a <label>: Tabulator listens on the menu item, and a
+      // label would forward a second click to its own checkbox, toggling the
+      // column straight back.
+      const item = document.createElement("span");
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.checked = isColumnWanted(column);
+      checkbox.tabIndex = -1;
+      item.appendChild(checkbox);
+      item.appendChild(
+        document.createTextNode(` ${column.getDefinition().title}`),
+      );
+
+      return {
+        label: item,
+        action: function (event) {
+          // Without this the menu closes on the first click, which makes
+          // hiding several columns needlessly tedious.
+          event.stopPropagation();
+          const wanted = !isColumnWanted(column);
+          columnWanted.set(column, wanted);
+          if (wanted) {
+            column.show();
+          } else {
+            column.hide();
+          }
+          checkbox.checked = wanted;
+          resyncResponsiveFold(table);
+        },
+      };
+    });
+}
+
+// ResponsiveLayout wires up a collapse toggle only when it finds a column
+// using its own `responsiveCollapse` formatter, and no `tabulator-*` attribute
+// can declare one — the formatter comes from the module rather than from the
+// markup. Without it `responsiveLayoutCollapseStartOpen` leaves the folded
+// block open under every row with no control to close it, so a collapsing
+// table gets the column added here.
+const COLLAPSE_HANDLE_COLUMN = {
+  formatter: "responsiveCollapse",
+  width: 30,
+  minWidth: 30,
+  hozAlign: "center",
+  resizable: false,
+  headerSort: false,
+  headerFilter: false,
+  // No title, which also keeps it out of the column visibility menu.
+  headerMenu: false,
+  // Never fold the control that unfolds everything else.
+  responsive: 0,
+  download: false,
+  clipboard: false,
+};
+
+// Restore the CSV and copy exports the DataTables toolbars carried, using
+// Tabulator's own Download and Clipboard modules. Both run over the rows as
+// filtered and sorted, across every page, which is the scope DataTables
+// exported. See https://www.tabulator.info/docs/6.x/download.
+function toolbarButton(label, iconClass, onClick) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "btn btn-outline-secondary";
+  const icon = document.createElement("i");
+  icon.className = `fa ${iconClass}`;
+  button.appendChild(icon);
+  button.appendChild(document.createTextNode(` ${label}`));
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+function exportToolbar(table, filename) {
+  const toolbar = document.createElement("div");
+  toolbar.className = "btn-group btn-group-sm mb-2";
+  toolbar.appendChild(
+    toolbarButton("Copy", "fa-copy", () => table.copyToClipboard("active")),
+  );
+  toolbar.appendChild(
+    toolbarButton("CSV", "fa-download", () =>
+      table.download("csv", `${filename}.csv`, {}, "active"),
+    ),
+  );
+  return toolbar;
+}
+
+function mountTable(element) {
+  const options = tableOptions(element);
+
+  options.columnDefaults = {
+    // Cell values are read out of the DOM as innerHTML, so they arrive
+    // already escaped by the template. Tabulator's default `plaintext`
+    // formatter escapes them a second time, which shows `&`, `<` and `>` as
+    // literal entities and renders links and badges as their own source.
+    // Re-injecting the same markup as innerHTML round-trips it exactly.
+    // A column needing real formatting overrides this, e.g.
+    // `tabulator-formatter="filesize"`.
+    //
+    // THE RULE THIS RESTS ON: a `data-tabulator` cell must contain only
+    // Jinja-autoescaped output. Never `|safe`, `Markup`, or anything else
+    // carrying unescaped user input into one of these tables — the value is
+    // re-injected as HTML. Group headings and the responsive-collapse block
+    // do that regardless of the formatter, so the rule holds for every
+    // column, not just the ones rendered here.
+    formatter: "html",
+    // Sort and filter on what the cell shows rather than on its markup.
+    sorter: "text",
+    // A box under each column heading, so it is obvious which column a
+    // search applies to. Columns where a text match would mislead — an icon
+    // with no text, an action button, a size rendered from a raw byte count —
+    // opt out with `tabulator-headerFilter="false"`.
+    headerFilter: "input",
+    headerFilterPlaceholder: "filter",
+    headerFilterFunc: (headerValue, rowValue) =>
+      cellText(rowValue).toLowerCase().includes(String(headerValue).toLowerCase()),
+    // Tabulator sizes a column to its widest cell, so one long payload or
+    // caveat blob would otherwise push every other column off screen. Capped
+    // and wrapped rather than capped and clipped, since a payload an admin
+    // cannot finish reading is the whole reason these columns are on the page.
+    // Admins can still drag a column wider.
+    maxInitialWidth: 480,
+    variableHeight: true,
+    // Exports carry what the cell shows, not the markup showing it.
+    accessorDownload: cellText,
+    accessorClipboard: cellText,
+  };
+
+  if (options.responsiveLayout === "collapse") {
+    // HtmlTableImport appends the columns it reads from the <th>s to whatever
+    // is here already, so the handle lands first.
+    options.columns = [{ ...COLLAPSE_HANDLE_COLUMN }];
+  }
+
+  // Opt in with `data-tabulator-column-menu` to hang a column list off every
+  // header, which is how an admin reaches a `tabulator-visible="false"`
+  // column. Left off by default, since it puts an icon in every header.
+  if (element.dataset.tabulatorColumnMenu !== undefined) {
+    options.columnDefaults.headerMenu = columnVisibilityMenu;
+  }
+
+  // Opt in with `data-tabulator-download` for the copy and CSV buttons.
+  const exporting = element.dataset.tabulatorDownload !== undefined;
+  if (exporting) {
+    // "copy" rather than true: the Clipboard module binds the copy listener
+    // `copyToClipboard` fires against only once this is set, and true would
+    // also have it read pastes into the table, which no admin table wants.
+    options.clipboard = "copy";
+  }
+
+  const table = new Tabulator(element, options);
+
+  if (exporting) {
+    const filename = element.id || "export";
+    table.on("tableBuilt", () => {
+      table.element.parentNode.insertBefore(
+        exportToolbar(table, filename),
+        table.element,
+      );
+    });
+  }
+}
+
+document.querySelectorAll("table[data-tabulator]").forEach(function (element) {
+  try {
+    mountTable(element);
+  } catch (error) {
+    // A bad attribute on one table is that table's problem alone. Letting it
+    // out of the loop would leave every table after it on the page as a plain
+    // <table> — no sorting, no filtering, no paging — and users/detail.html
+    // mounts five. Tabulator defers the build itself, so what this covers is
+    // reading the options and handing them over.
+    console.error("Could not build admin table", element, error);
+  }
 });

--- a/warehouse/admin/templates/admin/organizations/detail.html
+++ b/warehouse/admin/templates/admin/organizations/detail.html
@@ -706,9 +706,9 @@
                  tabulator-placeholder="No matching projects">
             <thead>
               <tr>
-                <th tabulator-formatter="html" tabulator-headerFilter="input">Project Name</th>
-                <th tabulator-formatter="html" tabulator-headerFilter="input">Lifecycle Status</th>
-                <th tabulator-formatter="filesize" tabulator-sorter="number" tabulator-responsive="2">Total Size</th>
+                <th>Project Name</th>
+                <th>Lifecycle Status</th>
+                <th tabulator-formatter="filesize" tabulator-sorter="number" tabulator-headerFilter="false" tabulator-responsive="2">Total Size</th>
               </tr>
             </thead>
             <tbody>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -985,11 +985,11 @@
                  tabulator-placeholder="No matching projects">
             <thead>
               <tr>
-                <th tabulator-formatter="html" tabulator-headerFilter="input">Project Name</th>
-                <th tabulator-headerFilter="input" tabulator-responsive="2">Role</th>
-                <th tabulator-formatter="html" tabulator-headerFilter="input">Lifecycle Status</th>
-                <th tabulator-sorter="number" tabulator-responsive="4">Releases</th>
-                <th tabulator-formatter="filesize" tabulator-sorter="number" tabulator-responsive="3">Total Size</th>
+                <th>Project Name</th>
+                <th tabulator-responsive="2">Role</th>
+                <th>Lifecycle Status</th>
+                <th tabulator-sorter="number" tabulator-headerFilter="false" tabulator-responsive="4">Releases</th>
+                <th tabulator-formatter="filesize" tabulator-sorter="number" tabulator-headerFilter="false" tabulator-responsive="3">Total Size</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
A `tabulator-*` attribute could be spelled right and still do nothing. Tabulator parses them in HtmlTableImport, which initializes after the core modules, so any option read during a module's `initialize()` (`layout`, `groupBy`) kept its default. Table options are read here now and handed to the constructor, with the attributes removed once read so the later parse cannot put the string back. The lookup uses `hasOwn`, since HTML lowercases attribute names and a plain lookup answers for `constructor`, and each table mounts in its own try/catch so one bad attribute cannot flatten every table after it.

Cell values arrive as innerHTML, already escaped by the template, and the default formatter escaped them a second time, so a project or status holding `&`, `<` or `>` rendered as a visible entity. Re-injecting the same markup round-trips it exactly and covers the link and badge columns that carried `tabulator-formatter="html"`. A new test asserts the rule this rests on: a `data-tabulator` cell may only hold Jinja-autoescaped output.

Since values are markup, sorting and filtering were comparing hrefs and class names, so both read the text out first, memoized because a sort asks for the same value many times. Blanks sort last either way, and columns cap their initial width and wrap at the cap rather than clipping, since Tabulator sizes to the widest cell and a payload or caveat blob is what the admin came to read.

`data-tabulator-column-menu` and `data-tabulator-download` bring back the DataTables column menu, copy and CSV over Tabulator's own Download and Clipboard modules. Exports read cell text, and the menu tracks what the admin asked for rather than `isVisible()`, which is also false for a column the responsive layout has folded away. A collapsing table gets the handle that opens the folded block, which no attribute can ask for.

Adds the first tests for admin JS. Jest could not load Tabulator at all, since the published CJS bundle is a browser UMD that exports nothing to require, so it maps the package to the ESM build webpack ships, with the flag that enables that quoted so the shell expands it.