### PR TITLE
Let translators tell the 'Deleted by:' strings apart

### DIFF
--- a/docs/dev/translations.md
+++ b/docs/dev/translations.md
@@ -61,6 +61,34 @@ ngettext("Yesterday", "In the past", numDays);
 // -> (en) numDays is 1: "Yesterday"; numDays is 3: "In the past"
 ```
 
+## Disambiguating strings that repeat
+
+The same English string can need different translations depending on what it
+refers to. `"Deleted by:"` appears on the organization, team and project
+history pages, and in Portuguese the participle inflects with the gender of the
+thing deleted - "project" is masculine where "organization" and "team" are
+feminine - so one catalog entry cannot serve all three.
+
+Give the string a context by putting a literal string immediately after
+`trans`:
+
+```html
+{% trans "organization" %}Deleted by:{% endtrans %}
+```
+
+Each context becomes a separate entry in the catalog, carrying an `msgctxt`
+line that tells the translator which occurrence they are looking at:
+
+```po
+msgctxt "organization"
+msgid "Deleted by:"
+msgstr ""
+```
+
+Adding a context to a string that already had translations resets them, since
+translators are now answering a different question. Only add one where the
+occurrences genuinely need to differ.
+
 ## Passing non-translatable values to translated strings
 
 In html, to pass values you don't want to be translated into

--- a/tests/unit/i18n/test_extensions.py
+++ b/tests/unit/i18n/test_extensions.py
@@ -33,6 +33,9 @@ def test_trim_trans_tags(ext, result):
     assert env.from_string("{% trans %}   hey   {% endtrans %}").render() == result
 
 
+PLURAL_CATALOG = {"team\x04%(num)s member": ("%(num)s membro", "%(num)s membros")}
+
+
 class TestFallbackInternationalizationExtension:
     @pytest.mark.parametrize(
         ("newstyle_env", "newstyle_param", "newer_called", "pgettext", "npgettext"),
@@ -83,6 +86,94 @@ class TestFallbackInternationalizationExtension:
         else:
             make_newer_gettext.assert_not_called()
             make_newer_ngettext.assert_not_called()
+
+    def test_install_derives_contextual_callables(self, mocker):
+        """pyramid_jinja2 passes gettext and ngettext only, so the contextual
+        pair has to be derived or `{% trans "context" %}` calls None."""
+        env = Environment(
+            autoescape=True,
+            extensions=[
+                "warehouse.i18n.extensions.FallbackInternationalizationExtension"
+            ],
+        )
+
+        env.install_gettext_callables(
+            mocker.stub(name="gettext"), mocker.stub(name="ngettext"), newstyle=True
+        )
+
+        assert env.globals["pgettext"] is not None
+        assert env.globals["npgettext"] is not None
+
+    @pytest.mark.parametrize(
+        ("catalog", "expected"),
+        [
+            # A translated context resolves to its own entry...
+            ({"team\x04Deleted by:": "Excluído por:"}, "Excluído por:"),
+            # ...and an untranslated one falls back to the bare message rather
+            # than leaking the context-prefixed key into the page.
+            ({}, "Deleted by:"),
+        ],
+    )
+    def test_pgettext_renders_context(self, mocker, catalog, expected):
+        templates = {"test.html": '{% trans "team" %}Deleted by:{% endtrans %}'}
+        env = Environment(
+            autoescape=True,
+            loader=DictLoader(templates),
+            extensions=[
+                "warehouse.i18n.extensions.FallbackInternationalizationExtension"
+            ],
+        )
+        env.install_gettext_callables(
+            lambda string: catalog.get(string, string),
+            mocker.stub(name="ngettext"),
+            newstyle=True,
+        )
+
+        assert env.get_template("test.html").render() == expected
+
+    @pytest.mark.parametrize(
+        ("catalog", "num", "expected"),
+        [
+            (
+                {"team\x04%(num)s member": ("%(num)s membro", "%(num)s membros")},
+                1,
+                "1 membro",
+            ),
+            (
+                {"team\x04%(num)s member": ("%(num)s membro", "%(num)s membros")},
+                2,
+                "2 membros",
+            ),
+            ({}, 1, "1 member"),
+            ({}, 2, "2 members"),
+        ],
+    )
+    def test_npgettext_renders_context(self, mocker, catalog, num, expected):
+        templates = {
+            "test.html": (
+                '{% trans "team" num=num %}{{ num }} member'
+                "{% pluralize %}{{ num }} members{% endtrans %}"
+            )
+        }
+
+        def ngettext(singular, plural, n):
+            forms = catalog.get(singular)
+            if forms is None:
+                return singular if n == 1 else plural
+            return forms[0] if n == 1 else forms[1]
+
+        env = Environment(
+            autoescape=True,
+            loader=DictLoader(templates),
+            extensions=[
+                "warehouse.i18n.extensions.FallbackInternationalizationExtension"
+            ],
+        )
+        env.install_gettext_callables(
+            mocker.stub(name="gettext"), ngettext, newstyle=True
+        )
+
+        assert env.get_template("test.html").render(num=num) == expected
 
     @pytest.mark.parametrize(
         ("translation", "expected"),

--- a/warehouse/i18n/extensions.py
+++ b/warehouse/i18n/extensions.py
@@ -70,12 +70,54 @@ def _make_newer_ngettext(
     return ngettext
 
 
+# GNU gettext stores a contextual message under "context\x04message", which is
+# what pybabel compiles an `msgctxt` into.
+CONTEXT_SEPARATOR = "\x04"
+
+
+def _make_context_gettext(func: t.Callable[[str], str]) -> t.Callable[[str, str], str]:
+    """
+    Derive a pgettext from a plain gettext.
+
+    pyramid_jinja2 installs only gettext and ngettext, so without this
+    `{% trans "context" %}` renders a call to None. Looking the message up under
+    its context-prefixed key is all a real pgettext does; a key that comes back
+    unchanged had no translation, and the bare message is the fallback.
+    """
+
+    def pgettext(context: str, message: str) -> str:
+        key = f"{context}{CONTEXT_SEPARATOR}{message}"
+        translated = func(key)
+        return message if translated == key else translated
+
+    return pgettext
+
+
+def _make_context_ngettext(
+    func: t.Callable[[str, str, int], str],
+) -> t.Callable[[str, str, str, int], str]:
+    """
+    Derive an npgettext from a plain ngettext, as _make_context_gettext does.
+
+    The context prefixes the singular, since that is the key a catalog stores
+    the plural forms under.
+    """
+
+    def npgettext(context: str, singular: str, plural: str, num: int) -> str:
+        key = f"{context}{CONTEXT_SEPARATOR}{singular}"
+        translated = func(key, plural, num)
+        return singular if translated == key else translated
+
+    return npgettext
+
+
 class FallbackInternationalizationExtension(InternationalizationExtension):
     """
     Replica of InternationalizationExtension which overrides a single
     method _install_callables to inject our own wrappers for gettext
     and ngettext with the _make_newer_gettext and _make_newer_ngettext
-    defined above.
+    defined above, and to supply a pgettext/npgettext pair that our
+    renderer never passes in.
 
     Diff from original method is:
 
@@ -83,6 +125,8 @@ class FallbackInternationalizationExtension(InternationalizationExtension):
     -            ngettext = _make_new_ngettext(ngettext)
     +            gettext = _make_newer_gettext(gettext)
     +            ngettext = _make_newer_ngettext(ngettext)
+
+    plus the pgettext/npgettext defaulting above the newstyle branch.
     """
 
     def _install_callables(
@@ -95,15 +139,20 @@ class FallbackInternationalizationExtension(InternationalizationExtension):
     ) -> None:
         if newstyle is not None:
             self.environment.newstyle_gettext = newstyle  # type: ignore[attr-defined]
+
+        # pyramid_jinja2 calls install_gettext_callables() with gettext and
+        # ngettext only, so a template using `{% trans "context" %}` would
+        # otherwise call None. Derive the contextual pair from the plain ones.
+        if pgettext is None:
+            pgettext = _make_context_gettext(gettext)
+        if npgettext is None:
+            npgettext = _make_context_ngettext(ngettext)
+
         if self.environment.newstyle_gettext:  # type: ignore[attr-defined]
             gettext = _make_newer_gettext(gettext)
             ngettext = _make_newer_ngettext(ngettext)
-
-            if pgettext is not None:
-                pgettext = _make_new_pgettext(pgettext)
-
-            if npgettext is not None:
-                npgettext = _make_new_npgettext(npgettext)
+            pgettext = _make_new_pgettext(pgettext)
+            npgettext = _make_new_npgettext(npgettext)
 
         self.environment.globals.update(
             gettext=gettext, ngettext=ngettext, pgettext=pgettext, npgettext=npgettext

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4567,7 +4567,7 @@ msgid "Recent account activity"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:938
-#: warehouse/templates/manage/organization/history.html:213
+#: warehouse/templates/manage/organization/history.html:218
 #: warehouse/templates/manage/project/history.html:333
 #: warehouse/templates/manage/team/history.html:87
 #: warehouse/templates/manage/unverified-account.html:530
@@ -4575,8 +4575,8 @@ msgid "Event"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:939
-#: warehouse/templates/manage/organization/history.html:214
-#: warehouse/templates/manage/organization/history.html:223
+#: warehouse/templates/manage/organization/history.html:219
+#: warehouse/templates/manage/organization/history.html:228
 #: warehouse/templates/manage/project/history.html:334
 #: warehouse/templates/manage/project/history.html:343
 #: warehouse/templates/manage/team/history.html:88
@@ -4586,7 +4586,7 @@ msgid "Time"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:940
-#: warehouse/templates/manage/organization/history.html:215
+#: warehouse/templates/manage/organization/history.html:220
 #: warehouse/templates/manage/team/history.html:89
 #: warehouse/templates/manage/unverified-account.html:532
 msgid "Additional Info"
@@ -4598,13 +4598,13 @@ msgid "Date / time"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:952
-#: warehouse/templates/manage/organization/history.html:227
+#: warehouse/templates/manage/organization/history.html:232
 #: warehouse/templates/manage/unverified-account.html:543
 msgid "Location Info"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:955
-#: warehouse/templates/manage/organization/history.html:230
+#: warehouse/templates/manage/organization/history.html:235
 #: warehouse/templates/manage/project/history.html:350
 #: warehouse/templates/manage/team/history.html:104
 #: warehouse/templates/manage/unverified-account.html:546
@@ -4954,7 +4954,7 @@ msgstr ""
 
 #: warehouse/templates/manage/manage_base.html:631
 #: warehouse/templates/manage/organization/history.html:113
-#: warehouse/templates/manage/organization/history.html:179
+#: warehouse/templates/manage/organization/history.html:184
 #: warehouse/templates/manage/project/history.html:27
 #: warehouse/templates/manage/project/history.html:80
 #: warehouse/templates/manage/project/history.html:119
@@ -4968,7 +4968,7 @@ msgstr ""
 
 #: warehouse/templates/manage/manage_base.html:633
 #: warehouse/templates/manage/organization/history.html:121
-#: warehouse/templates/manage/organization/history.html:184
+#: warehouse/templates/manage/organization/history.html:189
 #: warehouse/templates/manage/project/history.html:46
 #: warehouse/templates/manage/project/history.html:111
 #: warehouse/templates/manage/project/history.html:126
@@ -6417,45 +6417,49 @@ msgid "Created by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:158
-#: warehouse/templates/manage/project/history.html:293
-#: warehouse/templates/manage/project/history.html:315
 #: warehouse/templates/manage/team/history.html:57
+msgctxt "team"
 msgid "Deleted by:"
 msgstr ""
 
 #: warehouse/templates/manage/organization/history.html:163
+msgctxt "organization"
+msgid "Deleted by:"
+msgstr ""
+
+#: warehouse/templates/manage/organization/history.html:168
 #: warehouse/templates/manage/team/history.html:62
 msgid "Renamed by:"
 msgstr ""
 
-#: warehouse/templates/manage/organization/history.html:168
+#: warehouse/templates/manage/organization/history.html:173
 msgid "Approved by:"
 msgstr ""
 
-#: warehouse/templates/manage/organization/history.html:173
+#: warehouse/templates/manage/organization/history.html:178
 msgid "Declined by:"
 msgstr ""
 
-#: warehouse/templates/manage/organization/history.html:189
+#: warehouse/templates/manage/organization/history.html:194
 #: warehouse/templates/manage/project/history.html:133
 #: warehouse/templates/manage/project/history.html:179
 #: warehouse/templates/manage/team/history.html:78
 msgid "Changed by:"
 msgstr ""
 
-#: warehouse/templates/manage/organization/history.html:194
 #: warehouse/templates/manage/organization/history.html:199
+#: warehouse/templates/manage/organization/history.html:204
 #: warehouse/templates/manage/project/history.html:140
 #: warehouse/templates/manage/project/history.html:147
 msgid "Invited by:"
 msgstr ""
 
-#: warehouse/templates/manage/organization/history.html:204
+#: warehouse/templates/manage/organization/history.html:209
 #: warehouse/templates/manage/project/history.html:154
 msgid "Revoked by:"
 msgstr ""
 
-#: warehouse/templates/manage/organization/history.html:210
+#: warehouse/templates/manage/organization/history.html:215
 #: warehouse/templates/manage/project/history.html:330
 #: warehouse/templates/manage/team/history.html:84
 #, python-format
@@ -7270,6 +7274,12 @@ msgstr ""
 #: warehouse/templates/manage/project/history.html:291
 #: warehouse/templates/manage/project/history.html:313
 msgid "Project alternate repository deleted"
+msgstr ""
+
+#: warehouse/templates/manage/project/history.html:293
+#: warehouse/templates/manage/project/history.html:315
+msgctxt "alternate repository"
+msgid "Deleted by:"
 msgstr ""
 
 #: warehouse/templates/manage/project/history.html:335

--- a/warehouse/templates/manage/organization/history.html
+++ b/warehouse/templates/manage/organization/history.html
@@ -152,10 +152,15 @@
       <small>
         {% trans %}Created by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=created_by) }}">{{ created_by }}</a>
       </small>
+    {% elif event.tag == EventTag.Organization.TeamDelete %}
+      {% set deleted_by = get_user(event.additional.deleted_by_user_id).username %}
+      <small>
+        {% trans "team" %}Deleted by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=deleted_by) }}">{{ deleted_by }}</a>
+      </small>
     {% elif event.tag.endswith(":delete") %}
       {% set deleted_by = get_user(event.additional.deleted_by_user_id).username %}
       <small>
-        {% trans %}Deleted by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=deleted_by) }}">{{ deleted_by }}</a>
+        {% trans "organization" %}Deleted by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=deleted_by) }}">{{ deleted_by }}</a>
       </small>
     {% elif event.tag.endswith(":rename") %}
       {% set renamed_by = get_user(event.additional.renamed_by_user_id).username %}

--- a/warehouse/templates/manage/project/history.html
+++ b/warehouse/templates/manage/project/history.html
@@ -290,7 +290,7 @@
 {% elif event.tag == EventTag.Account.AlternateRepositoryDelete %}
   <strong>{% trans %}Project alternate repository deleted{% endtrans %}</strong>
   <small>
-    {% trans %}Deleted by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.deleted_by) }}">{{ event.additional.deleted_by }}</a>
+    {% trans "alternate repository" %}Deleted by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.deleted_by) }}">{{ event.additional.deleted_by }}</a>
   </small>
   <small>{% trans %}Name{% endtrans %}: {{ event.additional.display_name }}</small>
   <small>{% trans %}Url{% endtrans %}:
@@ -312,7 +312,7 @@
 {% elif event.tag == EventTag.Project.AlternateRepositoryDelete %}
   <strong>{% trans %}Project alternate repository deleted{% endtrans %}</strong>
   <small>
-    {% trans %}Deleted by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.deleted_by) }}">{{ event.additional.deleted_by }}</a>
+    {% trans "alternate repository" %}Deleted by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.deleted_by) }}">{{ event.additional.deleted_by }}</a>
   </small>
   <small>{% trans %}Name{% endtrans %}: {{ event.additional.display_name }}</small>
   <small>{% trans %}Url{% endtrans %}:

--- a/warehouse/templates/manage/team/history.html
+++ b/warehouse/templates/manage/team/history.html
@@ -54,7 +54,7 @@
     {% elif event.tag.endswith(":delete") %}
       {% set deleted_by = get_user(event.additional.deleted_by_user_id).username %}
       <small>
-        {% trans %}Deleted by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=deleted_by) }}">{{ deleted_by }}</a>
+        {% trans "team" %}Deleted by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=deleted_by) }}">{{ deleted_by }}</a>
       </small>
     {% elif event.tag.endswith(":rename") %}
       {% set renamed_by = get_user(event.additional.renamed_by_user_id).username %}


### PR DESCRIPTION
Fixes #18586

Gives each "Deleted by:" occurrence an `msgctxt` naming what was deleted, so a
translator can tell them apart. Three contexts across the four occurrences:

- `organization` — organization history, an organization was deleted
- `team` — organization history (team deleted) and team history
- `alternate repository` — both occurrences on project history

The organization page's `event.tag.endswith(":delete")` branch covered both
organization and team deletions, so it is split: the team case gets its own
branch and context, and the generic branch stays as the fallback so an
unrecognised `:delete` tag does not lose its line.

## The mechanism did not work as shipped

Adding the context strings on their own would have broken those four pages.
`pyramid_jinja2` calls `install_gettext_callables(gettext, ngettext)` and passes
no `pgettext`, so `pgettext` was `None` in the Jinja globals and any
`{% trans "context" %}` raised `TypeError: 'NoneType' object is not callable`.

So `FallbackInternationalizationExtension` — which already exists to wrap the
plain callables — now also derives the contextual pair from them when the
renderer supplies none. GNU gettext keys a contextual message as
`"context\x04message"`, which is exactly what pybabel compiles an `msgctxt`
into, so the lookup is a plain gettext of that key, falling back to the bare
message when the context has no translation. I verified the encoding against a
compiled `.mo` before relying on it.

`npgettext` gets the same treatment, so a contextual plural does not hit the
same crash later.

## Note for translators

Existing translations of the uncontexted "Deleted by:" will not carry over —
adding a context creates new catalog entries, which is the point, but it means
these show as untranslated in Weblate until they are redone.

`messages.pot` is regenerated. Only "Deleted by:" is changed; "Created by:",
"Renamed by:" and the rest have the same ambiguity, and I left them alone rather
than widen this. `docs/dev/translations.md` documents the mechanism.

## Testing

`tests/unit/i18n/`: 48 pass, `warehouse/i18n/extensions.py` at 100%, including
a render test for a translated context, an untranslated one falling back to the
bare English rather than leaking the `\x04` key, and the same for plurals.
`tests/functional/test_templates.py` and djlint pass on the touched templates.
