### PR TITLE
feat(accounts): rate limit registrations by IP

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,6 +250,7 @@ def pyramid_services(
     services.register_service(search_service, ISearchService)
     services.register_service(domain_status_service, IDomainStatusService)
     services.register_service(email_reputation_service, IEmailReputationService)
+    services.register_service(ratelimit_service, IRateLimiter, name="accounts.register")
     services.register_service(ratelimit_service, IRateLimiter, name="email.add")
     services.register_service(ratelimit_service, IRateLimiter, name="email.change")
     services.register_service(ratelimit_service, IRateLimiter, name="email.verify")

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -118,6 +118,7 @@ def test_includeme(monkeypatch):
                 "warehouse.account.verify_email_ratelimit_string": "3 per 6 hours",
                 "warehouse.account.password_reset_ratelimit_string": "5 per day",
                 "warehouse.account.accounts_search_ratelimit_string": "100 per hour",
+                "warehouse.account.register_ratelimit_string": "10 per 5 minutes, 30 per hour",  # noqa: E501
                 "github.oauth.backend": accounts.NullGitHubOAuthClient,
             }
         ),
@@ -184,6 +185,7 @@ def test_includeme(monkeypatch):
         pretend.call("5 per day", "password.reset"),
         pretend.call("3 per 6 hours", "email.verify"),
         pretend.call("100 per hour", "accounts.search"),
+        pretend.call("10 per 5 minutes, 30 per hour", "accounts.register"),
     ]
     assert config.add_request_method.calls == [
         pretend.call(accounts._user, name="user", reify=True),
@@ -235,6 +237,7 @@ def test_includeme_with_gitlab_oauth():
                 "warehouse.account.verify_email_ratelimit_string": "3 per 6 hours",
                 "warehouse.account.password_reset_ratelimit_string": "5 per day",
                 "warehouse.account.accounts_search_ratelimit_string": "100 per hour",
+                "warehouse.account.register_ratelimit_string": "10 per 5 minutes, 30 per hour",  # noqa: E501
                 "github.oauth.backend": accounts.NullGitHubOAuthClient,
                 "gitlab.oauth.backend": accounts.NullGitLabOAuthClient,
             }

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -1930,10 +1930,101 @@ class TestRegister:
             SimpleNamespace(merge=lambda policy: None), None, None, name="csp"
         )
 
