### PR TITLE
Drain the orphaned release descriptions

### DIFF
--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -18,6 +18,7 @@ from warehouse.packaging.models import File, Project, Release, Role
 from warehouse.packaging.services import project_service_factory
 from warehouse.packaging.tasks import (
     check_file_cache_tasks_outstanding,
+    delete_orphaned_descriptions,
     reconcile_file_storages,
     update_description_html,
 )
@@ -164,6 +165,10 @@ def test_includeme(monkeypatch, mocker):
     )
     assert (
         mocker.call(crontab(minute="*/5"), update_description_html)
+        in config.add_periodic_task.call_args_list
+    )
+    assert (
+        mocker.call(crontab(minute="*/5"), delete_orphaned_descriptions)
         in config.add_periodic_task.call_args_list
     )
     assert (

--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -15,12 +15,13 @@ import warehouse.packaging.tasks
 
 from warehouse.accounts.models import WebAuthn
 from warehouse.observations.models import ObservationKind
-from warehouse.packaging.models import DependencyKind, Description
+from warehouse.packaging.models import DependencyKind, Description, Release
 from warehouse.packaging.tasks import (
     check_file_cache_tasks_outstanding,
     compute_2fa_metrics,
     compute_packaging_metrics,
     compute_top_dependents_corpus,
+    delete_orphaned_descriptions,
     sync_file_to_cache,
     typo_check_project_name,
     update_bigquery_release_files,
@@ -380,6 +381,46 @@ def test_update_description_html(monkeypatch, db_request):
         (descriptions[1].raw, readme.render(descriptions[1].raw), current_version),
         (descriptions[2].raw, readme.render(descriptions[2].raw), current_version),
     }
+
+
+def test_delete_orphaned_descriptions(db_request, metrics):
+    # `releases.description_id` cascades the wrong way, so a referenced
+    # Description that got picked up here would take its Release with it.
+    attached = DescriptionFactory.create()
+    release = ReleaseFactory.create(description=attached)
+    orphans = [DescriptionFactory.create() for _ in range(3)]
+
+    db_request.find_service = pretend.call_recorder(
+        lambda svc, name=None, context=None: metrics
+    )
+    db_request.registry.settings["orphaned_descriptions.batch_size"] = 5000
+
+    delete_orphaned_descriptions(db_request)
+
+    assert db_request.db.query(Description.id).all() == [(attached.id,)]
+    assert db_request.db.get(Release, release.id) is not None
+    assert metrics.increment.calls == [
+        pretend.call(
+            "warehouse.packaging.orphaned_descriptions.deleted", value=len(orphans)
+        )
+    ]
+
+
+def test_delete_orphaned_descriptions_batches(db_request, metrics):
+    for _ in range(3):
+        DescriptionFactory.create()
+
+    db_request.find_service = pretend.call_recorder(
+        lambda svc, name=None, context=None: metrics
+    )
+    db_request.registry.settings["orphaned_descriptions.batch_size"] = 2
+
+    delete_orphaned_descriptions(db_request)
+
+    assert db_request.db.query(Description).count() == 1
+    assert metrics.increment.calls == [
+        pretend.call("warehouse.packaging.orphaned_descriptions.deleted", value=2)
+    ]
 
 
 def test_update_release_description(db_request):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -352,6 +352,7 @@ def test_configure(monkeypatch, mocker, settings, environment):
         "integrity.backend": "warehouse.attestations.services.IntegrityService",
         "warehouse.organizations.max_undecided_organization_applications": 3,
         "reconcile_file_storages.batch_size": 100,
+        "orphaned_descriptions.batch_size": 5000,
         "gcloud.service_account_info": {},
         "warehouse.forklift.legacy.MAX_FILESIZE_MIB": 100,
         "warehouse.forklift.legacy.MAX_PROJECT_SIZE_GIB": 10,

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -456,6 +456,13 @@ def configure(settings=None):
         coercer=int,
         default=100,
     )
+    maybe_set(
+        settings,
+        "orphaned_descriptions.batch_size",
+        "ORPHANED_DESCRIPTIONS_BATCH_SIZE",
+        coercer=int,
+        default=5000,
+    )
     maybe_set_compound(settings, "billing", "backend", "BILLING_BACKEND")
     maybe_set_compound(settings, "files", "backend", "FILES_BACKEND")
     maybe_set_compound(settings, "archive_files", "backend", "ARCHIVE_FILES_BACKEND")

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -21,6 +21,7 @@ from warehouse.packaging.tasks import (
     compute_2fa_metrics,
     compute_packaging_metrics,
     compute_top_dependents_corpus,
+    delete_orphaned_descriptions,
     reconcile_file_storages,
     update_description_html,
 )
@@ -176,6 +177,7 @@ def includeme(config):
     config.add_periodic_task(crontab(minute="*/15"), reconcile_file_storages)
 
     config.add_periodic_task(crontab(minute="*/5"), update_description_html)
