### PR TITLE
feat: scaffold IEmailReputationService with a null default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ from warehouse import admin, config, static
 from warehouse.accounts import services as account_services
 from warehouse.accounts.interfaces import (
     IDomainStatusService,
+    IEmailReputationService,
     ITokenService,
     IUserService,
 )
@@ -219,6 +220,7 @@ def pyramid_services(
     query_results_cache_service,
     search_service,
     domain_status_service,
+    email_reputation_service,
     ratelimit_service,
     github_oauth_provider_service,
 ):
@@ -247,6 +249,7 @@ def pyramid_services(
     services.register_service(query_results_cache_service, IQueryResultsCache)
     services.register_service(search_service, ISearchService)
     services.register_service(domain_status_service, IDomainStatusService)
+    services.register_service(email_reputation_service, IEmailReputationService)
     services.register_service(ratelimit_service, IRateLimiter, name="email.add")
     services.register_service(ratelimit_service, IRateLimiter, name="email.change")
     services.register_service(ratelimit_service, IRateLimiter, name="email.verify")
@@ -616,6 +619,11 @@ def domain_status_service(mocker):
     service = account_services.NullDomainStatusService()
     mocker.spy(service, "get_domain_status")
     return service
+
+
+@pytest.fixture
+def email_reputation_service():
+    return account_services.NullEmailReputationService()
 
 
 @pytest.fixture

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -8,6 +8,7 @@ from warehouse import accounts
 from warehouse.accounts.interfaces import (
     IDomainStatusService,
     IEmailBreachedService,
+    IEmailReputationService,
     IPasswordBreachedService,
     ITokenService,
     IUserService,
@@ -16,6 +17,7 @@ from warehouse.accounts.services import (
     HaveIBeenPwnedEmailBreachedService,
     HaveIBeenPwnedPasswordBreachedService,
     NullDomainStatusService,
+    NullEmailReputationService,
     TokenServiceFactory,
     database_login_factory,
 )
@@ -112,6 +114,7 @@ def test_includeme(monkeypatch):
                 "warehouse.account.2fa_ip_ratelimit_string": "10 per 5 minutes, 50 per hour",  # noqa: E501
                 "warehouse.account.email_add_ratelimit_string": "2 per day",
                 "warehouse.account.email_change_ratelimit_string": "5 per 5 minutes, 20 per hour",  # noqa: E501
+                "warehouse.account.email_reputation_ratelimit_string": "100 per hour",
                 "warehouse.account.verify_email_ratelimit_string": "3 per 6 hours",
                 "warehouse.account.password_reset_ratelimit_string": "5 per day",
                 "warehouse.account.accounts_search_ratelimit_string": "100 per hour",
@@ -160,6 +163,10 @@ def test_includeme(monkeypatch):
         ),
         pretend.call(NullDomainStatusService.create_service, IDomainStatusService),
         pretend.call(
+            NullEmailReputationService.create_service,
+            IEmailReputationService,
+        ),
+        pretend.call(
             accounts.NullGitHubOAuthClient.create_service,
             accounts.IOAuthProviderService,
             name="github",
@@ -173,6 +180,7 @@ def test_includeme(monkeypatch):
         pretend.call("10 per 5 minutes, 50 per hour", "2fa.ip"),
         pretend.call("2 per day", "email.add"),
         pretend.call("5 per 5 minutes, 20 per hour", "email.change"),
+        pretend.call("100 per hour", "email.reputation"),
         pretend.call("5 per day", "password.reset"),
         pretend.call("3 per 6 hours", "email.verify"),
         pretend.call("100 per hour", "accounts.search"),

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -17,8 +17,10 @@ from zope.interface.verify import verifyClass
 from warehouse.accounts import services
 from warehouse.accounts.interfaces import (
     BurnedRecoveryCode,
+    EmailReputationResult,
     IDomainStatusService,
     IEmailBreachedService,
+    IEmailReputationService,
     InvalidRecoveryCode,
     IPasswordBreachedService,
     ITokenService,
@@ -2259,6 +2261,45 @@ class TestFastlyDomainStatusService:
 
         assert svc._http is request.http
         assert svc.api_key == "some_api_key"
+
+
+class TestNullEmailReputationService:
+    def test_verify_service(self):
+        assert verifyClass(IEmailReputationService, services.NullEmailReputationService)
+
+    def test_check_email_returns_no_signals(self):
+        svc = services.NullEmailReputationService()
+
+        result = svc.check_email("foo@example.com")
+
+        assert result == EmailReputationResult()
+        assert result.signals == []
+        assert not result.should_block
+
+    def test_factory(self):
+        svc = services.NullEmailReputationService.create_service(None, None)
+
+        assert isinstance(svc, services.NullEmailReputationService)
+        assert svc.check_email("foo@example.com").signals == []
+
+
+class TestEmailReputationResult:
+    @pytest.mark.parametrize(
+        ("result_kwargs", "expected"),
+        [
+            # Domain-level disposability needs the public and relay flags
+            # to be explicitly clear.
+            ({"disposable": True, "public_domain": False, "relay_domain": False}, True),
+            ({"disposable": True, "public_domain": True, "relay_domain": False}, False),
+            ({"disposable": True, "public_domain": False, "relay_domain": True}, False),
+            ({"disposable": True}, False),
+            ({"public_domain": False, "relay_domain": False}, False),
+        ],
+    )
+    def test_disposable_domain_requires_explicit_flags(self, result_kwargs, expected):
+        result = EmailReputationResult(**result_kwargs)
+
+        assert result.disposable_domain is expected
 
 
 class TestDeviceIsKnown:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -339,6 +339,7 @@ def test_configure(monkeypatch, mocker, settings, environment):
         "warehouse.account.2fa_ip_ratelimit_string": "10 per 5 minutes, 50 per hour",
         "warehouse.account.email_add_ratelimit_string": "2 per day",
         "warehouse.account.email_change_ratelimit_string": "5 per 5 minutes, 20 per hour",  # noqa: E501
+        "warehouse.account.email_reputation_ratelimit_string": "100 per hour",
         "warehouse.account.verify_email_ratelimit_string": "3 per 6 hours",
         "warehouse.account.accounts_search_ratelimit_string": "100 per hour",
         "warehouse.account.password_reset_ratelimit_string": "5 per day",

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -5,6 +5,7 @@ from celery.schedules import crontab
 from warehouse.accounts.interfaces import (
     IDomainStatusService,
     IEmailBreachedService,
+    IEmailReputationService,
     IPasswordBreachedService,
     ITokenService,
     IUserService,
@@ -25,6 +26,7 @@ from warehouse.accounts.services import (
     HaveIBeenPwnedPasswordBreachedService,
     NullDomainStatusService,
     NullEmailBreachedService,
+    NullEmailReputationService,
     NullPasswordBreachedService,
     TokenServiceFactory,
     database_login_factory,
@@ -134,6 +136,17 @@ def includeme(config):
         domain_status_class.create_service, IDomainStatusService
     )
 
+    # Register our email reputation service, the third tier of email checks
+    # after the static and database blocklists.
+    email_reputation_class = config.maybe_dotted(
+        config.registry.settings.get(
+            "email_reputation.backend", NullEmailReputationService
+        )
+    )
+    config.register_service_factory(
+        email_reputation_class.create_service, IEmailReputationService
+    )
+
     # Register GitHub OAuth service for account associations.
     github_oauth_class = config.maybe_dotted(
         config.registry.settings["github.oauth.backend"]
@@ -200,6 +213,10 @@ def includeme(config):
         "warehouse.account.email_change_ratelimit_string"
     )
     config.register_rate_limiter(email_change_ratelimit_string, "email.change")
+    email_reputation_ratelimit_string = config.registry.settings.get(
+        "warehouse.account.email_reputation_ratelimit_string"
+    )
+    config.register_rate_limiter(email_reputation_ratelimit_string, "email.reputation")
     password_reset_ratelimit_string = config.registry.settings.get(
         "warehouse.account.password_reset_ratelimit_string"
     )

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+import dataclasses
+
 from zope.interface import Attribute, Interface
 
 from warehouse.rate_limiting.interfaces import RateLimiterException
@@ -10,6 +14,10 @@ class TooManyFailedLogins(RateLimiterException):
 
 
 class TooManyEmailsAdded(RateLimiterException):
+    pass
+
+
+class TooManyEmailReputationChecks(RateLimiterException):
     pass
 
 
@@ -329,4 +337,93 @@ class IDomainStatusService(Interface):
     def get_domain_status(domain: str) -> list[str] | None:
         """
         Returns a list of status strings for the given domain.
+        """
+
+
+@dataclasses.dataclass(frozen=True)
+class EmailReputationResult:
+    """
+    What an email reputation service reported about a single address.
+
+    "disposable" covers both a disposable domain and a single throwaway
+    address on a legitimate domain (an alias on a public provider); use
+    disposable_domain to tell whether the whole domain is implicated.
+
+    Signals are tri-state: True (reported), False (explicitly clear), and
+    None (unknown: absent from the response, or not a boolean). Blocking
+    and blocklisting act only on explicit values, so a payload revision
+    upstream can't turn into a false positive.
+    """
+
+    mx: bool | None = None
+    disposable: bool | None = None
+    public_domain: bool | None = None
+    relay_domain: bool | None = None
+    spam: bool | None = None
+    blocklisted: bool | None = None
+    disposable_provider: str | None = None
+
+    @property
+    def should_block(self) -> bool:
+        """
+        Whether this result should block use of the checked email address.
+        Only an explicit "disposable" blocks for now: every other signal is
+        observe-only, recorded in metrics until we've measured enough to
+        decide whether to gate on it too.
+        """
+        return self.disposable is True
+
+    @property
+    def disposable_domain(self) -> bool:
+        """
+        Whether the domain itself operates as a disposable provider, the
+        only case where prohibiting the whole domain is safe. The public and
+        relay flags must be explicitly clear: a throwaway address on a
+        public or relay domain, or one whose flags are unknown, must never
+        blocklist the domain, or the first disposable alias on gmail.com
+        would lock out everyone there.
+        """
+        return (
+            self.disposable is True
+            and self.public_domain is False
+            and self.relay_domain is False
+        )
+
+    @property
+    def signals(self) -> list[str]:
+        """
+        The names of the negative signals reported, sorted, for use in logs
+        and metrics. Empty if nothing was reported.
+        """
+        return sorted(
+            name
+            for name, reported in {
+                "blocklisted": self.blocklisted is True,
+                "disposable": self.disposable is True,
+                "no_mx": self.mx is False,
+                "public_domain": self.public_domain is True,
+                "relay_domain": self.relay_domain is True,
+                "spam": self.spam is True,
+            }.items()
+            if reported
+        )
+
+
+class IEmailReputationService(Interface):
+    def check_email(email: str) -> EmailReputationResult | None:
+        """
+        Returns what is known about the given email address, or None if no
+        verdict could be obtained -- callers are expected to fail open in
+        that case.
+
+        Raises TooManyEmailReputationChecks when the caller has spent their
+        rate-limit budget for the check. The budget is per-client, so failing
+        open here would let a caller exhaust it on purpose and skip the check
+        gating their own submissions.
+
+        Implementations receive the full address: a throwaway alias on a
+        public provider is invisible to a domain-only check, and catching
+        those is why this service exists. The compensating constraint is
+        that implementations must never write the address to logs; log
+        lines carry the domain only.
         """

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -31,8 +31,10 @@ from zope.interface import implementer
 
 from warehouse.accounts.interfaces import (
     BurnedRecoveryCode,
+    EmailReputationResult,
     IDomainStatusService,
     IEmailBreachedService,
+    IEmailReputationService,
     InvalidRecoveryCode,
     IPasswordBreachedService,
     ITokenService,
@@ -1269,3 +1271,13 @@ class FastlyDomainStatusService:
             return None
 
         return body["status"].split()
+
+
+@implementer(IEmailReputationService)
+class NullEmailReputationService:
+    @classmethod
+    def create_service(cls, _context, _request) -> NullEmailReputationService:
+        return cls()
+
+    def check_email(self, email: str) -> EmailReputationResult:
+        return EmailReputationResult()

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -468,6 +468,12 @@ def configure(settings=None):
     maybe_set_compound(settings, "breached_emails", "backend", "BREACHED_EMAILS")
     maybe_set_compound(settings, "breached_passwords", "backend", "BREACHED_PASSWORDS")
     maybe_set_compound(settings, "domain_status", "backend", "DOMAIN_STATUS_BACKEND")
+    maybe_set_compound(
+        settings,
+        "email_reputation",
+        "backend",
+        "EMAIL_REPUTATION_BACKEND",
+    )
     maybe_set_compound(settings, "github.oauth", "backend", "GITHUB_OAUTH_BACKEND")
     maybe_set_compound(settings, "gitlab.oauth", "backend", "GITLAB_OAUTH_BACKEND")
     maybe_set(
@@ -559,6 +565,12 @@ def configure(settings=None):
         "warehouse.account.email_change_ratelimit_string",
         "EMAIL_CHANGE_RATELIMIT_STRING",
         default="5 per 5 minutes, 20 per hour",
+    )
+    maybe_set(
+        settings,
+        "warehouse.account.email_reputation_ratelimit_string",
+        "EMAIL_REPUTATION_RATELIMIT_STRING",
+        default="100 per hour",
     )
     maybe_set(
         settings,


### PR DESCRIPTION
The interface for a third tier of email checks, after the static `disposable-email-domains` list and the `prohibited_email_domains` table: those only know about domains somebody has already reported, so disposable providers that cycle domains keep getting through.

The name is distinct from `IDomainStatusService` on purpose: that one asks a registrar-data API whether a domain still exists, on a 30-day batch cadence, while this one will ask a reputation API whether we should accept new addresses, inline at validation time.

`EmailReputationResult` carries three signals: `True` (reported), `False` (explicitly clear), `None` (unknown). Blocking and blocklisting act only on explicit values, so an upstream payload revision can't turn into a false positive, and `disposable_domain` requires the public and relay flags to be explicitly clear before a whole domain may be blocklisted.

The null implementation is the default and reports nothing. A per-IP rate limiter (`email.reputation`, default 100 per hour) is registered for the real backend to spend. Nothing calls the service yet, so this commit changes no behavior.