### PR TITLE
Add shield icon for security project links

### DIFF
--- a/docs/user/project_metadata.md
+++ b/docs/user/project_metadata.md
@@ -105,6 +105,7 @@ will be recognized.
 | Documentation^*^ | :fontawesome-solid-book:                  | Project documentation       | Docs^*^ , a URL pointing to [Read the Docs] domains or a URL starting with `docs.` or `documentation.` |
 | Bug^*^           | :fontawesome-solid-bug:                   | Bug/Issue report location   | Issue^*^, Tracker^*^, Report^*^                                                                        |
 | Funding^*^       | :fontawesome-solid-circle-dollar-to-slot: | Sponsoring information      | Sponsor^*^, Donation^*^, Donate^*^                                                                     |
+| Security         | :fontawesome-solid-shield:                | Security policy or vulnerability reporting page | Security Policy, securitypolicy                                                                       |
 | Source           | :fontawesome-solid-code-branch:           | Source code repository      | Source Code, Sourcecode, Repository                                                                    |
 
 [Read the Docs]: https://about.readthedocs.com/

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3786,16 +3786,16 @@ msgstr[1] ""
 msgid "Owner"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/metadata/project-links.html:60
+#: warehouse/templates/includes/packaging/metadata/project-links.html:62
 msgid "Project links"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/metadata/project-links.html:66
+#: warehouse/templates/includes/packaging/metadata/project-links.html:68
 #, python-format
 msgid "Data verified by PyPI on %(date)s"
 msgstr ""
 
-#: warehouse/templates/includes/packaging/metadata/project-links.html:69
+#: warehouse/templates/includes/packaging/metadata/project-links.html:71
 msgid ""
 "Data provided by the project maintainers, verified at the time the "
 "release was uploaded to PyPI."

--- a/warehouse/templates/includes/packaging/metadata/project-links.html
+++ b/warehouse/templates/includes/packaging/metadata/project-links.html
@@ -15,6 +15,8 @@
     {% set icon = "fas fa-bug" %}
   {% elif name.lower().startswith(("funding", "donate", "donation", "sponsor")) %}
     {% set icon = "fas fa-donate" %}
+  {% elif name|lower in ["security", "security policy", "securitypolicy"] %}
+    {% set icon = "fas fa-shield" %}
   {% elif parsed.netloc in ["github.com", "github.io"] or parsed.netloc.endswith((".github.com", ".github.io")) %}
     {% set icon = "fab fa-github" %}
   {% elif parsed.netloc == "gitlab.com" or parsed.netloc.endswith(".gitlab.com") %}


### PR DESCRIPTION
Adds a shield icon for the `security` well-known project URL label, including its documented aliases.

From https://github.com/pypa/packaging.python.org/pull/2127#issuecomment-5587675822