+    config.add_periodic_task(crontab(minute="*/5"), delete_orphaned_descriptions)
     config.add_periodic_task(crontab(minute="*/5"), update_role_invitation_status)
 
     # Add a periodic task to generate 2FA metrics

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -13,7 +13,7 @@ import structlog
 from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from packaging.utils import canonicalize_name
 from requests.exceptions import RequestException
-from sqlalchemy import desc, func, nulls_last, select
+from sqlalchemy import delete, desc, func, nulls_last, select
 from sqlalchemy.orm import joinedload
 
 from warehouse import tasks
@@ -295,6 +295,51 @@ def update_description_html(request):
     for description in descriptions:
         description.html = readme.render(description.raw, description.content_type)
         description.rendered_by = renderer_version
+
+
+@tasks.task(ignore_result=True, acks_late=True)
+def delete_orphaned_descriptions(request):
+    """Drain the backlog of Descriptions that no Release points at.
+
+    `releases.description_id` points *up* at the description, so its
+    `ON DELETE CASCADE` fires in the wrong direction: deleting a Release never
+    removed its Description, and deleting a Project removed its Releases at the
+    database level without the ORM's `delete-orphan` cascade ever running. The
+    `releases_delete_orphaned_description` trigger stops new orphans appearing;
+    this removes the ~844k that accumulated before it.
+
+    The direction of that foreign key is also why this deletes in batches
+    checked against `releases` rather than from a precomputed list of ids:
+    deleting a Description that *is* still referenced would cascade into
+    deleting the Release. The `NOT EXISTS` therefore stays inside the `DELETE`,
+    so it is evaluated against the same snapshot that removes the rows.
+    """
+    metrics = request.find_service(IMetricsService, context=None)
+    batch_size = request.registry.settings["orphaned_descriptions.batch_size"]
+
+    orphaned = (
+        select(Description.id)
+        .where(
+            ~select(Release.id).where(Release.description_id == Description.id).exists()
+        )
+        .limit(batch_size)
+        # SKIP LOCKED so a run that overlaps the previous one picks up different
+        # rows instead of blocking on them.
+        .with_for_update(skip_locked=True, of=Description)
+        .scalar_subquery()
+    )
+    deleted = request.db.execute(
+        delete(Description).where(Description.id.in_(orphaned)),
+        # Nothing here loads a Description, so there is no session state to
+        # synchronize. Left to "auto" this becomes "fetch", which appends a
+        # RETURNING clause and drags every deleted id back over the wire.
+        execution_options={"synchronize_session": False},
+    ).rowcount
+
+    logger.info("Deleted orphaned descriptions", count=deleted, batch_size=batch_size)
+    metrics.increment(
+        "warehouse.packaging.orphaned_descriptions.deleted", value=deleted
+    )
 
 
 @tasks.task(bind=True, ignore_result=True, acks_late=True)


### PR DESCRIPTION
Fixes #14825

Adds a `delete_orphaned_descriptions` periodic task that removes a batch of
`release_descriptions` rows no release points at, every five minutes, following
the plan in the issue: 5000 per run, draining the backlog in about half a day.

The trigger in #20216 stopped new orphans appearing and the count has been
stable at 844,170 since June, so what is left is the drain.

## The delete is checked against `releases`, not against a list of ids

`releases.description_id` cascades upward, so deleting a description that is
still referenced deletes its release. That makes the `WHERE` clause the only
thing standing between this task and removing packages, so the `NOT EXISTS`
stays inside the `DELETE` rather than filtering a precomputed batch of ids, and
is evaluated against the same snapshot that removes the rows.

For what it is worth, that window looks closed anyway: the only place a
`Description` is constructed is `Release(description=Description(...))` in
`forklift/legacy.py`, so a committed description always has its release
committed with it. The check is inside the statement regardless.

`SKIP LOCKED` so a run overlapping the previous one takes different rows rather
than blocking on them, matching `reconcile_file_storages`.

## Performance

Measured against a local 1M-row, 1GB replica of the two tables at the
production orphan ratio (~11%):

- typical batch: Postgres picks a merge anti-join, scans 45,709 rows to find the
  first 5,000 orphans, **431 ms**
- final batch, with only 5,000 orphans left: it switches to a hash anti-join
  over a sequential scan, **531 ms**

So the worst case is a single sequential scan rather than a blowup, and it grows
linearly with the table. Batch size is configurable via
`ORPHANED_DESCRIPTIONS_BATCH_SIZE` if you want it drained faster or slower.

`synchronize_session` is set to `False` explicitly: the task loads no
`Description` objects, and left on `auto` SQLAlchemy resolves it to `fetch`,
which appends a `RETURNING` clause and pulls all 5,000 ids back each run.

## Testing

`make tests` for `tests/unit/packaging/` and `tests/unit/test_config.py`: 394
pass, `warehouse/packaging/tasks.py` at 100%. One test asserts that a
*referenced* description and its release both survive a run, so an
implementation that over-deletes fails rather than silently passing.
