### PR TITLE
Handle case where `:action` param may be `None`

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -43,7 +43,14 @@ class TestRequireHTTPSTween:
         assert tween(pyramid_request) is mocker.sentinel.response
         handler.assert_called_once_with(pyramid_request)
 
-    @pytest.mark.parametrize(("params", "scheme"), [({":action": "thing"}, "http")])
+    @pytest.mark.parametrize(
+        ("params", "scheme"),
+        [
+            ({":action": "thing"}, "http"),
+            ({":action": None}, "http"),
+            ({":action": ""}, "http"),
+        ],
+    )
     def test_rejects(self, params, scheme, pyramid_request, mocker):
         pyramid_request.params = params
         pyramid_request.scheme = scheme

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -214,7 +214,7 @@ def require_https_tween_factory(handler, registry):
     def require_https_tween(request):
         # If we have an :action URL and we're not using HTTPS, then we want to
         # return a 403 error.
-        if request.params.get(":action", None) and request.scheme != "https":
+        if ":action" in request.params and request.scheme != "https":
             resp = HTTPForbidden(body="SSL is required.", content_type="text/plain")
             resp.status = "403 SSL is required"
             resp.headers["X-Fastly-Error"] = "803"


### PR DESCRIPTION
Fixes [WAREHOUSE-STAGING-1ZQ](https://python-software-foundation.sentry.io/issues/7721062523/events/55af67b5a0e14ec896c100284500527a/).

Previously, `require_https_tween` evaluated the truthiness of `request.params.get(":action", None)` to determine whether to require HTTPS.  When a request submits `:action` as part of a multipart payload (e.g. as a file upload), WebOb parses the field as an instance of `cgi.FieldStorage`. In `cgi.FieldStorage`, evaluating truthiness invokes `__bool__`, which raises `TypeError: Cannot be converted to bool.` when `self.list is None`.

Checking `":action" in request.params` instead tests for the presence of the parameter rather than evaluating its truthiness. This has the effect of letting HTTPS requests with 'falsey' action values through, but since the overall goal of the check is to ensuring any request containing an `:action` parameter over HTTP is rejected, not to validate the `:action` parameter, this should be fine.