+    def _post_a_registration(self, db_request):
+        """Fill in a POST body that would otherwise pass form validation."""
+        db_request.method = "POST"
+        db_request.POST.update(
+            {
+                "username": "username_value",
+                "new_password": "MyStr0ng!shP455w0rd",
+                "password_confirm": "MyStr0ng!shP455w0rd",
+                "email": "foo@bar.com",
+                "full_name": "full_name",
+            }
+        )
+
+    @pytest.mark.parametrize(
+        ("resets_in", "retry_after", "message"),
+        [
+            (
+                datetime.timedelta(seconds=3300),
+                "3300",
+                "Too many registration attempts from your network. Please try "
+                "again in 55 minutes.",
+            ),
+            (
+                None,
+                None,
+                "Too many registration attempts from your network. Please try "
+                "again later.",
+            ),
+        ],
+    )
+    def test_register_ratelimited(
+        self,
+        db_request,
+        pyramid_services,
+        metrics,
+        ratelimit_service,
+        mocker,
+        resets_in,
+        retry_after,
+        message,
+    ):
+        """A denied attempt returns 429 with a form error and the typed values
+        intact.
+        """
+        self._register_form_services(pyramid_services)
+        mocker.patch.object(ratelimit_service, "hit", return_value=False)
+        mocker.patch.object(ratelimit_service, "resets_in", return_value=resets_in)
+        self._post_a_registration(db_request)
+
+        result = views.register(db_request)
+
+        assert db_request.response.status_int == 429
+        # The typed values survive, so the user is not asked to start over.
+        assert result["form"].email.data == "foo@bar.com"
+        assert result["form"].username.data == "username_value"
+        # Only the form-level key: the limiter runs before validate(), so no
+        # per-field errors appear.
+        assert result["form"].errors == {"": [message]}
+        # Asserted on the raw header: WebOb's `retry_after` getter parses it
+        # back into an absolute datetime.
+        assert db_request.response.headers.get("Retry-After") == retry_after
+        ratelimit_service.hit.assert_called_once_with(db_request.remote_addr)
+        metrics.increment.assert_any_call(
+            "warehouse.accounts.register", tags=["outcome:ratelimited"]
+        )
+        metrics.increment.assert_any_call(
+            "warehouse.accounts.register.ratelimited", tags=["ratelimiter:ip"]
+        )
+
+    @pytest.mark.usefixtures("no_email_deliverability_check")
+    @pytest.mark.parametrize("remote_addr", [None, ""])
+    def test_register_skips_the_limiter_without_a_remote_addr(
+        self, db_request, pyramid_services, metrics, ratelimit_service, remote_addr
+    ):
+        """An unkeyable request is not metered into one bucket shared by all.
+
+        Gunicorn on a unix socket sends '' as REMOTE_ADDR, not None, so both
+        are exercised here.
+        """
+        self._register_form_services(pyramid_services)
+        db_request.method = "POST"
+        db_request.POST.update({"username": "username_value", "email": "not-an-email"})
+        db_request.remote_addr = remote_addr
+
+        views.register(db_request)
+
+        assert ratelimit_service.hit.call_count == 0
+        # Counted, so a limiter that has stopped running is not silent.
+        metrics.increment.assert_any_call("warehouse.accounts.register.unmetered")
+
     @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_register_counts_invalid_attempts(
-        self, db_request, pyramid_services, metrics
+        self, db_request, pyramid_services, metrics, ratelimit_service
     ):
+        """A failed attempt is charged, since validation costs DNS either way."""
         self._register_form_services(pyramid_services)
 
         db_request.method = "POST"
@@ -1942,18 +2033,20 @@ class TestRegister:
         result = views.register(db_request)
 
         assert result["form"].errors
+        ratelimit_service.hit.assert_called_once_with(db_request.remote_addr)
         metrics.increment.assert_any_call(
             "warehouse.accounts.register", tags=["outcome:invalid"]
         )
 
     def test_register_does_not_count_page_loads(
-        self, db_request, pyramid_services, metrics
+        self, db_request, pyramid_services, metrics, ratelimit_service
     ):
-        """A GET is a page view, not an attempt, so it stays out of the counter."""
+        """A GET is a page view, so it is neither counted nor charged."""
         self._register_form_services(pyramid_services)
 
         views.register(db_request)
 
+        assert ratelimit_service.hit.call_count == 0
         assert not [
             call
             for call in metrics.increment.calls
@@ -1974,9 +2067,10 @@ class TestRegister:
             lambda *args: None
         )
         db_request.session.record_password_timestamp = lambda ts: None
+        register_limiter_hit = pretend.call_recorder(lambda *a: True)
 
         def _find_service(service=None, name=None, context=None):
