### PR TITLE
feat(admin): rank pushable repositories first in the recovery challenge

### DIFF
--- a/tests/common/db/packaging.py
+++ b/tests/common/db/packaging.py
@@ -19,6 +19,7 @@ from warehouse.packaging.models import (
     Project,
     Provenance,
     Release,
+    ReleaseURL,
     Role,
     RoleInvitation,
 )
@@ -104,6 +105,25 @@ class ReleaseObservationFactory(WarehouseFactory):
     )
     payload = factory.Faker("json")
     summary = factory.Faker("paragraph")
+
+
+class ReleaseURLFactory(WarehouseFactory):
+    """
+    Build a `Release.project_urls` entry.
+
+    Declare `name` before `release`: `Release._project_urls` is an
+    `attribute_keyed_dict("name")`, and the declarative constructor assigns
+    kwargs in order, so setting `release` first inserts into that dict while the
+    key attribute is still unset.
+    """
+
+    class Meta:
+        model = ReleaseURL
+
+    name = factory.Sequence(lambda n: f"Link {n}")
+    release = factory.SubFactory(ReleaseFactory)
+    url = factory.Faker("uri")
+    verified = False
 
 
 class FileFactory(WarehouseFactory):

--- a/tests/functional/test_templates.py
+++ b/tests/functional/test_templates.py
@@ -37,6 +37,21 @@ SUBJECT_BLOCK_EXPRESSION = re.compile(
 )
 
 
+def _make_env(dir_name: Path) -> Environment:
+    env = Environment(
+        autoescape=True,
+        loader=FileSystemLoader(dir_name),
+        extensions=[
+            "jinja2.ext.i18n",
+            "warehouse.utils.html.ClientSideIncludeExtension",
+            "warehouse.i18n.extensions.TrimmedTranslatableTagsExtension",
+        ],
+        cache_size=0,
+    )
+    env.filters.update(FILTERS)
+    return env
+
+
 @pytest.mark.parametrize(
     "template",
     [
@@ -49,20 +64,7 @@ def test_templates_for_empty_titles(template: Path):
     Test if all HTML templates have defined the title block. See
     https://github.com/pypi/warehouse/issues/784
     """
-    dir_name = Path(warehouse.__path__[0]) / "templates"
-
-    env = Environment(
-        autoescape=True,
-        loader=FileSystemLoader(dir_name),
-        extensions=[
-            "jinja2.ext.i18n",
-            "warehouse.utils.html.ClientSideIncludeExtension",
-            "warehouse.i18n.extensions.TrimmedTranslatableTagsExtension",
-        ],
-        cache_size=0,
-    )
-
-    env.filters.update(FILTERS)
+    env = _make_env(Path(warehouse.__path__[0]) / "templates")
 
     if any(
         parent.name in ["includes", "api", "legacy", "email"]
@@ -87,20 +89,26 @@ def test_render_templates(template):
     Test if all HTML templates are rendered without Jinja exceptions.
     see https://github.com/pypi/warehouse/issues/6634
     """
-    dir_name = Path(warehouse.__path__[0]) / "templates"
+    env = _make_env(Path(warehouse.__path__[0]) / "templates")
 
-    env = Environment(
-        autoescape=True,
-        loader=FileSystemLoader(dir_name),
-        extensions=[
-            "jinja2.ext.i18n",
-            "warehouse.utils.html.ClientSideIncludeExtension",
-            "warehouse.i18n.extensions.TrimmedTranslatableTagsExtension",
-        ],
-        cache_size=0,
-    )
+    assert env.get_template(str(template))
 
-    env.filters.update(FILTERS)
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        f.relative_to(Path(warehouse.__path__[0]) / "admin" / "templates")
+        for f in Path(warehouse.__path__[0]).glob("admin/templates/**/*.html")
+    ],
+)
+def test_render_admin_templates(template):
+    """
+    Test if all admin HTML templates are rendered without Jinja exceptions.
+
+    The admin templates live outside `warehouse/templates`, so neither
+    `test_render_templates` nor `bin/lint`'s djlint invocation reaches them.
+    """
+    env = _make_env(Path(warehouse.__path__[0]) / "admin" / "templates")
 
     assert env.get_template(str(template))
 

--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -23,7 +23,7 @@ from warehouse.admin.views import users as views
 from warehouse.events.tags import EventTag
 from warehouse.observations.models import ObservationKind
 from warehouse.organizations.models import OrganizationRoleType
