### PR TITLE
Store callout block state in localStorage

### DIFF
--- a/tests/frontend/collapsible_controller_test.js
+++ b/tests/frontend/collapsible_controller_test.js
@@ -5,45 +5,77 @@
 import { Application } from "@hotwired/stimulus";
 import CollapsibleController from "../../warehouse/static/js/warehouse/controllers/collapsible_controller";
 
+const calloutBlock = `
+  <details id="element" class="callout-block" data-controller="collapsible" data-collapsible-identifier="project_roles" open>
+    <summary id="collapse" class="callout-block__heading" data-action="click->collapsible#save">Project Roles</summary>
+  </details>
+`;
+
+const start = () => {
+  const application = Application.start();
+  application.register("collapsible", CollapsibleController);
+};
+
 describe("Collapsible controller", () => {
   beforeEach(() => {
-    document.body.innerHTML = `
-  <details id="element" class="callout-block" data-controller="collapsible" data-collapsible-identifier="project_roles" open>
-    <summary id="collapse" class="callout-block__heading" data-action="click->collapsible#save">Project Roles</h3>
-  </details>
-    `;
-
-    const application = Application.start();
-    application.register("collapsible", CollapsibleController);
+    localStorage.clear();
+    document.body.innerHTML = calloutBlock;
   });
 
-  describe("no cookie is present", function() {
-    it("the element is not collapsed", function() {
-      const el = document.getElementById("element");
-      expect(el).toHaveAttribute("open");
+  describe("nothing stored", function () {
+    beforeEach(start);
+
+    it("the element keeps the state it was rendered with", function () {
+      expect(document.getElementById("element")).toHaveAttribute("open");
     });
 
-    it("the element is collapsible", function() {
-      const summary = document.getElementById("collapse");
-      summary.click();
+    it("collapsing stores the state", function (done) {
+      document.getElementById("collapse").click();
+      document.getElementById("element").removeAttribute("open");
 
-      const el = document.getElementById("element");
-      expect(el).not.toHaveAttribute("open");
-
-      setTimeout(function () {
-        expect(document.cookie).toContain("callout_block_project_role_collapsed=1");
+      // `save` defers to a macrotask so it observes the state the browser
+      // settles on after the summary click, so the assertion has to as well.
+      setTimeout(() => {
+        expect(localStorage.getItem("callout_block_project_roles_collapsed")).toEqual("1");
+        done();
       }, 0);
     });
   });
 
-  describe("cookie is present", function() {
-    it("the element is collapsed", function() {
-      document.cookie = "callout_block_settings_collapsed=1";
-      const application = Application.start();
-      application.register("collapsible", CollapsibleController);
+  describe("stored as collapsed", function () {
+    // Application.start() connects controllers asynchronously, so the store has
+    // to be seeded and the application started before the assertion's tick.
+    beforeEach(() => {
+      localStorage.setItem("callout_block_project_roles_collapsed", "1");
+      start();
+    });
 
-      const el = document.getElementById("element");
-      expect(el).toHaveAttribute("open");
+    it("the element starts collapsed", function () {
+      expect(document.getElementById("element")).not.toHaveAttribute("open");
+    });
+  });
+
+  describe("stored as expanded", function () {
+    // Application.start() connects controllers asynchronously, so the store has
+    // to be seeded and the application started before the assertion's tick.
+    beforeEach(() => {
+      localStorage.setItem("callout_block_project_roles_collapsed", "0");
+      start();
+    });
+
+    it("the element starts expanded", function () {
+      expect(document.getElementById("element")).toHaveAttribute("open");
+    });
+  });
+
+  describe("stored under a different identifier", function () {
+    beforeEach(() => {
+      localStorage.setItem("callout_block_organization_roles_collapsed", "1");
+      start();
+    });
+
+    it("the element is left alone", function () {
+      expect(document.getElementById("element")).toHaveAttribute("open");
     });
   });
 });

--- a/tests/frontend/dismissable_controller_test.js
+++ b/tests/frontend/dismissable_controller_test.js
@@ -5,54 +5,60 @@
 import { Application } from "@hotwired/stimulus";
 import DismissableController from "../../warehouse/static/js/warehouse/controllers/dismissable_controller";
 
-describe("Dismissable controller", () => {
-  beforeEach(() => {
-    document.body.innerHTML = `
+const calloutBlock = `
   <div id="element" class="callout-block" data-controller="dismissable" data-dismissable-identifier="settings">
     <h3>Project description and sidebar</h3>
-    <p>
-      To set the 'warehouse' description, author, links,
-      classifiers, and other details for your next release, use
-      the <a href="https://packaging.python.org/guides/distributing-packages-using-setuptools/#setup-args" rel="noopener" target="_blank"><code>setup()</code>
-      arguments in your <code>setup.py</code> file</a>. Updating these
-      fields will not change the metadata for past
-      releases. Additionally, you <strong>must</strong> use
-      <a href="https://twine.readthedocs.io/" rel="noopener" target="_blank">Twine</a>
-      to upload your files in order to get full support for these fields. See
-      <a href="https://packaging.python.org/guides/distributing-packages-using-setuptools/" rel="noopener" target="_blank">the Python Packaging User Guide</a> for more help.
-    </p>
     <button id="dismiss" type="button" title="Dismiss" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
   </div>
-    `;
+`;
 
-    const application = Application.start();
-    application.register("dismissable", DismissableController);
+const start = () => {
+  const application = Application.start();
+  application.register("dismissable", DismissableController);
+};
+
+describe("Dismissable controller", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = calloutBlock;
   });
 
-  describe("no cookie is present", function () {
+  describe("nothing stored", function () {
+    beforeEach(start);
+
     it("the element is not dismissed", function () {
-      const el = document.getElementById("element");
-      expect(el).not.toHaveClass("callout-block--dismissed");
+      expect(document.getElementById("element")).not.toHaveClass("callout-block--dismissed");
     });
 
-    it("the element is dismissable", function () {
-      const btn = document.getElementById("dismiss");
-      btn.click();
+    it("dismissing stores the state", function () {
+      document.getElementById("dismiss").click();
 
-      const el = document.getElementById("element");
-      expect(el).toHaveClass("callout-block--dismissed");
-      expect(document.cookie).toContain("callout_block_settings_dismissed=1");
+      expect(document.getElementById("element")).toHaveClass("callout-block--dismissed");
+      expect(localStorage.getItem("callout_block_settings_dismissed")).toEqual("1");
     });
   });
 
-  describe("cookie is present", function () {
-    it("the element is dismissed and not dismissable", function () {
-      document.cookie = "callout_block_settings_dismissed=1";
-      const application = Application.start();
-      application.register("dismissable", DismissableController);
+  describe("stored as dismissed", function () {
+    // Application.start() connects controllers asynchronously, so the store has
+    // to be seeded and the application started before the assertion's tick.
+    beforeEach(() => {
+      localStorage.setItem("callout_block_settings_dismissed", "1");
+      start();
+    });
 
-      const el = document.getElementById("element");
-      expect(el).toHaveClass("callout-block--dismissed");
+    it("the element starts dismissed", function () {
+      expect(document.getElementById("element")).toHaveClass("callout-block--dismissed");
+    });
+  });
+
+  describe("stored under a different identifier", function () {
+    beforeEach(() => {
+      localStorage.setItem("callout_block_releases_dismissed", "1");
+      start();
+    });
+
+    it("the element is left alone", function () {
+      expect(document.getElementById("element")).not.toHaveClass("callout-block--dismissed");
     });
   });
 });

--- a/warehouse/static/js/warehouse/controllers/collapsible_controller.js
+++ b/warehouse/static/js/warehouse/controllers/collapsible_controller.js
@@ -4,28 +4,31 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   /**
-   * Get element's collapsed status from the cookie.
+   * Get the localStorage key holding this element's collapsed state.
    * @private
    */
-  _getCollapsedCookie() {
-    const id = this.data.get("identifier");
-    const value = document.cookie.split(";").find(item => item.startsWith(`callout_block_${id}_collapsed=`));
-    return value ? value.split("=")[1] : null;
+  _storageKey() {
+    return `callout_block_${this.data.get("identifier")}_collapsed`;
   }
 
   /**
-   * Set element's collapsed status as a cookie.
+   * Get element's collapsed status from localStorage.
    * @private
    */
-  _setCollapsedCookie(value) {
-    if (this.data.get("setting") === "global")
-      document.cookie = `callout_block_${this.data.get("identifier")}_collapsed=${value};path=/`;
-    else
-      document.cookie = `callout_block_${this.data.get("identifier")}_collapsed=${value}`;
+  _getCollapsed() {
+    return localStorage.getItem(this._storageKey());
+  }
+
+  /**
+   * Persist element's collapsed status to localStorage.
+   * @private
+   */
+  _setCollapsed(value) {
+    localStorage.setItem(this._storageKey(), value);
   }
 
   initialize() {
-    switch (this._getCollapsedCookie()) {
+    switch (this._getCollapsed()) {
       case "1":
         this.collapse();
         break;
@@ -39,20 +42,20 @@ export default class extends Controller {
 
   collapse() {
     this.element.removeAttribute("open");
-    this._setCollapsedCookie("1");
+    this._setCollapsed("1");
   }
 
   expand() {
     this.element.setAttribute("open", "");
-    this._setCollapsedCookie("0");
+    this._setCollapsed("0");
   }
 
   save() {
     setTimeout(() => {
       if (!this.element.hasAttribute("open"))
-        this._setCollapsedCookie("1");
+        this._setCollapsed("1");
       else
-        this._setCollapsedCookie("0");
+        this._setCollapsed("0");
     }, 0);
   }
 }

--- a/warehouse/static/js/warehouse/controllers/dismissable_controller.js
+++ b/warehouse/static/js/warehouse/controllers/dismissable_controller.js
@@ -4,33 +4,36 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   /**
-   * Get element's dismissed status from the cookie.
+   * Get the localStorage key holding this element's dismissed state.
    * @private
    */
-  _getDismissedCookie() {
-    const id = this.data.get("identifier");
-    const value = document.cookie.split(";").find(item => item.startsWith(`callout_block_${id}_dismissed=`));
-    return value ? value.split("=")[1] : null;
+  _storageKey() {
+    return `callout_block_${this.data.get("identifier")}_dismissed`;
   }
 
   /**
-   * Set element's dismissed status as a cookie.
+   * Get element's dismissed status from localStorage.
    * @private
    */
-  _setDismissedCookie(value) {
-    if (this.data.get("setting") === "global")
-      document.cookie = `callout_block_${this.data.get("identifier")}_dismissed=${value};path=/`;
-    else
-      document.cookie = `callout_block_${this.data.get("identifier")}_dismissed=${value}`;
+  _getDismissed() {
+    return localStorage.getItem(this._storageKey());
+  }
+
+  /**
+   * Persist element's dismissed status to localStorage.
+   * @private
+   */
+  _setDismissed(value) {
+    localStorage.setItem(this._storageKey(), value);
   }
 
   initialize() {
-    if (this._getDismissedCookie() === "1")
+    if (this._getDismissed() === "1")
       this.dismiss();
   }
 
   dismiss() {
     this.element.classList.add("callout-block--dismissed");
-    this._setDismissedCookie("1");
+    this._setDismissed("1");
   }
 }

--- a/warehouse/templates/manage/organization/roles.html
+++ b/warehouse/templates/manage/organization/roles.html
@@ -30,7 +30,6 @@
   <details class="callout-block"
            data-controller="collapsible"
            data-collapsible-identifier="organization_roles"
-           data-collapsible-setting="global"
            open>
     <summary class="callout-block__heading" data-action="click->collapsible#save">
       {% trans %}Organization Roles{% endtrans %}

--- a/warehouse/templates/manage/project/roles.html
+++ b/warehouse/templates/manage/project/roles.html
@@ -34,7 +34,6 @@
   <details class="callout-block"
            data-controller="collapsible"
            data-collapsible-identifier="project_roles"
-           data-collapsible-setting="global"
            open>
     <summary class="callout-block__heading" data-action="click->collapsible#save">
       {% trans %}Project Roles{% endtrans %}


### PR DESCRIPTION
Fixes #14950

Moves the collapsible and dismissable controllers from `callout_block_*` cookies
to localStorage, following `notification_controller.js`. This state is only ever
read by the browser, so sending it up in the headers on every request bought
nothing.

## One behaviour change, and it is the interesting part

`data-*-setting="global"` existed to choose between a `path=/` cookie and a
path-scoped one. localStorage is origin-wide, so it no longer means anything and
is removed along with the two template attributes.

What it was doing turns out to matter, though. Every collapsible already set it,
so those are unaffected. No dismissable did — so a dismissed callout was scoped
to the URL directory, which means the same explanatory callout had to be
dismissed again on every project you own. That reads like an accident rather
than a decision, and it now sticks the first time. Happy to preserve the old
scoping if it was deliberate.

Existing cookies are not migrated. The state is "has read this help text", so a
callout reappearing once costs a click, which seemed cheaper than a migration
shim someone has to remember to delete.

## Not done

The issue floats converting all three controllers into one. That touches
`notification_controller` and its key naming too, so I left it — happy to follow
up if you want it.

## Testing

`npm test`: 111 pass under `TZ=UTC`, both controllers at 100%. `npm run lint`
and djlint clean.

Both test files are rewritten. The old collapsible test seeded a
`callout_block_settings_collapsed` cookie against a fixture whose identifier was
`project_roles`, so the controller never saw it and the assertion passed for the
wrong reason. The new tests fail against the cookie implementation (5 failures)
and pass against this one.