-            key = service or name
+            key = (service, name) if service is IRateLimiter else service or name
             return {
                 IUserService: pretend.stub(
                     username_is_prohibited=lambda a: False,
@@ -1994,7 +2088,10 @@ class TestRegister:
                 IPasswordBreachedService: pretend.stub(
                     check_password=lambda pw, tags=None: False,
                 ),
-                IRateLimiter: pretend.stub(hit=lambda user_id: None),
+                (IRateLimiter, "accounts.register"): pretend.stub(
+                    hit=register_limiter_hit
+                ),
+                (IRateLimiter, "email.verify"): pretend.stub(hit=lambda *a: True),
                 "csp": pretend.stub(merge=lambda *a, **kw: {}),
                 ICaptchaService: pretend.stub(
                     csp_policy={}, enabled=True, verify_response=lambda a: True
@@ -2003,16 +2100,8 @@ class TestRegister:
 
         db_request.find_service = pretend.call_recorder(_find_service)
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.POST.update(
-            {
-                "username": "username_value",
-                "new_password": "MyStr0ng!shP455w0rd",
-                "password_confirm": "MyStr0ng!shP455w0rd",
-                "email": "foo@bar.com",
-                "full_name": "full_name",
-                "g_recaptcha_response": "captchavalue",
-            }
-        )
+        self._post_a_registration(db_request)
+        db_request.POST.update({"g_recaptcha_response": "captchavalue"})
 
         send_email = pretend.call_recorder(lambda *a: None)
         monkeypatch.setattr(views, "send_email_verification_email", send_email)
@@ -2045,6 +2134,8 @@ class TestRegister:
         db_request.metrics.increment.assert_any_call(
             "warehouse.accounts.register", tags=["outcome:ok"]
         )
+        # Successes stay charged against the limiter too.
+        assert register_limiter_hit.calls == [pretend.call(db_request.remote_addr)]
 
     def test_register_fails_with_admin_flag_set(self, db_request):
         # This flag was already set via migration, just need to enable it
@@ -2053,17 +2144,7 @@ class TestRegister:
         )
         flag.enabled = True
 
-        db_request.method = "POST"
-
-        db_request.POST.update(
-            {
-                "username": "username_value",
-                "password": "MyStr0ng!shP455w0rd",
-                "password_confirm": "MyStr0ng!shP455w0rd",
-                "email": "foo@bar.com",
-                "full_name": "full_name",
-            }
-        )
+        self._post_a_registration(db_request)
 
         db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -343,6 +343,7 @@ def test_configure(monkeypatch, mocker, settings, environment):
         "warehouse.account.verify_email_ratelimit_string": "3 per 6 hours",
         "warehouse.account.accounts_search_ratelimit_string": "100 per hour",
         "warehouse.account.password_reset_ratelimit_string": "5 per day",
+        "warehouse.account.register_ratelimit_string": "10 per 5 minutes, 30 per hour",
         "warehouse.manage.oidc.user_registration_ratelimit_string": "100 per day",
         "warehouse.manage.oidc.ip_registration_ratelimit_string": "100 per day",
         "warehouse.packaging.project_create_user_ratelimit_string": "20 per hour",

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -229,6 +229,10 @@ def includeme(config):
         "warehouse.account.accounts_search_ratelimit_string"
     )
     config.register_rate_limiter(accounts_search_ratelimit_string, "accounts.search")
+    register_ratelimit_string = config.registry.settings.get(
+        "warehouse.account.register_ratelimit_string"
+    )
+    config.register_rate_limiter(register_ratelimit_string, "accounts.register")
 
     # Add a periodic task to generate Account metrics
     config.add_periodic_task(crontab(minute="*/20"), compute_user_metrics)

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -753,6 +753,47 @@ def register(request, _form_class=RegistrationForm):
         breach_service=breach_service,
     )
 
