### PR TITLE
feat(admin): decode as much of a token as possible

### DIFF
--- a/tests/functional/admin/test_macaroons.py
+++ b/tests/functional/admin/test_macaroons.py
@@ -2,27 +2,55 @@
 
 from http import HTTPStatus
 
-# The head of a truncated token, held apart from its `pypi-` prefix so secret
-# scanners have no token pattern to match. It carries no signature.
-_TOKEN_BODY = (
-    "AgEIcHlwaS5vcmcCJDAyZWRlM2ZlLWRjMDAtNDViOS05YTEzLTlmMTZhZDFjNDU0ZAACKlszLCJ"
-)
-TRUNCATED_TOKEN = "pypi-" + _TOKEN_BODY
+import pytest
+
+from tests.common.db import Session
+from tests.common.db.accounts import UserFactory
+from warehouse.macaroons import caveats
+from warehouse.macaroons.services import DatabaseMacaroonService
 
 
-class TestDecodeTruncatedToken:
-    def test_admin_sees_the_fields_that_could_be_read(self, webtest, login_admin):
-        """A token with no signature left still renders the fields it has."""
+@pytest.fixture
+def token():
+    """A real token and the macaroon behind it, as account settings mints them."""
+    owner = UserFactory.create()
+    return DatabaseMacaroonService(Session).create_macaroon(
+        location="pypi.org",
+        description="a token to look up",
+        scopes=[caveats.RequestUser(user_id=str(owner.id))],
+        user_id=owner.id,
+    )
+
+
+def _decode(webtest, raw_token):
+    page = webtest.get("/admin/token/decode", status=HTTPStatus.OK)
+    form = page.forms["decode-token"]
+    form["token"] = raw_token
+    return form.submit(status=HTTPStatus.OK)
+
+
+class TestDecodeToken:
+    def test_admin_sees_a_whole_token(self, webtest, login_admin, token):
+        """A whole token links to the macaroon it names."""
         login_admin()
+        raw_token, macaroon = token
 
-        page = webtest.get("/admin/token/decode", status=HTTPStatus.OK)
-        form = page.forms["decode-token"]
-        form["token"] = TRUNCATED_TOKEN
+        result = _decode(webtest, raw_token)
 
-        result = form.submit(status=HTTPStatus.OK)
+        assert f"/admin/macaroons/{macaroon.id}" in result.text
+        assert "truncated or otherwise malformed" not in result.text
+
+    def test_admin_sees_the_fields_a_truncated_token_holds(
+        self, webtest, login_admin, token
+    ):
+        """A token cut a few bytes into its first caveat still names its row."""
+        login_admin()
+        raw_token, macaroon = token
+
+        result = _decode(webtest, raw_token[:80])
 
         assert "truncated or otherwise malformed" in result.text
         assert "pypi.org" in result.text
-        assert "02ede3fe-dc00-45b9-9a13-9f16ad1c454d (Not found)" in result.text
+        assert f"/admin/macaroons/{macaroon.id}" in result.text
         # The caveat's own quote character comes back HTML escaped.
         assert "[3,&#34; (truncated, 42 bytes declared)" in result.text

--- a/tests/functional/admin/test_macaroons.py
+++ b/tests/functional/admin/test_macaroons.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from http import HTTPStatus
+
+# The head of a truncated token, held apart from its `pypi-` prefix so secret
+# scanners have no token pattern to match. It carries no signature.
+_TOKEN_BODY = (
+    "AgEIcHlwaS5vcmcCJDAyZWRlM2ZlLWRjMDAtNDViOS05YTEzLTlmMTZhZDFjNDU0ZAACKlszLCJ"
+)
+TRUNCATED_TOKEN = "pypi-" + _TOKEN_BODY
+
+
+class TestDecodeTruncatedToken:
+    def test_admin_sees_the_fields_that_could_be_read(self, webtest, login_admin):
+        """A token with no signature left still renders the fields it has."""
+        login_admin()
+
+        page = webtest.get("/admin/token/decode", status=HTTPStatus.OK)
+        form = page.forms["decode-token"]
+        form["token"] = TRUNCATED_TOKEN
+
+        result = form.submit(status=HTTPStatus.OK)
+
+        assert "truncated or otherwise malformed" in result.text
+        assert "pypi.org" in result.text
+        assert "02ede3fe-dc00-45b9-9a13-9f16ad1c454d (Not found)" in result.text
+        # The caveat's own quote character comes back HTML escaped.
+        assert "[3,&#34; (truncated, 42 bytes declared)" in result.text