-from warehouse.packaging.models import JournalEntry, Project, ReleaseURL
+from warehouse.packaging.models import JournalEntry, Project
 from warehouse.subscriptions.models import StripeSubscriptionStatus
 
 from ....common.db.accounts import (
@@ -42,6 +42,7 @@ from ....common.db.packaging import (
     JournalEntryFactory,
     ProjectFactory,
     ReleaseFactory,
+    ReleaseURLFactory,
     RoleFactory,
 )
 from ....common.db.subscriptions import StripeSubscriptionFactory
@@ -887,7 +888,7 @@ class TestUserResetPassword:
 
 
 class TestUserRecoverAccountInitiate:
-    def test_user_recover_account_initiate(self, db_request, db_session):
+    def test_user_recover_account_initiate(self, db_request):
         user = UserFactory.create(
             totp_secret=b"aaaaabbbbbcccccddddd",
             webauthn=[
@@ -902,29 +903,23 @@ class TestUserRecoverAccountInitiate:
         project0 = ProjectFactory.create()
         RoleFactory.create(user=user, project=project0)
         release0 = ReleaseFactory.create(project=project0)
-        db_session.add(
-            ReleaseURL(
-                release=release0, name="Homepage", url="https://example.com/home0"
-            )
+        ReleaseURLFactory.create(
+            name="Homepage", release=release0, url="https://example.com/home0"
         )
-        db_session.add(
-            ReleaseURL(
-                release=release0, name="Source Code", url="http://example.com/source0"
-            )
+        ReleaseURLFactory.create(
+            name="Source Code", release=release0, url="http://example.com/source0"
         )
         project1 = ProjectFactory.create()
         RoleFactory.create(user=user, project=project1)
         release1 = ReleaseFactory.create(project=project1)
-        db_session.add(
-            ReleaseURL(
-                release=release1, name="Homepage", url="https://example.com/home1"
-            )
+        ReleaseURLFactory.create(
+            name="Homepage", release=release1, url="https://example.com/home1"
         )
         project2 = ProjectFactory.create()
         RoleFactory.create(user=user, project=project2)
         release2 = ReleaseFactory.create(project=project2)
-        db_session.add(
-            ReleaseURL(release=release2, name="telnet", url="telnet://192.0.2.16:80/")
+        ReleaseURLFactory.create(
+            name="telnet", release=release2, url="telnet://192.0.2.16:80/"
         )
         project3 = ProjectFactory.create()
         RoleFactory.create(user=user, project=project3)
@@ -934,15 +929,186 @@ class TestUserRecoverAccountInitiate:
         assert result == {
             "user": user,
             "repo_urls": {
-                project0.name: {
-                    ("Homepage", "https://example.com/home0"),
-                    ("Source Code", "http://example.com/source0"),
-                },
-                project1.name: {
-                    ("Homepage", "https://example.com/home1"),
-                },
+                project0.name: [
+                    ("Homepage", "https://example.com/home0", False, False),
+                    ("Source Code", "http://example.com/source0", False, False),
+                ],
+                project1.name: [
+                    ("Homepage", "https://example.com/home1", False, False),
+                ],
             },
+            "explain_badge": False,
         }
+
+    def test_user_recover_account_initiate_prefers_verified_urls(self, db_request):
+        """A verified repository sorts first, as do the projects holding one."""
+        user = UserFactory.create()
+        unverified_project = ProjectFactory.create(name="aaa-unverified")
+        RoleFactory.create(user=user, project=unverified_project)
+        unverified_release = ReleaseFactory.create(project=unverified_project)
+        ReleaseURLFactory.create(
+            release=unverified_release,
+            name="Source",
+            url="https://github.com/an-org/unverified",
+        )
+
+        mixed_project = ProjectFactory.create(name="zzz-mixed")
+        RoleFactory.create(user=user, project=mixed_project)
+        mixed_release = ReleaseFactory.create(project=mixed_project)
+        for name, url, verified in [
+            ("Source", "https://gitlab.com/an-org/mixed", True),
+            ("Aardvark", "https://github.com/an-org/mixed-extras", False),
+            ("homepage", "https://mixed.example.com", False),
+        ]:
+            ReleaseURLFactory.create(
+                release=mixed_release, name=name, url=url, verified=verified
+            )
+
+        result = views.user_recover_account_initiate(user, db_request)
+
+        # `zzz-mixed` sorts ahead of `aaa-unverified` despite the name, because
+        # it holds a verified repository, which in turn sorts ahead of the
+        # alphabetically earlier `Aardvark`. Lowercase `homepage` sorts among the
+        # capitalized labels rather than after all of them.
+        assert list(result["repo_urls"].items()) == [
+            (
+                "zzz-mixed",
+                [
+                    ("Source", "https://gitlab.com/an-org/mixed", True, True),
+                    (
+                        "Aardvark",
+                        "https://github.com/an-org/mixed-extras",
+                        False,
+                        False,
+                    ),
+                    ("homepage", "https://mixed.example.com", False, False),
+                ],
+            ),
+            (
+                "aaa-unverified",
+                [("Source", "https://github.com/an-org/unverified", False, False)],
+            ),
+        ]
+        assert result["explain_badge"] is True
+
+    def test_user_recover_account_initiate_ignores_unpushable_verified_urls(
+        self, db_request
+    ):
+        """A verified URL that takes no git push must not outrank the repository.
+
+        `verify_url` marks verified both a project's own PyPI page and, for a
+        GitHub Trusted Publisher, its `{owner}.github.io/{repo}` docs site.
+        Neither accepts a branch, so neither may carry the badge.
+        """
+        user = UserFactory.create()
+        project = ProjectFactory.create(name="self-linker")
+        RoleFactory.create(user=user, project=project)
+        release = ReleaseFactory.create(project=project)
+        for name, url, verified in [
+            ("PyPI", "https://pypi.org/project/self-linker/", True),
+            ("Documentation", "https://an-org.github.io/self-linker/", True),
+            ("Source", "https://github.com/an-org/self-linker", False),
+        ]:
+            ReleaseURLFactory.create(
+                release=release, name=name, url=url, verified=verified
+            )
+
+        result = views.user_recover_account_initiate(user, db_request)
+
+        # The repository ranks first despite being unverified and sorting last
+        # alphabetically, because the other two take no push.
+        assert result["repo_urls"] == {
+            "self-linker": [
+                ("Source", "https://github.com/an-org/self-linker", False, False),
+                ("Documentation", "https://an-org.github.io/self-linker/", False, True),
+                ("PyPI", "https://pypi.org/project/self-linker/", False, True),
+            ]
+        }
+        # The legend still renders: two URLs are verified but carry no badge.
+        assert result["explain_badge"] is True
+
+    def test_user_recover_account_initiate_ignores_verified_subpaths(self, db_request):
+        """A verified page inside a repository must not outrank the repository.
+
+        A Trusted Publisher verifies every subpath of its repository, so an
+        issues page is as `verified` as the root. Only the root takes a push,
+        and it sorts last of the three by label, so nothing but the repository
+        check can put it first.
+        """
+        user = UserFactory.create()
+        project = ProjectFactory.create(name="subpaths")
+        RoleFactory.create(user=user, project=project)
+        release = ReleaseFactory.create(project=project)
+        for name, url in [
+            ("Bug Tracker", "https://github.com/an-org/subpaths/issues"),
+            ("Changelog", "https://github.com/an-org/subpaths/blob/main/CHANGELOG.md"),
+            ("Repository", "https://github.com/an-org/subpaths"),
+        ]:
+            ReleaseURLFactory.create(release=release, name=name, url=url, verified=True)
+
+        result = views.user_recover_account_initiate(user, db_request)
+
+        assert result["repo_urls"] == {
+            "subpaths": [
+                ("Repository", "https://github.com/an-org/subpaths", True, True),
+                (
+                    "Bug Tracker",
+                    "https://github.com/an-org/subpaths/issues",
+                    False,
+                    True,
+                ),
+                (
+                    "Changelog",
+                    "https://github.com/an-org/subpaths/blob/main/CHANGELOG.md",
+                    False,
+                    True,
+                ),
+            ]
+        }
+
+    def test_user_recover_account_initiate_ranks_projects_with_a_repo_first(
+        self, db_request
+    ):
+        """A project holding a repository outranks one holding none.
+
+        Neither is verified, so only the repository tier can reorder them, and
+        the names sort the other way round.
+        """
+        user = UserFactory.create()
+        for name, url_name, url in [
+            ("aaa-no-repo", "Documentation", "https://aaa.readthedocs.io/"),
+            ("zzz-has-repo", "Source", "https://github.com/an-org/zzz"),
+        ]:
+            project = ProjectFactory.create(name=name)
+            RoleFactory.create(user=user, project=project)
+            release = ReleaseFactory.create(project=project)
+            ReleaseURLFactory.create(release=release, name=url_name, url=url)
+
+        result = views.user_recover_account_initiate(user, db_request)
+
+        assert list(result["repo_urls"]) == ["zzz-has-repo", "aaa-no-repo"]
+        assert result["explain_badge"] is False
+
+    def test_user_recover_account_initiate_skips_host_reserved_paths(self, db_request):
+        """Forge service pages are not repositories, on either host."""
+        user = UserFactory.create()
+        project = ProjectFactory.create(name="reserved")
+        RoleFactory.create(user=user, project=project)
+        release = ReleaseFactory.create(project=project)
+        for name, url in [
+            ("Sponsor", "https://github.com/sponsors/an-org"),
+            ("Discuss", "https://gitlab.com/explore/projects"),
+            ("Snippet", "https://gitlab.com/-/snippets/12345"),
+        ]:
+            ReleaseURLFactory.create(release=release, name=name, url=url, verified=True)
+
+        result = views.user_recover_account_initiate(user, db_request)
+
+        assert [proven for *_, proven, _ in result["repo_urls"]["reserved"]] == [
+            False,
+            False,
+            False,
+        ]
 
     def test_user_recover_account_initiate_only_one(self, db_request):
         db_request.route_path = pretend.call_recorder(
@@ -977,9 +1143,7 @@ class TestUserRecoverAccountInitiate:
             pretend.call("admin.user.detail", username=user.username)
         ]
 
-    def test_user_recover_account_initiate_submit(
-        self, db_request, db_session, monkeypatch
-    ):
+    def test_user_recover_account_initiate_submit(self, db_request, monkeypatch):
         admin_user = UserFactory.create()
         user = UserFactory.create(
             totp_secret=b"aaaaabbbbbcccccddddd",
@@ -995,15 +1159,11 @@ class TestUserRecoverAccountInitiate:
         project = ProjectFactory.create()
         RoleFactory.create(user=user, project=project)
         release = ReleaseFactory.create(project=project)
-        db_session.add(
-            ReleaseURL(
-                release=release, name="Homepage", url="https://example.com/home0"
-            )
+        ReleaseURLFactory.create(
+            name="Homepage", release=release, url="https://example.com/home0"
         )
-        db_session.add(
-            ReleaseURL(
-                release=release, name="Source Code", url="http://example.com/source0"
-            )
+        ReleaseURLFactory.create(
+            name="Source Code", release=release, url="http://example.com/source0"
         )
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
@@ -1045,19 +1205,17 @@ class TestUserRecoverAccountInitiate:
             "completed": None,
             "token": "deadbeef",
             "project_name": project.name,
-            "repos": sorted(
-                [
-                    ("Source Code", "http://example.com/source0"),
-                    ("Homepage", "https://example.com/home0"),
-                ]
-            ),
+            "repos": [
+                ("Homepage", "https://example.com/home0", False, False),
+                ("Source Code", "http://example.com/source0", False, False),
+            ],
             "support_issue_link": "https://github.com/pypi/support/issues/666",
             "override_to_email": None,
         }
         assert account_recovery.additional == {"status": "initiated"}
 
     def test_user_recover_account_initiate_no_urls_submit(
-        self, db_request, db_session, monkeypatch
+        self, db_request, monkeypatch
     ):
         admin_user = UserFactory.create()
         user = UserFactory.create(
@@ -1074,8 +1232,8 @@ class TestUserRecoverAccountInitiate:
         project = ProjectFactory.create()
         RoleFactory.create(user=user, project=project)
         release = ReleaseFactory.create(project=project)
-        db_session.add(
-            ReleaseURL(release=release, name="telnet", url="telnet://192.0.2.16:80/")
+        ReleaseURLFactory.create(
+            name="telnet", release=release, url="telnet://192.0.2.16:80/"
         )
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
@@ -1124,7 +1282,7 @@ class TestUserRecoverAccountInitiate:
         assert account_recovery.additional == {"status": "initiated"}
 
     def test_user_recover_account_initiate_override_email(
-        self, db_request, db_session, monkeypatch
+        self, db_request, monkeypatch
     ):
         admin_user = UserFactory.create()
         user = UserFactory.create(
@@ -1141,8 +1299,8 @@ class TestUserRecoverAccountInitiate:
         project = ProjectFactory.create()
         RoleFactory.create(user=user, project=project)
         release = ReleaseFactory.create(project=project)
-        db_session.add(
-            ReleaseURL(release=release, name="telnet", url="telnet://192.0.2.16:80/")
+        ReleaseURLFactory.create(
+            name="telnet", release=release, url="telnet://192.0.2.16:80/"
         )
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
@@ -1195,7 +1353,7 @@ class TestUserRecoverAccountInitiate:
         assert account_recovery.additional == {"status": "initiated"}
 
     def test_user_recover_account_initiate_override_email_exists(
-        self, db_request, db_session, monkeypatch
+        self, db_request, monkeypatch
     ):
         admin_user = UserFactory.create()
         user = UserFactory.create(
@@ -1215,8 +1373,8 @@ class TestUserRecoverAccountInitiate:
         project = ProjectFactory.create()
         RoleFactory.create(user=user, project=project)
         release = ReleaseFactory.create(project=project)
-        db_session.add(
-            ReleaseURL(release=release, name="telnet", url="telnet://192.0.2.16:80/")
+        ReleaseURLFactory.create(
+            name="telnet", release=release, url="telnet://192.0.2.16:80/"
         )
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
@@ -1269,7 +1427,7 @@ class TestUserRecoverAccountInitiate:
         assert account_recovery.additional == {"status": "initiated"}
 
     def test_user_recover_account_initiate_override_email_exists_wrong_user(
-        self, db_request, db_session, monkeypatch
+        self, db_request, monkeypatch
     ):
         admin_user = UserFactory.create()
         user = UserFactory.create(
@@ -1290,8 +1448,8 @@ class TestUserRecoverAccountInitiate:
         project = ProjectFactory.create()
         RoleFactory.create(user=user, project=project)
         release = ReleaseFactory.create(project=project)
-        db_session.add(
-            ReleaseURL(release=release, name="telnet", url="telnet://192.0.2.16:80/")
+        ReleaseURLFactory.create(
+            name="telnet", release=release, url="telnet://192.0.2.16:80/"
         )
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
@@ -1326,7 +1484,7 @@ class TestUserRecoverAccountInitiate:
         assert len(user.active_account_recoveries) == 0
 
     def test_user_recover_account_initiate_no_support_issue_link_submit(
-        self, db_request, db_session
+        self, db_request
     ):
         admin_user = UserFactory.create()
         user = UserFactory.create(
@@ -1343,8 +1501,8 @@ class TestUserRecoverAccountInitiate:
         project = ProjectFactory.create()
         RoleFactory.create(user=user, project=project)
         release = ReleaseFactory.create(project=project)
-        db_session.add(
-            ReleaseURL(release=release, name="telnet", url="telnet://192.0.2.16:80/")
+        ReleaseURLFactory.create(
+            name="telnet", release=release, url="telnet://192.0.2.16:80/"
         )
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
@@ -1374,7 +1532,7 @@ class TestUserRecoverAccountInitiate:
         assert len(user.active_account_recoveries) == 0
 
     def test_user_recover_account_initiate_invalid_support_issue_link_submit(
-        self, db_request, db_session
+        self, db_request
     ):
         admin_user = UserFactory.create()
         user = UserFactory.create(
@@ -1391,8 +1549,8 @@ class TestUserRecoverAccountInitiate:
         project = ProjectFactory.create()
         RoleFactory.create(user=user, project=project)
         release = ReleaseFactory.create(project=project)
-        db_session.add(
-            ReleaseURL(release=release, name="telnet", url="telnet://192.0.2.16:80/")
+        ReleaseURLFactory.create(
+            name="telnet", release=release, url="telnet://192.0.2.16:80/"
         )
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)
@@ -1424,7 +1582,7 @@ class TestUserRecoverAccountInitiate:
         assert len(user.active_account_recoveries) == 0
 
     def test_recover_account_initiate_invalid_project_name_with_available_urls_submit(
-        self, db_request, db_session
+        self, db_request
     ):
         admin_user = UserFactory.create()
         user = UserFactory.create(
@@ -1441,8 +1599,8 @@ class TestUserRecoverAccountInitiate:
         project = ProjectFactory.create()
         RoleFactory.create(user=user, project=project)
         release = ReleaseFactory.create(project=project)
-        db_session.add(
-            ReleaseURL(release=release, name="Homepage", url="https://example.com/home")
+        ReleaseURLFactory.create(
+            name="Homepage", release=release, url="https://example.com/home"
         )
 
         send_email = pretend.call_recorder(lambda *a, **kw: None)

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -29,6 +29,10 @@ from warehouse.macaroons.models import Macaroon
 from warehouse.oidc.models import GitHubPublisher
 from warehouse.organizations.models import OrganizationType, TeamProjectRoleType
 from warehouse.packaging.models import (
+    GITHUB_REPO_HOSTS,
+    GITHUB_RESERVED_NAMES,
+    GITLAB_REPO_HOSTS,
+    GITLAB_RESERVED_NAMES,
     PROVENANCE_COMPARISON_WINDOW_DAYS,
     Description,
     File,
@@ -38,6 +42,7 @@ from warehouse.packaging.models import (
     ProjectMacaroonWarningAssociation,
     Release,
     ReleaseURL,
+    parse_user_name_and_repo_name,
 )
 from warehouse.utils.db.orm import NoSessionError
 
@@ -2360,3 +2365,61 @@ class TestProjectLimitProperties:
         expected = max(MAX_PROJECT_SIZE, 5000 * ONE_GIB, large_limit)
         assert project.total_size_limit_value == expected
         assert project.total_size_limit_value == large_limit
+
+
+class TestParseUserNameAndRepoName:
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            # A repository, and a page inside one.
+            ("https://github.com/an-org/a-repo", ("an-org", "a-repo")),
+            ("https://github.com/an-org/a-repo/issues", ("an-org", "a-repo")),
+            ("https://github.com/an-org/a-repo.git", ("an-org", "a-repo")),
+            # An explicit port is not part of the host.
+            ("https://github.com:443/an-org/a-repo", ("an-org", "a-repo")),
+            # Not a repository.
+            ("https://github.com/an-org", None),
+            ("https://example.com/an-org/a-repo", None),
+            ("https://github.com/sponsors/an-org", None),
+            # A path that parses into an empty repository name.
+            ("https://github.com/an-org/.git", None),
+            ("https://github.com/an-org//a-repo", None),
+            # Unparsable.
+            ("https://[/an-org/a-repo", None),
+        ],
+    )
+    def test_parses_github_urls(self, url, expected):
+        assert (
+            parse_user_name_and_repo_name(url, GITHUB_REPO_HOSTS, GITHUB_RESERVED_NAMES)
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://github.com/an-org/a-repo", ("an-org", "a-repo")),
+            ("https://github.com/an-org/a-repo/issues", None),
+            ("https://github.com/an-org/a-repo/blob/main/README.md", None),
+        ],
+    )
+    def test_root_only_rejects_subpaths(self, url, expected):
+        assert (
+            parse_user_name_and_repo_name(
+                url, GITHUB_REPO_HOSTS, GITHUB_RESERVED_NAMES, root_only=True
+            )
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://gitlab.com/explore/projects",
+            "https://gitlab.com/users/someone",
+            "https://gitlab.com/-/snippets/12345",
+        ],
+    )
+    def test_gitlab_service_paths_are_not_repositories(self, url):
+        assert (
+            parse_user_name_and_repo_name(url, GITLAB_REPO_HOSTS, GITLAB_RESERVED_NAMES)
+            is None
+        )

--- a/warehouse/admin/templates/admin/users/account_recovery/initiate.html
+++ b/warehouse/admin/templates/admin/users/account_recovery/initiate.html
@@ -60,18 +60,34 @@
         Ensure that the Project has at least one reachable URL that leads to a public source code repository.
       </p>
     {% if repo_urls %}
-      {% for project_name, repo_urls in repo_urls.items() %}
-        {% if repo_urls %}
-          <div class="form-check">
-            <input class="form-check-input" type="radio" name="project_name" value="{{ project_name }}" name="{{ project_name }}">
-            <label class="form-check-label" for="{{ project_name }}"><a href="{{ request.route_url("admin.project.detail", project_name=project_name) }}">{{ project_name }}</a></label>
-            <ul>
-            {% for kind, repo_url in repo_urls %}
-              <li>{{ kind }}: <a href="{{ repo_url }}" data-check-link-url="{{ request.camo_url(repo_url) }}"><i class="fa fa-question"></i> {{ repo_url }}</a></li>
-            {% endfor %}
-            </ul>
-          </div>
-        {% endif %}
+      {% if explain_badge %}
+        <p class="card-text">
+          A <span class="badge bg-success">verified</span> repository was proven to belong to whoever uploaded the
+          release, which is not necessarily this account. Treat it as evidence about the project rather than about the
+          requester. Repositories you can push a branch to are listed first, as are the projects holding them.
+        </p>
+        <p class="card-text">
+          PyPI also verifies pages that take no <code>git push</code>: a project's own PyPI page, its docs site, and any
+          page inside a verified repository such as <code>/issues</code>. Those get a
+          <span class="badge bg-secondary">verified, not pushable</span> badge. A verified repository on a host PyPI
+          does not recognize, such as a self-hosted GitLab, gets no badge at all and sorts last.
+        </p>
+      {% endif %}
+      {% for project_name, project_repo_urls in repo_urls.items() %}
+        <div class="form-check">
+          <input class="form-check-input" type="radio" name="project_name" id="project-{{ project_name }}" value="{{ project_name }}">
+          <label class="form-check-label" for="project-{{ project_name }}">{{ project_name }}</label>
+          <a href="{{ request.route_url("admin.project.detail", project_name=project_name) }}">{{ project_name }} in admin</a>
+          <ul>
+          {% for kind, repo_url, proven, verified in project_repo_urls %}
+            <li>
+              {{ kind }}: <a href="{{ repo_url }}" data-check-link-url="{{ request.camo_url(repo_url) }}"><i class="fa fa-question"></i> {{ repo_url }}</a>
+              {% if proven %}<span class="badge bg-success">verified</span>
+              {% elif verified %}<span class="badge bg-secondary">verified, not pushable</span>{% endif %}
+            </li>
+          {% endfor %}
+          </ul>
+        </div>
       {% endfor %}
     {% else %}
       <i>No repos found. You can proceed with recovery based on response alone.</i>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -451,7 +451,12 @@
                   <td>
                     <ul>
                       {% for url in account_recovery.payload["repos"] %}
-                      <li>{{ url[0] }}: <a href="{{ url[1] }}" data-check-link-url="{{ request.camo_url(url[1]) }}" ><i class="fa fa-question"></i> {{ url[1] }}</a></li>
+                      {# Older recoveries stored shorter entries, so index rather than unpack. #}
+                      <li>
+                        {{ url[0] }}: <a href="{{ url[1] }}" data-check-link-url="{{ request.camo_url(url[1]) }}" ><i class="fa fa-question"></i> {{ url[1] }}</a>
+                        {% if url|length > 2 and url[2] %}<span class="badge bg-success">verified</span>
+                        {% elif url|length > 3 and url[3] %}<span class="badge bg-secondary">verified, not pushable</span>{% endif %}
+                      </li>
                       {% endfor %}
                     </ul>
                   </td>

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -50,7 +50,14 @@ from warehouse.organizations.models import (
     OrganizationRole,
     OrganizationRoleType,
 )
-from warehouse.packaging.models import File, JournalEntry, Project, Release, Role
+from warehouse.packaging.models import (
+    File,
+    JournalEntry,
+    Project,
+    Release,
+    Role,
+    is_repository_root,
+)
 from warehouse.utils import now
 from warehouse.utils.paginate import paginate_url_factory
 from warehouse.utils.project import clear_project_quarantine, quarantine_project
@@ -569,17 +576,71 @@ def _is_a_valid_url(url):
     return url.startswith(("https://", "http://"))
 
 
-def _get_related_urls(user):
-    project_to_urls = defaultdict(set)
+def _get_related_urls(user: User) -> dict[str, list[tuple[str, str, bool, bool]]]:
+    """
+    Collect candidate repository URLs for the account recovery challenge.
+
+    Returns `{project_name: [(label, url, proven, verified), ...]}`. `proven`
+    means PyPI confirmed the URL belongs to the uploader AND it is a repository
+    root a branch can be pushed to. Those sort first within a project, and
+    projects holding one sort ahead of the rest.
+
+    `verified` alone is too broad to rank on. `verify_url` also sets it for a
+    project's own PyPI page, for each Trusted Publisher's docs site
+    (`{owner}.github.io/{repo}`, `{owner}.gitlab.io/...`, a
+    `platform.activestate.com` project page), and for every subpath of the
+    verified repository, so an issues page or a blob link carries it too. Those
+    were all genuinely proven and none accepts a git push, so ranking on
+    `verified` would put a docs site above the repository beside it.
+
+    `is_repository_root` decides the other half, and its own limits mean a
+    repository can lose a badge it earned rather than gain one it did not.
+
+    Both flags are kept. The recovery observation stores this list verbatim and a
+    later release replaces the `ReleaseURL` rows, leaving it the only record of
+    what PyPI had verified when the challenge was issued; with `proven` alone an
+    auditor cannot tell "never verified" from "verified, but not a repository".
+    """
+    ranked: defaultdict[str, list[tuple[bool, bool, str, str, bool]]] = defaultdict(
+        list
+    )
     for project in user.projects:
         if project.releases:
             release = project.releases[0]
+            verified_urls = set(release.urls_by_verify_status(verified=True).values())
 
             for kind, url in release.urls.items():
                 if _is_a_valid_url(url):
-                    project_to_urls[project.name].add((kind, url))
+                    pushable = is_repository_root(url)
+                    verified = url in verified_urls
+                    proven = pushable and verified
+                    ranked[project.name].append((proven, pushable, kind, url, verified))
 
-    return dict(project_to_urls)
+    # A repository ranks above a page that takes no push even when neither is
+    # proven, so a moderator never has to scroll past a docs site to find the
+    # repo. Labels break the remaining ties case-insensitively, since both
+    # `Homepage` and `repository` are idiomatic and raw ASCII would put every
+    # capitalized label first.
+    for entries in ranked.values():
+        entries.sort(key=lambda e: (not e[0], not e[1], e[2].casefold(), e[3]))
+
+    # Projects rank on the same two tiers as the URLs inside them, so the entry
+    # just sorted to the front states the project's tier. Proven URLs need a
+    # Trusted Publisher upload and so are rare; without the `pushable` tier a
+    # project with no repository at all would outrank one that has one.
+    return {
+        name: [
+            (kind, url, proven, verified) for proven, _, kind, url, verified in entries
+        ]
+        for name, entries in sorted(
+            ranked.items(),
+            key=lambda item: (
+                not item[1][0][0],
+                not item[1][0][1],
+                item[0].casefold(),
+            ),
+        )
+    }
 
 
 @view_config(
@@ -669,7 +730,7 @@ def user_recover_account_initiate(user, request):
                     "completed": None,
                     "token": token,
                     "project_name": project_name,
-                    "repos": sorted(repo_urls.get(project_name, [])),
+                    "repos": repo_urls.get(project_name, []),
                     "support_issue_link": support_issue_link,
                     "override_to_email": override_to_email,
                 },
@@ -702,6 +763,12 @@ def user_recover_account_initiate(user, request):
     return {
         "user": user,
         "repo_urls": repo_urls,
+        # The legend earns its space only when a badge is on screen, which needs
+        # a Trusted Publisher upload and so is rare. `proven` implies
+        # `verified`, so this one scan covers both badges.
+        "explain_badge": any(
+            verified for urls in repo_urls.values() for *_, verified in urls
+        ),
     }
 
 

--- a/warehouse/cli/db/seed.py
+++ b/warehouse/cli/db/seed.py
@@ -13,8 +13,9 @@ def seed(config):  # pragma: no cover # dev-only tool
 
     Creates a standard set of projects whose releases exhibit each of the
     provenance states surfaced in the UI (full/partial/inconsistent/lost/
-    changed provenance) and each of the "file added late" cases, owned by the
-    `seed-user` account.
+    changed provenance), each of the "file added late" cases, and each of the
+    project-URL shapes the admin account recovery picker has to rank, owned by
+    the `seed-user` account.
 
     Attestation material is fabricated; nothing seeded here will pass cryptographic
     verification.
@@ -45,6 +46,7 @@ def seed(config):  # pragma: no cover # dev-only tool
         ProjectFactory,
         ProvenanceFactory,
         ReleaseFactory,
+        ReleaseURLFactory,
         RoleFactory,
     )
     from warehouse.accounts.models import User
@@ -76,6 +78,18 @@ def seed(config):  # pragma: no cover # dev-only tool
         predicate_types, repo, _ = spec
         return (predicate_types, repo, days)
 
+    # A URL spec is (label, url, verified). Only mark a URL `verify_url` could
+    # actually verify: the project's own PyPI page, or anything at or under the
+    # publisher's repository or docs domain. A real Trusted Publisher therefore
+    # verifies the repository root and every page inside it, so an `/issues`
+    # link beside a verified repository is verified too.
+    #
+    # `urls` is keyed by version. Only the highest-versioned release reaches the
+    # admin recovery picker (`Project.releases` is ordered by `_pypi_ordering`,
+    # which `_sort_releases` assigns in PEP 440 order, so it is the greatest
+    # version rather than the newest upload), so keying by version lets a
+    # scenario put URLs on a release the picker will not read.
+    #
     # Each release is (version, days_ago, file_specs). A release's `days_ago`
     # has to exceed its longest delay, or its files would arrive in the future.
     scenarios = [
@@ -165,7 +179,152 @@ def seed(config):  # pragma: no cover # dev-only tool
             # file that made it so is the late one.
             "releases": [("1.0.0", 60, [pypi_a] * 2 + [after(pypi_b, 45)])],
         },
+        # The nine below feed the admin account recovery picker at
+        # /admin/users/seed-user/account_recovery/initiate/. Expected result:
+        # `mixed`, `repo` and `subpaths` are listed first with a green badge on
+        # the repository root, then `docs-site`, `pypi-self-link` and
+        # `unverified`, then `self-hosted` last with no badge at all. Names break
+        # ties within a tier. `nonhttp` and `stale` are absent.
+        {
+            "name": "seed-recovery-urls-repo",
+            "summary": "Dev seed: a verified repository URL",
+            "releases": [("1.0.0", 1, [unattested])],
+            "urls": {
+                "1.0.0": [
+                    ("Source", "https://github.com/seed-org/alpha", True),
+                    ("Homepage", "https://alpha.example.com", False),
+                ]
+            },
+        },
+        {
+            "name": "seed-recovery-urls-mixed",
+            "summary": "Dev seed: a verified repository beside unverified URLs",
+            "releases": [("1.0.0", 1, [unattested])],
+            # `Source` is verified so it outranks `Bug Tracker` despite sorting
+            # after it alphabetically. The homepage is on an unrelated domain no
+            # publisher could verify.
+            "urls": {
+                "1.0.0": [
+                    ("Source", "https://gitlab.com/seed-org/beta", True),
+                    ("Bug Tracker", "https://gitlab.com/other/tracker", False),
+                    ("Homepage", "https://beta.example.com", False),
+                ]
+            },
+        },
+        {
+            "name": "seed-recovery-urls-subpaths",
+            "summary": "Dev seed: verified pages inside a verified repository",
+            "releases": [("1.0.0", 1, [unattested])],
+            # A Trusted Publisher verifies every subpath of its repository, so
+            # all three of these are genuinely verified. Only the root takes a
+            # push, so only it may be badged and ranked first. The labels sort
+            # the other way round, which is what makes this worth seeding.
+            "urls": {
+                "1.0.0": [
+                    ("Bug Tracker", "https://github.com/seed-org/theta/issues", True),
+                    (
+                        "Changelog",
+                        "https://github.com/seed-org/theta/blob/main/CHANGELOG.md",
+                        True,
+                    ),
+                    ("Repository", "https://github.com/seed-org/theta", True),
+                ]
+            },
+        },
+        {
+            "name": "seed-recovery-urls-docs-site",
+            "summary": "Dev seed: the only verified URL is a Pages docs site",
+            "releases": [("1.0.0", 1, [unattested])],
+            # A GitHub Trusted Publisher verifies `{owner}.github.io/{repo}`, so
+            # this is genuinely proven, but it serves rendered docs and takes no
+            # git push. The repository here is on a different owner, so the
+            # publisher that verified the docs site would not verify it.
+            "urls": {
+                "1.0.0": [
+                    ("Documentation", "https://seed-org.github.io/delta/", True),
+                    ("Source", "https://github.com/another-org/delta", False),
+                ]
+            },
+        },
+        {
+            "name": "seed-recovery-urls-self-hosted",
+            "summary": "Dev seed: a verified repository on a self-hosted GitLab",
+            "releases": [("1.0.0", 1, [unattested])],
+            # A self-hosted GitLab is a supported Trusted Publisher issuer, so
+            # this really was proven, but the host allowlist does not cover it.
+            # The badge is lost rather than wrongly granted; the moderator has
+            # to check this one by hand.
+            "urls": {
+                "1.0.0": [("Source", "https://gitlab.seed-corp.example/eng/iota", True)]
+            },
+        },
+        {
+            "name": "seed-recovery-urls-pypi-self-link",
+            "summary": "Dev seed: the only verified URL is the PyPI page itself",
+            "releases": [("1.0.0", 1, [unattested])],
+            # `verify_url` marks a project's own PyPI page verified without any
+            # Trusted Publisher, and nobody can push a branch to pypi.org.
+            "urls": {
+                "1.0.0": [
+                    (
+                        "PyPI",
+                        "https://pypi.org/project/seed-recovery-urls-pypi-self-link/",
+                        True,
+                    ),
+                    ("Source", "https://github.com/seed-org/zeta", False),
+                ]
+            },
+        },
+        {
+            "name": "seed-recovery-urls-unverified",
+            "summary": "Dev seed: no project URL is verified",
+            "releases": [("1.0.0", 1, [unattested])],
+            # Lowercase labels are idiomatic in pyproject.toml, and must sort
+            # among the capitalized ones rather than after all of them.
+            "urls": {
+                "1.0.0": [
+                    ("repository", "https://github.com/seed-org/gamma", False),
+                    ("Homepage", "https://gamma.example.com", False),
+                ]
+            },
+        },
+        {
+            "name": "seed-recovery-urls-nonhttp",
+            "summary": "Dev seed: project URLs the recovery picker filters out",
+            "releases": [("1.0.0", 1, [unattested])],
+            "urls": {
+                "1.0.0": [
+                    ("Repository", "git@github.com:seed-org/eta.git", False),
+                    ("Chat", "irc://irc.libera.chat/seed", False),
+                ]
+            },
+        },
+        {
+            "name": "seed-recovery-urls-stale",
+            "summary": "Dev seed: project URLs dropped after the first release",
+            "releases": [
+                ("1.0.0", 7, [unattested]),
+                ("2.0.0", 1, [unattested]),
+            ],
+            # Only 1.0.0 carries URLs, and the picker reads the latest release,
+            # so this project offers the moderator nothing.
+            "urls": {
+                "1.0.0": [("Source", "https://github.com/seed-org/epsilon", True)]
+            },
+        },
     ]
+
+    # `file_specs` fails loudly on a miscount via `zip(strict=True)` below, but a
+    # mistyped `urls` version key would just silently seed no URLs at all, which
+    # is the one thing these scenarios exist to produce. Catch it before any DB
+    # work happens.
+    for scenario in scenarios:
+        declared = {version for version, _, _ in scenario["releases"]}
+        if unknown := set(scenario.get("urls", {})) - declared:
+            raise click.ClickException(
+                f"{scenario['name']}: `urls` names versions with no release: "
+                f"{sorted(unknown)}"
+            )
 
     wheel_tags = [
         "py3-none-any",
@@ -201,6 +360,10 @@ def seed(config):  # pragma: no cover # dev-only tool
                 uploader=user,
                 summary=scenario["summary"],
             )
+            for label, url, verified in scenario.get("urls", {}).get(version, []):
+                ReleaseURLFactory.create(
+                    release=release, name=label, url=url, verified=verified
+                )
             base = scenario["name"].replace("-", "_")
             filenames = [f"{base}-{version}.tar.gz"] + [
                 f"{base}-{version}-{tag}.whl"

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -865,6 +865,99 @@ DynamicFieldsEnum = ENUM(
     name="release_dynamic_fields",
 )
 
+# Hosts whose `/{owner}/{repo}` paths address a git repository, paired with the
+# owner names that host reserves for itself. Deliberately excludes the Pages
+# domains (`*.github.io`, `*.gitlab.io`): a Trusted Publisher verifies those for
+# its own project, but they serve rendered docs rather than a git remote.
+#
+# These cover the public forges only. A self-hosted GitLab is a supported
+# Trusted Publisher issuer, so a repository there is genuinely verifiable and
+# still will not match. Callers ranking on the result get a false negative,
+# never a false positive.
+GITHUB_REPO_HOSTS = {"github.com", "www.github.com"}
+GITLAB_REPO_HOSTS = {"gitlab.com", "www.gitlab.com"}
+
+# gitlab.com serves these as its own pages, so `/{first}/{second}` under them
+# names no repository. GitHub's equivalent list is `github_reserved_names.ALL`.
+GITLAB_RESERVED_NAMES = frozenset(
+    {
+        "-",
+        "admin",
+        "api",
+        "dashboard",
+        "explore",
+        "groups",
+        "help",
+        "profile",
+        "projects",
+        "public",
+        "search",
+        "snippets",
+        "users",
+    }
+)
+
+
+def parse_user_name_and_repo_name(
+    url: str,
+    domains: set[str],
+    reserved_names: typing.Collection[str] | None = None,
+    *,
+    root_only: bool = False,
+) -> tuple[str, str] | None:
+    """
+    Split a repository URL into its owner and repository name.
+
+    Returns `None` unless the URL addresses a repository on one of `domains`,
+    which rules out an unrelated host, a path too short to name a repository, and
+    an owner segment the host reserves for its own pages.
+
+    By default a URL *inside* a repository resolves to that repository, so
+    `github.com/o/r/issues` yields `("o", "r")`. Pass `root_only` to reject it:
+    a caller offering the URL as a git remote needs the repository itself, and
+    Trusted Publisher verification extends to every subpath of the repository.
+    """
+    try:
+        parsed = parse_url(url)
+    except LocationParseError:
+        return None
+    # `host` rather than `netloc`, which carries any explicit port.
+    if parsed.host not in domains:
+        return None
+    segments = parsed.path.strip("/").split("/") if parsed.path else []
+    if len(segments) < 2 or (root_only and len(segments) != 2):
+        return None
+    user_name, repo_name = segments[:2]
+    if reserved_names and user_name in reserved_names:
+        return None
+    repo_name = repo_name.removesuffix(".git")
+    if not (user_name and repo_name):
+        return None
+    return user_name, repo_name
+
+
+REPO_FORGES = (
+    (GITHUB_REPO_HOSTS, GITHUB_RESERVED_NAMES),
+    (GITLAB_REPO_HOSTS, GITLAB_RESERVED_NAMES),
+)
+
+
+def is_repository_root(url: str) -> bool:
+    """
+    Report whether the URL addresses a repository a branch can be pushed to.
+
+    The forge list above is an allowlist, so this also demands a two-segment
+    path, which costs an answer on an allowlisted host: GitLab issues Trusted
+    Publishers for projects under a subgroup, so `gitlab.com/group/subgroup/repo`
+    really does take a push and is reported here as if it did not. Accepting it
+    would give up the only signal separating a repository root from a subpath on
+    GitLab.
+    """
+    return any(
+        parse_user_name_and_repo_name(url, hosts, reserved, root_only=True)
+        for hosts, reserved in REPO_FORGES
+    )
+
 
 class Release(HasObservations, db.Model):
     __tablename__ = "releases"
@@ -1094,24 +1187,14 @@ class Release(HasObservations, db.Model):
         self, domains: set[str], reserved_names: typing.Collection[str] | None = None
     ):
         for url in self.urls_by_verify_status(verified=True).values():
-            try:
-                parsed = parse_url(url)
-            except LocationParseError:
-                continue
-            segments = parsed.path.strip("/").split("/") if parsed.path else []
-            if parsed.netloc in domains and len(segments) >= 2:
-                user_name, repo_name = segments[:2]
-                if reserved_names and user_name in reserved_names:
-                    continue
-                if repo_name.endswith(".git"):
-                    repo_name = repo_name.removesuffix(".git")
-                return user_name, repo_name
+            if pair := parse_user_name_and_repo_name(url, domains, reserved_names):
+                return pair
         return None, None
 
     @property
     def verified_github_user_name_and_repo_name(self):
         return self.verified_user_name_and_repo_name(
-            {"github.com", "www.github.com"}, GITHUB_RESERVED_NAMES
+            GITHUB_REPO_HOSTS, GITHUB_RESERVED_NAMES
         )
 
     @property
@@ -1133,7 +1216,7 @@ class Release(HasObservations, db.Model):
 
     @property
     def verified_gitlab_user_name_and_repo_name(self):
-        return self.verified_user_name_and_repo_name({"gitlab.com", "www.gitlab.com"})
+        return self.verified_user_name_and_repo_name(GITLAB_REPO_HOSTS)
 
     @property
     def verified_gitlab_repository(self):


### PR DESCRIPTION
The challenge asks the requester to push a branch to a repo in the project's metadata, but the picker offered every release URL in arbitrary order, leaving the moderator to find a usable one. Rank the URLs PyPI can vouch for.

`ReleaseURL.verified` is the wrong signal to rank on. `verify_url` sets it for a project's own PyPI page, for each Trusted Publisher's docs site (`{owner}.github.io/{repo}` and friends), and for every subpath of the verified repository, so an `/issues` link carries it too. All genuinely proven, none of them a git remote. `is_repository_root` supplies the other half, generalizing the owner/repo parse `verified_user_name_and_repo_name` already needed rather
than copying it. Repositories also outrank unpushable pages when neither is verified, so `Source` stops hiding under `Documentation`.

Matching on `host` rather than `netloc` keeps a URL with an explicit port. `root_only` rejects subpaths. Each host's reserved names keep `gitlab.com/explore/projects` and `github.com/sponsors/x` out. Labels tie-break case-insensitively, since `Homepage` and `repository` are both idiomatic and raw ASCII sorted every capitalized label first.

Entries keep `verified` beside `proven`. The observation stores the list verbatim and a later release replaces the `ReleaseURL` rows, so it is the only record of what PyPI had verified when the challenge went out.

The radio button had a duplicate `name` and no `id`, so its label selected nothing and clicking the project name left the form, discarding the support link already typed in.

Includes other commits making tests and local development a little easier.