### PR TITLE
fix(admin): keep project activity table from overflowing the panel

### DIFF
--- a/warehouse/admin/static/css/admin.css
+++ b/warehouse/admin/static/css/admin.css
@@ -22,6 +22,7 @@ table.dataTable {
 .table td,
 .table th {
   max-width: 30em;
+  overflow-wrap: anywhere;
 }
 
 /* Tabulator replaces the <table> with divs, so the rule above cannot reach its

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -702,6 +702,7 @@
   </div>
 
   <div class="card-body">
+    <div class="table-responsive p-0">
     <table class="table table-hover">
       <thead>
         <tr>
@@ -729,6 +730,7 @@
       </tbody>
     </table>
   </div>
+ </div>
 </div> <!-- .card #projectActivity -->
 
 <div class="card card-primary card-outline collapsed-card" id="reindex">


### PR DESCRIPTION
## Summary

This PR addresses the CSS overflow issue in the Admin **Project activity** panel described in #20382.

The Project activity table contains fields that can have very long values, such as hashed IP addresses and JSON in the **Additional information** column. These values could cause the table to extend beyond the boundaries of the panel.

### Changes

- Added `overflow-wrap: anywhere` to table cells so long, unbroken values can wrap within the available space.
- Wrapped the Project activity table in a `table-responsive` container so it remains contained within the panel on smaller screens.

This PR focuses specifically on **item 3 (CSS overflow)** from #20382. Pagination and the improved display of activity data are not included.

## Testing

- Tested the Project activity panel in the local Warehouse Admin UI.
- Tested the panel at a narrower browser width.
- Verified that long cell content no longer causes the page/panel to overflow.
- Ran `git diff --check` successfully.

## Screenshot
<img width="541" height="486" alt="Screenshot 2026-09-06 at 2 29 22 PM" src="https://github.com/user-attachments/assets/df955ed3-b9c4-49dc-bf70-800d1cf1a724" />

The screenshot  shows the Project activity panel after the CSS changes.

Related to #20382