--- a/tests/unit/admin/views/test_macaroons.py
+++ b/tests/unit/admin/views/test_macaroons.py
@@ -10,6 +10,10 @@ from warehouse.macaroons import caveats
 from ....common.db.accounts import UserFactory
 from ....common.db.macaroons import MacaroonFactory
 
+# Held apart from its `pypi-` prefix so secret scanners have no token pattern
+# to match. Truncated inside the macaroon identifier.
+_TRUNCATED_BODY = "AgEIcHlwaS5vcmcCJDAyZWRl"
+
 
 @pytest.fixture
 def raw_token():
@@ -66,6 +70,63 @@ class TestMacaroonDecodeToken:
 
         assert result["macaroon"].location == "fake location"
         assert result["db_record"].description == "real description"
+
+    def test_post_truncated_token(self, db_request, macaroon_service):
+        """A token cut short still resolves to its database record."""
+        user = UserFactory.create()
+        db_request.user = user
+        token, macaroon = macaroon_service.create_macaroon(
+            location="fake location",
+            description="real description",
+            scopes=[caveats.RequestUser(user_id=str(user.id))],
+            user_id=user.id,
+        )
+        db_request.method = "POST"
+        db_request.POST = {"token": token[:85]}
+
+        result = views.macaroon_decode_token(db_request)
+
+        assert "macaroon" not in result
+        assert result["partial"].identifier == str(macaroon.id)
+        assert result["partial"].signature is None
+        assert result["db_record"] == macaroon
+
+    def test_post_truncated_token_not_found(
+        self, db_request, macaroon_service, raw_token
+    ):
+        db_request.method = "POST"
+        db_request.POST = {"token": raw_token[:75]}
+
+        result = views.macaroon_decode_token(db_request)
+
+        assert result["partial"].location == "pypi.org"
+        assert result["db_record"] is None
+
+    def test_post_truncated_identifier_is_not_looked_up(
+        self, db_request, macaroon_service, mocker
+    ):
+        """A partial identifier cannot match a record, so it is not looked up."""
+        find_macaroon = mocker.spy(macaroon_service, "find_macaroon")
+        db_request.method = "POST"
+        db_request.POST = {"token": "pypi-" + _TRUNCATED_BODY}
+
+        result = views.macaroon_decode_token(db_request)
+
+        assert result["partial"].identifier_complete is False
+        assert result["db_record"] is None
+        find_macaroon.assert_not_called()
+
+    def test_post_token_with_non_ascii(self, db_request, macaroon_service):
+        """A token elided with an ellipsis gets a 400."""
+        db_request.method = "POST"
+        db_request.POST = {"token": "pypi-AgEIcHl\u2026"}
+
+        with pytest.raises(views.HTTPBadRequest) as excinfo:
+            views.macaroon_decode_token(db_request)
+        assert excinfo.value.message == (
+            "The token cannot be deserialized: InvalidMacaroonError('malformed "
+            "macaroon')"
+        )
 
     def test_post_token_not_found(self, db_request, macaroon_service, raw_token):
         db_request.method = "POST"

--- a/tests/unit/admin/views/test_macaroons.py
+++ b/tests/unit/admin/views/test_macaroons.py
@@ -2,6 +2,7 @@
 
 import uuid
 
+import pymacaroons
 import pytest
 
 from warehouse.admin.views import macaroons as views
@@ -127,6 +128,22 @@ class TestMacaroonDecodeToken:
             "The token cannot be deserialized: InvalidMacaroonError('malformed "
             "macaroon')"
         )