+    # Charged before validating anything: a failed attempt still costs the
+    # deliverability DNS lookups and discloses whether an address is registered.
+    #
+    # Deliberately no RateLimit/RateLimit-Policy headers, unlike the search and
+    # project-create limiters. This endpoint is unauthenticated and has no
+    # legitimate scripted callers, so publishing the remaining quota would tell
+    # an enumerator how to pace under the cap.
+    register_limiter = request.find_service(IRateLimiter, name="accounts.register")
+
+    if request.method == "POST" and not request.remote_addr:
+        # Nothing to key on, and one shared bucket for every address-less
+        # request is worse than no limit. Counted so that a limiter which
+        # has stopped running is still visible.
+        request.metrics.increment("warehouse.accounts.register.unmetered")
+    elif request.method == "POST" and not register_limiter.hit(request.remote_addr):
+        _outcome("ratelimited")
+        request.metrics.increment(
+            "warehouse.accounts.register.ratelimited",
+            tags=["ratelimiter:ip"],
+        )
+        # Form errors render without JavaScript; flashes do not.
+        request.response.status = 429
+        _resets_in = register_limiter.resets_in(request.remote_addr)
+        if _resets_in is not None:
+            request.response.retry_after = _resets_in.total_seconds()
+            form.form_errors.append(
+                request._(
+                    "Too many registration attempts from your network. "
+                    "Please try again in ${time}.",
+                    mapping={"time": humanize.naturaldelta(_resets_in.total_seconds())},
+                )
+            )
+        else:
+            form.form_errors.append(
+                request._(
+                    "Too many registration attempts from your network. "
+                    "Please try again later."
+                )
+            )
+        return {"form": form}
+
     if request.method == "POST" and form.validate():
         email_limiter = request.find_service(IRateLimiter, name="email.verify")
         user = user_service.create_user(

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -586,6 +586,12 @@ def configure(settings=None):
     )
     maybe_set(
         settings,
+        "warehouse.account.register_ratelimit_string",
+        "REGISTER_RATELIMIT_STRING",
+        default="10 per 5 minutes, 30 per hour",
+    )
+    maybe_set(
+        settings,
         "warehouse.manage.oidc.user_registration_ratelimit_string",
         "USER_OIDC_REGISTRATION_RATELIMIT_STRING",
         default="100 per day",

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -172,171 +172,182 @@ msgid ""
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:893
+#: warehouse/accounts/views.py:783
+#, python-brace-format
+msgid ""
+"Too many registration attempts from your network. Please try again in "
+"${time}."
+msgstr ""
+
+#: warehouse/accounts/views.py:791
+msgid "Too many registration attempts from your network. Please try again later."
+msgstr ""
+
+#: warehouse/accounts/views.py:934
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:895
+#: warehouse/accounts/views.py:936
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:897 warehouse/accounts/views.py:1010
-#: warehouse/accounts/views.py:1075 warehouse/accounts/views.py:1181
-#: warehouse/accounts/views.py:1352
+#: warehouse/accounts/views.py:938 warehouse/accounts/views.py:1051
+#: warehouse/accounts/views.py:1116 warehouse/accounts/views.py:1222
+#: warehouse/accounts/views.py:1393
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:901
+#: warehouse/accounts/views.py:942
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:906 warehouse/accounts/views.py:1019
+#: warehouse/accounts/views.py:947 warehouse/accounts/views.py:1060
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:917
+#: warehouse/accounts/views.py:958
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:935
+#: warehouse/accounts/views.py:976
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:966
+#: warehouse/accounts/views.py:1007
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:1006
+#: warehouse/accounts/views.py:1047
 msgid "Expired token: please try to login again"
 msgstr ""
 
-#: warehouse/accounts/views.py:1008
+#: warehouse/accounts/views.py:1049
 msgid "Invalid token: please try to login again"
 msgstr ""
 
-#: warehouse/accounts/views.py:1014
+#: warehouse/accounts/views.py:1055
 msgid "Invalid token: not a login confirmation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1029
+#: warehouse/accounts/views.py:1070
 msgid "Invalid login attempt."
 msgstr ""
 
-#: warehouse/accounts/views.py:1034
+#: warehouse/accounts/views.py:1075
 msgid ""
 "Device details didn't match, please try again from the device you "
 "originally used to log in."
 msgstr ""
 
-#: warehouse/accounts/views.py:1045
+#: warehouse/accounts/views.py:1086
 msgid "Your login has been confirmed and this device is now recognized."
 msgstr ""
 
-#: warehouse/accounts/views.py:1071
+#: warehouse/accounts/views.py:1112
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:1073
+#: warehouse/accounts/views.py:1114
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:1079
+#: warehouse/accounts/views.py:1120
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1088
+#: warehouse/accounts/views.py:1129
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:1091
+#: warehouse/accounts/views.py:1132
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:1111
+#: warehouse/accounts/views.py:1152
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1114
+#: warehouse/accounts/views.py:1155
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1120
+#: warehouse/accounts/views.py:1161
 #, python-brace-format
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:1177
+#: warehouse/accounts/views.py:1218
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1179
+#: warehouse/accounts/views.py:1220
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1185
+#: warehouse/accounts/views.py:1226
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1189 warehouse/accounts/views.py:1200
+#: warehouse/accounts/views.py:1230 warehouse/accounts/views.py:1241
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1198
+#: warehouse/accounts/views.py:1239
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1252
+#: warehouse/accounts/views.py:1293
 #, python-brace-format
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1315
+#: warehouse/accounts/views.py:1356
 #, python-brace-format
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1348
+#: warehouse/accounts/views.py:1389
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1350
+#: warehouse/accounts/views.py:1391
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1356
+#: warehouse/accounts/views.py:1397
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1360 warehouse/accounts/views.py:1380
+#: warehouse/accounts/views.py:1401 warehouse/accounts/views.py:1421
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1367
+#: warehouse/accounts/views.py:1408
 msgid "Invalid token: project does not exist"
 msgstr ""
 
-#: warehouse/accounts/views.py:1378
+#: warehouse/accounts/views.py:1419
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1412
+#: warehouse/accounts/views.py:1453
 #, python-brace-format
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1478
+#: warehouse/accounts/views.py:1519
 #, python-brace-format
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1589
+#: warehouse/accounts/views.py:1630
 #, python-brace-format
 msgid "Please review our updated <a href=\"${tos_url}\">Terms of Service</a>."
 msgstr ""
 
-#: warehouse/accounts/views.py:1816 warehouse/accounts/views.py:2084
+#: warehouse/accounts/views.py:1857 warehouse/accounts/views.py:2125
 #: warehouse/manage/views/oidc_publishers.py:126
 #: warehouse/manage/views/organizations.py:1721
 msgid ""
@@ -344,22 +355,22 @@ msgid ""
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1837
+#: warehouse/accounts/views.py:1878
 #: warehouse/manage/views/organizations.py:1744
 msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1853
+#: warehouse/accounts/views.py:1894
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1866
+#: warehouse/accounts/views.py:1907
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1881
+#: warehouse/accounts/views.py:1922
 #: warehouse/manage/views/oidc_publishers.py:308
 #: warehouse/manage/views/oidc_publishers.py:423
 #: warehouse/manage/views/oidc_publishers.py:539
@@ -369,7 +380,7 @@ msgid ""
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1891
+#: warehouse/accounts/views.py:1932
 #: warehouse/manage/views/oidc_publishers.py:321
 #: warehouse/manage/views/oidc_publishers.py:436
 #: warehouse/manage/views/oidc_publishers.py:552
@@ -378,30 +389,30 @@ msgstr ""
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1906
+#: warehouse/accounts/views.py:1947
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1931
+#: warehouse/accounts/views.py:1972
 msgid ""
 "A pending trusted publisher matching this configuration has already been "
 "registered for a different project name. Please contact PyPI's admins if "
 "this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1954
+#: warehouse/accounts/views.py:1995
 #: warehouse/manage/views/organizations.py:1812
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:2097 warehouse/accounts/views.py:2110
-#: warehouse/accounts/views.py:2117
+#: warehouse/accounts/views.py:2138 warehouse/accounts/views.py:2151
+#: warehouse/accounts/views.py:2158
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:2124
+#: warehouse/accounts/views.py:2165
 msgid "Removed trusted publisher for project "
 msgstr ""
 


### PR DESCRIPTION
Add an `accounts.register` limiter keyed on the client IP and charged before `form.validate()`, since the email field validates ahead of the captcha. A rejected attempt returns 429 with the typed values intact and the wait shown as a form error, matching the login lockout views.

There are no `RateLimit` headers on purpose. The endpoint is not meant to be scripted, and the header would only tell an enumerator how to pace.

Refs #20470