### PR TITLE
Add Telegram icon to "Project links"

### DIFF
--- a/docs/user/project_metadata.md
+++ b/docs/user/project_metadata.md
@@ -132,6 +132,7 @@ To display a custom icon, an entry must either :
 | Platform | Icon                              | Name     | Domain                                        |
 |:---------|:----------------------------------|:---------|:----------------------------------------------|
 | Discord  | :fontawesome-brands-discord:      |          | `discord.com`, `discordapp.com`, `discord.gg` |
+| Telegram | :fontawesome-brands-telegram:     |          | `t.me`, `telegram.me`, `telegram.dog`         |
 | Gitter   | :fontawesome-brands-gitter:       |          | `gitter.im`                                   |
 | Mastodon | :fontawesome-brands-mastodon:     | Mastodon |                                               |
 | Reddit   | :fontawesome-brands-reddit-alien: |          | `reddit.com`                                  |

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3737,16 +3737,16 @@ msgstr[1] ""
 msgid "Owner"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/metadata/project-links.html:54
+#: warehouse/templates/includes/packaging/metadata/project-links.html:56
 msgid "Project links"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/metadata/project-links.html:60
+#: warehouse/templates/includes/packaging/metadata/project-links.html:62
 #, python-format
 msgid "Data verified by PyPI on %(date)s"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/metadata/project-links.html:63
+#: warehouse/templates/includes/packaging/metadata/project-links.html:65
 msgid ""
 "Data provided by the project maintainers, verified at the time the "
 "release was uploaded to PyPI."

--- a/warehouse/templates/includes/packaging/metadata/project-links.html
+++ b/warehouse/templates/includes/packaging/metadata/project-links.html
@@ -23,6 +23,8 @@
     {% set icon = "fab fa-gitter" %}
   {% elif parsed.netloc in ["discord.com", "discordapp.com", "discord.gg"] %}
     {% set icon = "fab fa-discord" %}
+  {% elif parsed.netloc in ["t.me", "telegram.me"] or parsed.netloc.endswith(".t.me") or parsed.netloc.endswith(".telegram.me") %}
+    {% set icon = "fab fa-telegram" %}
   {% elif parsed.netloc == "google.com" or parsed.netloc.endswith(".google.com") %}
     {% set icon = "fab fa-google" %}
   {% elif parsed.netloc == "bitbucket.org" or parsed.netloc.endswith(".bitbucket.org") %}

--- a/warehouse/templates/includes/packaging/metadata/project-links.html
+++ b/warehouse/templates/includes/packaging/metadata/project-links.html
@@ -23,7 +23,7 @@
     {% set icon = "fab fa-gitter" %}
   {% elif parsed.netloc in ["discord.com", "discordapp.com", "discord.gg"] %}
     {% set icon = "fab fa-discord" %}
-  {% elif parsed.netloc in ["t.me", "telegram.me"] or parsed.netloc.endswith(".t.me") or parsed.netloc.endswith(".telegram.me") %}
+  {% elif parsed.netloc in ["t.me", "telegram.me", "telegram.dog"] or parsed.netloc.endswith(".t.me") or parsed.netloc.endswith(".telegram.me") or parsed.netloc.endswith(".telegram.dog") %}
     {% set icon = "fab fa-telegram" %}
   {% elif parsed.netloc == "google.com" or parsed.netloc.endswith(".google.com") %}
     {% set icon = "fab fa-google" %}

--- a/warehouse/templates/includes/packaging/metadata/project-links.html
+++ b/warehouse/templates/includes/packaging/metadata/project-links.html
@@ -23,7 +23,7 @@
     {% set icon = "fab fa-gitter" %}
   {% elif parsed.netloc in ["discord.com", "discordapp.com", "discord.gg"] %}
     {% set icon = "fab fa-discord" %}
-  {% elif parsed.netloc in ["t.me", "telegram.me", "telegram.dog"] or parsed.netloc.endswith(".t.me") or parsed.netloc.endswith(".telegram.me") or parsed.netloc.endswith(".telegram.dog") %}
+  {% elif parsed.netloc in ["t.me", "telegram.me", "telegram.dog"] or parsed.netloc.endswith((".t.me", ".telegram.me", ".telegram.dog")) %}
     {% set icon = "fab fa-telegram" %}
   {% elif parsed.netloc == "google.com" or parsed.netloc.endswith(".google.com") %}
     {% set icon = "fab fa-google" %}


### PR DESCRIPTION
This PR adds an icon for Telegram URLs in the "Project Links" section.

<img width="268" height="186" alt="Example screenshot." src="https://github.com/user-attachments/assets/45f13c60-9360-4950-b44d-ddfb76b066f2" />

`t.me` links are [special deep links](https://telegram.org/faq#usernames-and-t-me) that can directly open a chat in the Telegram app.

This mirrors the icon assigned to `discord.gg` links, which have the same functionality.

According to Telegram Desktop's source code, aliases for `t.me` are:
- [`telegram.me`](https://github.com/telegramdesktop/tdesktop/blob/087b18b89194ab474526ca61b7992f32f52c983b/changelog.txt#L3971)
- [`telegram.dog`](https://github.com/telegramdesktop/tdesktop/blob/087b18b89194ab474526ca61b7992f32f52c983b/Telegram/SourceFiles/boxes/stickers_box.cpp#L2190) (undocumented)