+
+    def test_post_token_with_binary_identifier(self, db_request, macaroon_service):
+        """A macaroon can carry bytes here that no template can render."""
+        macaroon = pymacaroons.Macaroon(
+            location="pypi.org",
+            # These 16 bytes are not UTF-8, and their hex is a valid UUID.
+            identifier=uuid.UUID("02ede3fe-dc00-45b9-9a13-9f16ad1c454d").bytes,
+            key=b"fake key",
+            version=pymacaroons.MACAROON_V2,
+        )
+        db_request.method = "POST"
+        db_request.POST = {"token": "pypi-" + macaroon.serialize()}
+
+        with pytest.raises(views.HTTPBadRequest) as excinfo:
+            views.macaroon_decode_token(db_request)
+        assert "malformed macaroon identifier" in excinfo.value.message
 
     def test_post_token_not_found(self, db_request, macaroon_service, raw_token):
         db_request.method = "POST"

--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -4,7 +4,7 @@ import base64
 import binascii
 import struct
 
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pymacaroons
 import pytest
@@ -718,6 +718,29 @@ class TestDeserializePartialMacaroon:
     def test_oversized_token_is_not_walked(self):
         """A paste past a few kilobytes is refused."""
         token = _token(_HEADER, extra=bytes(services._MAX_TOKEN_BYTES))
+
+        assert services.deserialize_partial_macaroon(token) is None
+
+    def test_a_second_identifier_does_not_speak_over_the_first(self):
+        """Fields climb within a section, so the second identifier ends the read."""
+        token = _token([*_HEADER[:2], (BinarySerializer._IDENTIFIER, b'[3,"forged"]')])
+
+        partial = services.deserialize_partial_macaroon(token)
+
+        assert partial.identifier == "02ede3fe-dc00-45b9-9a13-9f16ad1c454d"
+        assert partial.caveats == []
+
+    def test_identifier_that_is_not_utf8(self):
+        """Hex would name a macaroon that the identifier itself cannot."""
+        # These 16 bytes are not UTF-8, and their hex is a valid UUID.
+        identifier = UUID("02ede3fe-dc00-45b9-9a13-9f16ad1c454d").bytes
+        token = _token(
+            [
+                (BinarySerializer._LOCATION, b"pypi.org"),
+                (BinarySerializer._IDENTIFIER, identifier),
+                (BinarySerializer._EOS, None),
+            ]
+        )
 
         assert services.deserialize_partial_macaroon(token) is None
 

--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import binascii
 import struct
 
@@ -9,6 +10,7 @@ import pymacaroons
 import pytest
 
 from pymacaroons.exceptions import MacaroonDeserializationException
+from pymacaroons.serializers.binary_serializer import BinarySerializer
 
 from warehouse.errors import WarehouseDenied
 from warehouse.macaroons import caveats, services
@@ -551,3 +553,183 @@ class TestDatabaseMacaroonService:
                 [{"version": 1, "permissions": "user"}],
                 user_id=user.id,
             )
