### PR TITLE
chore(dependabot): only track direct Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,10 @@ updates:
     interval: daily
   open-pull-requests-limit: 99
   allow:
+  # Only the ~137 packages named in requirements/*.in. Checking the ~293
+  # packages in the compiled requirements/*.txt makes the grouped job too slow
+  # to finish, and transitive pins move anyway when pip-compile reruns.
   - dependency-type: direct
-  - dependency-type: indirect
   rebase-strategy: "disabled"
   ignore:
   # These update basically every day, and 99.9% of the time we don't care


### PR DESCRIPTION
Allowing indirect updates means each grouped run checks the ~293 packages in the compiled requirements/*.txt rather than the ~137 named in the .in files. A local run of the grouped job got through 101 of main.txt's packages in 54 minutes without reaching the other seven stems, which is well past any job time limit and matches the silence since early July: no pull request, and no failure either.

Transitive pins still move whenever pip-compile reruns, and security updates continue to cover vulnerable lock file entries.