+
+
+def _token(
+    packets: list[tuple[int, bytes | None]],
+    keep: int | None = None,
+    extra: bytes = b"",
+) -> str:
+    """
+    Build a `pypi-` token from raw v2 packets, however malformed, appending
+    `extra` bytes verbatim and optionally keeping only the first `keep`
+    characters of its base64 body.
+    """
+    serializer = BinarySerializer()
+    data = bytearray([pymacaroons.MACAROON_V2])
+    for field_type, payload in packets:
+        serializer._append_packet(data, field_type, payload)
+    data.extend(extra)
+
+    body = base64.urlsafe_b64encode(bytes(data)).decode().rstrip("=")
+    return "pypi-" + (body if keep is None else body[:keep])
+
+
+_HEADER = [
+    (BinarySerializer._LOCATION, b"pypi.org"),
+    (BinarySerializer._IDENTIFIER, b"02ede3fe-dc00-45b9-9a13-9f16ad1c454d"),
+    (BinarySerializer._EOS, None),
+]
+
+
+class TestDeserializePartialMacaroon:
+    def test_truncated_mid_caveat(self):
+        """A token cut off inside its first caveat, as a leak report would carry."""
+        token = _token(
+            [
+                *_HEADER,
+                (BinarySerializer._IDENTIFIER, b'[3,"%s"]' % (b"a" * 36)),
+                (BinarySerializer._EOS, None),
+            ],
+            keep=75,
+        )
+
+        partial = services.deserialize_partial_macaroon(token)
+
+        assert partial == services.PartialMacaroon(
+            location="pypi.org",
+            identifier="02ede3fe-dc00-45b9-9a13-9f16ad1c454d",
+            identifier_complete=True,
+            caveats=['[3," (truncated, 42 bytes declared)'],
+            signature=None,
+        )
+
+    @pytest.mark.parametrize(
+        ("suffix", "where"),
+        [("\n", "a trailing newline"), (" ", "a trailing space"), ("\r\n", "a CRLF")],
+    )
+    def test_whitespace_around_the_token(self, suffix, where):
+        """A pasted token brings whitespace with it, which is not data."""
+        token = _token(
+            [
+                *_HEADER,
+                (BinarySerializer._IDENTIFIER, b'[3,"%s"]' % (b"a" * 36)),
+                (BinarySerializer._EOS, None),
+            ],
+            keep=75,
+        )
+
+        assert services.deserialize_partial_macaroon(
+            token + suffix
+        ) == services.deserialize_partial_macaroon(token)
+
+    def test_truncated_mid_identifier(self):
+        """A half-read identifier is no use for a lookup."""
+        partial = services.deserialize_partial_macaroon(_token(_HEADER, keep=24))
+
+        assert partial == services.PartialMacaroon(
+            location="pypi.org",
+            identifier="02ede (truncated, 36 bytes declared)",
+            identifier_complete=False,
+        )
+
+    def test_truncated_before_any_payload(self):
+        """A packet header with no payload after it still names a length."""
+        partial = services.deserialize_partial_macaroon(_token(_HEADER, keep=4))
+
+        assert partial == services.PartialMacaroon(
+            location="(truncated, 8 bytes declared)"
+        )
+
+    def test_truncated_mid_packet_header(self):
+        """A cut inside a packet's own varints ends the read."""
+        token = _token([(BinarySerializer._LOCATION, b"pypi.org")], keep=3)
+
+        assert services.deserialize_partial_macaroon(token) is None
+
+    def test_long_caveat_uses_multibyte_length(self):
+        """A payload over 127 bytes declares its length in two varint bytes."""
+        token = _token(
+            [
+                *_HEADER,
+                (BinarySerializer._IDENTIFIER, b'[1,["%s"]]' % (b"a" * 200)),
+                (BinarySerializer._EOS, None),
+            ],
+            keep=80,
+        )
+
+        partial = services.deserialize_partial_macaroon(token)
+
+        assert partial.caveats == ['[1,["aa (truncated, 208 bytes declared)']
+
+    def test_malformed_header_still_yields_caveats_and_signature(self):
+        """A whole macaroon that will not deserialize still gives up its fields."""
+        token = _token(
+            [
+                (BinarySerializer._LOCATION, b"pypi.org"),
+                (BinarySerializer._EOS, None),  # no identifier: invalid header
+                (BinarySerializer._IDENTIFIER, b"\xff\xfe"),
+                (BinarySerializer._EOS, None),
+                (BinarySerializer._EOS, None),
+                (BinarySerializer._SIGNATURE, bytes(range(4))),
+            ]
+        )
+
+        with pytest.raises(services.InvalidMacaroonError):
+            services.deserialize_raw_macaroon(token)
+
+        assert services.deserialize_partial_macaroon(token) == services.PartialMacaroon(
+            location="pypi.org",
+            identifier=None,
+            caveats=["fffe"],  # not valid UTF-8, so shown as hex
+            signature="00010203",
+        )
+
+    def test_third_party_caveat_fields_are_ignored(self):
+        """A third party caveat's location and key id have nothing to show."""
+        token = _token(
+            [
+                *_HEADER,
+                (BinarySerializer._LOCATION, b"elsewhere.example"),
+                (BinarySerializer._IDENTIFIER, b"who knows"),
+                (BinarySerializer._VID, b"key id"),
+                (BinarySerializer._EOS, None),
+            ]
+        )
+
+        partial = services.deserialize_partial_macaroon(token)
+
+        assert partial.location == "pypi.org"
+        assert partial.caveats == ["who knows"]
+
+    def test_absurd_length_varint_stops_the_read(self):
+        """A length varint longer than any real one ends the read."""
+        token = _token(
+            _HEADER,
+            # A caveat identifier whose length runs to a fourth varint byte.
+            extra=bytes([BinarySerializer._IDENTIFIER, 0x80, 0x80, 0x80, 0x01]),
+        )
+
+        partial = services.deserialize_partial_macaroon(token)
+
+        assert partial.identifier == "02ede3fe-dc00-45b9-9a13-9f16ad1c454d"
+        assert partial.caveats == []
+
+    def test_oversized_token_is_not_walked(self):
+        """A paste past a few kilobytes is refused."""
+        token = _token(_HEADER, extra=bytes(services._MAX_TOKEN_BYTES))
+
+        assert services.deserialize_partial_macaroon(token) is None
+
+    @pytest.mark.parametrize(
+        ("token", "reason"),
+        [
+            ("invalid", "no pypi- prefix"),
+            ("pypi-A!!!", "body is not decodable base64"),
+            ("pypi-AQEIcHlwaS5vcmc", "version 1, which we never issue"),
+            ("pypi-Ag", "nothing after the version byte"),
+            ("pypi-AgEIcHl\u2026", "a non-ASCII character, as when a UI elides"),
+        ],
+    )
+    def test_nothing_readable(self, token, reason):
+        assert services.deserialize_partial_macaroon(token) is None

--- a/warehouse/admin/templates/admin/macaroons/decode_token.html
+++ b/warehouse/admin/templates/admin/macaroons/decode_token.html
@@ -12,7 +12,7 @@
 <div class="card">
   <div class="card-header">Decode an API Token</div>
   <div class="card-body">
-    <form action="/admin/token/decode" method="POST">
+    <form id="decode-token" action="/admin/token/decode" method="POST">
       <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
       <div class="input-group input-group-lg">
         <input name="token" type="text" class="form-control input-lg" placeholder="pypi-AgE... "{% if query %} value="{{ query }}"{% endif %}>
@@ -21,6 +21,53 @@
         </div>
       </div>
     </form>
+  {% if partial %}
+    <hr/>
+    <div class="alert alert-warning">
+      <i class="fa fa-exclamation-triangle"></i>
+      This token is truncated or otherwise malformed and could not be fully
+      deserialized. The fields below are what could be read.
+    </div>
+    <table class="table table-striped">
+      <tbody>
+      <tr>
+        <td>Location</td>
+        <td>{{ partial.location or "Not read" }}</td>
+      </tr>
+      <tr>
+        <td>Identifier</td>
+        <td>
+          {% if not partial.identifier %}
+            Not read
+          {% elif not partial.identifier_complete %}
+            {{ partial.identifier }}
+          {% elif db_record %}
+          <a href="{{ request.route_path('admin.macaroon.detail', macaroon_id=db_record.id) }}">
+            {{ partial.identifier }}
+          </a>
+          {% else %}
+            {{ partial.identifier }} (Not found)
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <td>Signature</td>
+        <td>{{ partial.signature or "Not read" }}</td>
+      </tr>
+      {% for caveat in partial.caveats %}
+      <tr>
+        <td>Caveat {{ loop.index }}</td>
+        <td>{{ caveat }}</td>
+      </tr>
+      {% else %}
+      <tr>
+        <td>Caveats</td>
+        <td>Not read</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
   {% if macaroon %}
     <hr/>
     <table class="table table-striped">

--- a/warehouse/admin/templates/admin/macaroons/decode_token.html
+++ b/warehouse/admin/templates/admin/macaroons/decode_token.html
@@ -81,10 +81,10 @@
         <td>
           {%  if db_record.id %}
           <a href="{{ request.route_path('admin.macaroon.detail', macaroon_id=db_record.id) }}">
-            {{ macaroon.identifier.decode() }}
+            {{ identifier }}
           </a>
           {% else %}
-            {{ macaroon.identifier.decode() }} (Not found)
+            {{ identifier }} (Not found)
           {% endif %}
         </td>
       </tr>

--- a/warehouse/admin/views/macaroons.py
+++ b/warehouse/admin/views/macaroons.py
@@ -10,7 +10,10 @@ from warehouse.events.tags import EventTag
 from warehouse.macaroons.errors import InvalidMacaroonError
 from warehouse.macaroons.interfaces import IMacaroonService
 from warehouse.macaroons.models import Macaroon
-from warehouse.macaroons.services import deserialize_raw_macaroon
+from warehouse.macaroons.services import (
+    deserialize_partial_macaroon,
+    deserialize_raw_macaroon,
+)
 
 
 @view_config(
@@ -43,13 +46,27 @@ def macaroon_decode_token(request):
     if not token:
         raise HTTPBadRequest("No token provided.")
 
+    macaroon_service = request.find_service(IMacaroonService, context=None)
+
     try:
         macaroon = deserialize_raw_macaroon(token)
     except InvalidMacaroonError as e:
-        raise HTTPBadRequest(f"The token cannot be deserialized: {e!r}") from e
+        # A truncated token still names the macaroon it came from, so read
+        # what is there instead of refusing the whole thing.
+        partial = deserialize_partial_macaroon(token)
+        if partial is None:
+            raise HTTPBadRequest(f"The token cannot be deserialized: {e!r}") from e
+
+        return {
+            "partial": partial,
+            "db_record": (
+                macaroon_service.find_macaroon(partial.identifier)
+                if partial.identifier_complete
+                else None
+            ),
+        }
 
     # Try to find the database record for this macaroon
-    macaroon_service = request.find_service(IMacaroonService, context=None)
     try:
         db_record = macaroon_service.find_from_raw(token)
     except InvalidMacaroonError:

--- a/warehouse/admin/views/macaroons.py
+++ b/warehouse/admin/views/macaroons.py
@@ -11,6 +11,7 @@ from warehouse.macaroons.errors import InvalidMacaroonError
 from warehouse.macaroons.interfaces import IMacaroonService
 from warehouse.macaroons.models import Macaroon
 from warehouse.macaroons.services import (
+    _decode_identifier,
     deserialize_partial_macaroon,
     deserialize_raw_macaroon,
 )
@@ -50,6 +51,8 @@ def macaroon_decode_token(request):
 
     try:
         macaroon = deserialize_raw_macaroon(token)
+        # Decoding here keeps the template from meeting bytes it cannot render.
+        identifier = _decode_identifier(macaroon)
     except InvalidMacaroonError as e:
         # A truncated token still names the macaroon it came from, so read
         # what is there instead of refusing the whole thing.
@@ -66,13 +69,11 @@ def macaroon_decode_token(request):
             ),
         }
 
-    # Try to find the database record for this macaroon
-    try:
-        db_record = macaroon_service.find_from_raw(token)
-    except InvalidMacaroonError:
-        db_record = None
-
-    return {"macaroon": macaroon, "db_record": db_record}
+    return {
+        "macaroon": macaroon,
+        "identifier": identifier,
+        "db_record": macaroon_service.find_macaroon(identifier),
+    }
 
 
 @view_config(

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -152,14 +152,24 @@ def _read_packets(data: bytes) -> Iterator[_Packet]:
     rather than rejecting the macaroon as a whole. A packet whose payload was
     cut short is yielded last: its declared length takes the index past the
     end of `data`.
+
+    Field types climb within a section, so a repeated or out of order field
+    ends the read. Without that rule a second identifier packet would speak
+    over the first, and a caveat in a stream that never ends its header would
+    be read as the identifier.
     """
     index = 0
+    previous_field_type = _PACKET_EOS
     while index < len(data):
         try:
             field_type, index = _read_uvarint(data, index)
             if field_type == _PACKET_EOS:
+                previous_field_type = _PACKET_EOS
                 yield _Packet(field_type, b"", 0)
                 continue
+            if field_type <= previous_field_type:
+                return
+            previous_field_type = field_type
             declared_length, index = _read_uvarint(data, index)
         except ValueError:
             return
@@ -215,6 +225,12 @@ def deserialize_partial_macaroon(
             partial.location = _packet_text(packet)
         elif packet.field_type == _PACKET_IDENTIFIER:
             if in_header:
+                try:
+                    packet.payload.decode()
+                except UnicodeDecodeError:
+                    # `uuid.UUID` would take the hex we would render this
+                    # as, naming a macaroon the token itself cannot name.
+                    return None
                 partial.identifier = _packet_text(packet)
                 partial.identifier_complete = packet.complete
             else:

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import base64
+import dataclasses
 import datetime
 import typing
 import uuid
+
+from collections.abc import Iterator
 
 import pymacaroons
 
@@ -53,6 +57,170 @@ def deserialize_raw_macaroon(raw_macaroon: str | None) -> pymacaroons.Macaroon:
         Exception,  # https://github.com/ecordell/pymacaroons/issues/50
     ) as e:
         raise InvalidMacaroonError("malformed macaroon") from e
+
+
+# Packet field types of the v2 macaroon format, which is a stream of
+# `field_type, length, payload` packets, both numbers LEB128 varints, with a
+# zero byte ending each section: the header, then one section per caveat, then
+# the signature.
+# https://github.com/rescrv/libmacaroons/blob/master/doc/format.txt
+_PACKET_EOS = 0
+_PACKET_LOCATION = 1
+_PACKET_IDENTIFIER = 2
+_PACKET_SIGNATURE = 6
+
+# Three varint bytes already span 21 bits, well past any length a real packet
+# declares. Reading further only builds an integer too large to render.
+_MAX_VARINT_BYTES = 3
+
+# A token scoped to many projects names each one in a caveat, so leave room
+# for a few kilobytes of them. Past this a paste is not a macaroon.
+_MAX_TOKEN_BYTES = 16 * 1024
+
+
+@dataclasses.dataclass(frozen=True)
+class _Packet:
+    """
+    One packet of a v2 macaroon. A packet cut short has a `payload` shorter
+    than its `declared_length`.
+    """
+
+    field_type: int
+    payload: bytes
+    declared_length: int
+
+    @property
+    def complete(self) -> bool:
+        return len(self.payload) == self.declared_length
+
+
+@dataclasses.dataclass
+class PartialMacaroon:
+    """
+    The fields recovered from a macaroon that will not fully deserialize, as
+    display strings. A field cut short carries a note of its declared length.
+    """
+
+    location: str | None = None
+    identifier: str | None = None
+    identifier_complete: bool = False
+    """Whether the identifier was read whole, so it can be looked up."""
+
+    caveats: list[str] = dataclasses.field(default_factory=list)
+    signature: str | None = None
+
+
+def _b64_prefix_decode(raw_macaroon: str) -> bytes:
+    """
+    Decode a base64url string that may have been cut mid-quantum, keeping the
+    bytes its final partial quantum still encodes. Returns b"" if even that
+    cannot be decoded, as when the string holds a non-ASCII character such as
+    an elision ellipsis.
+    """
+    # A paste carries whitespace that b64decode would drop anyway, and that
+    # would throw off the quantum arithmetic below if left in.
+    body = "".join(raw_macaroon.split())
+    # A lone trailing character encodes no whole byte.
+    body = body[:-1] if len(body) % 4 == 1 else body
+    try:
+        return base64.urlsafe_b64decode(body + "=" * (-len(body) % 4))
+    except ValueError:
+        return b""
+
+
+def _read_uvarint(data: bytes, index: int) -> tuple[int, int]:
+    """
+    Read the LEB128 varint at `index`, returning it and the index after it.
+    Raises ValueError if `data` ends mid-varint, or if the varint runs on
+    longer than a packet field ever needs.
+    """
+    value = 0
+    for shift in range(0, 7 * _MAX_VARINT_BYTES, 7):
+        if index >= len(data):
+            raise ValueError("varint cut short")
+        byte = data[index]
+        index += 1
+        value |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return value, index
+    raise ValueError("varint too long for a packet field")
+
+
+def _read_packets(data: bytes) -> Iterator[_Packet]:
+    """
+    Yield the packets of a v2 macaroon body, stopping once `data` runs out
+    rather than rejecting the macaroon as a whole. A packet whose payload was
+    cut short is yielded last: its declared length takes the index past the
+    end of `data`.
+    """
+    index = 0
+    while index < len(data):
+        try:
+            field_type, index = _read_uvarint(data, index)
+            if field_type == _PACKET_EOS:
+                yield _Packet(field_type, b"", 0)
+                continue
+            declared_length, index = _read_uvarint(data, index)
+        except ValueError:
+            return
+        payload = data[index : index + declared_length]
+        index += declared_length
+        yield _Packet(field_type, payload, declared_length)
+
+
+def _packet_text(packet: _Packet) -> str:
+    """Render a packet's payload for display, with a note if it was cut short."""
+    if packet.field_type == _PACKET_SIGNATURE:
+        text = packet.payload.hex()
+    else:
+        try:
+            text = packet.payload.decode()
+        except UnicodeDecodeError:
+            text = packet.payload.hex()
+
+    if not packet.complete:
+        note = f"(truncated, {packet.declared_length} bytes declared)"
+        return f"{text} {note}" if text else note
+    return text
+
+
+def deserialize_partial_macaroon(
+    prefixed_macaroon: str | None,
+) -> PartialMacaroon | None:
+    """
+    Returns whatever fields can still be read out of a PyPI macaroon that
+    `deserialize_raw_macaroon` rejects, usually one that was truncated.
+
+    Returns None if nothing could be read, including anything that is not a
+    v2 macaroon.
+    """
+    raw_macaroon = _extract_raw_macaroon(prefixed_macaroon)
+    if raw_macaroon is None:
+        return None
+
+    data = _b64_prefix_decode(raw_macaroon)
+    if not data or len(data) > _MAX_TOKEN_BYTES or data[0] != pymacaroons.MACAROON_V2:
+        return None
+
+    partial = PartialMacaroon()
+    in_header = True
+    for packet in _read_packets(data[1:]):
+        # A caveat's own location and verification key id are ignored: PyPI
+        # only issues first party caveats, which have neither.
+        if packet.field_type == _PACKET_EOS:
+            in_header = False
+        elif packet.field_type == _PACKET_SIGNATURE:
+            partial.signature = _packet_text(packet)
+        elif packet.field_type == _PACKET_LOCATION and in_header:
+            partial.location = _packet_text(packet)
+        elif packet.field_type == _PACKET_IDENTIFIER:
+            if in_header:
+                partial.identifier = _packet_text(packet)
+                partial.identifier_complete = packet.complete
+            else:
+                partial.caveats.append(_packet_text(packet))
+
+    return partial if partial != PartialMacaroon() else None
 
 
 def _decode_identifier(macaroon: pymacaroons.Macaroon) -> str:


### PR DESCRIPTION
Tokens may show up truncated, quoted in a leak report or copied out of a log, and the decode admin page will reject them with a 400. A partial macaroon may contain enough to decide the identifier, which is enough to pull up the row.

`deserialize_partial_macaroon` reads the v2 packets itself. `pymacaroons` raises before telling you how long the payload it couldn't read was meant to be, and that length is the useful part. A fragment ending in [3," has a 42-byte caveat behind it, so it is an untouched RequestUser.

Strict deserialization is untouched. The view only reaches for the partial read once it raises, and a token with nothing readable still gets its 400. An identifier that was itself cut short is shown as-is, never looked up.